### PR TITLE
feat(steps): add steps component

### DIFF
--- a/packages/element-plus/index.ts
+++ b/packages/element-plus/index.ts
@@ -20,6 +20,7 @@ import ElNotification from '@element-plus/notification'
 import ElPageHeader from '@element-plus/page-header'
 import ElRadio from '@element-plus/radio'
 import ElScrollBar from '@element-plus/scrollbar'
+import ElSteps from '@element-plus/steps'
 import ElCollapse from '@element-plus/collapse'
 
 export {
@@ -43,6 +44,7 @@ export {
   ElNotification,
   ElPageHeader,
   ElScrollBar,
+  ElSteps,
   ElRadio,
   ElCollapse,
 }
@@ -68,6 +70,7 @@ export default function install(app: App): void {
   ElNotification(app)
   ElPageHeader(app)
   ElScrollBar(app)
+  ElSteps(app)
   ElRadio(app)
   ElCollapse(app)
 }

--- a/packages/element-plus/package.json
+++ b/packages/element-plus/package.json
@@ -31,6 +31,7 @@
     "@element-plus/radio": "^0.0.0",
     "@element-plus/page-header": "^0.0.0",
     "@element-plus/scrollbar": "^0.0.0",
+    "@element-plus/steps": "^0.0.0",
     "@element-plus/notification": "^0.0.0",
     "@element-plus/collapse": "^0.0.0"
   }

--- a/packages/steps/__tests__/steps.spec.ts
+++ b/packages/steps/__tests__/steps.spec.ts
@@ -1,0 +1,150 @@
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import Steps from '../src/index.vue'
+import Step from '../src/item.vue'
+
+const _mount = (template: string) => mount({
+  components: {
+    'el-steps': Steps,
+    'el-step': Step,
+  },
+  template,
+}, {
+  attachTo: document.body,
+  global: {
+    provide: {
+      ElSteps: {},
+    },
+  },
+})
+
+describe('Steps.vue', () => {
+  test('render', () => {
+    const wrapper = _mount(`
+      <el-steps>
+        <el-step />
+        <el-step />
+        <el-step />
+      </el-steps>
+    `)
+    expect(wrapper.findAll('.el-step').length).toBe(3)
+    expect(wrapper.classes()).toContain('el-steps--horizontal')
+    expect(wrapper.find('.el-step').classes()).toContain('is-horizontal')
+  })
+
+  test('space', () => {
+    const wrapper = _mount(`
+      <el-steps :space="100">
+        <el-step />
+      </el-steps>
+    `)
+    expect(wrapper.find('.el-step').attributes('style')).toMatch('flex-basis: 100px;')
+  })
+
+  test('alignCenter', () => {
+    const wrapper = _mount(`
+      <el-steps alignCenter>
+        <el-step />
+      </el-steps>
+    `)
+    expect(wrapper.find('.el-step').classes()).toContain('is-center')
+  })
+
+  test('direction', () => {
+    const wrapper = _mount(`
+      <el-steps direction="vertical">
+        <el-step />
+      </el-steps>
+    `)
+    expect(wrapper.classes()).toContain('el-steps--vertical')
+    expect(wrapper.find('.el-step').classes()).toContain('is-vertical')
+  })
+
+  test('simple', () => {
+    const wrapper = _mount(`
+      <el-steps simple direction="vertical" :space="100" alignCenter>
+        <el-step />
+      </el-steps>
+    `)
+    expect(wrapper.classes()).toContain('el-steps--simple')
+    expect(wrapper.find('is-center').exists()).toBe(false)
+    expect(wrapper.find('is-vertical').exists()).toBe(false)
+  })
+
+  test('active', async () => {
+    const wrapper = _mount(`
+      <el-steps :active="0">
+        <el-step />
+        <el-step />
+        <el-step />
+      </el-steps>
+    `)
+    await nextTick()
+    expect(wrapper.findAll('.el-step')[0].find('.el-step__head').classes()).toContain('is-process')
+    expect(wrapper.findAll('.el-step')[1].find('.el-step__head').classes()).toContain('is-wait')
+    expect(wrapper.findAll('.el-step')[2].find('.el-step__head').classes()).toContain('is-wait')
+    await wrapper.setProps({ active: 1 })
+    expect(wrapper.findAll('.el-step')[0].find('.el-step__head').classes()).toContain('is-finish')
+    expect(wrapper.findAll('.el-step')[1].find('.el-step__head').classes()).toContain('is-process')
+    expect(wrapper.findAll('.el-step')[2].find('.el-step__head').classes()).toContain('is-wait')
+    await wrapper.setProps({ active: 2 })
+    expect(wrapper.findAll('.el-step')[0].find('.el-step__head').classes()).toContain('is-finish')
+    expect(wrapper.findAll('.el-step')[1].find('.el-step__head').classes()).toContain('is-finish')
+    expect(wrapper.findAll('.el-step')[2].find('.el-step__head').classes()).toContain('is-process')
+    await wrapper.setProps({ active: 3 })
+    expect(wrapper.findAll('.el-step')[2].find('.el-step__head').classes()).toContain('is-finish')
+  })
+
+  test('process-status', async () => {
+    const wrapper = _mount(`
+      <el-steps :active="2" process-status="success">
+        <el-step />
+        <el-step />
+        <el-step />
+      </el-steps>
+    `)
+    await nextTick()
+    expect(wrapper.findAll('.el-step')[2].find('.el-step__head').classes()).toContain('is-success')
+    await wrapper.setProps({ processStatus: 'error' })
+    expect(wrapper.findAll('.el-step')[2].find('.el-step__head').classes()).toContain('is-error')
+  })
+
+  test('finish-status', async () => {
+    const wrapper = _mount(`
+      <el-steps :active="2" finish-status="error">
+        <el-step />
+        <el-step />
+        <el-step />
+      </el-steps>
+    `)
+    await nextTick()
+    expect(wrapper.findAll('.el-step')[0].find('.el-step__head').classes()).toContain('is-error')
+    await wrapper.setProps({ finishStatus: 'success' })
+    expect(wrapper.findAll('.el-step')[0].find('.el-step__head').classes()).toContain('is-success')
+  })
+
+  test('step attribute', () => {
+    const wrapper = _mount(`
+      <el-steps :active="0">
+        <el-step icon="el-icon-edit" title="title" description="description" status="wait" />
+      </el-steps>
+    `)
+    expect(wrapper.find('.el-step__head').classes()).toContain('is-wait')
+    expect(wrapper.find('.el-icon-edit').exists()).toBe(true)
+    expect(wrapper.find('.el-step__title').text()).toBe('title')
+    expect(wrapper.find('.el-step__description').text()).toBe('description')
+  })
+
+  test('step slot', () => {
+    const wrapper = _mount(`
+      <el-steps :active="0">
+        <el-step>
+          <template v-slot:title>A</template>
+          <template v-slot:description>B</template>
+        </el-step>
+      </el-steps>
+    `)
+    expect(wrapper.find('.el-step__title').text()).toBe('A')
+    expect(wrapper.find('.el-step__description').text()).toBe('B')
+  })
+})

