### PR TITLE
Release automation feature: #776 auto publish to npmjs when creating manual github release

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,33 @@
+name: Publish to NPM registry
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+      - name: Install dependencies
+        run: yarn bootstrap
+      - name: Lint
+        run: yarn lint
+      - name: Test
+        run: yarn test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          registry-url: https://registry.npmjs.org/
+      - run: yarn bootstrap
+      - run: yarn build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
This implements #776 

When manually creating a new release from Github, this will automatically pack and publish to npmjs registry.
* Note: the published version will use the version in the root `package.json`, not the version read from Github release. So we should be careful to check the version in `package.json` before each release.
