### PR TITLE
Feat: Enable CI tests using GitHub actions

### DIFF
--- a/.github/workflows/yarn.js.yml
+++ b/.github/workflows/yarn.js.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dev
+      - 'feat/**'
+  pull_request:
+    branches:
+      - dev
+      - 'feat/**'
+
+jobs:
+  build:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: install --frozen-lockfile
+      - run: npx lerna bootstrap
+      - uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: test

--- a/.github/workflows/yarn.js.yml
+++ b/.github/workflows/yarn.js.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: borales/actions-yarn@v2.0.0
         with:
           cmd: install --frozen-lockfile
-      - run: npx lerna bootstrap
       - uses: borales/actions-yarn@v2.0.0
         with:
           cmd: test


### PR DESCRIPTION
- Use Github Actions for automated tests. Use a 3rd party action: https://github.com/marketplace/actions/github-action-for-yarn
- Included: tests.
- Not included: packaging, publishing.