### PR TITLE
fix(switch): fix switch has outline

### DIFF
--- a/packages/theme-chalk/src/switch.scss
+++ b/packages/theme-chalk/src/switch.scss
@@ -9,6 +9,7 @@
   line-height: $--switch-height;
   height: $--switch-height;
   vertical-align: middle;
+  outline: none;
   @include when(disabled) {
     & .el-switch__core,
     & .el-switch__label {


### PR DESCRIPTION
fix switch has outline, the class el-switch need to add outline:none


- [ switch] Component Migration

Fix #468
