### PR TITLE
fix(popper): fix popper tabindex error

### DIFF
--- a/packages/popper/__tests__/popper.spec.ts
+++ b/packages/popper/__tests__/popper.spec.ts
@@ -164,7 +164,7 @@ describe('Popper.vue', () => {
     const wrapper = _mount({
       appendToBody: false,
     })
-    expect(wrapper.find(`.${TEST_TRIGGER}`).attributes('tabindex')).toBe('0')
+    expect(wrapper.find(`.el-popper`).attributes('tabindex')).toBe('0')
   })
 
   test('should initialize a new popper when component mounted', async () => {

--- a/packages/popper/src/index.vue
+++ b/packages/popper/src/index.vue
@@ -82,6 +82,7 @@ export default defineComponent({
         onMouseLeave: onPopperMouseLeave,
         onAfterEnter,
         onAfterLeave,
+        tabindex: tabIndex,
         visibility,
       },
       [
@@ -99,7 +100,6 @@ export default defineComponent({
       ariaDescribedby: popperId,
       class: kls,
       ref: 'triggerRef',
-      tabindex: tabIndex,
       ...this.events,
     }
 

--- a/packages/popper/src/renderers/popper.ts
+++ b/packages/popper/src/renderers/popper.ts
@@ -13,6 +13,7 @@ interface IRenderPopperProps {
   popperId: string
   popperRef?: Ref<HTMLElement>
   pure: boolean
+  tabindex: number
   visibility: boolean
   onMouseEnter: () => void
   onMouseLeave: () => void
@@ -32,6 +33,7 @@ export default function renderPopper(
     popperRef,
     pure,
     popperId,
+    tabindex,
     visibility,
     onMouseEnter,
     onMouseLeave,
@@ -71,6 +73,7 @@ export default function renderPopper(
             id: popperId,
             ref: popperRef ?? 'popperRef',
             role: 'tooltip',
+            tabindex,
             onMouseEnter,
             onMouseLeave,
             onClick: stop,
@@ -87,6 +90,7 @@ export default function renderPopper(
             'onMouseup',
             'onClick',
             'id',
+            'tabindex',
           ],
         ),
         [[vShow, visibility]],


### PR DESCRIPTION
- Move tabindex attr from trigger to popper

This should fix error all components depend on `el-popper` like #468, `tabindex` attribute should be assigned to `popper` instead of `trigger`