### PR TITLE
fix(table): fix that the column width is calculated incorrectly

### DIFF
--- a/packages/table/src/table-body/styles-helper.ts
+++ b/packages/table/src/table-body/styles-helper.ts
@@ -2,7 +2,7 @@ import { getCurrentInstance } from 'vue'
 import { TableBodyProps } from './table-body'
 import { Table, AnyObject, TableColumnCtx } from '../table.type'
 
-function useStyles(props: TableBodyProps) {
+function useStyles (props: TableBodyProps) {
   const instance = getCurrentInstance()
   const parent = instance.parent as Table
   const isColumnHidden = index => {
@@ -146,7 +146,7 @@ function useStyles(props: TableBodyProps) {
       return columns[index].realWidth
     }
     const widthArr = columns
-      .map(({ realWidth }) => realWidth)
+      .map(({ realWidth, width }) => realWidth || width)
       .slice(index, index + colspan)
     return widthArr.reduce((acc, width) => acc + width, -1)
   }


### PR DESCRIPTION
Fix the bug that the column width is calculated incorrectly when dragging the header

fix #1355

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
