### PR TITLE
fix(TimePicker | DatePicker | DateTimePicker): popper border .is-light shows the dark style in the default state

### DIFF
--- a/packages/theme-chalk/src/popper.scss
+++ b/packages/theme-chalk/src/popper.scss
@@ -25,10 +25,10 @@
 
   @include when(light) {
     background: $--color-white;
-    border: 1px solid $--color-text-primary;
+    border: 1px solid $--border-color-light;
 
     #{$arrow-selector}::before {
-      border: 1px solid $--color-text-primary;
+      border: 1px solid $--border-color-light;
       background: $--color-white;
       right: 0;
     }


### PR DESCRIPTION
Fix the problem that the value of popper border .is-light shows the dark style in the default state of the component "TimePicker/DatePicker/DateTimePicker"'
[dev 524afaa] Fix the problem that the value of popper border .is-light shows the dark style in the default state of the component "TimePicker/DatePicker/DateTimePicker

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
