### PR TITLE
fix(popper): fix popper gets covered by dialog/drawer

### DIFF
--- a/packages/popper/src/use-popper/index.ts
+++ b/packages/popper/src/use-popper/index.ts
@@ -1,4 +1,4 @@
-import { computed, ref, reactive, watch } from 'vue'
+import { computed, ref, reactive, watch, CSSProperties } from 'vue'
 import { createPopper } from '@popperjs/core'
 
 import {
@@ -41,11 +41,7 @@ export default function(
 
   const isManualMode = () => props.manualMode || props.trigger === 'manual'
 
-  const popperStyle = computed(() => {
-    return {
-      zIndex: String(PopupManager.nextZIndex()),
-    }
-  })
+  const popperStyle = ref<CSSProperties>({ zIndex: PopupManager.nextZIndex() })
 
   const popperOptions = usePopperOptions(props, {
     arrow: arrowRef,
@@ -189,6 +185,7 @@ export default function(
 
   function onVisibilityChange(toState: boolean) {
     if (toState) {
+      popperStyle.value.zIndex = PopupManager.nextZIndex()
       initializePopper()
     }
   }


### PR DESCRIPTION
- Make popper's zIndex dynamic in order to allow popper related features in `Dialog/Drawer` to show
Close #789 
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
