### PR TITLE
fix(notification): remove dom when destoryed

### DIFF
--- a/packages/form/src/form-item.vue
+++ b/packages/form/src/form-item.vue
@@ -63,7 +63,7 @@ import LabelWrap from './label-wrap'
 import { getPropByPath, useGlobalConfig } from '@element-plus/utils/util'
 import { isValidComponentSize } from '@element-plus/utils/validators'
 import mitt from 'mitt'
-import { elFormKey, elFormItemKey } from './token'
+import { elFormKey, elFormItemKey, elFormEvents } from './token'
 
 import type { PropType } from 'vue'
 import type { ElFormContext, ValidateFieldCallback } from './token'
@@ -339,7 +339,7 @@ export default defineComponent({
 
     onMounted(() => {
       if (props.prop) {
-        elForm.formMitt?.emit('el.form.addField', elFormItem)
+        elForm.formMitt?.emit(elFormEvents.addField, elFormItem)
 
         let value = fieldValue.value
         initialValue = Array.isArray(value)
@@ -349,7 +349,7 @@ export default defineComponent({
       }
     })
     onBeforeUnmount(() => {
-      elForm.formMitt?.emit('el.form.removeField', elFormItem)
+      elForm.formMitt?.emit(elFormEvents.removeField, elFormItem)
     })
 
     provide(elFormItemKey, elFormItem)

--- a/packages/notification/__tests__/notification.spec.ts
+++ b/packages/notification/__tests__/notification.spec.ts
@@ -139,7 +139,8 @@ describe('Notification.vue', () => {
 
       const closeBtn = wrapper.find('.el-notification__closeBtn')
       expect(closeBtn.exists()).toBe(true)
-      wrapper.vm.destroyElement()
+      wrapper.vm.visible = false
+      wrapper.vm.onClose()
 
       expect(onClose).toHaveBeenCalled()
     })

--- a/packages/notification/src/index.vue
+++ b/packages/notification/src/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition name="el-notification-fade">
+  <transition name="el-notification-fade" @after-leave="onClose">
     <div
       v-show="visible"
       :id="id"
@@ -117,14 +117,6 @@ export default defineComponent({
       timer,
     }
   },
-  watch: {
-    closed(newVal: boolean) {
-      if (newVal) {
-        this.visible = false
-        on(this.$el, 'transitionend', this.destroyElement)
-      }
-    },
-  },
   mounted() {
     if (this.duration > 0) {
       this.timer = setTimeout(() => {
@@ -140,11 +132,6 @@ export default defineComponent({
     off(document, 'keydown', this.keydown)
   },
   methods: {
-    destroyElement() {
-      this.visible = false
-      off(this.$el, 'transitionend', this.destroyElement)
-      this.onClose()
-    },
     // start counting down to destroy notification instance
     startTimer() {
       if (this.duration > 0) {
@@ -165,6 +152,7 @@ export default defineComponent({
       this?.onClick()
     },
     close() {
+      this.visible = false
       this.closed = true
       this.timer = null
     },


### PR DESCRIPTION
fixed: notification component dom destory.  relative issue #1225
optimize: remove the magic event name string in form-item.

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
