### PR TITLE
feat(hooks): add useAttrs hook

### DIFF
--- a/packages/divider/src/index.vue
+++ b/packages/divider/src/index.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    v-bind="$attrs"
-    :class="['el-divider', `el-divider--${direction}`]"
-  >
+  <div :class="['el-divider', `el-divider--${direction}`]">
     <div
       v-if="$slots.default && direction !== 'vertical'"
       :class="['el-divider__text', `is-${contentPosition}`]"

--- a/packages/hooks/__tests__/use-attrs.spec.ts
+++ b/packages/hooks/__tests__/use-attrs.spec.ts
@@ -1,0 +1,100 @@
+import { mount } from '@vue/test-utils'
+import useAttrs from '../use-attrs'
+import type { ComponentOptions } from 'vue'
+
+const CLASS = 'a'
+const WIDTH = '50px'
+const TEST_KEY = 'test'
+const TEST_VALUE = 'fake'
+
+const handleClick = jest.fn()
+
+const genComp = (
+  inheritAttrs = true,
+  excludeListeners = false,
+  excludesKeys: string[] = [],
+) => {
+  return {
+    template: `
+      <div>
+        <span v-bind="attrs"></span>
+      </div>
+    `,
+    inheritAttrs,
+    props: {},
+    setup() {
+      const attrs = useAttrs(excludeListeners, excludesKeys)
+
+      return {
+        attrs,
+      }
+    },
+  }
+}
+
+const _mount = (Comp: ComponentOptions) => {
+  return mount({
+    components: { Comp },
+    template: `
+      <comp
+        class="${CLASS}"
+        style="width: ${WIDTH}"
+        ${TEST_KEY}="${TEST_VALUE}"
+        @click="handleClick"
+      />`,
+    methods: {
+      handleClick,
+    },
+  })
+}
+
+afterEach(() => {
+  handleClick.mockClear()
+})
+
+describe('useAttrs', () => {
+  test('class and style should not bind to child node', async () => {
+    const wrapper = _mount(genComp(true))
+    const container = wrapper.element as HTMLDivElement
+    const span = wrapper.find('span')
+
+    expect(wrapper.classes(CLASS)).toBe(true)
+    expect(container.style.width).toBe(WIDTH)
+    expect(span.classes(CLASS)).toBe(false)
+    expect(span.element.style.width).toBe('')
+    expect(span.attributes(TEST_KEY)).toBe(TEST_VALUE)
+
+    await span.trigger('click')
+
+    expect(handleClick).toBeCalledTimes(2)
+  })
+
+  test('class and style should still bind to root node when inheritAttrs is false', async () => {
+    const wrapper = _mount(genComp(false))
+    const container = wrapper.element as HTMLDivElement
+    const width = '0px'
+
+    expect(wrapper.classes(CLASS)).toBe(true)
+    expect(container.style.width).toBe(WIDTH)
+
+    await wrapper.setProps({ style: { width } })
+
+    expect(container.style.width).toBe(width)
+  })
+
+  test('excluded listeners should not bind to child node', async () => {
+    const wrapper = _mount(genComp(true, true))
+    const span = wrapper.find('span')
+
+    await span.trigger('click')
+
+    expect(handleClick).toBeCalledTimes(1)
+  })
+
+  test('excluded attributes should not bind to child node', async () => {
+    const wrapper = _mount(genComp(true, false, [TEST_KEY]))
+    const span = wrapper.find('span')
+
+    expect(span.attributes(TEST_KEY)).toBeUndefined()
+  })
+})

--- a/packages/hooks/__tests__/use-attrs.spec.ts
+++ b/packages/hooks/__tests__/use-attrs.spec.ts
@@ -69,19 +69,6 @@ describe('useAttrs', () => {
     expect(handleClick).toBeCalledTimes(2)
   })
 
