### PR TITLE
style(notification): fix style when its type set and title not set

### DIFF
--- a/packages/notification/src/index.vue
+++ b/packages/notification/src/index.vue
@@ -20,7 +20,7 @@
         :class="{ 'is-with-icon': typeClass || iconClass }"
       >
         <h2 class="el-notification__title" v-text="title"></h2>
-        <div v-show="message" class="el-notification__content">
+        <div v-show="message" class="el-notification__content" :style="!!title ? null : 'margin: 0'">
           <slot>
             <p v-if="!dangerouslyUseHTMLString">{{ message }}</p>
             <!-- Caution here, message could've been compromized, nerver use user's input as message -->

--- a/packages/theme-chalk/src/notification.scss
+++ b/packages/theme-chalk/src/notification.scss
@@ -37,8 +37,7 @@
 
   @include e(content) {
     font-size: $--notification-content-font-size;
-    line-height: 21px;
-    margin: 6px 0 0 0;
+    line-height: 24px;
     color: $--notification-content-color;
     text-align: justify;
 

--- a/packages/theme-chalk/src/notification.scss
+++ b/packages/theme-chalk/src/notification.scss
@@ -38,6 +38,7 @@
   @include e(content) {
     font-size: $--notification-content-font-size;
     line-height: 24px;
+    margin: 6px 0 0 0;
     color: $--notification-content-color;
     text-align: justify;
 


### PR DESCRIPTION
When you set type but not title in your notification, I don't think its style is centered. You can find this problem in the example on the official website.

In this modification, I checked 4 cases of setting and not setting type and title respectively, and the style is normal.

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
