### PR TITLE
fix(message-box): modified the default text of the ElMessageBox button

### DIFF
--- a/packages/message-box/src/index.vue
+++ b/packages/message-box/src/index.vue
@@ -155,7 +155,7 @@ export default defineComponent({
     callback: Function,
     cancelButtonText: {
       type: String,
-      default: 'Cancel',
+      default: t('el.messagebox.cancel'),
     },
     cancelButtonClass: String,
     center: Boolean,
@@ -173,7 +173,7 @@ export default defineComponent({
     },
     confirmButtonText: {
       type: String,
-      default: 'OK',
+      default: t('el.messagebox.confirm'),
     },
     confirmButtonClass: String,
     container: {


### PR DESCRIPTION
modified the default text of the ElMessageBox button

fix #1311

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

I changed the default values of `cancelButtonText` and `confirmButtonText` of the `ElMessageBox` component to take the data of i18n
