### PR TITLE
build: adjust the order of file extensions by usage frequency in jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -30,5 +30,8 @@ module.exports = {
       },
     ],
   },
-  moduleFileExtensions: ['vue', 'json', 'ts', 'tsx', 'js', 'json'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json', 'vue'],
+  // u can change this option to a more specific folder for test single component or util when dev
+  // for example, ['<rootDir>/packages/input']
+  roots: ['<rootDir>'],
 }


### PR DESCRIPTION
The old `moduleFileExtensions` in jest may cause some problems in some cases. For example, there are two files `index.ts` and `index.vue` which share the same name but different extentions. When I `import Index from 'index'`, I mean to load `index.ts`, but it will parse into `import Index from 'index.vue'`. I think it's more approprivate to priority ts resolution and keep consistent with resolve extension sequence in webpack for we are using typescript.