### PR TITLE
fix(docs): the page generates multiple useless form elements

### DIFF
--- a/website/components/demo-block.vue
+++ b/website/components/demo-block.vue
@@ -237,6 +237,7 @@ ${this.codepen.style}
       document.body.appendChild(form)
 
       form.submit()
+      document.body.removeChild(form)
     },
 
     scrollHandler() {


### PR DESCRIPTION
点击文档示例代码块中的“在线运行", 页面总是会生成新的 form 元素，当跳转到 ”codepen.io" 后，该 form 元素就没有用了，应该删除，否则多次点击“在线运行”，form 元素递增
