### PR TITLE
fix(button): fix warn of validator when no type passed

### DIFF
--- a/packages/button/src/button.vue
+++ b/packages/button/src/button.vue
@@ -26,8 +26,8 @@
 <script lang='ts'>
 import { computed, inject, defineComponent, PropType } from 'vue'
 
-type IButtonType = PropType<'primary' | 'success' | 'warning' | 'danger' | 'info' | 'text' | ''>
-type IButtonSize = PropType<'medium' | 'small' | 'mini' | ''>
+type IButtonType = PropType<'primary' | 'success' | 'warning' | 'danger' | 'info' | 'text' | 'default'>
+type IButtonSize = PropType<'medium' | 'small' | 'mini'>
 type IButtonNativeType = PropType<'button' | 'submit' | 'reset'>
 const ELEMENT: {
   size?: number
@@ -70,7 +70,7 @@ export default defineComponent({
       default: 'default',
       validator: (val: string) => {
         return [
-          '',
+          'default',
           'primary',
           'success',
           'warning',
@@ -82,9 +82,8 @@ export default defineComponent({
     },
     size: {
       type: String as IButtonType,
-      default: '',
       validator: (val: string) => {
-        return ['', 'medium', 'small', 'mini'].includes(val)
+        return ['medium', 'small', 'mini'].includes(val)
       },
     },
     icon: {


### PR DESCRIPTION
<!-- Specify your pull request type -->
- [x] Bug Fix

<!-- Specify the component migration issue -->
1. Fix warn of validator when no type passed.
2. `''` should not be valid value of `size`

Old code:
```
type: {
  type: String as IButtonType,
  default: 'default',
  validator: (val: string) => {
    return [
      '',
      'primary',
      'success',
      'warning',
      'info',
      'danger',
      'text',
    ].includes(val)
  },
},
```

![image](https://user-images.githubusercontent.com/33176053/92302307-cc04ec00-ef9d-11ea-9aad-a1fe55983952.png)
