### PR TITLE
docs(popover): change value/v-model to visible

### DIFF
--- a/website/docs/en-US/popover.md
+++ b/website/docs/en-US/popover.md
@@ -163,7 +163,7 @@ Of course, you can nest other operations. It's more light-weight than using a di
 |  width        |  popover width  | string, number            | — | Min width 150px |
 |  placement        |  popover placement  | string | top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end |  bottom |
 |  disabled       |  whether Popover is disabled  | boolean    | — |  false |
-|  visible        |  whether popover is visible  | Boolean           | — |  false |
+|  visible / v-model:visible  |  whether popover is visible  | Boolean           | — |  false |
 |  offset        |  popover offset  | number           | — |  0 |
 |  transition     |  popover transition animation      | string             | — | el-fade-in-linear |
 |  show-arrow   |  whether a tooltip arrow is displayed or not. For more info, please refer to [Vue-popper](https://github.com/element-component/vue-popper) | boolean | — | true |

--- a/website/docs/en-US/popover.md
+++ b/website/docs/en-US/popover.md
@@ -163,7 +163,7 @@ Of course, you can nest other operations. It's more light-weight than using a di
 |  width        |  popover width  | string, number            | — | Min width 150px |
 |  placement        |  popover placement  | string | top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end |  bottom |
 |  disabled       |  whether Popover is disabled  | boolean    | — |  false |
-|  value / v-model        |  whether popover is visible  | Boolean           | — |  false |
+|  visible        |  whether popover is visible  | Boolean           | — |  false |
 |  offset        |  popover offset  | number           | — |  0 |
 |  transition     |  popover transition animation      | string             | — | el-fade-in-linear |
 |  show-arrow   |  whether a tooltip arrow is displayed or not. For more info, please refer to [Vue-popper](https://github.com/element-component/vue-popper) | boolean | — | true |

--- a/website/docs/es/popover.md
+++ b/website/docs/es/popover.md
@@ -162,7 +162,7 @@ Por supuesto, puedes anidar otras operaciones. Es más ligero que utilizar un `d
 | width          | ancho del popover                        | string, number | —                                        | Min width 150px                          |
 | placement      | posición del popover en la pantalla      | string         | top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end | bottom                                   |
 | disabled       | si el popover está deshabilitado         | boolean        | —                                        | false                                    |
-| visible | si el popover está visible               | Boolean        | —                                        | false                                    |
+| visible / v-model:visible | si el popover está visible               | Boolean        | —                                        | false                                    |
 | offset         | popover offset                           | number         | —                                        | 0                                        |
 | transition     | animación de transición del popover | string         | —                                        | el-fade-in-linear                        |
 | show-arrow  | si una flecha del tooltip es mostrada o no. Para más información, por favor refiérase a [Vue-popper](https://github.com/element-component/vue-popper) | boolean        | —                                        | true                                     |

--- a/website/docs/es/popover.md
+++ b/website/docs/es/popover.md
@@ -162,7 +162,7 @@ Por supuesto, puedes anidar otras operaciones. Es más ligero que utilizar un `d
 | width          | ancho del popover                        | string, number | —                                        | Min width 150px                          |
 | placement      | posición del popover en la pantalla      | string         | top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end | bottom                                   |
 | disabled       | si el popover está deshabilitado         | boolean        | —                                        | false                                    |
-| value / v-model | si el popover está visible               | Boolean        | —                                        | false                                    |
+| visible | si el popover está visible               | Boolean        | —                                        | false                                    |
 | offset         | popover offset                           | number         | —                                        | 0                                        |
 | transition     | animación de transición del popover | string         | —                                        | el-fade-in-linear                        |
 | show-arrow  | si una flecha del tooltip es mostrada o no. Para más información, por favor refiérase a [Vue-popper](https://github.com/element-component/vue-popper) | boolean        | —                                        | true                                     |

--- a/website/docs/fr-FR/popover.md
+++ b/website/docs/fr-FR/popover.md
@@ -164,7 +164,7 @@ Vous pouvez aussi imbriquer des opérations. Procéder ainsi est plus léger que
 | width | Largeur du popover. | string, number  | — | Min width 150px |
 | placement | Emplacement du popover. | string | top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end |  bottom |
 | disabled | Si le popover est désactivé. | boolean | — |  false |
-| visible | Si le popover est visible. | Boolean | — |  false |
+| visible / v-model:visible | Si le popover est visible. | Boolean | — |  false |
 | offset | Décalage du popover. | number | — |  0 |
 | transition | Animation de transition du popover. | string | — | el-fade-in-linear |
 | show-arrow | Si une flèche doit être affichée ou non. Pour plus d'informations, référez-vous à [Vue-popper](https://github.com/element-component/vue-popper). | boolean | — | true |

--- a/website/docs/fr-FR/popover.md
+++ b/website/docs/fr-FR/popover.md
@@ -164,7 +164,7 @@ Vous pouvez aussi imbriquer des opérations. Procéder ainsi est plus léger que
 | width | Largeur du popover. | string, number  | — | Min width 150px |
 | placement | Emplacement du popover. | string | top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end |  bottom |
 | disabled | Si le popover est désactivé. | boolean | — |  false |
-| value / v-model | Si le popover est visible. | Boolean | — |  false |
+| visible | Si le popover est visible. | Boolean | — |  false |
 | offset | Décalage du popover. | number | — |  0 |
 | transition | Animation de transition du popover. | string | — | el-fade-in-linear |
 | show-arrow | Si une flèche doit être affichée ou non. Pour plus d'informations, référez-vous à [Vue-popper](https://github.com/element-component/vue-popper). | boolean | — | true |

--- a/website/docs/jp/popover.md
+++ b/website/docs/jp/popover.md
@@ -163,7 +163,7 @@ popoverの中には、他のコンポーネントを入れ子にすることが�
 |  width        |  popover幅  | string, number            | — | Min width 150px |
 |  placement        |  popover配置  | string | top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end |  bottom |
 |  disabled       |  popoverが無効になっているかどうか  | boolean    | — |  false |
-|  visible        |  popoverが表示されているかどうか  | Boolean           | — |  false |
+|  visible / v-model:visible  |  popoverが表示されているかどうか  | Boolean           | — |  false |
 |  offset        |  popoverオフセット  | number           | — |  0 |
 |  transition     |  popoverトランジションアニメーション      | string             | — | el-fade-in-linear |
 |  show-arrow   |  ツールチップの矢印が表示されているかどうかを指定します。詳細については [Vue-popper](https://github.com/element-component/vue-popper) | boolean | — | true |

--- a/website/docs/jp/popover.md
+++ b/website/docs/jp/popover.md
@@ -163,7 +163,7 @@ popoverの中には、他のコンポーネントを入れ子にすることが�
 |  width        |  popover幅  | string, number            | — | Min width 150px |
 |  placement        |  popover配置  | string | top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end |  bottom |
 |  disabled       |  popoverが無効になっているかどうか  | boolean    | — |  false |
-|  value / v-model        |  popoverが表示されているかどうか  | Boolean           | — |  false |
+|  visible        |  popoverが表示されているかどうか  | Boolean           | — |  false |
 |  offset        |  popoverオフセット  | number           | — |  0 |
 |  transition     |  popoverトランジションアニメーション      | string             | — | el-fade-in-linear |
 |  show-arrow   |  ツールチップの矢印が表示されているかどうかを指定します。詳細については [Vue-popper](https://github.com/element-component/vue-popper) | boolean | — | true |

--- a/website/docs/zh-CN/popover.md
+++ b/website/docs/zh-CN/popover.md
@@ -161,7 +161,7 @@ Popover 的属性与 Tooltip 很类似，它们都是基于`Vue-popper`开发的
 |  width        |  宽度  | String, Number            | — | 最小宽度 150px |
 |  placement        |  出现位置  | String | top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end |  bottom |
 |  disabled       |  Popover 是否可用  | Boolean           | — |  false |
-|  value / v-model        |  状态是否可见  | Boolean           | — |  false |
+|  visible        |  状态是否可见  | Boolean           | — |  false |
 |  offset        |  出现位置的偏移量  | Number           | — |  0 |
 |  transition     |  定义渐变动画      | String             | — | fade-in-linear |
 |  show-arrow   |  是否显示 Tooltip 箭头，更多参数可见[Vue-popper](https://github.com/element-component/vue-popper) | Boolean | — | true |

--- a/website/docs/zh-CN/popover.md
+++ b/website/docs/zh-CN/popover.md
@@ -161,7 +161,7 @@ Popover 的属性与 Tooltip 很类似，它们都是基于`Vue-popper`开发的
 |  width        |  宽度  | String, Number            | — | 最小宽度 150px |
 |  placement        |  出现位置  | String | top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end |  bottom |
 |  disabled       |  Popover 是否可用  | Boolean           | — |  false |
-|  visible        |  状态是否可见  | Boolean           | — |  false |
+|  visible / v-model:visible  |  状态是否可见  | Boolean           | — |  false |
 |  offset        |  出现位置的偏移量  | Number           | — |  0 |
 |  transition     |  定义渐变动画      | String             | — | fade-in-linear |
 |  show-arrow   |  是否显示 Tooltip 箭头，更多参数可见[Vue-popper](https://github.com/element-component/vue-popper) | Boolean | — | true |


### PR DESCRIPTION
Fix that the popover component value/v-model doesn't work, because the doc document doesn't synchronize the code changes, and the source code is actually visible to control