### PR TITLE
feat(components): [el-upload] `clearFiles` support filter status

### DIFF
--- a/packages/components/upload/src/useHandlers.ts
+++ b/packages/components/upload/src/useHandlers.ts
@@ -6,6 +6,7 @@ import cloneDeep from 'lodash/cloneDeep'
 import type {
   ListType,
   UploadFile,
+  UploadStatus,
   ElFile,
   ElUploadProgressEvent,
   IUseHandlersProps,
@@ -33,15 +34,9 @@ export default (props: IUseHandlersProps) => {
     uploadRef.value.abort(file)
   }
 
-  function clearFiles(status = ['success', 'fail']) {
-    uploadFiles.value = []
-    let n
-    uploadFiles.value = uploadFiles.value.filter(row => {
-      n = 0
-      status.forEach(item => {
-        n += row.status === item
-      })
-      return !n
+  function clearFiles(status: UploadStatus[] = ['success', 'fail']) {
+    uploadFiles.value = uploadFiles.value.filter((row) => {
+      return status.indexOf(row.status) === -1
     })
   }
 

--- a/packages/components/upload/src/useHandlers.ts
+++ b/packages/components/upload/src/useHandlers.ts
@@ -33,8 +33,16 @@ export default (props: IUseHandlersProps) => {
     uploadRef.value.abort(file)
   }
 
-  function clearFiles() {
+  function clearFiles(status = ['success', 'fail']) {
     uploadFiles.value = []
+    let n
+    uploadFiles.value = uploadFiles.value.filter(row => {
+      n = 0
+      status.forEach(item => {
+        n += row.status === item
+      })
+      return !n
+    })
   }
 
   function handleError(err: Error, rawFile: ElFile) {


### PR DESCRIPTION
[https://github.com/ElemeFE/element/pull/18518/commits/9116ae75f6787fa60075776c2b3f2df478a2c424](https://github.com/ElemeFE/element/pull/18518/commits/9116ae75f6787fa60075776c2b3f2df478a2c424)


## 问题描述：多选文件上传时，第一个文件上传成功后会清空上传文件列表（包括正在上传的文件），导致后续文件上传成功后页面报错

## 修复clearFiles方法：上传多个文件时，当第一个文件上传成功后，只清除uploadFiles中成功和失败的文件。
