### PR TITLE
fix(avatar): need reset hasLoadError to false, if src changed

### DIFF
--- a/packages/avatar/src/index.vue
+++ b/packages/avatar/src/index.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref, PropType } from 'vue'
+import { defineComponent, computed, ref, PropType, watch, toRefs } from 'vue'
 
 const ERROR_EVENT = 'error'
 export default defineComponent({
@@ -49,6 +49,12 @@ export default defineComponent({
   emits: [ERROR_EVENT],
   setup(props, { emit }) {
     const hasLoadError = ref(false)
+
+    const { src } = toRefs(props)
+    // need reset hasLoadError to false if src changed
+    watch(src,()=>{
+      hasLoadError.value = false
+    })
 
     const avatarClass = computed(() => {
       const { size, icon, shape } = props


### PR DESCRIPTION
头像组件在图片加载失败的情况会出引起src改变失效。具体原因是hasLoadError变量置为true后img标签会取消渲染，无法再次加载图片，需要在src改变的时候重置hasLoadError为false。