### PR TITLE
修复了级联选择器面板选中后不能显示的问题

### DIFF
--- a/packages/cascader/src/index.vue
+++ b/packages/cascader/src/index.vue
@@ -445,6 +445,10 @@ export default defineComponent({
     }
 
     const handleExpandChange = (value: CascaderValue) => {
+      if (popperVisible.value) return
+      if (!popperVisible.value) {
+        togglePopperVisible(true)
+      }
       updatePopperPosition()
       emit('expand-change', value)
     }


### PR DESCRIPTION
Use version：
vue：3.0.0
element-plus：1.0.1-alpha.16

problem：
After the cascade is selected, clicking the panel and the outside of the panel area will be hidden directly

Solution results：
After the cascade is selected, the click panel will not be hidden, and the outside of the click panel area will be hidden