### PR TITLE
fix(input): add resizeTextarea method

### DIFF
--- a/packages/input/__tests__/input.spec.ts
+++ b/packages/input/__tests__/input.spec.ts
@@ -276,14 +276,24 @@ describe('Input.vue', () => {
     test('method:resizeTextarea', async () => {
       const testContent = 'TEXT:resizeTextarea'
       const wrapper = _mount({
-        template: `<el-input  ref="textarea"  type="textarea" v-model="text" />`,
+        template: `<el-input  ref="textarea"  :autosize="autoSize" type="textarea" v-model="text" />`,
         data() {
           return {
             text: testContent,
+            autoSize:{ minRows: 1, maxRows: 1 }
           }
         },
       })
-      wrapper.vm.$refs.textarea.resizeTextarea()
+      const _ref = wrapper.vm.$refs.textarea
+      wrapper.vm.autoSize.minRows = 5
+      wrapper.vm.autoSize.maxRows = 5
+      await sleep()
+      let originHeight = _ref.inputOrTextarea.clientHeight
+      _ref.resizeTextarea()
+      await sleep()
+      let nowHeight = _ref.inputOrTextarea.clientHeight
+
+      expect(originHeight!==nowHeight).toBe(true)
     })
   })
 

--- a/packages/input/__tests__/input.spec.ts
+++ b/packages/input/__tests__/input.spec.ts
@@ -273,6 +273,18 @@ describe('Input.vue', () => {
       expect(input.selectionStart).toEqual(0)
       expect(input.selectionEnd).toEqual(testContent.length)
     })
+    test('method:resizeTextarea', async () => {
+      const testContent = 'TEXT:resizeTextarea'
+      const wrapper = _mount({
+        template: `<el-input  ref="textarea"  type="textarea" v-model="text" />`,
+        data() {
+          return {
+            text: testContent,
+          }
+        },
+      })
+      wrapper.vm.$refs.textarea.resizeTextarea()
+    })
   })
 
   describe('Input Events', () => {

--- a/packages/input/src/index.vue
+++ b/packages/input/src/index.vue
@@ -463,6 +463,7 @@ export default defineComponent({
       textarea,
       attrs,
       inputSize,
+      resizeTextarea,
       validateState,
       validateIcon,
       textareaStyle,


### PR DESCRIPTION
i think we need export resizeTextarea to support dynamic size like element2
```javascript
this.$refs.textarea.resizeTextarea();
```
