### PR TITLE
fix(popper): fix the bug caused by popper destroy and recreated

### DIFF
--- a/packages/popper/doc/basic.vue
+++ b/packages/popper/doc/basic.vue
@@ -32,7 +32,7 @@ export default {
       referrer: ref(null),
       placement,
       toggle: () => {
-        const random = Math.floor(Math.random() * 13)
+        const random = Math.floor(Math.random() * 11)
         placement.value = placements[random]
       },
     }

--- a/packages/popper/src/index.vue
+++ b/packages/popper/src/index.vue
@@ -319,6 +319,9 @@ export default defineComponent({
       on(referenceElement, 'focus', handleFocus)
       on(referenceElement, 'blur', handleBlur)
       on(popperRef.value, 'click', stop)
+      if (props.appendToBody && popperRef.value) {
+        document.body.appendChild(popperRef.value)
+      }
     }
 
     watch(
@@ -351,9 +354,6 @@ export default defineComponent({
 
     onMounted(() => {
       initializePopper()
-      if (props.appendToBody && popperRef.value) {
-        document.body.appendChild(popperRef.value)
-      }
     })
 
     onBeforeUnmount(() => {

--- a/packages/popper/src/index.vue
+++ b/packages/popper/src/index.vue
@@ -283,6 +283,8 @@ export default defineComponent({
       _show()
     }
 
+    let cachedPopperOptions = null
+
     function initializePopper() {
       const subTree = getTrigger()
 
@@ -301,7 +303,7 @@ export default defineComponent({
       trigger.value = referenceElement
       const modifiers = useModifer(popperOptions.value.modifierOptions)
 
-      popperInstance.value = createPopper(referenceElement, popperRef.value, {
+      popperInstance.value = createPopper(referenceElement, popperRef.value, cachedPopperOptions !== null ? cachedPopperOptions : {
         placement: popperOptions.value.placement,
         onFirstUpdate: () => {
           popperInstance.value.forceUpdate()
@@ -309,6 +311,7 @@ export default defineComponent({
         strategy: popperOptions.value.strategy,
         modifiers,
       })
+      cachedPopperOptions = null
       referenceElement.setAttribute('aria-describedby', popperId.value)
       referenceElement.setAttribute('tabindex', props.tabIndex)
       on(referenceElement, 'mouseenter', _show)
@@ -330,6 +333,14 @@ export default defineComponent({
     )
 
     watch(() => popperOptions.value, val => {
+      if(!popperInstance.value){
+        cachedPopperOptions = {
+          placement: val.placement,
+          strategy: val.strategy,
+          modifiers: useModifier(val.modifierOptions),
+        }
+        return
+      }
       popperInstance.value.setOptions({
         placement: val.placement,
         strategy: val.strategy,


### PR DESCRIPTION
<!-- Specify your pull request type -->
- [ ] Component Migration

<!-- Specify the component migration issue -->
First bug:
After popper was destroyed, modify some props which will make `popperOptions` changed , then the watcher of `popperOptions.value` will be called and throw a error of `cannot read porperty of null`
fixed: [commit](https://github.com/element-plus/element-plus/commit/4c6ec7356d5ab34490d551a4a539eb114329d277)

Second bug:
After destroying popper, make popper be recreated by changing `disabled` to `true`, but popper's HtmlElement will not be mounted.
fixed: [commit](https://github.com/element-plus/element-plus/commit/81adfab9d88c691c0273478aa02f9e785dc05f48)

Last commit: 
The `placements.length` is 12, but `Math.floor(Math.random() * 13)` maybe be 12 and 13 that greater than the valid value of 11.