--- a/packages/steps/doc/basic.vue
+++ b/packages/steps/doc/basic.vue
@@ -1,0 +1,43 @@
+<template>
+  <el-steps :active="active" direction="vertical" :space="100">
+    <el-step title="Step 1" description="This is a long long long description" />
+    <el-step title="Step 2" description="This is a long long long description" />
+    <el-step title="Step 3" description="This is a long long long description" />
+  </el-steps>
+  <el-steps :active="active">
+    <el-step title="Step 1" icon="el-icon-edit" />
+    <el-step title="Step 2" icon="el-icon-upload" />
+    <el-step title="Step 3" icon="el-icon-picture" />
+  </el-steps>
+  <el-steps :active="active" simple>
+    <el-step title="Step 1" icon="el-icon-edit" />
+    <el-step title="Step 2" icon="el-icon-upload" />
+    <el-step title="Step 3" icon="el-icon-picture" />
+  </el-steps>
+  <el-button type="primary" @click="handleClick">move</el-button>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  setup() {
+    const active = ref(0)
+
+    const handleClick = () => {
+      if (active.value++ > 2) active.value = 0
+    }
+
+    return {
+      active,
+      handleClick,
+    }
+  },
+})
+</script>
+
+<style scoped>
+  .el-steps {
+    margin-bottom: 50px;
+  }
+</style>

--- a/packages/steps/doc/index.stories.ts
+++ b/packages/steps/doc/index.stories.ts
@@ -1,0 +1,5 @@
+export { default as BasicUsage } from './basic.vue'
+
+export default {
+  title: 'Steps',
+}

--- a/packages/steps/index.ts
+++ b/packages/steps/index.ts
@@ -1,0 +1,7 @@
+import { App } from 'vue'
+import Steps from './src/index.vue'
+import Step from './src/item.vue'
+export default (app: App): void => {
+  app.component(Steps.name, Steps)
+  app.component(Step.name, Step)
+}

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@element-plus/steps",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "peerDependencies": {
+    "vue": "^3.0.0-rc.1"
+  },
+  "devDependencies": {
+    "@vue/test-utils": "^2.0.0-beta.0"
+  }
+}

