### PR TITLE
fix(directives): fix click touch pad once but the value changes twice

### DIFF
--- a/packages/directives/__tests__/repeat-click.spec.ts
+++ b/packages/directives/__tests__/repeat-click.spec.ts
@@ -29,7 +29,7 @@ describe('Directives.vue', () => {
     const testTime = 330
     await sleep(testTime)
     block.trigger('mouseup')
-    const expectResult = Math.floor(testTime / 100)
+    const expectResult = Math.floor((testTime - 300) / 100) + 1
     expect(handler).toHaveBeenCalledTimes(expectResult)
   })
 })

--- a/packages/directives/repeat-click/index.ts
+++ b/packages/directives/repeat-click/index.ts
@@ -3,23 +3,33 @@ import { on, once } from '@element-plus/utils/dom'
 import type { ObjectDirective } from 'vue'
 export default {
   beforeMount(el, binding) {
-    let interval = null
-    let startTime: number
+    const DELAY = 300
+    const INTERVAL = 100
+    let intervalTimer = null
+    let delayTimer = null
     const handler = () => binding.value && binding.value()
     const clear = () => {
-      if (Date.now() - startTime < 100) {
-        handler()
-      }
-      clearInterval(interval)
-      interval = null
+      clearInterval(intervalTimer)
+      clearTimeout(delayTimer)
+      intervalTimer = null
+      delayTimer = null
     }
 
     on(el, 'mousedown', e => {
       if ((e as any).button !== 0) return
-      startTime = Date.now()
-      once(document as any, 'mouseup', clear)
-      clearInterval(interval)
-      interval = setInterval(handler, 100)
+
+      handler()
+      once(el, 'mouseup', clear)
+      clearInterval(intervalTimer)
+
+      if (delayTimer) {
+        clearTimeout(delayTimer)
+      }
+
+      delayTimer = setTimeout(() => {
+        intervalTimer = setInterval(handler, INTERVAL)
+        delayTimer = null
+      }, DELAY)
     })
   },
 } as ObjectDirective


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

I changed way of implementation to fix the bug and also make the click behavior being consistent with other UI frameworks for better experience.(hold down the mouse , it will change once and pause for a short time, then changes rapidly).
This bug appears in some component like Input-Number and Time-Picker when use some laptop's touch pad.
I also have  submitted a PR on previous version  ElemeFE/element repository https://github.com/ElemeFE/element/pull/20153.




