### PR TITLE
Fixed a problem where the Cascader selector panel cannot be displayed when selected

### DIFF
--- a/packages/cascader/src/index.vue
+++ b/packages/cascader/src/index.vue
@@ -445,7 +445,6 @@ export default defineComponent({
     }
 
     const handleExpandChange = (value: CascaderValue) => {
-      if (popperVisible.value) return
       if (!popperVisible.value) {
         togglePopperVisible(true)
       }

--- a/packages/cascader/src/index.vue
+++ b/packages/cascader/src/index.vue
@@ -445,6 +445,10 @@ export default defineComponent({
     }
 
     const handleExpandChange = (value: CascaderValue) => {
+      if (popperVisible.value) return
+      if (!popperVisible.value) {
+        togglePopperVisible(true)
+      }
       updatePopperPosition()
       emit('expand-change', value)
     }


### PR DESCRIPTION
Use version：
vue：3.0.0
element-plus：1.0.1-alpha.16

problem：
After the cascade is selected, clicking the panel and the outside of the panel area will be hidden directly

Solution results：
After the cascade is selected, the click panel will not be hidden, and the outside of the click panel area will be hidden。The test passed
