### PR TITLE
fix(locale): setting locale does not work for DayJS

### DIFF
--- a/packages/locale/index.ts
+++ b/packages/locale/index.ts
@@ -28,6 +28,13 @@ export const t = (path:string, option?): string => {
 export const use = (l): void => {
   lang = l || lang
   if (lang.name) {
+    try {
+      require('dayjs/locale/' + lang.name + '.js')
+    } catch(e) {
+      console.warn(
+        `[Element Warn][locale] ${lang.name} was not found`,
+      )
+    }
     dayjs.locale(lang.name)
   }
 }


### PR DESCRIPTION
Setting locale does not work for DayJS

Vue：3.0.4
element-plus： 1.0.1-beta.7

I set the locale, but the week display in the calendar component is not in Chinese