### PR TITLE
improvement(project): remove mitt #419

### DIFF
--- a/packages/collapse/package.json
+++ b/packages/collapse/package.json
@@ -4,7 +4,6 @@
   "main": "dist/index.js",
   "license": "MIT",
   "dependencies": {
-    "mitt": "^2.1.0",
     "@element-plus/utils": "^0.0.0"
   },
   "peerDependencies": {

--- a/packages/collapse/src/collapse-item.vue
+++ b/packages/collapse/src/collapse-item.vue
@@ -71,7 +71,6 @@ export default defineComponent({
   },
   setup(props) {
     const collapse = inject<CollapseProvider>('collapse')
-    const collapseMitt = collapse?.collapseMitt
 
     const contentWrapStyle = ref({
       height: 'auto',
@@ -98,13 +97,13 @@ export default defineComponent({
 
     const handleHeaderClick = () => {
       if(props.disabled) return
-      collapseMitt?.emit('item-click', props.name)
+      collapse?.triggerClick(props.name)
       focusing.value = false
       isClick.value = true
     }
 
     const handleEnterClick = () => {
-      collapseMitt?.emit('item-click', props.name)
+      collapse?.triggerClick(props.name)
     }
 
     return {

--- a/packages/collapse/src/collapse.ts
+++ b/packages/collapse/src/collapse.ts
@@ -1,7 +1,6 @@
-import { Emitter } from 'mitt'
 import { Ref } from 'vue'
 
 export interface CollapseProvider {
   activeNames: Ref
-  collapseMitt: Emitter
+  triggerClick: (name: string | number) => void
 }

--- a/packages/collapse/src/collapse.vue
+++ b/packages/collapse/src/collapse.vue
@@ -14,11 +14,10 @@ import {
   Ref,
   onUnmounted,
 } from 'vue'
-import mitt, { Emitter } from 'mitt'
 
 export interface CollapseProvider {
   activeNames: Ref
-  collapseMitt: Emitter
+  triggerClick: (name: string | number) => void
 }
 export default defineComponent({
   name: 'ElCollapse',
@@ -34,7 +33,6 @@ export default defineComponent({
   emits: ['update:modelValue'],
   setup(props, { emit }) {
     const activeNames = ref([].concat(props.modelValue))
-    const collapseMitt: Emitter = mitt()
 
     const setActiveNames = _activeNames => {
       activeNames.value = [].concat(_activeNames)
@@ -70,15 +68,9 @@ export default defineComponent({
       },
     )
 
-    collapseMitt.on('item-click', handleItemClick)
-
-    onUnmounted(() => {
-      collapseMitt.all.clear()
-    })
-
     provide('collapse', {
       activeNames,
-      collapseMitt,
+      triggerClick: handleItemClick,
     })
 
     return {

--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -15,10 +15,9 @@ import {
   defineComponent, provide, watch, ref,
   computed, reactive, toRefs,
 } from 'vue'
-import mitt from 'mitt'
 import {
   elFormKey, ElFormItemContext as FormItemCtx,
-  elFormEvents, ValidateFieldCallback,
+  ValidateFieldCallback,
 } from './token'
 import { FieldErrorList } from 'async-validator'
 
@@ -93,35 +92,29 @@ export default defineComponent({
     },
   },
   setup(props, { emit }) {
-    const formMitt = mitt()
 
     const fields: FormItemCtx[] = []
 
     watch(
       () => props.rules,
       () => {
-        fields.forEach(field => {
-          field.removeValidateEvents()
-          field.addValidateEvents()
-        })
-
         if (props.validateOnRuleChange) {
           validate(() => ({}))
         }
       },
     )
 
-    formMitt.on<FormItemCtx>(elFormEvents.addField, field => {
+    const addField = (field: FormItemCtx) => {
       if (field) {
         fields.push(field)
       }
-    })
+    }
 
-    formMitt.on<FormItemCtx>(elFormEvents.removeField, field => {
+    const removeField = (field: FormItemCtx) => {
       if (field.prop) {
         fields.splice(fields.indexOf(field), 1)
       }
-    })
+    }
 
     const resetFields = () => {
       if (!props.model) {
@@ -202,12 +195,13 @@ export default defineComponent({
     }
 
     const elForm = reactive({
-      formMitt,
       ...toRefs(props),
       resetFields,
       clearValidate,
       validateField,
       emit,
+      addField,
+      removeField,
       ...useFormLabelWidth(),
     })
 

--- a/packages/form/src/token.ts
+++ b/packages/form/src/token.ts
@@ -1,5 +1,4 @@
-import type { InjectionKey } from 'vue'
-import type { Emitter } from 'mitt'
+import type { ComputedRef, InjectionKey, Ref } from 'vue'
 import type {
   FieldErrorList,
 } from 'async-validator'
@@ -8,13 +7,15 @@ export interface ElFormContext {
   registerLabelWidth(width: number, oldWidth: number): void
   deregisterLabelWidth(width: number): void
   autoLabelWidth: string | undefined
-  formMitt: Emitter
   emit: (evt: string, ...args: any[]) => void
+  addField: (field: ElFormItemContext) => void
+  removeField: (field: ElFormItemContext) => void
 
   labelSuffix: string
   inline?: boolean
   model?: Record<string, unknown>
   size?: string
+  disabled?: boolean
   showMessage?: boolean
   labelPosition?: string
   labelWidth?: string
@@ -29,20 +30,13 @@ export interface ValidateFieldCallback {
 
 export interface ElFormItemContext {
   prop?: string
+  validateState: Ref<string> | string
+  elFormItemSize: ComputedRef<string> | string
   validate(trigger?: string, callback?: ValidateFieldCallback): void
   updateComputedLabelWidth(width: number): void
-  addValidateEvents(): void
-  removeValidateEvents(): void
   resetField(): void
   clearValidate(): void
 }
 
-// TODO: change it to symbol
-export const elFormKey: InjectionKey<ElFormContext> = 'elForm' as any
-
-export const elFormItemKey: InjectionKey<ElFormItemContext> = 'elFormItem' as any
-
-export const elFormEvents = {
-  addField: 'el.form.addField',
-  removeField: 'el.form.removeField',
-} as const
+export const elFormKey: InjectionKey<ElFormContext> = Symbol('elForm')
+export const elFormItemKey: InjectionKey<ElFormItemContext> = Symbol('elFormItem')

--- a/packages/select/src/option-group.vue
+++ b/packages/select/src/option-group.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, provide, inject, ref, reactive, toRefs } from 'vue'
+import { defineComponent, provide, inject, ref, reactive, toRefs, watch, toRef } from 'vue'
 import { selectGroupKey, selectKey, selectEvents } from './token'
 
 export default defineComponent({
@@ -37,10 +37,11 @@ export default defineComponent({
 
     const select = inject(selectKey)
 
-    const queryChange = () => {
+    const groupQueryChange = toRef(select, 'groupQueryChange')
+
+    watch(groupQueryChange, () => {
       visible.value = select?.options?.some(option => option.visible === true)
-    }
-    select.selectEmitter.on(selectEvents.groupQueryChange, queryChange)
+    })
 
     return {
       visible,

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -294,6 +294,8 @@ export default defineComponent({
       getValueKey,
       navigateOptions,
       dropMenuVisible,
+      queryChange,
+      groupQueryChange,
 
       reference,
       input,
@@ -330,12 +332,13 @@ export default defineComponent({
       filteredOptionsCount,
       hoverIndex,
       handleOptionSelect,
-      selectEmitter: states.selectEmitter,
       onOptionDestroy,
       props,
       inputWidth,
       selectWrapper,
       popper,
+      queryChange,
+      groupQueryChange,
     }))
 
     onMounted(() => {

--- a/packages/select/src/token.ts
+++ b/packages/select/src/token.ts
@@ -1,8 +1,11 @@
-import type { InjectionKey } from 'vue'
-import type { Emitter } from 'mitt'
+import type { InjectionKey, Ref } from 'vue'
 
 interface SelectGroupContext {
   disabled: boolean
+}
+
+export interface QueryChangeCtx {
+  query: string
 }
 
 export interface SelectContext {
@@ -14,6 +17,8 @@ export interface SelectContext {
     modelValue: unknown[]
     popperClass: string
   }
+  queryChange: Ref<QueryChangeCtx>
+  groupQueryChange: Ref<string>
   selectWrapper: HTMLElement
   cachedOptions: any[]
   selected: any | any[]
@@ -25,7 +30,6 @@ export interface SelectContext {
   optionsCount: number
   filteredOptionsCount: number
   options: unknown[]
-  selectEmitter: Emitter
   onOptionDestroy(i: number)
   handleOptionSelect(vm: unknown, byClick: boolean)
 }
@@ -33,8 +37,3 @@ export interface SelectContext {
 export const selectGroupKey: InjectionKey<SelectGroupContext> = Symbol('SelectGroup')
 
 export const selectKey: InjectionKey<SelectContext> = Symbol('Select')
-
-export const selectEvents = {
-  queryChange: 'elOptionQueryChange',
-  groupQueryChange: 'elOptionGroupQueryChange',
-}

--- a/packages/select/src/useOption.ts
+++ b/packages/select/src/useOption.ts
@@ -3,11 +3,13 @@ import {
   computed,
   getCurrentInstance,
   watch,
+  Ref,
+  toRef,
+  unref,
 } from 'vue'
 import { getValueByPath, escapeRegexpString } from '@element-plus/utils/util'
 import {
-  selectKey, selectGroupKey,
-  selectEvents,
+  selectKey, selectGroupKey,QueryChangeCtx,
 } from './token'
 
 export function useOption(props, states) {
@@ -103,8 +105,8 @@ export function useOption(props, states) {
     }
   })
 
-  // Emitter
-  select.selectEmitter.on(selectEvents.queryChange, queryChange)
+  const queryChangeRef = toRef(select, 'queryChange')
+  watch(queryChangeRef, (changes: Ref<QueryChangeCtx>) => queryChange(unref(changes).query))
 
   return {
     select,

--- a/packages/select/src/useSelect.ts
+++ b/packages/select/src/useSelect.ts
@@ -1,4 +1,3 @@
-import mitt from 'mitt'
 import { UPDATE_MODEL_EVENT } from '@element-plus/utils/constants'
 import { t } from '@element-plus/locale'
 import isServer from '@element-plus/utils/isServer'
@@ -12,6 +11,8 @@ import {
   watch,
   ref,
   reactive,
+  shallowRef,
+  triggerRef,
 } from 'vue'
 import {
   getValueByPath,
@@ -19,11 +20,11 @@ import {
   isEdge,
 } from '@element-plus/utils/util'
 import isEqual from 'lodash/isEqual'
+import { QueryChangeCtx } from './token'
 
 const ELEMENT = { size: 'medium' }
 
 export function useSelectStates(props) {
-  const selectEmitter = mitt()
   return reactive({
     options: [],
     cachedOptions: [],
@@ -47,7 +48,6 @@ export function useSelectStates(props) {
     menuVisibleOnFocus: false,
     isOnComposition: false,
     isSilentBlur: false,
-    selectEmitter,
   })
 }
 
@@ -62,6 +62,8 @@ export const useSelect = (props, states: States, ctx) => {
   const selectWrapper = ref<HTMLElement | null>(null)
   const scrollbar = ref(null)
   const hoverOption = ref(-1)
+  const queryChange = shallowRef<QueryChangeCtx>({ query: '' })
+  const groupQueryChange= shallowRef('')
 
   // inject
   const elForm = inject<any>('elForm', {})
@@ -194,8 +196,8 @@ export const useSelect = (props, states: States, ctx) => {
           input.value.focus()
         } else {
           if (!props.remote) {
-            states.selectEmitter.emit('elOptionQueryChange', '')
-            states.selectEmitter.emit('elOptionGroupQueryChange')
+            triggerRef(queryChange)
+            triggerRef(groupQueryChange)
           }
 
           if (states.selectedLabel) {
@@ -280,11 +282,12 @@ export const useSelect = (props, states: States, ctx) => {
       props.remoteMethod(val)
     } else if (typeof props.filterMethod === 'function') {
       props.filterMethod(val)
-      states.selectEmitter.emit('elOptionGroupQueryChange')
+      triggerRef(groupQueryChange)
     } else {
       states.filteredOptionsCount = states.optionsCount
-      states.selectEmitter.emit('elOptionQueryChange', val)
-      states.selectEmitter.emit('elOptionGroupQueryChange')
+      queryChange.value.query = val
+      triggerRef(queryChange)
+      triggerRef(groupQueryChange)
     }
     if (props.defaultFirstOption && (props.filterable || props.remote) && states.filteredOptionsCount) {
       checkDefaultFirstOption()
@@ -711,6 +714,8 @@ export const useSelect = (props, states: States, ctx) => {
     getValueKey,
     navigateOptions,
     dropMenuVisible,
+    queryChange,
+    groupQueryChange,
 
     // DOM ref
     reference,

--- a/packages/tree/src/tree-node.vue
+++ b/packages/tree/src/tree-node.vue
@@ -82,9 +82,9 @@ import { Checkbox as ElCheckbox } from '@element-plus/checkbox'
 import NodeContent from './tree-node-content.vue'
 import { getNodeKey as getNodeKeyUtil } from './model/util'
 import { useNodeExpandEventBroadcast } from './model/useNodeExpandEventBroadcast'
-import { useDragNodeEmitter } from './model/useDragNode'
 import Node from './model/node'
 import { TreeOptionProps, TreeNodeData, RootTreeType } from './tree.d'
+import { dragEventsKey } from './model/useDragNode'
 
 export default defineComponent({
   name: 'ElTreeNode',
@@ -118,8 +118,8 @@ export default defineComponent({
     const oldChecked = ref<boolean>(null)
     const oldIndeterminate = ref<boolean>(null)
     const node$ = ref<Nullable<HTMLElement>>(null)
-    const { emitter } = useDragNodeEmitter()
     const instance = getCurrentInstance()
+    const dragEvents = inject(dragEventsKey)
 
     provide('NodeInstance', instance)
     if(!tree) {
@@ -220,12 +220,12 @@ export default defineComponent({
 
     const handleDragStart = (event: DragEvent) => {
       if (!tree.props.draggable) return
-      emitter.emit('tree-node-drag-start', { event, treeNode: props })
+      dragEvents.treeNodeDragStart({ event, treeNode: props })
     }
 
     const handleDragOver = (event: DragEvent) => {
       if (!tree.props.draggable) return
-      emitter.emit('tree-node-drag-over', { event, treeNode: { $el: node$.value, node: props.node } })
+      dragEvents.treeNodeDragOver({ event, treeNode: { $el: node$.value, node: props.node } })
       event.preventDefault()
     }
 
@@ -235,7 +235,7 @@ export default defineComponent({
 
     const handleDragEnd = (event: DragEvent) => {
       if (!tree.props.draggable) return
-      emitter.emit('tree-node-drag-end', event)
+      dragEvents.treeNodeDragEnd(event)
     }
 
     return {
@@ -245,7 +245,6 @@ export default defineComponent({
       childNodeRendered,
       oldChecked,
       oldIndeterminate,
-      emitter,
       parent,
       getNodeKey,
       handleSelectChange,

--- a/packages/utils/after-leave.ts
+++ b/packages/utils/after-leave.ts
@@ -13,6 +13,13 @@ export default function(instance: ComponentPublicInstance, callback: (...args: u
     }
   }
   // TODO: migrate to [mitt](https://github.com/developit/mitt)
+
+  // TODO: Instead mitt:  ( https://github.com/element-plus/element-plus/issues/419 )
+  // 1) We can use provide/inject, if we want to trigger parent function
+  // 2) Just passing 'ref' with provide/inject end 'watch' it inside child. Because in Vue 3, provided data is reactive
+  // 3) Or combine 'shallowRef' and 'triggerRef' if you need trigger effects manually
+  //    For example, if we want notiy child component to do some stuff, like signaling event.
+
   // if (once) {
   //   instance.$once('after-leave', afterLeaveCallback)
   // } else {


### PR DESCRIPTION
Giving up mitt from all components. Instead of this, we can use:

1) We can use provide/inject, if we want to trigger parent function
2) Just passing 'ref' with provide/inject end 'watch' it inside child. Because in Vue 3, provided data is reactive
3) Or combine 'shallowRef' and 'triggerRef' if you need to trigger effects manually
 For example, if we want notify child component to do some stuff, something like signaling event.