### PR TITLE
fix(scrollbar): fix the style of scrollbar

### DIFF
--- a/packages/scrollbar/src/index.vue
+++ b/packages/scrollbar/src/index.vue
@@ -25,12 +25,11 @@
     </template>
   </div>
 </template>
-<script lang='ts'>
+<script lang="ts">
 import {
   addResizeListener,
   removeResizeListener,
 } from '@element-plus/utils/resize-event'
-import scrollbarWidth from '@element-plus/utils/scrollbar-width'
 import { toObject } from '@element-plus/utils/util'
 import {
   defineComponent,
@@ -45,9 +44,7 @@ import Bar from './bar'
 
 export default defineComponent({
   name: 'ElScrollbar',
-
   components: { Bar },
-
   props: {
     native: {
       type: Boolean,
@@ -75,7 +72,6 @@ export default defineComponent({
       default: 'div',
     },
   },
-
   setup(props) {
     const sizeWidth = ref('0')
     const sizeHeight = ref('0')
@@ -115,23 +111,10 @@ export default defineComponent({
       if (props.native) return
       !props.noresize && removeResizeListener(resize.value, update)
     })
-    const gutter = computed(() => {
-      return scrollbarWidth()
-    })
     const style = computed(() => {
-      const gutter = scrollbarWidth()
       let style = props.wrapStyle
-      if (gutter) {
-        const gutterWith = `-${gutter}px`
-        const gutterStyle = `margin-bottom: ${gutterWith}; margin-right: ${gutterWith};`
-        if (Array.isArray(props.wrapStyle)) {
-          style = toObject(props.wrapStyle)
-          style.marginRight = style.marginBottom = gutterWith
-        } else if (typeof props.wrapStyle === 'string') {
-          style += gutterStyle
-        } else {
-          style = gutterStyle
-        }
+      if (Array.isArray(props.wrapStyle)) {
+        style = toObject(props.wrapStyle)
       }
       return style
     })
@@ -141,7 +124,6 @@ export default defineComponent({
       sizeWidth,
       sizeHeight,
       style,
-      gutter,
       wrap,
       resize,
       update,

--- a/packages/theme-chalk/src/scrollbar.scss
+++ b/packages/theme-chalk/src/scrollbar.scss
@@ -20,6 +20,7 @@
     height: 100%;
 
     @include m(hidden-default) {
+      scrollbar-width: none;
       &::-webkit-scrollbar {
         display: none;
       }

--- a/packages/theme-chalk/src/scrollbar.scss
+++ b/packages/theme-chalk/src/scrollbar.scss
@@ -16,13 +16,12 @@
   }
 
   @include e(wrap) {
-    overflow: scroll;
+    overflow: auto;
     height: 100%;
 
     @include m(hidden-default) {
-      scrollbar-width: none;
       &::-webkit-scrollbar {
-        opacity: 0;
+        display: none;
       }
     }
   }


### PR DESCRIPTION
#1034

Before
![image](https://user-images.githubusercontent.com/38392315/102588690-d3b16080-4148-11eb-8044-d0abd011ae53.png)

After
![image](https://user-images.githubusercontent.com/38392315/102588819-0196a500-4149-11eb-9a37-a966a541cc60.png)

I find the `gutter` of scrollbar has some weird style. And I boldly removed this attribute, and did some changes. Everything looks normal. It's my modification suggestion.

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
