### PR TITLE
test: avoid mock the whole lodash but only debounce

### DIFF
--- a/packages/popper/__mocks__/lodash.js
+++ b/packages/popper/__mocks__/lodash.js
@@ -1,5 +1,5 @@
 
-const _ = jest.genMockFromModule('lodash')
+const _ = jest.requireActual('lodash')
 
 
 const debounce = jest.fn(fn => {


### PR DESCRIPTION
Avoid mock the whole lodash but only debounce in `Popper`, since global mock will cause some side effects to other.