### PR TITLE
perf(select): select options watch flush post

### DIFF
--- a/packages/carousel/__tests__/carousel.spec.ts
+++ b/packages/carousel/__tests__/carousel.spec.ts
@@ -210,6 +210,7 @@ describe('Carousel', () => {
     await nextTick()
     await wrapper.find('.el-carousel').trigger('mouseenter')
     const items = wrapper.vm.$el.querySelectorAll('.el-carousel__item')
+    await nextTick()
     await wait(60)
     expect(items[1].classList.contains('is-active')).toBeTruthy()
     done()

--- a/packages/select/__tests__/select.spec.ts
+++ b/packages/select/__tests__/select.spec.ts
@@ -164,6 +164,38 @@ describe('Select', () => {
     expect(wrapper.find('.el-input__inner').element.value).toBe('双皮奶')
   })
 
+
+  test('sync set value and options', async () => {
+    const wrapper = _mount(`
+    <el-select v-model="value">
+      <el-option
+        v-for="item in options"
+        :label="item.label"
+        :key="item.value"
+        :value="item.value">
+      </el-option>
+    </el-select>
+  `,
+    () => ({
+      options: [{
+        value: '选项1',
+        label: '黄金糕',
+      }, {
+        value: '选项2',
+        label: '双皮奶',
+      }],
+      value: '选项2',
+    }))
+    const vm = wrapper.vm as any
+    vm.options = [{
+      value: '选项1',
+      label: '黄金糕',
+    }]
+    vm.value = '选项1'
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.el-input__inner').element.value).toBe('黄金糕')
+  })
+
   test('single select', async () => {
     const wrapper = _mount(`
       <el-select v-model="value" @change="handleChange">

--- a/packages/select/src/useSelect.ts
+++ b/packages/select/src/useSelect.ts
@@ -229,6 +229,9 @@ export const useSelect = (props, states: States, ctx) => {
         checkDefaultFirstOption()
       }
     },
+    {
+      flush: 'post',
+    },
   )
 
   watch(() => states.hoverIndex, val => {


### PR DESCRIPTION
option after next-tick invoke select.onOptionCreate

![image](https://user-images.githubusercontent.com/31573022/109110875-e496d780-7772-11eb-8ec9-1fdfba68f057.png)

When some options are added to the select, the watch function will execute once for each option. When many options are added, the performance of the select will be poor, for example, when there are multiple time-select components with a step of 1 minute.

"fix #1512" "fix #1526" 

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
