### PR TITLE
fix:Fit Avatar Container style

### DIFF
--- a/packages/avatar/doc/fit-container.vue
+++ b/packages/avatar/doc/fit-container.vue
@@ -29,7 +29,7 @@ export default {
   justify-content:space-between
 }
 .demo-fit .block {
-  flex:1;
+  flex:auto;
   display:flex;
   flex-direction:column;
   flex-grow:0


### PR DESCRIPTION
Fix #303
原设置`flex：1`；会被解析为：`flex：1 1 0%`；
下面又设置了`flex-grow：0`；
最后的结果就是`flex：0 1 0%`；导致这个盒子没有宽度
修改为：`flex:auto;`
`flex-basis`的值为`auto`，可修复该问题