### PR TITLE
fix(input): non-emit events such as keyup not work

### DIFF
--- a/packages/hooks/__tests__/use-attrs.spec.ts
+++ b/packages/hooks/__tests__/use-attrs.spec.ts
@@ -6,6 +6,7 @@ const CLASS = 'a'
 const WIDTH = '50px'
 const TEST_KEY = 'test'
 const TEST_VALUE = 'fake'
+const ANOTHER_TEST_VALUE = 'fake1'
 
 const handleClick = jest.fn()
 
@@ -54,7 +55,7 @@ afterEach(() => {
 
 describe('useAttrs', () => {
   test('class and style should not bind to child node', async () => {
-    const wrapper = _mount(genComp(true))
+    const wrapper = _mount(genComp())
     const container = wrapper.element as HTMLDivElement
     const span = wrapper.find('span')
 
@@ -67,6 +68,14 @@ describe('useAttrs', () => {
     await span.trigger('click')
 
     expect(handleClick).toBeCalledTimes(2)
+  })
+
+  test('child node\'s attributes should update when prop change', async () => {
+    const wrapper = _mount(genComp())
+    const span = wrapper.find('span')
+
+    await wrapper.setProps({ [TEST_KEY]: ANOTHER_TEST_VALUE })
+    expect(span.attributes(TEST_KEY)).toBe(ANOTHER_TEST_VALUE)
   })
 
   test('excluded listeners should not bind to child node', async () => {

--- a/packages/input/__tests__/input.spec.ts
+++ b/packages/input/__tests__/input.spec.ts
@@ -414,6 +414,18 @@ describe('Input.vue', () => {
     })
   })
 
+  test('non-emit event such as keyup should work', async () => {
+    const handleKeyup = jest.fn()
+    const wrapper = mount(Input, {
+      attrs: {
+        onKeyup: handleKeyup,
+      },
+    })
+
+    await wrapper.find('input').trigger('keyup')
+    expect(handleKeyup).toBeCalledTimes(1)
+  })
+
   // TODO: validateEvent & input containes select cases should be added after the rest components finished
   // ...
 

--- a/packages/input/src/index.vue
+++ b/packages/input/src/index.vue
@@ -219,7 +219,8 @@ export default defineComponent({
 
   setup(props, ctx) {
     const instance = getCurrentInstance()
-    const attrs = useAttrs({ excludeListeners: true })
+    const attrs = useAttrs()
+    console.log(attrs)
     const $ElEMENT = useGlobalConfig()
 
     const elForm = inject(elFormKey, {} as ElFormContext)

--- a/packages/input/src/index.vue
+++ b/packages/input/src/index.vue
@@ -220,7 +220,6 @@ export default defineComponent({
   setup(props, ctx) {
     const instance = getCurrentInstance()
     const attrs = useAttrs()
-    console.log(attrs)
     const $ElEMENT = useGlobalConfig()
 
     const elForm = inject(elFormKey, {} as ElFormContext)


### PR DESCRIPTION
- remove `excludeListeners: true` in `useAttrs`, for there is no need with `inheritAttrs: true` of `input`, fix #837
- complete `useAttrs` test case

