### PR TITLE
fix(dialog): fix on demand importing dialog lacking overlay css

### DIFF
--- a/packages/theme-chalk/src/dialog.scss
+++ b/packages/theme-chalk/src/dialog.scss
@@ -2,6 +2,7 @@
 @import 'mixins/utils';
 @import 'common/var';
 @import 'common/popup';
+@import './overlay.scss';
 
 @include b(dialog) {
   position: relative;


### PR DESCRIPTION
- Fix issue causing dialog unable to load overlay css. Close #792 

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
