### PR TITLE
Fix esm bundler alias

### DIFF
--- a/packages/popper/src/popper/index.ts
+++ b/packages/popper/src/popper/index.ts
@@ -160,6 +160,14 @@ export default function (props: IPopperOptions, { emit }: SetupContext<string[]>
     onBlur?: (e: Event) => void
   }
 
+  function update() {
+    if (popperInstance) {
+      popperInstance.update()
+    } else {
+      initializePopper()
+    }
+  }
+
   if (!isManualMode()) {
     const toggleState = () => {
       if (visibility.value) {
@@ -236,18 +244,10 @@ export default function (props: IPopperOptions, { emit }: SetupContext<string[]>
     popperInstance.update()
   })
 
-  watch(visibility, () => {
-    if (popperInstance) {
-      popperInstance.update()
-    } else {
-      initializePopper()
-    }
-  })
+  watch(visibility, update)
 
   return {
-    update() {
-      popperInstance.update()
-    },
+    update,
     doDestroy,
     show,
     hide,

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -94,7 +94,7 @@ const config = {
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.vue', '.json'],
     alias: {
-      'vue': '@vue/runtime-dom',
+      'vue': 'vue/dist/vue.esm-browser.js',
       examples: path.resolve(__dirname),
     },
   },


### PR DESCRIPTION
when running website, the following warning is fired:
```
ou are running the esm-bundler build of Vue. It is recommended to configure your bundler to explicitly replace feature flag globals with boolean literals to get proper tree-shaking in the final bundle. See http://link.vuejs.org/feature-flags for more details.
```
![image](https://user-images.githubusercontent.com/10941033/95377718-3ed9ed80-08e3-11eb-97db-fe5139c6c9f6.png)
