### PR TITLE
fix/popper-api-consistency

### DIFF
--- a/packages/popper/__tests__/popper.spec.ts
+++ b/packages/popper/__tests__/popper.spec.ts
@@ -257,7 +257,7 @@ describe('Popper.vue', () => {
       const wrapper = _mount({
         trigger: [CLICK_EVENT],
         appendToBody: false,
-        closeDelay: 0,
+        hideAfter: 0,
       })
       await nextTick()
 
@@ -286,7 +286,7 @@ describe('Popper.vue', () => {
       const wrapper = _mount({
         trigger: CLICK_EVENT,
         appendToBody: false,
-        closeDelay: 0,
+        hideAfter: 0,
       })
       await nextTick()
 
@@ -307,7 +307,7 @@ describe('Popper.vue', () => {
       const wrapper = _mount({
         trigger: ['hover'],
         appendToBody: false,
-        closeDelay: 0,
+        hideAfter: 0,
       })
       await nextTick()
 
@@ -337,7 +337,7 @@ describe('Popper.vue', () => {
       const wrapper = _mount({
         trigger: [FOCUS_EVENT],
         appendToBody: false,
-        closeDelay: 0,
+        hideAfter: 0,
       })
       await nextTick()
 
@@ -376,7 +376,7 @@ describe('Popper.vue', () => {
       const wrapper = _mount({
         trigger: [FOCUS_EVENT, CLICK_EVENT, 'hover'],
         appendToBody: false,
-        closeDelay: 0,
+        hideAfter: 0,
       })
       await nextTick()
 

--- a/packages/popper/src/use-popper/defaults.ts
+++ b/packages/popper/src/use-popper/defaults.ts
@@ -17,9 +17,9 @@ export type Trigger = TriggerType | TriggerType[]
 
 export type IPopperOptions = {
   arrowOffset: number
+  autoClose: number
   boundariesPadding: number
   class: string
-  closeDelay: number
   cutoff: boolean
   disabled: boolean
   enterable: boolean
@@ -50,6 +50,10 @@ export default {
     type: Boolean,
     default: true,
   },
+  autoClose: {
+    type: Number,
+    default: 0,
+  },
   boundariesPadding: {
     type: Number,
     default: 0,
@@ -63,7 +67,7 @@ export default {
     default: '',
   },
   style: Object,
-  closeDelay: {
+  hideAfter: {
     type: Number,
     default: 200,
   },
@@ -82,10 +86,6 @@ export default {
   enterable: {
     type: Boolean,
     default: true,
-  },
-  hideAfter: {
-    type: Number,
-    default: 0,
   },
   manualMode: {
     type: Boolean,

--- a/packages/popper/src/use-popper/index.ts
+++ b/packages/popper/src/use-popper/index.ts
@@ -70,10 +70,10 @@ export default function(
   })
 
   function _show() {
-    if (props.hideAfter > 0) {
+    if (props.autoClose > 0) {
       hideTimer = window.setTimeout(() => {
         _hide()
-      }, props.hideAfter)
+      }, props.autoClose)
     }
     visibility.value = true
   }
@@ -102,10 +102,10 @@ export default function(
   const hide = () => {
     if (isManualMode()) return
     clearTimers()
-    if (props.closeDelay > 0) {
+    if (props.hideAfter > 0) {
       hideTimer = window.setTimeout(() => {
         close()
-      }, props.closeDelay)
+      }, props.hideAfter)
     } else {
       close()
     }

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -44,7 +44,7 @@ export default defineComponent({
     },
     hideAfter: {
       type: Number,
-      default: 0,
+      default: 200,
     },
     manual: {
       type: Boolean,

--- a/website/docs/en-US/popover.md
+++ b/website/docs/en-US/popover.md
@@ -170,7 +170,7 @@ Of course, you can nest other operations. It's more light-weight than using a di
 |  popper-options        | parameters for [popper.js](https://popper.js.org/documentation.html) | object            | please refer to [popper.js](https://popper.js.org/documentation.html) | `{ boundariesElement: 'body', gpuAcceleration: false }` |
 |  popper-class        |  custom class name for popover | string | — | — |
 | show-after | delay of appearance, in millisecond | number | — | 0 |
-| close-after | delay of disappear, in millisecond | number | — | 0 |
+| hide-after | delay of disappear, in millisecond | number | — | 0 |
 | auto-close | timeout in milliseconds to hide tooltip | number | — | 0 |
 |  tabindex          | [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) of Popover | number | — | 0 |
 

--- a/website/docs/en-US/popover.md
+++ b/website/docs/en-US/popover.md
@@ -169,8 +169,9 @@ Of course, you can nest other operations. It's more light-weight than using a di
 |  show-arrow   |  whether a tooltip arrow is displayed or not. For more info, please refer to [Vue-popper](https://github.com/element-component/vue-popper) | boolean | — | true |
 |  popper-options        | parameters for [popper.js](https://popper.js.org/documentation.html) | object            | please refer to [popper.js](https://popper.js.org/documentation.html) | `{ boundariesElement: 'body', gpuAcceleration: false }` |
 |  popper-class        |  custom class name for popover | string | — | — |
-|  show-after        | delay before appearing when `trigger` is hover, in milliseconds | number | — | 0 |
-|  close-delay        | delay before disappearing when `trigger` is hover, in milliseconds | number | — | 200 |
+| show-after | delay of appearance, in millisecond | number | — | 0 |
+| close-after | delay of disappear, in millisecond | number | — | 0 |
+| auto-close | timeout in milliseconds to hide tooltip | number | — | 0 |
 |  tabindex          | [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) of Popover | number | — | 0 |
 
 ### Slot

--- a/website/docs/en-US/tooltip.md
+++ b/website/docs/en-US/tooltip.md
@@ -192,7 +192,7 @@ Disabled form elements are not supported for Tooltip, more information can be fo
 |  visible-arrow   |  whether an arrow is displayed. For more information, check [Vue-popper](https://github.com/element-component/vue-popper) page | boolean | — | true |
 |  popper-options        | [popper.js](https://popper.js.org/documentation.html) parameters | Object            | refer to [popper.js](https://popper.js.org/documentation.html) doc | `{ boundariesElement: 'body', gpuAcceleration: false }` |
 | show-after | delay of appearance, in millisecond | number | — | 0 |
-| close-after | delay of disappear, in millisecond | number | — | 0 |
+| hide-after | delay of disappear, in millisecond | number | — | 0 |
 | auto-close | timeout in milliseconds to hide tooltip | number | — | 0 |
 | manual | whether to control Tooltip manually. `mouseenter` and `mouseleave` won't have effects if set to `true` | boolean | — | false |
 |  popper-class  |  custom class name for Tooltip's popper | string | — | — |

--- a/website/docs/en-US/tooltip.md
+++ b/website/docs/en-US/tooltip.md
@@ -191,9 +191,10 @@ Disabled form elements are not supported for Tooltip, more information can be fo
 |  transition     |  animation name | string             | — | el-fade-in-linear |
 |  visible-arrow   |  whether an arrow is displayed. For more information, check [Vue-popper](https://github.com/element-component/vue-popper) page | boolean | — | true |
 |  popper-options        | [popper.js](https://popper.js.org/documentation.html) parameters | Object            | refer to [popper.js](https://popper.js.org/documentation.html) doc | `{ boundariesElement: 'body', gpuAcceleration: false }` |
-| open-delay | delay of appearance, in millisecond | number | — | 0 |
+| show-after | delay of appearance, in millisecond | number | — | 0 |
+| close-after | delay of disappear, in millisecond | number | — | 0 |
+| auto-close | timeout in milliseconds to hide tooltip | number | — | 0 |
 | manual | whether to control Tooltip manually. `mouseenter` and `mouseleave` won't have effects if set to `true` | boolean | — | false |
 |  popper-class  |  custom class name for Tooltip's popper | string | — | — |
 | enterable | whether the mouse can enter the tooltip | Boolean | — | true |
-| hide-after | timeout in milliseconds to hide tooltip | number | — | 0 |
 | tabindex   | [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) of Tooltip | number | — | 0 |

--- a/website/docs/es/popover.md
+++ b/website/docs/es/popover.md
@@ -168,8 +168,9 @@ Por supuesto, puedes anidar otras operaciones. Es más ligero que utilizar un `d
 | show-arrow  | si una flecha del tooltip es mostrada o no. Para más información, por favor refiérase a [Vue-popper](https://github.com/element-component/vue-popper) | boolean        | —                                        | true                                     |
 | popper-options | parámetros para [popper.js](https://popper.js.org/documentation.html) | object         | por favor, refiérase a [popper.js](https://popper.js.org/documentation.html) | `{ boundariesElement: 'body', gpuAcceleration: false }` |
 | popper-class   | clase propia para popover                | string         | —                                        | —                                        |
-| show-after     | retraso de la aparición cuando `trigger` es hover, en milisegundos | number         | —                                        | 0                                        |
-| close-delay    | Retraso antes de desaparecer cuando el `trigger` es hover, en milisegundos. | number | — | 200 |
+| show-after     | retraso de la apariencia, en milisegundos | number  | —                                        | 0                                        |
+| close-after     | retraso en el cierre, en milisegundos | number  | —                                        | 0                                        |
+| auto-close     | tiempo a esperar en milisegundos para esconder el Tooltip | number  | —                                        | 0                                        |
 | tabindex       | [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) de Popover |   number           |      —      |  0    |
 
 ### Slot

--- a/website/docs/es/popover.md
+++ b/website/docs/es/popover.md
@@ -169,7 +169,7 @@ Por supuesto, puedes anidar otras operaciones. Es más ligero que utilizar un `d
 | popper-options | parámetros para [popper.js](https://popper.js.org/documentation.html) | object         | por favor, refiérase a [popper.js](https://popper.js.org/documentation.html) | `{ boundariesElement: 'body', gpuAcceleration: false }` |
 | popper-class   | clase propia para popover                | string         | —                                        | —                                        |
 | show-after     | retraso de la apariencia, en milisegundos | number  | —                                        | 0                                        |
-| close-after     | retraso en el cierre, en milisegundos | number  | —                                        | 0                                        |
+| hide-after     | retraso en el cierre, en milisegundos | number  | —                                        | 0                                        |
 | auto-close     | tiempo a esperar en milisegundos para esconder el Tooltip | number  | —                                        | 0                                        |
 | tabindex       | [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) de Popover |   number           |      —      |  0    |
 

--- a/website/docs/es/tooltip.md
+++ b/website/docs/es/tooltip.md
@@ -191,9 +191,10 @@ Es necesario envolver los elementos de forma deshabilitados en un elemento conte
 | transition     | nombre de animación                      | string  | —                                        | el-fade-in-linear                        |
 | visible-arrow  | si una flecha es mostrada. Para mayor información, revisar la página de [Vue-popper](https://github.com/element-component/vue-popper) | boolean | —                                        | true                                     |
 | popper-options | parámetros de [popper.js](https://popper.js.org/documentation.html) | Object  | referirse a la documentación de [popper.js](https://popper.js.org/documentation.html) | `{ boundariesElement: 'body', gpuAcceleration: false }` |
-| open-delay     | retraso de la apariencia, en milisegundos | number  | —                                        | 0                                        |
+| show-after     | retraso de la apariencia, en milisegundos | number  | —                                        | 0                                        |
+| close-after     | retraso en el cierre, en milisegundos | number  | —                                        | 0                                        |
+| auto-close     | tiempo a esperar en milisegundos para esconder el Tooltip | number  | —                                        | 0                                        |
 | manual         | si el Tooltipo será controlado de forma manual. `mouseenter` y `mouseleave` no tendrán efecto si fue establecido como `true` | boolean | —                                        | false                                    |
 | popper-class   | nombre de clase personalizada para el popper del Tooltip | string  | —                                        | —                                        |
 | enterable      | si el mouse puede entrar al Tooltip      | Boolean | —                                        | true                                     |
-| hide-after     | tiempo a esperar en milisegundos para esconder el Tooltip | number  | —                                        | 0                                        |
 | tabindex       | [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) of Tooltip | number   | —                      | 0              |

--- a/website/docs/es/tooltip.md
+++ b/website/docs/es/tooltip.md
@@ -192,7 +192,7 @@ Es necesario envolver los elementos de forma deshabilitados en un elemento conte
 | visible-arrow  | si una flecha es mostrada. Para mayor información, revisar la página de [Vue-popper](https://github.com/element-component/vue-popper) | boolean | —                                        | true                                     |
 | popper-options | parámetros de [popper.js](https://popper.js.org/documentation.html) | Object  | referirse a la documentación de [popper.js](https://popper.js.org/documentation.html) | `{ boundariesElement: 'body', gpuAcceleration: false }` |
 | show-after     | retraso de la apariencia, en milisegundos | number  | —                                        | 0                                        |
-| close-after     | retraso en el cierre, en milisegundos | number  | —                                        | 0                                        |
+| hide-after     | retraso en el cierre, en milisegundos | number  | —                                        | 0                                        |
 | auto-close     | tiempo a esperar en milisegundos para esconder el Tooltip | number  | —                                        | 0                                        |
 | manual         | si el Tooltipo será controlado de forma manual. `mouseenter` y `mouseleave` no tendrán efecto si fue establecido como `true` | boolean | —                                        | false                                    |
 | popper-class   | nombre de clase personalizada para el popper del Tooltip | string  | —                                        | —                                        |

--- a/website/docs/fr-FR/popover.md
+++ b/website/docs/fr-FR/popover.md
@@ -170,8 +170,9 @@ Vous pouvez aussi imbriquer des opérations. Procéder ainsi est plus léger que
 | show-arrow | Si une flèche doit être affichée ou non. Pour plus d'informations, référez-vous à [Vue-popper](https://github.com/element-component/vue-popper). | boolean | — | true |
 | popper-options | Paramètres pour [popper.js](https://popper.js.org/documentation.html). | object | Référez-vous à [popper.js](https://popper.js.org/documentation.html). | `{ boundariesElement: 'body', gpuAcceleration: false }` |
 | popper-class | Classe du popover. | string | — | — |
-| show-after | Délai d'affichage, lorsque `trigger` est 'hover', en millisecondes. | number | — | 0 |
-| close-delay | delay before disappearing when `trigger` is hover, in milliseconds | number | — | 200 |
+| show-after | Délai avant l'apparition en millisecondes. | number | — | 0 |
+| show-after | Le temps de disparaître en millisecondes | number | — | 0 |
+| auto-close | Délai avant disparition. | number | — | 0 |
 | tabindex   | [tabindex](https://developer.mozilla.org/fr/docs/Web/HTML/Attributs_universels/tabindex) de Popover | number | — | 0 |
 
 ### Slot

--- a/website/docs/fr-FR/popover.md
+++ b/website/docs/fr-FR/popover.md
@@ -171,7 +171,7 @@ Vous pouvez aussi imbriquer des opérations. Procéder ainsi est plus léger que
 | popper-options | Paramètres pour [popper.js](https://popper.js.org/documentation.html). | object | Référez-vous à [popper.js](https://popper.js.org/documentation.html). | `{ boundariesElement: 'body', gpuAcceleration: false }` |
 | popper-class | Classe du popover. | string | — | — |
 | show-after | Délai avant l'apparition en millisecondes. | number | — | 0 |
-| show-after | Le temps de disparaître en millisecondes | number | — | 0 |
+| hide-after | Le temps de disparaître en millisecondes | number | — | 0 |
 | auto-close | Délai avant disparition. | number | — | 0 |
 | tabindex   | [tabindex](https://developer.mozilla.org/fr/docs/Web/HTML/Attributs_universels/tabindex) de Popover | number | — | 0 |
 

--- a/website/docs/fr-FR/tooltip.md
+++ b/website/docs/fr-FR/tooltip.md
@@ -193,7 +193,7 @@ Les éléments de formulaire désactivés ne sont pas supportés par Tooltip, pl
 | visible-arrow | Si une flèche doit être affichée. Pour plus d'information, voir [Vue-popper](https://github.com/element-component/vue-popper). | boolean | — | true |
 | popper-options | Paramètres [popper.js](https://popper.js.org/documentation.html). | Object | Se référer à  [popper.js](https://popper.js.org/documentation.html). | `{ boundariesElement: 'body', gpuAcceleration: false }` |
 | show-after | Délai avant l'apparition en millisecondes. | number | — | 0 |
-| show-after | Le temps de disparaître en millisecondes | number | — | 0 |
+| hide-after | Le temps de disparaître en millisecondes | number | — | 0 |
 | auto-close | Délai avant disparition. | number | — | 0 |
 | manual | Si le contrôle du Tooltip doit être manuel. `mouseenter` et `mouseleave` n'auront pas d'effet si `true`. | boolean | — | false |
 | popper-class | Classe du popper de Tooltip. | string | — | — |

--- a/website/docs/fr-FR/tooltip.md
+++ b/website/docs/fr-FR/tooltip.md
@@ -192,9 +192,10 @@ Les éléments de formulaire désactivés ne sont pas supportés par Tooltip, pl
 | transition | Animation de transition. | string | — | el-fade-in-linear |
 | visible-arrow | Si une flèche doit être affichée. Pour plus d'information, voir [Vue-popper](https://github.com/element-component/vue-popper). | boolean | — | true |
 | popper-options | Paramètres [popper.js](https://popper.js.org/documentation.html). | Object | Se référer à  [popper.js](https://popper.js.org/documentation.html). | `{ boundariesElement: 'body', gpuAcceleration: false }` |
-| open-delay | Délai avant l'apparition en millisecondes. | number | — | 0 |
+| show-after | Délai avant l'apparition en millisecondes. | number | — | 0 |
+| show-after | Le temps de disparaître en millisecondes | number | — | 0 |
+| auto-close | Délai avant disparition. | number | — | 0 |
 | manual | Si le contrôle du Tooltip doit être manuel. `mouseenter` et `mouseleave` n'auront pas d'effet si `true`. | boolean | — | false |
 | popper-class | Classe du popper de Tooltip. | string | — | — |
 | enterable | Si la souris peut entrer dans la Tooltip. | Boolean | — | true |
-| hide-after | Délai avant disparition. | number | — | 0 |
 | tabindex   | [tabindex](https://developer.mozilla.org/fr/docs/Web/HTML/Attributs_universels/tabindex) de Tooltip. | number | — | 0 |

--- a/website/docs/jp/popover.md
+++ b/website/docs/jp/popover.md
@@ -169,8 +169,9 @@ popoverの中には、他のコンポーネントを入れ子にすることが�
 |  show-arrow   |  ツールチップの矢印が表示されているかどうかを指定します。詳細については [Vue-popper](https://github.com/element-component/vue-popper) | boolean | — | true |
 |  popper-options        | [popper.js](https://popper.js.org/documentation.html) のためのパラメータ | object            | please refer to [popper.js](https://popper.js.org/documentation.html) | `{ boundariesElement: 'body', gpuAcceleration: false }` |
 |  popper-class        |  popover用カスタムクラス名 | string | — | — |
-|  show-after        | `trigger` がホバーされたときに表示されるまでの遅延時間(ミリ秒単位) | number | — | 0 |
-|  close-delay        | `trigger` がホバーされたときに消えるまでの遅延時間(ミリ秒単位) | number | — | 200 |
+| show-after | ミリ秒単位の出現の遅延 | number | — | 0 |
+| hide-after | ミリ秒単位の消えるの遅延 | number | — | 0 |
+| auto-close | ツールチップを非表示にするタイムアウト（ミリ秒単位） | number | — | 0 |
 |  tabindex          | [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) のpopover | number | — | 0 |
 
 ### スロット

--- a/website/docs/jp/tooltip.md
+++ b/website/docs/jp/tooltip.md
@@ -191,9 +191,10 @@
 |  transition     |  アニメーション名 | string             | — | el-fade-in-linear |
 |  visible-arrow   |  矢印が表示されているかどうかを指定します。詳しくは、[Vue-popper](https://github.com/element-component/vue-popper)のページを参照してください。 | boolean | — | true |
 |  popper-options        | [popper.js](https://popper.js.org/documentation.html) parameters | Object            | refer to [popper.js](https://popper.js.org/documentation.html) doc | `{ boundariesElement: 'body', gpuAcceleration: false }` |
-| open-delay | ミリ秒単位の出現の遅延 | number | — | 0 |
+| show-after | ミリ秒単位の出現の遅延 | number | — | 0 |
+| hide-after | ミリ秒単位の消えるの遅延 | number | — | 0 |
+| auto-close | ツールチップを非表示にするタイムアウト（ミリ秒単位） | number | — | 0 |
 | manual | ツールチップを手動で制御するかどうかを指定します。`true` に設定すると `mouseenter` と `mouseleave` は効果を持ちません。 | boolean | — | false |
 |  popper-class  |  ツールチップのポッパーのカスタムクラス名 | string | — | — |
 | enterable | マウスがツールチップに入るかどうか | Boolean | — | true |
-| hide-after | ツールチップを非表示にするタイムアウト（ミリ秒単位） | number | — | 0 |
 | tabindex   | [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) のツールチップ | number | — | 0 |

--- a/website/docs/zh-CN/popover.md
+++ b/website/docs/zh-CN/popover.md
@@ -167,8 +167,9 @@ Popover 的属性与 Tooltip 很类似，它们都是基于`Vue-popper`开发的
 |  show-arrow   |  是否显示 Tooltip 箭头，更多参数可见[Vue-popper](https://github.com/element-component/vue-popper) | Boolean | — | true |
 |  popper-options        | [popper.js](https://popper.js.org/documentation.html) 的参数 | Object            | 参考 [popper.js](https://popper.js.org/documentation.html) 文档 | `{ boundariesElement: 'body', gpuAcceleration: false }` |
 | popper-class | 为 popper 添加类名 | String | — | — |
-| show-after | 触发方式为 hover 时的显示延迟，单位为毫秒 | Number | — | 0 |
-| close-delay | 触发方式为 hover 时的隐藏延迟，单位为毫秒 | number | — | 200 |
+| show-after | 延迟出现，单位毫秒 | Number | — | 0 |
+| hide-after | 延迟关闭，单位毫秒 | Number | — | 0 |
+| auto-close | Tooltip 出现后自动隐藏延时，单位毫秒，为 0 则不会自动隐藏 | number | — | 0 |
 | tabindex   | Popover 组件的 [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) | number | — | 0 |
 
 ### Slot

--- a/website/docs/zh-CN/tooltip.md
+++ b/website/docs/zh-CN/tooltip.md
@@ -172,9 +172,10 @@ tooltip 内不支持 disabled form 元素，参考[MDN](https://developer.mozill
 |  transition     |  定义渐变动画      | String             | — | el-fade-in-linear |
 |  visible-arrow   |  是否显示 Tooltip 箭头，更多参数可见[Vue-popper](https://github.com/element-component/vue-popper) | Boolean | — | true |
 |  popper-options        | [popper.js](https://popper.js.org/documentation.html) 的参数 | Object            | 参考 [popper.js](https://popper.js.org/documentation.html) 文档 | { boundariesElement: 'body', gpuAcceleration: false } |
-| open-delay | 延迟出现，单位毫秒 | Number | — | 0 |
+| show-after | 延迟出现，单位毫秒 | Number | — | 0 |
+| hide-after | 延迟关闭，单位毫秒 | Number | — | 0 |
+| auto-close | Tooltip 出现后自动隐藏延时，单位毫秒，为 0 则不会自动隐藏 | number | — | 0 |
 | manual | 手动控制模式，设置为 true 后，mouseenter 和 mouseleave 事件将不会生效 | Boolean | — | false |
 | popper-class | 为 Tooltip 的 popper 添加类名 | String | — | — |
 | enterable | 鼠标是否可进入到 tooltip 中 | Boolean | — | true |
-| hide-after | Tooltip 出现后自动隐藏延时，单位毫秒，为 0 则不会自动隐藏 | number | — | 0 |
 | tabindex   | Tooltip 组件的 [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) | number | — | 0 |


### PR DESCRIPTION
- Fix `tooltip` API attributes
- Fix `popover` API attributes
- Reorganize API: 
  - Rename `hide-after` to `auto-close` for better semantic.
  - Make `show-after` and `hide-after` as a pair API for better semantic.
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
