### PR TITLE
fix(col): col will always be hidden when responsive span is zero

### DIFF
--- a/packages/theme-chalk/src/col.scss
+++ b/packages/theme-chalk/src/col.scss
@@ -48,6 +48,9 @@
   }
   @for $i from 0 through 24 {
     .#{$namespace}-col-xs-#{$i} {
+      @if $i != 0 {
+        display: block;
+      }
       max-width: (1 / 24 * $i * 100) * 1%;
       flex: 0 0 (1 / 24 * $i * 100) * 1%;
     }
@@ -77,6 +80,9 @@
   }
   @for $i from 0 through 24 {
     .#{$namespace}-col-sm-#{$i} {
+      @if $i != 0 {
+        display: block;
+      }
       max-width: (1 / 24 * $i * 100) * 1%;
       flex: 0 0 (1 / 24 * $i * 100) * 1%;
     }
@@ -106,6 +112,9 @@
   }
   @for $i from 0 through 24 {
     .#{$namespace}-col-md-#{$i} {
+      @if $i != 0 {
+        display: block;
+      }
       max-width: (1 / 24 * $i * 100) * 1%;
       flex: 0 0 (1 / 24 * $i * 100) * 1%;
     }
@@ -135,6 +144,9 @@
   }
   @for $i from 0 through 24 {
     .#{$namespace}-col-lg-#{$i} {
+      @if $i != 0 {
+        display: block;
+      }
       max-width: (1 / 24 * $i * 100) * 1%;
       flex: 0 0 (1 / 24 * $i * 100) * 1%;
     }
@@ -164,6 +176,9 @@
   }
   @for $i from 0 through 24 {
     .#{$namespace}-col-xl-#{$i} {
+      @if $i != 0 {
+        display: block;
+      }
       max-width: (1 / 24 * $i * 100) * 1%;
       flex: 0 0 (1 / 24 * $i * 100) * 1%;
     }


### PR DESCRIPTION
fix #1509

I think #1509 is a bug. span=0 means display:none in design, but modifying the display property will affect the responsiveness.


Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
