### PR TITLE
fix: app.use(comp.vue) type is not compatible

### DIFF
--- a/build/gen-type.js
+++ b/build/gen-type.js
@@ -37,7 +37,7 @@ fs.readdirSync(libDirPath).forEach(comp => {
       if(outsideImport.test(imp) || imp.includes('@element-plus/')) {
         const newImp = imp.replace(outsideImport, (i, c) => {
           return i.replace(`../${c}`, `../el-${c}`)
-        }).replace('@element-plus/', '../el-')
+        }).replace('@element-plus/', '../el-').replace('el-utils', 'utils')
         fs.writeFileSync(path.resolve(__dirname, '../lib', newCompName, 'index.d.ts'), newImp)
       }
     }

--- a/packages/alert/index.ts
+++ b/packages/alert/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Alert from './src/index.vue'
 
 Alert.install = (app: App): void => {

--- a/packages/alert/index.ts
+++ b/packages/alert/index.ts
@@ -1,9 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Alert from './src/index.vue'
 
 Alert.install = (app: App): void => {
   app.component(Alert.name, Alert)
 }
 
-export default Alert
+const _Alert: SFCWithInstall<typeof Alert> = Alert
 
+export default _Alert

--- a/packages/aside/index.ts
+++ b/packages/aside/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Aside from '../container/src/aside.vue'
 
 Aside.install = (app: App): void => {

--- a/packages/aside/index.ts
+++ b/packages/aside/index.ts
@@ -1,9 +1,12 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Aside from '../container/src/aside.vue'
 
 Aside.install = (app: App): void => {
   app.component(Aside.name, Aside)
 }
 
-export default Aside
+const _Aside: SFCWithInstall<typeof Aside> = Aside
+
+export default _Aside
 

--- a/packages/autocomplete/index.ts
+++ b/packages/autocomplete/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Autocomplete from './src/index.vue'
 
 Autocomplete.install = (app: App): void => {

--- a/packages/autocomplete/index.ts
+++ b/packages/autocomplete/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Autocomplete from './src/index.vue'
 
 Autocomplete.install = (app: App): void => {
   app.component(Autocomplete.name, Autocomplete)
 }
 
-export default Autocomplete
+const _Autocomplete: SFCWithInstall<typeof Autocomplete> = Autocomplete
+
+export default _Autocomplete

--- a/packages/avatar/index.ts
+++ b/packages/avatar/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Avatar from './src/index.vue'
 
 Avatar.install = (app: App): void => {

--- a/packages/avatar/index.ts
+++ b/packages/avatar/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Avatar from './src/index.vue'
 
 Avatar.install = (app: App): void => {
   app.component(Avatar.name, Avatar)
 }
 
-export default Avatar
+const _Avatar: SFCWithInstall<typeof Avatar> = Avatar
+
+export default _Avatar

--- a/packages/backtop/index.ts
+++ b/packages/backtop/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Backtop from './src/index.vue'
 
 Backtop.install = (app: App): void => {

--- a/packages/backtop/index.ts
+++ b/packages/backtop/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Backtop from './src/index.vue'
 
 Backtop.install = (app: App): void => {
   app.component(Backtop.name, Backtop)
 }
 
-export default Backtop
+const _Backtop: SFCWithInstall<typeof Backtop> = Backtop
+
+export default _Backtop

--- a/packages/badge/index.ts
+++ b/packages/badge/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Badge from './src/index.vue'
 
 Badge.install = (app: App): void => {
   app.component(Badge.name, Badge)
 }
 
-export default Badge
+const _Badge: SFCWithInstall<typeof Badge> = Badge
+
+export default _Badge

--- a/packages/badge/index.ts
+++ b/packages/badge/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Badge from './src/index.vue'
 
 Badge.install = (app: App): void => {

--- a/packages/breadcrumb-item/index.ts
+++ b/packages/breadcrumb-item/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import BreadcrumbItem from '../breadcrumb/src/item.vue'
 
 BreadcrumbItem.install = (app: App): void => {
   app.component(BreadcrumbItem.name, BreadcrumbItem)
 }
 
-export default BreadcrumbItem
+const _BreadcrumbItem: SFCWithInstall<typeof BreadcrumbItem> = BreadcrumbItem
+
+export default _BreadcrumbItem

--- a/packages/breadcrumb-item/index.ts
+++ b/packages/breadcrumb-item/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import BreadcrumbItem from '../breadcrumb/src/item.vue'
 
 BreadcrumbItem.install = (app: App): void => {

--- a/packages/breadcrumb/index.ts
+++ b/packages/breadcrumb/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Breadcrumb from './src/index.vue'
 
 Breadcrumb.install = (app: App): void => {
   app.component(Breadcrumb.name, Breadcrumb)
 }
 
-export default Breadcrumb
+const _Breadcrumb: SFCWithInstall<typeof Breadcrumb> = Breadcrumb
+
+export default _Breadcrumb

--- a/packages/breadcrumb/index.ts
+++ b/packages/breadcrumb/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Breadcrumb from './src/index.vue'
 
 Breadcrumb.install = (app: App): void => {

--- a/packages/button-group/index.ts
+++ b/packages/button-group/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import ButtonGroup from '../button/src/button-group.vue'
 
 ButtonGroup.install = (app: App): void => {
   app.component(ButtonGroup.name, ButtonGroup)
 }
 
-export default ButtonGroup
+const _ButtonGroup: SFCWithInstall<typeof ButtonGroup> = ButtonGroup
+
+export default _ButtonGroup

--- a/packages/button-group/index.ts
+++ b/packages/button-group/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import ButtonGroup from '../button/src/button-group.vue'
 
 ButtonGroup.install = (app: App): void => {

--- a/packages/button/index.ts
+++ b/packages/button/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Button from './src/button.vue'
 
 Button.install = (app: App): void => {

--- a/packages/button/index.ts
+++ b/packages/button/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Button from './src/button.vue'
 
 Button.install = (app: App): void => {
   app.component(Button.name, Button)
 }
 
-export default Button
+const _Button: SFCWithInstall<typeof Button> = Button
+
+export default _Button

--- a/packages/calendar/index.ts
+++ b/packages/calendar/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Calendar from './src/index.vue'
 
 Calendar.install = (app: App): void => {
   app.component(Calendar.name, Calendar)
 }
 
-export default Calendar
+const _Calendar: SFCWithInstall<typeof Calendar> = Calendar
+
+export default _Calendar

--- a/packages/calendar/index.ts
+++ b/packages/calendar/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Calendar from './src/index.vue'
 
 Calendar.install = (app: App): void => {

--- a/packages/card/index.ts
+++ b/packages/card/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Card from './src/index.vue'
 
 Card.install = (app: App): void => {

--- a/packages/card/index.ts
+++ b/packages/card/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Card from './src/index.vue'
 
 Card.install = (app: App): void => {
   app.component(Card.name, Card)
 }
 
-export default Card
+const _Card: SFCWithInstall<typeof Card> = Card
+
+export default _Card

--- a/packages/carousel-item/index.ts
+++ b/packages/carousel-item/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import CarouselItem from '../carousel/src/item.vue'
 
 CarouselItem.install = (app: App): void => {
   app.component(CarouselItem.name, CarouselItem)
 }
 
-export default CarouselItem
+const _CarouselItem: SFCWithInstall<typeof CarouselItem> = CarouselItem
+
+export default _CarouselItem

--- a/packages/carousel-item/index.ts
+++ b/packages/carousel-item/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import CarouselItem from '../carousel/src/item.vue'
 
 CarouselItem.install = (app: App): void => {

--- a/packages/carousel/index.ts
+++ b/packages/carousel/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Carousel from './src/main.vue'
 
 Carousel.install = (app: App): void => {
   app.component(Carousel.name, Carousel)
 }
 
-export default Carousel
+const _Carousel: SFCWithInstall<typeof Carousel> = Carousel
+
+export default _Carousel

--- a/packages/carousel/index.ts
+++ b/packages/carousel/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Carousel from './src/main.vue'
 
 Carousel.install = (app: App): void => {

--- a/packages/cascader-panel/index.ts
+++ b/packages/cascader-panel/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import CascaderPanel from './src/index.vue'
 
 

--- a/packages/cascader-panel/index.ts
+++ b/packages/cascader-panel/index.ts
@@ -1,4 +1,5 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import CascaderPanel from './src/index.vue'
 
 
@@ -6,6 +7,8 @@ CascaderPanel.install = (app: App): void => {
   app.component(CascaderPanel.name, CascaderPanel)
 }
 
-export default CascaderPanel
+const _CascaderPanel: SFCWithInstall<typeof CascaderPanel> = CascaderPanel
+
+export default _CascaderPanel
 export * from './src/types'
 export * from './src/config'

--- a/packages/cascader/index.ts
+++ b/packages/cascader/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Cascader from './src/index.vue'
 
 Cascader.install = (app: App): void => {
   app.component(Cascader.name, Cascader)
 }
 
-export default Cascader
+const _Cascader: SFCWithInstall<typeof Cascader> = Cascader
+
+export default _Cascader

--- a/packages/cascader/index.ts
+++ b/packages/cascader/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Cascader from './src/index.vue'
 
 Cascader.install = (app: App): void => {

--- a/packages/checkbox-button/index.ts
+++ b/packages/checkbox-button/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import CheckboxButton from '../checkbox/src/checkbox-button.vue'
 
 CheckboxButton.install = (app: App): void => {
   app.component(CheckboxButton.name, CheckboxButton)
 }
 
-export default CheckboxButton
+const _CheckboxButton: SFCWithInstall<typeof CheckboxButton> = CheckboxButton
+
+export default _CheckboxButton

--- a/packages/checkbox-button/index.ts
+++ b/packages/checkbox-button/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import CheckboxButton from '../checkbox/src/checkbox-button.vue'
 
 CheckboxButton.install = (app: App): void => {

--- a/packages/checkbox-group/index.ts
+++ b/packages/checkbox-group/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import CheckboxGroup from '../checkbox/src/checkbox-group.vue'
 
 CheckboxGroup.install = (app: App): void => {

--- a/packages/checkbox-group/index.ts
+++ b/packages/checkbox-group/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import CheckboxGroup from '../checkbox/src/checkbox-group.vue'
 
 CheckboxGroup.install = (app: App): void => {
   app.component(CheckboxGroup.name, CheckboxGroup)
 }
 
-export default CheckboxGroup
+const _CheckboxGroup: SFCWithInstall<typeof CheckboxGroup> = CheckboxGroup
+
+export default _CheckboxGroup

--- a/packages/checkbox/index.ts
+++ b/packages/checkbox/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Checkbox from './src/checkbox.vue'
 
 Checkbox.install = (app: App): void => {
   app.component(Checkbox.name, Checkbox)
 }
 
-export default Checkbox
+const _Checkbox: SFCWithInstall<typeof Checkbox> = Checkbox
+
+export default _Checkbox

--- a/packages/checkbox/index.ts
+++ b/packages/checkbox/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Checkbox from './src/checkbox.vue'
 
 Checkbox.install = (app: App): void => {

--- a/packages/collapse-item/index.ts
+++ b/packages/collapse-item/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import CollapseItem from '../collapse/src/collapse-item.vue'
 
 CollapseItem.install = (app: App): void => {
   app.component(CollapseItem.name, CollapseItem)
 }
 
-export default CollapseItem
+const _CollapseItem: SFCWithInstall<typeof CollapseItem> = CollapseItem
+
+export default _CollapseItem

--- a/packages/collapse-item/index.ts
+++ b/packages/collapse-item/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import CollapseItem from '../collapse/src/collapse-item.vue'
 
 CollapseItem.install = (app: App): void => {

--- a/packages/collapse-transition/index.ts
+++ b/packages/collapse-transition/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import CollapseTransition from '../transition/collapse-transition/index.vue'
 
 CollapseTransition.install = (app: App): void => {
   app.component(CollapseTransition.name, CollapseTransition)
 }
 
-export default CollapseTransition
+const _CollapseTransition: SFCWithInstall<typeof CollapseTransition> = CollapseTransition
+
+export default _CollapseTransition

--- a/packages/collapse-transition/index.ts
+++ b/packages/collapse-transition/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import CollapseTransition from '../transition/collapse-transition/index.vue'
 
 CollapseTransition.install = (app: App): void => {

--- a/packages/collapse/index.ts
+++ b/packages/collapse/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Collapse from './src/collapse.vue'
 
 Collapse.install = (app: App): void => {

--- a/packages/collapse/index.ts
+++ b/packages/collapse/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Collapse from './src/collapse.vue'
 
 Collapse.install = (app: App): void => {
   app.component(Collapse.name, Collapse)
 }
 
-export default Collapse
+const _Collapse: SFCWithInstall<typeof Collapse> = Collapse
+
+export default _Collapse

--- a/packages/color-picker/index.ts
+++ b/packages/color-picker/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import ColorPicker from './src/index.vue'
 
 ColorPicker.install = (app: App): void => {
   app.component(ColorPicker.name, ColorPicker)
 }
 
-export default ColorPicker
+const _ColorPicker: SFCWithInstall<typeof ColorPicker> = ColorPicker
+
+export default _ColorPicker

--- a/packages/color-picker/index.ts
+++ b/packages/color-picker/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import ColorPicker from './src/index.vue'
 
 ColorPicker.install = (app: App): void => {

--- a/packages/container/index.ts
+++ b/packages/container/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Container from './src/container.vue'
 
 Container.install = (app: App): void => {
   app.component(Container.name, Container)
 }
 
-export default Container
+const _Container: SFCWithInstall<typeof Container> = Container
+
+export default _Container

--- a/packages/container/index.ts
+++ b/packages/container/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Container from './src/container.vue'
 
 Container.install = (app: App): void => {

--- a/packages/dialog/index.ts
+++ b/packages/dialog/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Dialog from './src/index.vue'
 
 Dialog.install = (app: App): void => {

--- a/packages/dialog/index.ts
+++ b/packages/dialog/index.ts
@@ -1,9 +1,12 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Dialog from './src/index.vue'
 
 Dialog.install = (app: App): void => {
   app.component(Dialog.name, Dialog)
 }
 
-export default Dialog
+const _Dialog: SFCWithInstall<typeof Dialog> = Dialog
+
+export default _Dialog
 export { default as useDialog } from './src/useDialog'

--- a/packages/divider/index.ts
+++ b/packages/divider/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Divider from './src/index.vue'
 
 Divider.install = (app: App): void => {

--- a/packages/divider/index.ts
+++ b/packages/divider/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Divider from './src/index.vue'
 
 Divider.install = (app: App): void => {
   app.component(Divider.name, Divider)
 }
 
-export default Divider
+const _Divider: SFCWithInstall<typeof Divider> = Divider
+
+export default _Divider

--- a/packages/drawer/index.ts
+++ b/packages/drawer/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Drawer from './src/index.vue'
 
 Drawer.install = (app: App): void => {

--- a/packages/drawer/index.ts
+++ b/packages/drawer/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Drawer from './src/index.vue'
 
 Drawer.install = (app: App): void => {
   app.component(Drawer.name, Drawer)
 }
 
-export default Drawer
+const _Drawer: SFCWithInstall<typeof Drawer> = Drawer
+
+export default _Drawer

--- a/packages/dropdown-item/index.ts
+++ b/packages/dropdown-item/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import DropdownItem from '../dropdown/src/dropdown-item.vue'
 
 DropdownItem.install = (app: App): void => {
   app.component(DropdownItem.name, DropdownItem)
 }
 
-export default DropdownItem
+const _DropdownItem: SFCWithInstall<typeof DropdownItem> = DropdownItem
+
+export default _DropdownItem

--- a/packages/dropdown-item/index.ts
+++ b/packages/dropdown-item/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import DropdownItem from '../dropdown/src/dropdown-item.vue'
 
 DropdownItem.install = (app: App): void => {

--- a/packages/dropdown-menu/index.ts
+++ b/packages/dropdown-menu/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import DropdownMenu from '../dropdown/src/dropdown-menu.vue'
 
 DropdownMenu.install = (app: App): void => {
   app.component(DropdownMenu.name, DropdownMenu)
 }
 
-export default DropdownMenu
+const _DropdownMenu: SFCWithInstall<typeof DropdownMenu> = DropdownMenu
+
+export default _DropdownMenu

--- a/packages/dropdown-menu/index.ts
+++ b/packages/dropdown-menu/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import DropdownMenu from '../dropdown/src/dropdown-menu.vue'
 
 DropdownMenu.install = (app: App): void => {

--- a/packages/dropdown/index.ts
+++ b/packages/dropdown/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Dropdown from './src/dropdown.vue'
 
 Dropdown.install = (app: App): void => {

--- a/packages/dropdown/index.ts
+++ b/packages/dropdown/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Dropdown from './src/dropdown.vue'
 
 Dropdown.install = (app: App): void => {
   app.component(Dropdown.name, Dropdown)
 }
 
-export default Dropdown
+const _Dropdown: SFCWithInstall<typeof Dropdown> = Dropdown
+
+export default _Dropdown

--- a/packages/footer/index.ts
+++ b/packages/footer/index.ts
@@ -1,9 +1,12 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Footer from '../container/src/footer.vue'
 
 Footer.install = (app: App): void => {
   app.component(Footer.name, Footer)
 }
 
-export default Footer
+const _Footer: SFCWithInstall<typeof Footer> = Footer
+
+export default _Footer
 

--- a/packages/footer/index.ts
+++ b/packages/footer/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Footer from '../container/src/footer.vue'
 
 Footer.install = (app: App): void => {

--- a/packages/form-item/index.ts
+++ b/packages/form-item/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import FormItem from '../form/src/form-item.vue'
 
 FormItem.install = (app: App): void => {
   app.component(FormItem.name, FormItem)
 }
 
-export default FormItem
+const _FormItem: SFCWithInstall<typeof FormItem> = FormItem
+
+export default _FormItem

--- a/packages/form-item/index.ts
+++ b/packages/form-item/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import FormItem from '../form/src/form-item.vue'
 
 FormItem.install = (app: App): void => {

--- a/packages/form/index.ts
+++ b/packages/form/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Form from './src/form.vue'
 
 Form.install = (app: App): void => {

--- a/packages/form/index.ts
+++ b/packages/form/index.ts
@@ -1,11 +1,14 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Form from './src/form.vue'
 
 Form.install = (app: App): void => {
   app.component(Form.name, Form)
 }
 
-export default Form
+const _Form: SFCWithInstall<typeof Form> = Form
+
+export default _Form
 
 
 export * from './src/token'

--- a/packages/header/index.ts
+++ b/packages/header/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Header from '../container/src/header.vue'
 
 Header.install = (app: App): void => {

--- a/packages/header/index.ts
+++ b/packages/header/index.ts
@@ -1,9 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Header from '../container/src/header.vue'
 
 Header.install = (app: App): void => {
   app.component(Header.name, Header)
 }
+const _Header: SFCWithInstall<typeof Header> = Header
 
-export default Header
+export default _Header
 

--- a/packages/icon/index.ts
+++ b/packages/icon/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Icon from './src/index.vue'
 
 Icon.install = (app: App): void => {
   app.component(Icon.name, Icon)
 }
 
-export default Icon
+const _Icon: SFCWithInstall<typeof Icon> = Icon
+
+export default _Icon

--- a/packages/image/index.ts
+++ b/packages/image/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Image from './src/index.vue'
 
 Image.install = (app: App): void => {
   app.component(Image.name, Image)
 }
 
-export default Image
+const _Image: SFCWithInstall<typeof Image> = Image
+
+export default _Image

--- a/packages/input-number/index.ts
+++ b/packages/input-number/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import InputNumber from './src/index.vue'
 
 InputNumber.install = (app: App): void => {

--- a/packages/input-number/index.ts
+++ b/packages/input-number/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import InputNumber from './src/index.vue'
 
 InputNumber.install = (app: App): void => {
   app.component(InputNumber.name, InputNumber)
 }
 
-export default InputNumber
+const _InputNumber: SFCWithInstall<typeof InputNumber> = InputNumber
+
+export default _InputNumber

--- a/packages/input/index.ts
+++ b/packages/input/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Input from './src/index.vue'
 
 Input.install = (app: App): void => {
   app.component(Input.name, Input)
 }
 
-export default Input
+const _Input: SFCWithInstall<typeof Input> = Input
+
+export default _Input

--- a/packages/input/index.ts
+++ b/packages/input/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Input from './src/index.vue'
 
 Input.install = (app: App): void => {

--- a/packages/link/index.ts
+++ b/packages/link/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Link from './src/index.vue'
 
 Link.install = (app: App): void => {

--- a/packages/link/index.ts
+++ b/packages/link/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Link from './src/index.vue'
 
 Link.install = (app: App): void => {
   app.component(Link.name, Link)
 }
 
-export default Link
+const _Link: SFCWithInstall<typeof Link> = Link
+
+export default _Link

--- a/packages/main/index.ts
+++ b/packages/main/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Main from '../container/src/main.vue'
 
 Main.install = (app: App): void => {

--- a/packages/main/index.ts
+++ b/packages/main/index.ts
@@ -1,9 +1,12 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Main from '../container/src/main.vue'
 
 Main.install = (app: App): void => {
   app.component(Main.name, Main)
 }
 
-export default Main
+const _Main: SFCWithInstall<typeof Main> = Main
+
+export default _Main
 

--- a/packages/menu-item-group/index.ts
+++ b/packages/menu-item-group/index.ts
@@ -1,9 +1,12 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import MenuItemGroup from '../menu/src/menuItemGroup.vue'
 
 MenuItemGroup.install = (app: App): void => {
   app.component(MenuItemGroup.name, MenuItemGroup)
 }
 
-export default MenuItemGroup
+const _MenuItemGroup: SFCWithInstall<typeof MenuItemGroup> = MenuItemGroup
+
+export default _MenuItemGroup
 

--- a/packages/menu-item-group/index.ts
+++ b/packages/menu-item-group/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import MenuItemGroup from '../menu/src/menuItemGroup.vue'
 
 MenuItemGroup.install = (app: App): void => {

--- a/packages/menu-item/index.ts
+++ b/packages/menu-item/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import MenuItem from '../menu/src/menuItem.vue'
 
 MenuItem.install = (app: App): void => {

--- a/packages/menu-item/index.ts
+++ b/packages/menu-item/index.ts
@@ -1,9 +1,12 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import MenuItem from '../menu/src/menuItem.vue'
 
 MenuItem.install = (app: App): void => {
   app.component(MenuItem.name, MenuItem)
 }
 
-export default MenuItem
+const _MenuItem: SFCWithInstall<typeof MenuItem> = MenuItem
+
+export default _MenuItem
 

--- a/packages/menu/index.ts
+++ b/packages/menu/index.ts
@@ -1,9 +1,12 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Menu from './src/menu.vue'
 
 Menu.install = (app: App): void => {
   app.component(Menu.name, Menu)
 }
 
-export default Menu
+const _Menu: SFCWithInstall<typeof Menu> = Menu
+
+export default _Menu
 

--- a/packages/menu/index.ts
+++ b/packages/menu/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Menu from './src/menu.vue'
 
 Menu.install = (app: App): void => {

--- a/packages/option-group/index.ts
+++ b/packages/option-group/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import OptionGroup from '../select/src/option-group.vue'
 
 OptionGroup.install = (app: App): void => {
   app.component(OptionGroup.name, OptionGroup)
 }
 
-export default OptionGroup
+const _OptionGroup: SFCWithInstall<typeof OptionGroup> = OptionGroup
+
+export default _OptionGroup

--- a/packages/option-group/index.ts
+++ b/packages/option-group/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import OptionGroup from '../select/src/option-group.vue'
 
 OptionGroup.install = (app: App): void => {

--- a/packages/page-header/index.ts
+++ b/packages/page-header/index.ts
@@ -1,9 +1,12 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import PageHeader from './src/index.vue'
 
 PageHeader.install = (app: App): void => {
   app.component(PageHeader.name, PageHeader)
 }
 
-export default PageHeader
+const _PageHeader: SFCWithInstall<typeof PageHeader> = PageHeader
+
+export default _PageHeader
 

--- a/packages/page-header/index.ts
+++ b/packages/page-header/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import PageHeader from './src/index.vue'
 
 PageHeader.install = (app: App): void => {

--- a/packages/popconfirm/index.ts
+++ b/packages/popconfirm/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Popconfirm from './src/index.vue'
 
 Popconfirm.install = (app: App): void => {

--- a/packages/popconfirm/index.ts
+++ b/packages/popconfirm/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Popconfirm from './src/index.vue'
 
 Popconfirm.install = (app: App): void => {
   app.component(Popconfirm.name, Popconfirm)
 }
 
-export default Popconfirm
+const _Popconfirm: SFCWithInstall<typeof Popconfirm> = Popconfirm
+
+export default _Popconfirm

--- a/packages/popover/index.ts
+++ b/packages/popover/index.ts
@@ -1,4 +1,5 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Popover from './src/index.vue'
 import PopoverDirective, { VPopover } from './src/directive'
 
@@ -7,4 +8,7 @@ Popover.install = (app: App): void => {
   app.directive(VPopover, PopoverDirective)
 }
 Popover.directive = PopoverDirective
-export default Popover
+
+const _Popover: SFCWithInstall<typeof Popover> = Popover
+
+export default _Popover

--- a/packages/popover/index.ts
+++ b/packages/popover/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Popover from './src/index.vue'
 import PopoverDirective, { VPopover } from './src/directive'
 

--- a/packages/popper/index.ts
+++ b/packages/popper/index.ts
@@ -1,11 +1,14 @@
 import type { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Popper from './src/index.vue'
 
 Popper.install = (app: App): void => {
   app.component(Popper.name, Popper)
 }
 
-export default Popper
+const _Popper: SFCWithInstall<typeof Popper> = Popper
+
+export default _Popper
 
 export { default as defaultProps, Effect, Placement, Options } from './src/use-popper/defaults'
 export type { TriggerType, IPopperOptions, PopperInstance } from './src/use-popper/defaults'

--- a/packages/popper/index.ts
+++ b/packages/popper/index.ts
@@ -1,5 +1,5 @@
 import type { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Popper from './src/index.vue'
 
 Popper.install = (app: App): void => {

--- a/packages/progress/index.ts
+++ b/packages/progress/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Progress from './src/index.vue'
 
 Progress.install = (app: App): void => {

--- a/packages/progress/index.ts
+++ b/packages/progress/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Progress from './src/index.vue'
 
 Progress.install = (app: App): void => {
   app.component(Progress.name, Progress)
 }
 
-export default Progress
+const _Progress: SFCWithInstall<typeof Progress> = Progress
+
+export default _Progress

--- a/packages/radio-button/index.ts
+++ b/packages/radio-button/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import RadioButton from '../radio/src/radio-button.vue'
 
 RadioButton.install = (app: App): void => {

--- a/packages/radio-button/index.ts
+++ b/packages/radio-button/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import RadioButton from '../radio/src/radio-button.vue'
 
 RadioButton.install = (app: App): void => {
   app.component(RadioButton.name, RadioButton)
 }
 
-export default RadioButton
+const _RadioButton: SFCWithInstall<typeof RadioButton> = RadioButton
+
+export default _RadioButton

--- a/packages/radio-group/index.ts
+++ b/packages/radio-group/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import RadioGroup from '../radio/src/radio-group.vue'
 
 RadioGroup.install = (app: App): void => {

--- a/packages/radio-group/index.ts
+++ b/packages/radio-group/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import RadioGroup from '../radio/src/radio-group.vue'
 
 RadioGroup.install = (app: App): void => {
   app.component(RadioGroup.name, RadioGroup)
 }
 
-export default RadioGroup
+const _RadioGroup: SFCWithInstall<typeof RadioGroup> = RadioGroup
+
+export default _RadioGroup

--- a/packages/radio/index.ts
+++ b/packages/radio/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Radio from './src/radio.vue'
 
 Radio.install = (app: App): void => {

--- a/packages/radio/index.ts
+++ b/packages/radio/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Radio from './src/radio.vue'
 
 Radio.install = (app: App): void => {
   app.component(Radio.name, Radio)
 }
 
-export default Radio
+const _Radio: SFCWithInstall<typeof Radio> = Radio
+
+export default _Radio

--- a/packages/rate/index.ts
+++ b/packages/rate/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Rate from './src/index.vue'
 
 Rate.install = (app: App): void => {
   app.component(Rate.name, Rate)
 }
 
-export default Rate
+const _Rate: SFCWithInstall<typeof Rate> = Rate
+
+export default _Rate

--- a/packages/rate/index.ts
+++ b/packages/rate/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Rate from './src/index.vue'
 
 Rate.install = (app: App): void => {

--- a/packages/scrollbar/index.ts
+++ b/packages/scrollbar/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Scrollbar from './src/index.vue'
 
 Scrollbar.install = (app: App): void => {

--- a/packages/scrollbar/index.ts
+++ b/packages/scrollbar/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Scrollbar from './src/index.vue'
 
 Scrollbar.install = (app: App): void => {
   app.component(Scrollbar.name, Scrollbar)
 }
 
-export default Scrollbar
+const _Scrollbar: SFCWithInstall<typeof Scrollbar> = Scrollbar
+
+export default _Scrollbar

--- a/packages/select/index.ts
+++ b/packages/select/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Select from './src/select.vue'
 import Option from './src/option.vue'
 

--- a/packages/select/index.ts
+++ b/packages/select/index.ts
@@ -1,4 +1,5 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Select from './src/select.vue'
 import Option from './src/option.vue'
 
@@ -6,5 +7,7 @@ Select.install = (app: App): void => {
   app.component(Select.name, Select)
 }
 
+const _Select: SFCWithInstall<typeof Select> = Select
+
 export { Option }
-export default Select
+export default _Select

--- a/packages/slider/index.ts
+++ b/packages/slider/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Slider from './src/index.vue'
 
 Slider.install = (app: App): void => {
   app.component(Slider.name, Slider)
 }
 
-export default Slider
+const _Slider: SFCWithInstall<typeof Slider> = Slider
+
+export default _Slider

--- a/packages/slider/index.ts
+++ b/packages/slider/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Slider from './src/index.vue'
 
 Slider.install = (app: App): void => {

--- a/packages/step/index.ts
+++ b/packages/step/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Step from '../steps/src/item.vue'
 
 Step.install = (app: App): void => {

--- a/packages/step/index.ts
+++ b/packages/step/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Step from '../steps/src/item.vue'
 
 Step.install = (app: App): void => {
   app.component(Step.name, Step)
 }
 
-export default Step
+const _Step: SFCWithInstall<typeof Step> = Step
+
+export default _Step

--- a/packages/steps/index.ts
+++ b/packages/steps/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Steps from './src/index.vue'
 
 Steps.install = (app: App): void => {

--- a/packages/steps/index.ts
+++ b/packages/steps/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Steps from './src/index.vue'
 
 Steps.install = (app: App): void => {
   app.component(Steps.name, Steps)
 }
 
-export default Steps
+const _Steps: SFCWithInstall<typeof Steps> = Steps
+
+export default _Steps

--- a/packages/submenu/index.ts
+++ b/packages/submenu/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Submenu from '../menu/src/submenu.vue'
 
 Submenu.install = (app: App): void => {
   app.component(Submenu.name, Submenu)
 }
 
-export default Submenu
+const _Submenu: SFCWithInstall<typeof Submenu> = Submenu
+
+export default _Submenu

--- a/packages/submenu/index.ts
+++ b/packages/submenu/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Submenu from '../menu/src/submenu.vue'
 
 Submenu.install = (app: App): void => {

--- a/packages/switch/index.ts
+++ b/packages/switch/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Switch from './src/index.vue'
 
 Switch.install = (app: App): void => {
   app.component(Switch.name, Switch)
 }
 
-export default Switch
+const _Switch: SFCWithInstall<typeof Switch> = Switch
+
+export default _Switch

--- a/packages/switch/index.ts
+++ b/packages/switch/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Switch from './src/index.vue'
 
 Switch.install = (app: App): void => {

--- a/packages/tab-pane/index.ts
+++ b/packages/tab-pane/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import TabPane from '../tabs/src/tab-pane.vue'
 
 TabPane.install = (app: App): void => {
   app.component(TabPane.name, TabPane)
 }
 
-export default TabPane
+const _TabPane: SFCWithInstall<typeof TabPane> = TabPane
+
+export default _TabPane

--- a/packages/tab-pane/index.ts
+++ b/packages/tab-pane/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import TabPane from '../tabs/src/tab-pane.vue'
 
 TabPane.install = (app: App): void => {

--- a/packages/table/index.ts
+++ b/packages/table/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Table from './src/table.vue'
 
 Table.install = (app: App): void => {

--- a/packages/table/index.ts
+++ b/packages/table/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Table from './src/table.vue'
 
 Table.install = (app: App): void => {
   app.component(Table.name, Table)
 }
 
-export default Table
+const _Table: SFCWithInstall<typeof Table> = Table
+
+export default _Table

--- a/packages/tabs/index.ts
+++ b/packages/tabs/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Tabs from './src/tabs.vue'
 
 Tabs.install = (app: App): void => {

--- a/packages/tabs/index.ts
+++ b/packages/tabs/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Tabs from './src/tabs.vue'
 
 Tabs.install = (app: App): void => {
   app.component(Tabs.name, Tabs)
 }
 
-export default Tabs
+const _Tabs: SFCWithInstall<typeof Tabs> = Tabs
+
+export default _Tabs

--- a/packages/tag/index.ts
+++ b/packages/tag/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Tag from './src/index.vue'
 
 Tag.install = (app: App): void => {

--- a/packages/tag/index.ts
+++ b/packages/tag/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Tag from './src/index.vue'
 
 Tag.install = (app: App): void => {
   app.component(Tag.name, Tag)
 }
 
-export default Tag
+const _Tag: SFCWithInstall<typeof Tag> = Tag
+
+export default _Tag

--- a/packages/time-select/index.ts
+++ b/packages/time-select/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import TimeSelect from './src/time-select.vue'
 
 TimeSelect.install = (app: App): void => {
   app.component(TimeSelect.name, TimeSelect)
 }
 
-export default TimeSelect
+const _TimeSelect: SFCWithInstall<typeof TimeSelect> = TimeSelect
+
+export default _TimeSelect

--- a/packages/time-select/index.ts
+++ b/packages/time-select/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import TimeSelect from './src/time-select.vue'
 
 TimeSelect.install = (app: App): void => {

--- a/packages/timeline-item/index.ts
+++ b/packages/timeline-item/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import TimelineItem from '../timeline/src/item.vue'
 
 TimelineItem.install = (app: App): void => {

--- a/packages/timeline-item/index.ts
+++ b/packages/timeline-item/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import TimelineItem from '../timeline/src/item.vue'
 
 TimelineItem.install = (app: App): void => {
   app.component(TimelineItem.name, TimelineItem)
 }
 
-export default TimelineItem
+const _TimelineItem: SFCWithInstall<typeof TimelineItem> = TimelineItem
+
+export default _TimelineItem

--- a/packages/timeline/index.ts
+++ b/packages/timeline/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Timeline from './src/index.vue'
 
 Timeline.install = (app: App): void => {
   app.component(Timeline.name, Timeline)
 }
 
-export default Timeline
+const _Timeline: SFCWithInstall<typeof Timeline> = Timeline
+
+export default _Timeline

--- a/packages/timeline/index.ts
+++ b/packages/timeline/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Timeline from './src/index.vue'
 
 Timeline.install = (app: App): void => {

--- a/packages/transfer/index.ts
+++ b/packages/transfer/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Transfer from './src/index.vue'
 
 Transfer.install = (app: App): void => {
   app.component(Transfer.name, Transfer)
 }
 
-export default Transfer
+const _Transfer: SFCWithInstall<typeof Transfer> = Transfer
+
+export default _Transfer

--- a/packages/transfer/index.ts
+++ b/packages/transfer/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Transfer from './src/index.vue'
 
 Transfer.install = (app: App): void => {

--- a/packages/transition/index.ts
+++ b/packages/transition/index.ts
@@ -5,4 +5,5 @@ export default (app: App): void => {
   app.component(ElCollapseTransition.name, ElCollapseTransition)
 }
 
+
 export { ElCollapseTransition }

--- a/packages/tree/index.ts
+++ b/packages/tree/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Tree from './src/tree.vue'
 
 Tree.install = (app: App): void => {
   app.component(Tree.name, Tree)
 }
 
-export default Tree
+const _Tree: SFCWithInstall<typeof Tree> = Tree
+
+export default _Tree

--- a/packages/tree/index.ts
+++ b/packages/tree/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Tree from './src/tree.vue'
 
 Tree.install = (app: App): void => {

--- a/packages/upload/index.ts
+++ b/packages/upload/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import Upload from './src/index.vue'
 
 Upload.install = (app: App): void => {
   app.component(Upload.name, Upload)
 }
 
-export default Upload
+const _Upload: SFCWithInstall<typeof Upload> = Upload
+
+export default _Upload

--- a/packages/upload/index.ts
+++ b/packages/upload/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import Upload from './src/index.vue'
 
 Upload.install = (app: App): void => {

--- a/packages/utils/types.ts
+++ b/packages/utils/types.ts
@@ -1,3 +1,5 @@
+import { App } from 'vue'
+
 type OptionalKeys<T extends Record<string, unknown>> = {
   [K in keyof T]: T extends Record<K, T[K]>
     ? never
@@ -16,3 +18,5 @@ export type EventEmitter<T extends Record<string, unknown>> =
 export type AnyFunction<T> = (...args: any[]) => T
 
 export type PartialReturnType<T extends (...args: unknown[]) =>  unknown> = Partial<ReturnType<T>>
+
+export type SFCWithInstall<T> = T & { install(app: App): void; }

--- a/packages/virtual-list/index.ts
+++ b/packages/virtual-list/index.ts
@@ -1,8 +1,11 @@
 import { App } from 'vue'
+import { SFCWithInstall } from '../utils/types'
 import VirtualList from './src/index.vue'
 
 VirtualList.install = (app: App): void => {
   app.component(VirtualList.name, VirtualList)
 }
 
-export default VirtualList
+const _VirtualList: SFCWithInstall<typeof VirtualList> = VirtualList
+
+export default _VirtualList

--- a/packages/virtual-list/index.ts
+++ b/packages/virtual-list/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { SFCWithInstall } from '../utils/types'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 import VirtualList from './src/index.vue'
 
 VirtualList.install = (app: App): void => {

--- a/typings/vue-shim.d.ts
+++ b/typings/vue-shim.d.ts
@@ -1,6 +1,8 @@
 declare module '*.vue' {
-  import { defineComponent } from 'vue'
-  const component: ReturnType<typeof defineComponent>
+  import { App, defineComponent } from 'vue'
+  const component: ReturnType<typeof defineComponent> & {
+    install(app: App): void
+  }
   export default component
 }
 


### PR DESCRIPTION
Adding `install` function to the default import `.vue` sfc does not generate the type of `install`.
By reassigning a variable and declaring its type, it's possible to export d.ts that have both the
component type and the `install` type, but only work for `.vue` sfc.

```ts
// component index.ts
import { App } from 'vue'
import SomeComp from './SomeComp.vue'

const _SomeComp: typeof SomeComp & { install(app: App): void } = SomeComp

// vue-shim.d.ts
declare module '*.vue' {
  import { App, defineComponent } from 'vue'
  const component: ReturnType<typeof defineComponent> & {
    install(app: App): void
  }
  export default component
}
```


Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
