### PR TITLE
fix(select): fix Click scrollbar when mouseup still scroll by mousemove

### DIFF
--- a/packages/directives/click-outside/index.ts
+++ b/packages/directives/click-outside/index.ts
@@ -38,7 +38,7 @@ function createDocumentHandler(
     excludes.push(binding.arg as unknown as HTMLElement)
   }
   return function(mouseup, mousedown) {
-    const popperRef = (binding.instance as ComponentPublicInstance<{
+    let popperRef = (binding.instance as ComponentPublicInstance<{
       popperRef: Nullable<HTMLElement>
     }>).popperRef
     const mouseUpTarget = mouseup.target as Node
@@ -47,13 +47,14 @@ function createDocumentHandler(
     const isTargetExists = !mouseUpTarget || !mouseDownTarget
     const isContainedByEl = el.contains(mouseUpTarget) || el.contains(mouseDownTarget)
     const isSelf = el === mouseUpTarget
-
     const isTargetExcluded =
       ( excludes.length &&
         excludes.some(item => item?.contains(mouseUpTarget))
       ) || (
         excludes.length && excludes.includes(mouseDownTarget as HTMLElement)
       )
+
+    popperRef = (popperRef as any).popperRef as HTMLElement
     const isContainedByPopper = (
       popperRef &&
       (

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -7,7 +7,7 @@
     @click.stop="toggleMenu"
   >
     <el-popper
-      ref="popper"
+      ref="popperRef"
       v-model:visible="dropMenuVisible"
       placement="bottom-start"
       :append-to-body="popperAppendToBody"
@@ -18,6 +18,7 @@
       trigger="click"
       transition="el-zoom-in-top"
       :gpu-acceleration="false"
+      :stop-popper-mouse-event="false"
       @before-enter="handleMenuEnter"
     >
       <template #trigger>
@@ -296,7 +297,7 @@ export default defineComponent({
 
       reference,
       input,
-      popper,
+      popper:popperRef,
       tags,
       selectWrapper,
       scrollbar,
@@ -429,7 +430,7 @@ export default defineComponent({
 
       reference,
       input,
-      popper,
+      popperRef,
       tags,
       selectWrapper,
       scrollbar,


### PR DESCRIPTION
1. el-popper 阻止了 mouseup 事件冒泡 导致 scrollbar组件的bar组件 添加在 document上面的mouseup事件无法触发。
2. el-popper 添加 stopPopperMouseEvent 使其不再阻止事件冒泡
3. 出现新的问题 点击移动滚动条 直接关闭了 el-popper(找到原因 v-clickOutside 点击滚动条触发 v-clickOutside传入的 handleClose方法关闭的popper)
4. 按理 点击的是 popper组件内部的 元素应该不会触发 关闭事件(找到原因 因为 ref没有转发 导致下面代码 popperRef 是poperRef组件而不是dom元素 从而 isContainedByPopper的逻辑无法正常运行)
5. 潜在问题: popper组件的 popperRef 属性没有对外暴露成属性,导致无法获取 内容的真实dom元素
6. 潜在问题: v-clickOutside 获取 popper获取 ref 和 select中申明的ref名称不统一

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
