### PR TITLE
fix(popover): fix popover positioning

### DIFF
--- a/packages/popconfirm/src/index.vue
+++ b/packages/popconfirm/src/index.vue
@@ -4,6 +4,7 @@
     :trigger="['click']"
     effect="light"
     popper-class="el-popover"
+    append-to-body
   >
     <div class="el-popconfirm">
       <p class="el-popconfirm__main">

--- a/packages/popover/__tests__/directive.spec.ts
+++ b/packages/popover/__tests__/directive.spec.ts
@@ -2,6 +2,7 @@ import { nextTick } from 'vue'
 import Popover from '../src/index.vue'
 import PopoverDirective, { VPopover } from '../src/directive'
 import makeMount from '@element-plus/test-utils/make-mount'
+import { rAF } from '@element-plus/test-utils/tick'
 
 import type { ComponentPublicInstance } from 'vue'
 
@@ -42,8 +43,8 @@ describe('v-popover', () => {
   test('should render correctly', () => {
     const wrapper = mount()
 
-    expect(wrapper.text()).toContain(AXIOM)
-
+    expect(document.body.querySelector('.el-popover').innerHTML).toContain(AXIOM)
+    wrapper.unmount()
   })
 
   test('should show popover when reference is mounted', async () => {
@@ -55,8 +56,11 @@ describe('v-popover', () => {
     await nextTick()
 
     expect(wrapper.find(refNode).exists()).toBe(true)
-    expect(wrapper.find('.el-popover').attributes('style')).toContain('display: none')
+    expect(document.body.querySelector('.el-popover').getAttribute('style')).toContain('display: none')
     await wrapper.find(refNode).trigger('click')
-    expect(wrapper.find('.el-popover').attributes('style')).not.toContain('display: none')
+    await rAF()
+    await nextTick()
+    expect(document.body.querySelector('.el-popover').getAttribute('style')).not.toContain('display: none')
+    wrapper.unmount()
   })
 })

--- a/packages/popover/__tests__/popover.spec.ts
+++ b/packages/popover/__tests__/popover.spec.ts
@@ -8,6 +8,9 @@ const mount = makeMount(Popover, {
   slots: {
     default: AXIOM,
   },
+  props: {
+    appendToBody: false,
+  },
 })
 describe('Popover.vue', () => {
   test('render test', () => {
@@ -59,10 +62,12 @@ describe('Popover.vue', () => {
     const wrapper = makeMount(Popover, {
       props: {
         content,
+        appendToBody: false,
       },
     })()
 
     expect(wrapper.text()).toBe(content)
+    wrapper.unmount()
   })
 
   test('popper z-index should be dynamical', () => {

--- a/packages/popover/src/index.vue
+++ b/packages/popover/src/index.vue
@@ -116,14 +116,13 @@ export default defineComponent({
       ...events,
     }) : createCommentVNode('v-if', true)
 
-    return renderBlock(Fragment, { key: 0 }, [
+    return renderBlock(Fragment, null, [
       this.trigger === 'click'
         ? withDirectives(_trigger, [[ClickOutside, this.hide]])
         : _trigger,
       createVNode(Teleport as any, {
         disabled: !this.appendToBody,
         to: 'body',
-        key: 1,
       }, [popover], PatchFlags.PROPS, ['disabled']),
     ])
   },

--- a/packages/popover/src/index.vue
+++ b/packages/popover/src/index.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, Fragment, createTextVNode, renderSlot, toDisplayString, createCommentVNode, withDirectives } from 'vue'
+import { defineComponent, Fragment, createTextVNode, renderSlot, toDisplayString, createCommentVNode, withDirectives, Teleport, createVNode } from 'vue'
 import ElPopper from '@element-plus/popper'
 import { defaultProps, Effect } from '@element-plus/popper'
 import { renderPopper, renderTrigger, renderArrow } from '@element-plus/popper'
@@ -41,6 +41,10 @@ export default defineComponent({
     width: {
       type: [String, Number],
       default: 150,
+    },
+    appendToBody: {
+      type: Boolean,
+      default: true,
     },
   },
   emits,
@@ -112,14 +116,16 @@ export default defineComponent({
       ...events,
     }) : createCommentVNode('v-if', true)
 
-
-    return renderBlock(Fragment, null, [
+    return renderBlock(Fragment, { key: 0 }, [
       this.trigger === 'click'
         ? withDirectives(_trigger, [[ClickOutside, this.hide]])
         : _trigger,
-      popover,
+      createVNode(Teleport as any, {
+        disabled: !this.appendToBody,
+        to: 'body',
+        key: 1,
+      }, [popover], PatchFlags.PROPS, ['disabled']),
     ])
   },
 })
 </script>
-

--- a/packages/popover/src/usePopover.ts
+++ b/packages/popover/src/usePopover.ts
@@ -19,7 +19,7 @@ export default function usePopover(props: IUsePopover, ctx: SetupContext<string[
     let _width: string
 
     if (isString(props.width)) {
-      _width = props.width
+      _width = props.width as string
     } else {
       _width = props.width + 'px'
     }

--- a/packages/popper/src/index.vue
+++ b/packages/popper/src/index.vue
@@ -118,7 +118,6 @@ export default defineComponent({
         {
           to: 'body',
           disabled: !appendToBody,
-          key: 0,
         },
         [popper],
         PatchFlags.PROPS,

--- a/packages/popper/src/index.vue
+++ b/packages/popper/src/index.vue
@@ -118,6 +118,7 @@ export default defineComponent({
         {
           to: 'body',
           disabled: !appendToBody,
+          key: 0,
         },
         [popper],
         PatchFlags.PROPS,

--- a/packages/popper/src/renderers/popper.ts
+++ b/packages/popper/src/renderers/popper.ts
@@ -18,10 +18,10 @@ interface IRenderPopperProps {
   visibility: boolean
   onMouseEnter: () => void
   onMouseLeave: () => void
-  onAfterEnter: () => void
-  onAfterLeave: () => void
-  onBeforeEnter: () => void
-  onBeforeLeave: () => void
+  onAfterEnter?: () => void
+  onAfterLeave?: () => void
+  onBeforeEnter?: () => void
+  onBeforeLeave?: () => void
 }
 
 export default function renderPopper(

--- a/website/docs/en-US/tooltip.md
+++ b/website/docs/en-US/tooltip.md
@@ -181,6 +181,7 @@ Disabled form elements are not supported for Tooltip, more information can be fo
 ### Attributes
 | Attribute      | Description          | Type      | Accepted Values       | Default  |
 |----------------|---------|-----------|-------------|--------|
+| append-to-body | whether to append Dialog itself to body. A nested Dialog should have this attribute set to `true` | boolean   | — | false |
 |  effect   |  Tooltip theme  | string   | dark/light  | dark  |
 |  content  | display content, can be overridden by `slot#content` | String   | — | — |
 |  placement | position of Tooltip   | string    |  top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end |  bottom |

--- a/website/docs/es/tooltip.md
+++ b/website/docs/es/tooltip.md
@@ -181,6 +181,7 @@ Es necesario envolver los elementos de forma deshabilitados en un elemento conte
 ### Atributos
 | Atributo       | Descripción                              | Tipo    | Valores aceptados                        | Por defecto                              |
 | -------------- | ---------------------------------------- | ------- | ---------------------------------------- | ---------------------------------------- |
+| append-to-body | Si adjuntar el cuadro de diálogo al cuerpo | boolean                                          | —                 |   false              |
 | effect         | tema del Tooltip                         | string  | dark/light                               | dark                                     |
 | content        | contenido a mostrar, puede ser sobre-escrito por `slot#content` | string  | —                                        | —                                        |
 | placement      | posición del Tooltip                     | string  | top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end | bottom                                   |

--- a/website/docs/fr-FR/tooltip.md
+++ b/website/docs/fr-FR/tooltip.md
@@ -182,6 +182,7 @@ Les éléments de formulaire désactivés ne sont pas supportés par Tooltip, pl
 
 | Attribut      | Description          | Type      | Valeurs acceptées       | Défaut  |
 |----------------|---------|-----------|-------------|--------|
+| append-to-body     | S'il faut ajouter le Dialog au body. Un Dialog imbriqué doit avoir cet attribut à `true`. | boolean   | — | false |
 | effect | Thème du Tooltip.  | string   | dark/light  | dark  |
 | content | Contenu à afficher, écrasé par `slot#content`. | String   | — | — |
 | placement | Position du Tooltip. | string |  top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end |  bottom |

--- a/website/docs/jp/tooltip.md
+++ b/website/docs/jp/tooltip.md
@@ -181,6 +181,7 @@
 ### 属性
 | Attribute      | Description          | Type      | Accepted Values       | Default  |
 |----------------|---------|-----------|-------------|--------|
+| append-to-body | dialog自身をボディに追加するかどうかを指定します。入れ子になったdialogは、この属性を `true` に設定しなければなりません。 | boolean   | — | false |
 |  effect   |  ツールチップのテーマ  | string   | dark/light  | dark  |
 |  content  | コンテンツを表示、`slot#content` で上書きすることができます。 | String   | — | — |
 |  placement | ツールチップの位置   | string    |  top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end |  bottom |

--- a/website/docs/zh-CN/tooltip.md
+++ b/website/docs/zh-CN/tooltip.md
@@ -162,6 +162,7 @@ tooltip 内不支持 disabled form 元素，参考[MDN](https://developer.mozill
 ### Attributes
 | 参数               | 说明                                                     | 类型              | 可选值      | 默认值 |
 |--------------------|----------------------------------------------------------|-------------------|-------------|--------|
+|  append-to-body | 决定 popper 是否传送到 document.body 下 | Boolean | - | false |
 |  effect        |  默认提供的主题  | String            | dark/light | dark  |
 |  content        |  显示的内容，也可以通过 `slot#content` 传入 DOM  | String            | — | — |
 |  placement        |  Tooltip 的出现位置  | String           |  top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end |  bottom |


### PR DESCRIPTION
- Popover and popconfirm are now inserted to document.body by default close #778 

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
