### PR TITLE
fix(dropdown): fix popper position error

### DIFF
--- a/packages/theme-chalk/src/dropdown.scss
+++ b/packages/theme-chalk/src/dropdown.scss
@@ -7,19 +7,7 @@
   position: relative;
   color: $--color-text-regular;
   font-size: $--font-size-base;
-  line-height: $--input-height;
-
-  @include m(mini) {
-    line-height: $--input-mini-height;
-  }
-
-  @include m(small) {
-    line-height: $--input-small-height;
-  }
-
-  @include m(medium) {
-    line-height: $--input-medium-height;
-  }
+  line-height: 1;
 
   @include e(popper) {
     // using attributes selector to override


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

Fix popper position error when trigger element's height is less than line-height.
