### PR TITLE
fix(table): fix column default rendering errors

### DIFF
--- a/packages/table/src/table-column/index.ts
+++ b/packages/table/src/table-column/index.ts
@@ -74,10 +74,10 @@ export default defineComponent({
     index: [Number, Function],
     sortOrders: {
       type: Array,
-      default() {
+      default () {
         return ['ascending', 'descending', null]
       },
-      validator(val: unknown[]) {
+      validator (val: unknown[]) {
         return val.every(
           (order: string) =>
             ['ascending', 'descending', null].indexOf(order) > -1,
@@ -85,7 +85,7 @@ export default defineComponent({
       },
     },
   },
-  setup(prop, { slots }) {
+  setup (prop, { slots }) {
     const instance = getCurrentInstance() as TableColumn
     const columnConfig = ref<Partial<TableColumnCtx>>({})
     const props = (prop as unknown) as TableColumnCtx
@@ -187,14 +187,16 @@ export default defineComponent({
       const children = isSubColumn.value
         ? parent.vnode.el.children
         : parent.refs.hiddenColumns?.children
-      const getColumnIndex = () => getColumnElIndex(children || [], instance.vnode.el)
+      const getColumnIndex = () =>
+        getColumnElIndex(children || [], instance.vnode.el)
       columnConfig.value.getColumnIndex = getColumnIndex
       const columnIndex = getColumnIndex()
-      columnIndex > -1 && owner.value.store.commit(
-        'insertColumn',
-        columnConfig.value,
-        isSubColumn.value ? parent.columnConfig.value : null,
-      )
+      columnIndex > -1 &&
+        owner.value.store.commit(
+          'insertColumn',
+          columnConfig.value,
+          isSubColumn.value ? parent.columnConfig.value : null,
+        )
     })
     onBeforeUnmount(() => {
       owner.value.store.commit(
@@ -209,18 +211,9 @@ export default defineComponent({
     instance.columnConfig = columnConfig
     return
   },
-  render() {
+  render () {
     try {
-      return h(
-        'div',
-        this.$slots.default?.({
-          store: {},
-          _self: {},
-          column: {},
-          row: {},
-          $index: -1,
-        }),
-      )
+      return h('div', this.$slots.default?.())
     } catch {
       return h('div')
     }


### PR DESCRIPTION
When rendering columns by default, default parameters should not be provided. Default parameters
cannot be passed in as props of other components, which will cause other components to report errors

fix #1232

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
