### PR TITLE
fix(link): change default value of type to 'default' instead of ''

### DIFF
--- a/packages/link/doc/index.stories.ts
+++ b/packages/link/doc/index.stories.ts
@@ -10,7 +10,7 @@ export const BasicLinks = () => `
 <el-link ${commonProps} type="success">success link</el-link>
 <el-link ${commonProps} type="info">info link</el-link>
 <el-link ${commonProps} type="warning">warning link</el-link>
-<el-link ${commonProps} type="error">error link</el-link>
+<el-link ${commonProps} type="danger">error link</el-link>
 `
 
 export const DisabledLinks = () => `

--- a/packages/link/src/index.vue
+++ b/packages/link/src/index.vue
@@ -22,16 +22,16 @@
 <script lang='ts'>
 import { defineComponent, PropType } from 'vue'
 
-type ILinkType = PropType<'primary' | 'success' | 'warning' | 'info' | 'danger' | ''>
+type ILinkType = PropType<'primary' | 'success' | 'warning' | 'info' | 'danger' | 'default'>
 
 export default defineComponent({
   name: 'ElLink',
   props: {
     type: {
       type: String as ILinkType,
-      default: '',
+      default: 'default',
       validator: (val: string) => {
-        return ['', 'primary', 'success', 'warning', 'info', 'danger'].includes(val)
+        return ['default', 'primary', 'success', 'warning', 'info', 'danger'].includes(val)
       },
     },
     underline: {


### PR DESCRIPTION
<!-- Specify your pull request type -->
- [x] Bug Fix

<!-- Specify the component migration issue -->
Change default value of `type` to `default` instead of empty string, make behavior same as element2.

if not change and `default` is passed to `link`, validator of `type` will get a warn.
