### PR TITLE
fix(table): fix that the column width is calculated incorrectly

### DIFF
--- a/packages/table/src/table-column/render-helper.ts
+++ b/packages/table/src/table-column/render-helper.ts
@@ -10,7 +10,7 @@ import { cellForced, defaultRenderCell, treeCellPrefix } from '../config'
 import { parseWidth, parseMinWidth } from '../util'
 import { TableColumn, TableColumnCtx } from '../table.type'
 
-function useRender(props: TableColumnCtx, slots, owner: ComputedRef<any>) {
+function useRender (props: TableColumnCtx, slots, owner: ComputedRef<any>) {
   const instance = (getCurrentInstance() as unknown) as TableColumn
   const columnId = ref('')
   const isSubColumn = ref(false)
@@ -69,7 +69,7 @@ function useRender(props: TableColumnCtx, slots, owner: ComputedRef<any>) {
     } else {
       check(children)
     }
-    function check(item) {
+    function check (item) {
       if (item?.type?.name === 'ElTableColumn') {
         item.vParent = instance
       }
@@ -122,9 +122,6 @@ function useRender(props: TableColumnCtx, slots, owner: ComputedRef<any>) {
         }
         if (column.showOverflowTooltip) {
           props.class += ' el-tooltip'
-          props.style = {
-            width: (data.column.realWidth || data.column.width) - 1 + 'px',
-          }
         }
         checkSubColumn(children)
         return h('div', props, [prefix, children])


### PR DESCRIPTION
Fix the bug that the column width is calculated incorrectly when dragging the header

fix #1335

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