--- a/packages/steps/src/index.vue
+++ b/packages/steps/src/index.vue
@@ -21,6 +21,7 @@ export default defineComponent({
     direction: {
       type: String,
       default: 'horizontal',
+      validator: (val: string): boolean => ['horizontal', 'vertical'].indexOf(val) > -1,
     },
     alignCenter: {
       type: Boolean,
@@ -33,10 +34,12 @@ export default defineComponent({
     finishStatus: {
       type: String,
       default: 'finish',
+      validator: (val: string): boolean => ['wait', 'process', 'finish', 'error', 'success'].indexOf(val) > -1,
     },
     processStatus: {
       type: String,
       default: 'process',
+      validator: (val: string): boolean => ['wait', 'process', 'finish', 'error', 'success'].indexOf(val) > -1,
     },
   },
   setup(props) {

--- a/packages/steps/src/index.vue
+++ b/packages/steps/src/index.vue
@@ -1,0 +1,58 @@
+<template>
+  <div :class="['el-steps', simple ? 'el-steps--simple' : `el-steps--${direction}`]">
+    <slot></slot>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, watch, ref, provide } from 'vue'
+
+export default defineComponent({
+  name: 'ElSteps',
+  props: {
+    space: {
+      type: [Number, String],
+      default: '',
+    },
+    active: {
+      type: Number,
+      default: 0,
+    },
+    direction: {
+      type: String,
+      default: 'horizontal',
+    },
+    alignCenter: {
+      type: Boolean,
+      default: false,
+    },
+    simple: {
+      type: Boolean,
+      default: false,
+    },
+    finishStatus: {
+      type: String,
+      default: 'finish',
+    },
+    processStatus: {
+      type: String,
+      default: 'process',
+    },
+  },
+  setup(props) {
+    const steps = ref([])
+
+    watch(steps, () => {
+      steps.value.forEach((instance, index) => {
+        instance.ctx.setIndex(index)
+      })
+    })
+
+    provide('ElSteps', { props, steps })
+
+    return {
+      steps,
+    }
+  },
+})
+</script>

--- a/packages/steps/src/item.vue
+++ b/packages/steps/src/item.vue
@@ -1,0 +1,198 @@
+<template>
+  <div
+    :style="style"
+    :class="[
+      'el-step',
+      isSimple ? 'is-simple' : `is-${parent.props.direction}`,
+      isLast && !space && !isCenter && 'is-flex',
+      isCenter && !isVertical && !isSimple && 'is-center'
+    ]"
+  >
+    <!-- icon & line -->
+    <div :class="['el-step__head', `is-${currentStatus}`]">
+      <div class="el-step__line">
+        <i class="el-step__line-inner" :style="lineStyle"></i>
+      </div>
+
+      <div :class="['el-step__icon', `is-${icon ? 'icon' : 'text'}`]">
+        <slot
+          v-if="currentStatus !== 'success' && currentStatus !== 'error'"
+          name="icon"
+        >
+          <i v-if="icon" :class="['el-step__icon-inner', icon]"></i>
+          <div v-if="!icon && !isSimple" class="el-step__icon-inner">{{ index + 1 }}</div>
+        </slot>
+        <i
+          v-else
+          :class="['el-step__icon-inner', 'is-status', `el-icon-${currentStatus === 'success' ? 'check' : 'close'}`]"
+        >
+        </i>
+      </div>
+    </div>
+    <!-- title & description -->
+    <div class="el-step__main">
+      <div :class="['el-step__title', `is-${currentStatus}`]">
+        <slot name="title">{{ title }}</slot>
+      </div>
+      <div v-if="isSimple" class="el-step__arrow"></div>
+      <div v-else :class="['el-step__description', `is-${currentStatus}`]">
+        <slot name="description">{{ description }}</slot>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, inject, watch, onBeforeUnmount, onMounted, getCurrentInstance } from 'vue'
+import type { Ref, ComponentInternalInstance } from 'vue'
+
+interface IStepsProps {
+  space: number | string
+  active: number
+  direction: string
+  alignCenter: boolean
+  simple: boolean
+  finishStatus: string
+  processStatus: string
+}
+
+interface IStepInstance extends ComponentInternalInstance {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ctx: any
+}
+
+interface IStepsInject {
+  props: IStepsProps
+  steps: Ref<Array<IStepInstance>>
+}
+
+export default defineComponent({
+  name: 'ElStep',
+  props: {
+    title: {
+      type: String,
+      default: '',
+    },
+    icon: {
+      type: String,
+      default: '',
+    },
+    description: {
+      type: String,
+      default: '',
+    },
+    status: {
+      type: String,
+      default: '',
+    },
+  },
+  setup(props) {
+    const index = ref(-1)
+    const lineStyle = ref({})
+    const internalStatus = ref('')
+    const parent: IStepsInject = inject('ElSteps')
+    const currentInstance = getCurrentInstance() as IStepInstance
+
+    parent.steps.value = [...parent.steps.value, currentInstance]
+
+    onMounted(() => {
+      watch([() => parent.props.active, () => parent.props.processStatus, () => parent.props.finishStatus], ([active]) => {
+        updateStatus(active)
+      }, { immediate: true })
+    })
+
+    onBeforeUnmount(() => {
+      parent.steps.value = parent.steps.value.filter(instance => instance.uid !== currentInstance.uid)
+    })
+
+    const currentStatus = computed(() => {
+      return props.status || internalStatus.value
+    })
+    const prevStatus = computed(() => {
+      const prevStep = parent.steps[index.value - 1]
+      return prevStep ? prevStep.ctx.currentStatus : 'wait'
+    })
+    const isCenter = computed(() => {
+      return parent.props.alignCenter
+    })
+    const isVertical = computed(() => {
+      return parent.props.direction === 'vertical'
+    })
+    const isSimple = computed(() => {
+      return parent.props.simple
+    })
+    const stepsCount = computed(() => {
+      return parent.steps.value.length
+    })
+    const isLast = computed(() => {
+      return parent.steps.value[stepsCount.value - 1].uid === currentInstance.uid
+    })
+    const space = computed(() => {
+      return isSimple.value ? '' : parent.props.space
+    })
+    const style = computed(() => {
+      const style: Record<string, unknown> = {
+        flexBasis: (typeof space.value === 'number'
+          ? `${space.value}px`
+          : space.value
+            ? space.value
+            : 100 / (stepsCount.value - (isCenter.value ? 0 : 1)) + '%'),
+      }
+      if (isVertical.value) return style
+      if (isLast.value) {
+        style.maxWidth = 100 / stepsCount.value + '%'
+      }
+      return style
+    })
+
+    const setIndex = val => {
+      index.value = val
+    }
+    const calcProgress = status => {
+      let step = 100
+      const style: Record<string, unknown> = {}
+
+      style.transitionDelay = 150 * index.value + 'ms'
+      if (status === parent.props.processStatus) {
+        step = 0
+      } else if (status === 'wait') {
+        step = 0
+        style.transitionDelay = (-150 * index.value) + 'ms'
+      }
+      style.borderWidth = step && !isSimple.value ? '1px' : 0
+      style[parent.props.direction === 'vertical' ? 'height' : 'width'] = `${step}%`
+      lineStyle.value = style
+    }
+    const updateStatus = activeIndex => {
+      if (activeIndex > index.value) {
+        internalStatus.value = parent.props.finishStatus
+      } else if (activeIndex === index.value && prevStatus.value !== 'error') {
+        internalStatus.value = parent.props.processStatus
+      } else {
+        internalStatus.value = 'wait'
+      }
+      const prevChild = parent.steps.value[stepsCount.value - 1]
+      if (prevChild) prevChild.ctx.calcProgress(internalStatus.value)
+    }
+
+    return {
+      index,
+      lineStyle,
+      internalStatus,
+      currentStatus,
+      prevStatus,
+      isCenter,
+      isVertical,
+      isSimple,
+      isLast,
+      stepsCount,
+      space,
+      style,
+      parent,
+      setIndex,
+      calcProgress,
+      updateStatus,
+    }
+  },
+})
+</script>

--- a/packages/steps/src/item.vue
+++ b/packages/steps/src/item.vue
@@ -84,6 +84,7 @@ export default defineComponent({
     status: {
       type: String,
       default: '',
+      validator: (val: string): boolean => ['', 'wait', 'process', 'finish', 'error', 'success'].indexOf(val) > -1,
     },
   },
   setup(props) {


### PR DESCRIPTION
<!-- Specify your pull request type -->
- [x] Component Migration

<!-- Specify the component migration issue -->
Fix #121 

compare with `element-ui/packages/steps/src/steps.vue`, there are a lot of changes:

+ remove Migrating mixin
+ remove `$emit('change')`
+ remove `stepOffset`

In `el-steps` component, `el-steps` will call `el-step`'s method,  meanwhile, `el-step` will call siblings' method, so....

````javascript
this.$parent.steps.push(this)
````

change to 

````javascript
import type { Ref, ComponentInternalInstance } from 'vue'

interface IStepInstance extends ComponentInternalInstance {
  // eslint-disable-next-line @typescript-eslint/no-explicit-any
  ctx: any
}
const currentInstance = getCurrentInstance() as IStepInstance

parent.steps.value = [...parent.steps.value, currentInstance]
````

Is there a better way?