-  test('class and style should still bind to root node when inheritAttrs is false', async () => {
-    const wrapper = _mount(genComp(false))
-    const container = wrapper.element as HTMLDivElement
-    const width = '0px'
-
-    expect(wrapper.classes(CLASS)).toBe(true)
-    expect(container.style.width).toBe(WIDTH)
-
-    await wrapper.setProps({ style: { width } })
-
-    expect(container.style.width).toBe(width)
-  })
-
   test('excluded listeners should not bind to child node', async () => {
     const wrapper = _mount(genComp(true, true))
     const span = wrapper.find('span')

--- a/packages/hooks/index.ts
+++ b/packages/hooks/index.ts
@@ -1,3 +1,4 @@
+export { default as useAttrs } from './use-attrs'
 export { default as useEvents } from './use-events'
 export { default as useLockScreen } from './use-lockscreen'
 export { default as useRestoreActive } from './use-restore-active'

--- a/packages/hooks/use-attrs/index.ts
+++ b/packages/hooks/use-attrs/index.ts
@@ -1,69 +1,16 @@
 import {
   getCurrentInstance,
-  onMounted,
   reactive,
   shallowRef,
-  watch,
   watchEffect,
 } from 'vue'
-import { entries, isUndefined, isEqual } from '@element-plus/utils/util'
-import { addClass, removeClass, setStyle, removeStyle } from '@element-plus/utils/dom'
-import type { ComponentInternalInstance } from 'vue'
-
-interface Attrs extends Record<string, unknown> {
-  class?: string
-  style?: Hash<string>
-}
+import { entries } from '@element-plus/utils/util'
 
 const DEFAULT_EXCLUDE_KEYS = ['class', 'style']
 const LISTENER_PREFIX = /^on[A-Z]/
 
-function syncAttribute<T extends string, P = Attrs[T]>(
-  instance: ComponentInternalInstance,
-  attributeName: T,
-  handler: (instance: ComponentInternalInstance, newVal: P, oldVal?: P) => void,
-) {
-  const attrs = instance.attrs
-  const initialValue = attrs[attributeName]
-
-  if (isUndefined(attrs[attributeName])) return
-
-  onMounted(handler.bind(null, instance, initialValue))
-  watch(
-    () => attrs[attributeName],
-    handler.bind(null, instance),
-  )
-}
-
-function syncClass(
-  instance: ComponentInternalInstance,
-  newClass: string,
-  oldClass?: string,
-) {
-  const el = instance.vnode.el as HTMLElement
-
-  if (!el) return
-
-  oldClass && removeClass(el, oldClass)
-  newClass && addClass(el, newClass)
-}
-
-function syncStyle(
-  instance: ComponentInternalInstance,
-  newStyle: CSSStyleDeclaration,
-  oldStyle?: CSSStyleDeclaration,
-) {
-  const el = instance.vnode.el as HTMLElement
-
-  if (!el || isEqual(newStyle, oldStyle)) return
-
-  oldStyle && removeStyle(el, oldStyle)
-  newStyle && setStyle(el, newStyle)
-}
-
 export default (excludeListeners = false, excludeKeys: string[] = []) => {
   const instance = getCurrentInstance()
-  const { inheritAttrs } = instance.type
   const attrs = shallowRef({})
   const allExcludeKeys = excludeKeys.concat(DEFAULT_EXCLUDE_KEYS)
 
@@ -85,11 +32,6 @@ export default (excludeListeners = false, excludeKeys: string[] = []) => {
 
     attrs.value = res
   })
-
-  if (!inheritAttrs) {
-    syncAttribute(instance, 'class', syncClass)
-    syncAttribute(instance, 'style', syncStyle)
-  }
 
   return attrs
 }

--- a/packages/hooks/use-attrs/index.ts
+++ b/packages/hooks/use-attrs/index.ts
@@ -1,0 +1,95 @@
+import {
+  getCurrentInstance,
+  onMounted,
+  reactive,
+  shallowRef,
+  watch,
+  watchEffect,
+} from 'vue'
+import { entries, isUndefined, isEqual } from '@element-plus/utils/util'
+import { addClass, removeClass, setStyle, removeStyle } from '@element-plus/utils/dom'
+import type { ComponentInternalInstance } from 'vue'
+
+interface Attrs extends Record<string, unknown> {
+  class?: string
+  style?: Hash<string>
+}
+
+const DEFAULT_EXCLUDE_KEYS = ['class', 'style']
+const LISTENER_PREFIX = /^on[A-Z]/
+
+function syncAttribute<T extends string, P = Attrs[T]>(
+  instance: ComponentInternalInstance,
+  attributeName: T,
+  handler: (instance: ComponentInternalInstance, newVal: P, oldVal?: P) => void,
+) {
+  const attrs = instance.attrs
+  const initialValue = attrs[attributeName]
+
+  if (isUndefined(attrs[attributeName])) return
+
+  onMounted(handler.bind(null, instance, initialValue))
+  watch(
+    () => attrs[attributeName],
+    handler.bind(null, instance),
+  )
+}
+
+function syncClass(
+  instance: ComponentInternalInstance,
+  newClass: string,
+  oldClass?: string,
+) {
+  const el = instance.vnode.el as HTMLElement
+
+  if (!el) return
+
+  oldClass && removeClass(el, oldClass)
+  newClass && addClass(el, newClass)
+}
+
+function syncStyle(
+  instance: ComponentInternalInstance,
+  newStyle: CSSStyleDeclaration,
+  oldStyle?: CSSStyleDeclaration,
+) {
+  const el = instance.vnode.el as HTMLElement
+
+  if (!el || isEqual(newStyle, oldStyle)) return
+
+  oldStyle && removeStyle(el, oldStyle)
+  newStyle && setStyle(el, newStyle)
+}
+
+export default (excludeListeners = false, excludeKeys: string[] = []) => {
+  const instance = getCurrentInstance()
+  const { inheritAttrs } = instance.type
+  const attrs = shallowRef({})
+  const allExcludeKeys = excludeKeys.concat(DEFAULT_EXCLUDE_KEYS)
+
+  // Since attrs are not reactive, make it reactive instead of doing in `onUpdated` hook for better performance
+  instance.attrs = reactive(instance.attrs)
+
+  watchEffect(() => {
+    const res = entries(instance.attrs)
+      .reduce((acm, [key, val]) => {
+        if (
+          !allExcludeKeys.includes(key) &&
+          !(excludeListeners && LISTENER_PREFIX.test(key))
+        ) {
+          acm[key] = val
+        }
+
+        return acm
+      }, {})
+
+    attrs.value = res
+  })
+
+  if (!inheritAttrs) {
+    syncAttribute(instance, 'class', syncClass)
+    syncAttribute(instance, 'style', syncStyle)
+  }
+
+  return attrs
+}

--- a/packages/image/src/index.vue
+++ b/packages/image/src/index.vue
@@ -1,5 +1,9 @@
 <template>
-  <div ref="container" class="el-image">
+  <div
+    ref="container"
+    :class="['el-image', $attrs.class]"
+    :style="$attrs.style"
+  >
     <slot v-if="loading" name="placeholder">
       <div class="el-image__placeholder"></div>
     </slot>

--- a/packages/image/src/index.vue
+++ b/packages/image/src/index.vue
@@ -9,7 +9,7 @@
     <img
       v-else
       class="el-image__inner"
-      v-bind="$attrs"
+      v-bind="attrs"
       :src="src"
       :style="imageStyle"
       :class="{ 'el-image__inner--center': alignCenter, 'el-image__preview': preview }"
@@ -32,10 +32,11 @@
 import { defineComponent, computed, ref, onMounted, onBeforeUnmount, watch } from 'vue'
 import { isString } from '@vue/shared'
 import throttle from 'lodash/throttle'
+import { useAttrs } from '@element-plus/hooks'
 import isServer from '@element-plus/utils/isServer'
 import { on, off, getScrollContainer, isInContainer } from '@element-plus/utils/dom'
 import { t } from '@element-plus/locale'
-import ImageViewer from './image-viewer'
+import ImageViewer from './image-viewer.vue'
 
 const isSupportObjectFit = () => document.documentElement.style.objectFit !== undefined
 const isHtmlEle = e => e && e.nodeType === 1
@@ -55,6 +56,7 @@ export default defineComponent({
   components: {
     ImageViewer,
   },
+  inheritAttrs: false,
   props: {
     src: {
       type: String,
@@ -82,12 +84,13 @@ export default defineComponent({
     },
   },
   emits: ['error'],
-  setup(props, { emit, attrs }) {
+  setup(props, { emit }) {
     // init here
+    const attrs = useAttrs()
     const hasLoadError = ref(false)
     const loading = ref(true)
-    const imgWidth = ref(false)
-    const imgHeight = ref(false)
+    const imgWidth = ref(0)
+    const imgHeight = ref(0)
     const showViewer = ref(false)
     const container = ref<HTMLElement | null>(null)
     const show = ref(props.lazy)
@@ -158,6 +161,8 @@ export default defineComponent({
     const loadImage = () => {
       if (isServer) return
 
+      const attributes = attrs.value
+
       // reset status
       loading.value = true
       hasLoadError.value = false
@@ -168,15 +173,15 @@ export default defineComponent({
 
       // bind html attrs
       // so it can behave consistently
-      Object.keys(attrs)
+      Object.keys(attributes)
         .forEach(key => {
-          const value = attrs[key]
+          const value = attributes[key]
           img.setAttribute(key, value)
         })
       img.src = props.src
     }
 
-    function handleLoad(e: Event, img: Any) {
+    function handleLoad(e: Event, img: HTMLImageElement) {
       imgWidth.value = img.width
       imgHeight.value = img.height
       loading.value = false
@@ -255,6 +260,7 @@ export default defineComponent({
     })
 
     return {
+      attrs,
       loading,
       hasLoadError,
       showViewer,
@@ -272,6 +278,3 @@ export default defineComponent({
   },
 })
 </script>
-
-<style>
-</style>

--- a/packages/input/__tests__/input.spec.ts
+++ b/packages/input/__tests__/input.spec.ts
@@ -2,7 +2,6 @@ import { ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { sleep, defineGetter } from '@element-plus/test-utils'
 import Input from '../src/index.vue'
-import input from '..'
 
 const _mount = options => mount({
   components: {

--- a/packages/input/__tests__/input.spec.ts
+++ b/packages/input/__tests__/input.spec.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { sleep, defineGetter } from '@element-plus/test-utils'
 import Input from '../src/index.vue'
+import input from '..'
 
 const _mount = options => mount({
   components: {
@@ -36,15 +37,16 @@ describe('Input.vue', () => {
 
     const inputElm = wrapper.find('input')
     const vm = wrapper.vm as any
+    const nativeInput = inputElm.element
 
     await inputElm.trigger('focus')
 
     expect(inputElm.exists()).toBe(true)
     expect(handleFocus).toHaveBeenCalled()
-    expect(wrapper.attributes('placeholder')).toBe('请输入内容')
-    expect(inputElm.element.value).toBe('input')
-    expect(wrapper.attributes('minlength')).toBe('3')
-    expect(wrapper.attributes('maxlength')).toBe('5')
+    expect(nativeInput.placeholder).toBe('请输入内容')
+    expect(nativeInput.value).toBe('input')
+    expect(nativeInput.minLength).toBe(3)
+    expect(nativeInput.maxLength).toBe(5)
 
     vm.input = 'text'
     await sleep()
@@ -406,7 +408,7 @@ describe('Input.vue', () => {
       await inputWrapper.trigger('compositionupdate')
       await inputWrapper.trigger('input')
       await inputWrapper.trigger('compositionend')
-      expect(handleInput).toBeCalled()
+      expect(handleInput).toBeCalledTimes(1)
       // native input value is controlled
       expect(vm.input).toEqual('a')
       expect(nativeInput.value).toEqual('a')

--- a/packages/input/src/index.vue
+++ b/packages/input/src/index.vue
@@ -11,8 +11,10 @@
         'el-input-group--prepend': $slots.prepend,
         'el-input--prefix': $slots.prefix || prefixIcon,
         'el-input--suffix': $slots.suffix || suffixIcon || clearable || showPassword
-      }
+      },
+      $attrs.class
     ]"
+    :style="$attrs.style"
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
   >

--- a/packages/input/src/index.vue
+++ b/packages/input/src/index.vue
@@ -25,7 +25,7 @@
         v-if="type !== 'textarea'"
         ref="input"
         class="el-input__inner"
-        v-bind="$attrs"
+        v-bind="attrs"
         :type="showPassword ? (passwordVisible ? 'text': 'password') : type"
         :disabled="inputDisabled"
         :readonly="readonly"
@@ -79,7 +79,7 @@
       v-else
       ref="textarea"
       class="el-textarea__inner"
-      v-bind="$attrs"
+      v-bind="attrs"
       :tabindex="tabindex"
       :disabled="inputDisabled"
       :readonly="readonly"
@@ -112,6 +112,7 @@ import {
   onMounted,
   onUpdated,
 } from 'vue'
+import { useAttrs } from '@element-plus/hooks'
 import { UPDATE_MODEL_EVENT, VALIDATE_STATE_MAP } from '@element-plus/utils/constants'
 import { isObject } from '@element-plus/utils/util'
 import isServer from '@element-plus/utils/isServer'
@@ -144,6 +145,8 @@ const PENDANT_MAP = {
 
 export default defineComponent({
   name: 'ElInput',
+
+  inheritAttrs: false,
 
   props: {
     modelValue: {
@@ -217,10 +220,11 @@ export default defineComponent({
     },
   },
 
-  emits: [UPDATE_MODEL_EVENT, 'change', 'focus', 'blur', 'clear'],
+  emits: [UPDATE_MODEL_EVENT, 'input', 'change', 'focus', 'blur', 'clear'],
 
   setup(props, ctx) {
     const instance = getCurrentInstance()
+    const attrs = useAttrs(true)
 
     const elForm = inject<ElForm>('elForm', {} as any)
     const elFormItem = inject<ElFormItem>('elFormItem', {} as any)
@@ -319,15 +323,18 @@ export default defineComponent({
     }
 
     const handleInput = event => {
+      const { value } = event.target
+
       // should not emit input during composition
       // see: https://github.com/ElemeFE/element/issues/10516
       if (isComposing.value) return
 
       // hack for https://github.com/ElemeFE/element/issues/8548
       // should remove the following line when we don't support IE
-      if (event.target.value === nativeInputValue.value) return
+      if (value === nativeInputValue.value) return
 
-      ctx.emit(UPDATE_MODEL_EVENT, event.target.value)
+      ctx.emit(UPDATE_MODEL_EVENT, value)
+      ctx.emit('input', value)
 
       // ensure native input value is controlled
       // see: https://github.com/ElemeFE/element/issues/12850
@@ -442,6 +449,7 @@ export default defineComponent({
     return {
       input,
       textarea,
+      attrs,
       inputSize,
       validateState,
       validateIcon,

--- a/packages/link/src/index.vue
+++ b/packages/link/src/index.vue
@@ -7,7 +7,6 @@
       underline && !disabled && 'is-underline'
     ]"
     :href="disabled ? null : href"
-    v-bind="$attrs"
     @click="handleClick"
   >
     <i v-if="icon" :class="icon"></i>

--- a/packages/utils/dom.ts
+++ b/packages/utils/dom.ts
@@ -1,5 +1,5 @@
 import isServer from './isServer'
-import { camelize } from './util'
+import { camelize, isObject } from './util'
 
 /* istanbul ignore next */
 const trim = function(s: string) {
@@ -127,20 +127,29 @@ export const getStyle = function(
 export function setStyle(
   element: HTMLElement,
   styleName: CSSStyleDeclaration | string,
-  value: string,
+  value?: string,
 ): void {
   if (!element || !styleName) return
 
-  if (typeof styleName === 'object') {
-    for (const prop in styleName) {
-      if (styleName.hasOwnProperty(prop)) {
-        setStyle(element, prop, styleName[prop])
-      }
-    }
+  if (isObject(styleName)) {
+    Object.keys(styleName).forEach(prop => {
+      setStyle(element, prop, styleName[prop])
+    })
   } else {
     styleName = camelize(styleName)
-
     element.style[styleName] = value
+  }
+}
+
+export function removeStyle(element: HTMLElement, style: CSSStyleDeclaration | string) {
+  if (!element || !style) return
+
+  if (isObject(style)) {
+    Object.keys(style).forEach(prop => {
+      setStyle(element, prop, '')
+    })
+  } else {
+    setStyle(element, style, '')
   }
 }
 

--- a/packages/utils/util.ts
+++ b/packages/utils/util.ts
@@ -164,4 +164,8 @@ export function entries<T>(obj: Hash<T>): [string, T][] {
     .map((key: string) => ([key, obj[key]]))
 }
 
+export function isUndefined(val: any) {
+  return val === void 0
+}
+
 export { isVNode } from 'vue'


### PR DESCRIPTION
Smooth out the differences between vue2 and vue3 when using `$attrs`,  `class` `style` and other specific attributes will not bind to child node but just root node.

Fix  #234 , #235 
