### PR TITLE
 fix label-wrap import

### DIFF
--- a/packages/form/index.ts
+++ b/packages/form/index.ts
@@ -1,7 +1,7 @@
 import { App } from 'vue'
 import Form from './src/form.vue'
 import FormItem from './src/form-item.vue'
-import LabelWrap from './src/label-wrap.vue'
+import LabelWrap from './src/label-wrap'
 
 export default (app: App): void => {
   app.component(Form.name, Form)


### PR DESCRIPTION
on the current dev branch when running `yarn website-dev` we got the following error:
```
ERROR in ./packages/form/index.ts
Module not found: Error: Can't resolve './src/label-wrap.vue' in '/Users/g3r4n/projects/element-plus/packages/form'
```