### PR TITLE
fix: some components miss install type

### DIFF
--- a/packages/col/index.ts
+++ b/packages/col/index.ts
@@ -1,8 +1,10 @@
-import { App } from 'vue'
 import Col from './src/col'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 
-Col.install = (app: App): void => {
-  app.component(Col.name, Col)
+const _Col: SFCWithInstall<typeof Col> = Col as SFCWithInstall<typeof Col>
+
+_Col.install = app => {
+  app.component(_Col.name, _Col)
 }
 
-export default Col
+export default _Col

--- a/packages/date-picker/index.ts
+++ b/packages/date-picker/index.ts
@@ -1,8 +1,11 @@
-import { App } from 'vue'
 import DatePicker from './src/date-picker'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 
-DatePicker.install = (app: App): void => {
-  app.component(DatePicker.name, DatePicker)
+const _DatePicker: SFCWithInstall<typeof DatePicker> = DatePicker as SFCWithInstall<typeof DatePicker>
+
+_DatePicker.install = app => {
+  app.component(_DatePicker.name, _DatePicker)
 }
 
-export default DatePicker
+
+export default _DatePicker

--- a/packages/element-plus/index.ts
+++ b/packages/element-plus/index.ts
@@ -102,11 +102,13 @@ type DWindow =  Window & typeof globalThis & {
   dayjs?: typeof dayjs
 }
 
-const _window: DWindow = window
-
 // expose Day.js to window to make full bundle i18n work
-if (!isServer && !_window.dayjs) {
-  _window.dayjs = dayjs
+if (!isServer) {
+  const _window: DWindow = window
+
+  if (!_window.dayjs) {
+    _window.dayjs = dayjs
+  }
 }
 
 const version = version_ // version_ to fix tsc issue

--- a/packages/element-plus/index.ts
+++ b/packages/element-plus/index.ts
@@ -98,9 +98,15 @@ import { setConfig } from '@element-plus/utils/config'
 import isServer from '@element-plus/utils/isServer'
 import dayjs from 'dayjs'
 
+type DWindow =  Window & typeof globalThis & {
+  dayjs?: typeof dayjs
+}
+
+const _window: DWindow = window
+
 // expose Day.js to window to make full bundle i18n work
-if (!isServer && !(window as any).dayjs) {
-  (window as any).dayjs = dayjs
+if (!isServer && !_window.dayjs) {
+  _window.dayjs = dayjs
 }
 
 const version = version_ // version_ to fix tsc issue
@@ -222,7 +228,7 @@ const install = (app: App, opt: InstallOptions): void => {
   })
 
   plugins.forEach(plugin => {
-    app.use(plugin as any)
+    app.use(plugin)
   })
 }
 

--- a/packages/infinite-scroll/index.ts
+++ b/packages/infinite-scroll/index.ts
@@ -1,8 +1,10 @@
-import { App } from 'vue'
 import InfiniteScroll from './src/index'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 
-(InfiniteScroll as any).install = (app: App): void => {
-  app.directive('InfiniteScroll', InfiniteScroll)
+const _InfiniteScroll: SFCWithInstall<typeof InfiniteScroll> = InfiniteScroll as SFCWithInstall<typeof InfiniteScroll>
+
+_InfiniteScroll.install = app => {
+  app.directive('InfiniteScroll', _InfiniteScroll)
 }
 
-export default InfiniteScroll
+export default _InfiniteScroll

--- a/packages/message-box/index.ts
+++ b/packages/message-box/index.ts
@@ -1,12 +1,14 @@
-import { App } from 'vue'
 import MessageBox from './src/messageBox'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 
-(MessageBox as any).install = (app: App): void => {
-  app.config.globalProperties.$msgbox = MessageBox
-  app.config.globalProperties.$messageBox = MessageBox
-  app.config.globalProperties.$alert = MessageBox.alert
-  app.config.globalProperties.$confirm = MessageBox.confirm
-  app.config.globalProperties.$prompt = MessageBox.prompt
+const _MessageBox: SFCWithInstall<typeof MessageBox> = MessageBox as SFCWithInstall<typeof MessageBox>
+
+_MessageBox.install = app => {
+  app.config.globalProperties.$msgbox = _MessageBox
+  app.config.globalProperties.$messageBox = _MessageBox
+  app.config.globalProperties.$alert = _MessageBox.alert
+  app.config.globalProperties.$confirm = _MessageBox.confirm
+  app.config.globalProperties.$prompt = _MessageBox.prompt
 }
 
-export default MessageBox
+export default _MessageBox

--- a/packages/message/index.ts
+++ b/packages/message/index.ts
@@ -1,8 +1,10 @@
-import { App } from 'vue'
 import Message from './src/message'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 
-(Message as any).install = (app: App): void => {
-  app.config.globalProperties.$message = Message
+const _Message: SFCWithInstall<typeof Message> = Message as SFCWithInstall<typeof Message>
+
+_Message.install = app => {
+  app.config.globalProperties.$message = _Message
 }
 
-export default Message
+export default _Message

--- a/packages/notification/index.ts
+++ b/packages/notification/index.ts
@@ -1,8 +1,10 @@
-import { App } from 'vue'
 import Notify from './src/notify'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 
-(Notify as any).install = (app: App): void => {
-  app.config.globalProperties.$notify = Notify
+const _Notify: SFCWithInstall<typeof Notify> = Notify as SFCWithInstall<typeof Notify>
+
+_Notify.install = app => {
+  app.config.globalProperties.$notify = _Notify
 }
 
-export default Notify
+export default _Notify

--- a/packages/option/index.ts
+++ b/packages/option/index.ts
@@ -1,8 +1,10 @@
-import { App } from 'vue'
 import { Option } from '@element-plus/select'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 
-Option.install = (app: App): void => {
-  app.component(Option.name, Option)
+const _Option: SFCWithInstall<typeof Option> = Option as SFCWithInstall<typeof Option>
+
+_Option.install = app => {
+  app.component(_Option.name, _Option)
 }
 
-export default Option
+export default _Option

--- a/packages/pagination/index.ts
+++ b/packages/pagination/index.ts
@@ -1,9 +1,10 @@
-import { App } from 'vue'
 import Pagination from './src/index'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 
-Pagination.install = (app: App): void => {
-  app.component(Pagination.name, Pagination)
+const _Pagination: SFCWithInstall<typeof Pagination> = Pagination as SFCWithInstall<typeof Pagination>
+
+_Pagination.install = app => {
+  app.component(_Pagination.name, _Pagination)
 }
 
-export default Pagination
-
+export default _Pagination

--- a/packages/row/index.ts
+++ b/packages/row/index.ts
@@ -1,8 +1,10 @@
-import { App } from 'vue'
 import Row from '../col/src/row'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 
-Row.install = (app: App): void => {
-  app.component(Row.name, Row)
+const _Row: SFCWithInstall<typeof Row> = Row as SFCWithInstall<typeof Row>
+
+_Row.install = app => {
+  app.component(_Row.name, _Row)
 }
 
-export default Row
+export default _Row

--- a/packages/space/index.ts
+++ b/packages/space/index.ts
@@ -1,11 +1,10 @@
-import { App } from 'vue'
 import Space from './src/index'
 import type { SFCWithInstall } from '@element-plus/utils/types'
 
-Space.install = (app: App): void => {
-  app.component(Space.name, Space)
-}
+const _Space: SFCWithInstall<typeof Space> = Space as SFCWithInstall<typeof Space>
 
-const _Space: SFCWithInstall<typeof Space> = Space as any
+_Space.install = app => {
+  app.component(_Space.name, _Space)
+}
 
 export default _Space

--- a/packages/table-column/index.ts
+++ b/packages/table-column/index.ts
@@ -1,8 +1,10 @@
-import { App } from 'vue'
 import TableColumn from '../table/src/tableColumn'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 
-TableColumn.install = (app: App): void => {
-  app.component(TableColumn.name, TableColumn)
+const _TableColumn: SFCWithInstall<typeof TableColumn> = TableColumn as SFCWithInstall<typeof TableColumn>
+
+_TableColumn.install = app => {
+  app.component(_TableColumn.name, _TableColumn)
 }
 
-export default TableColumn
+export default _TableColumn

--- a/packages/time-picker/index.ts
+++ b/packages/time-picker/index.ts
@@ -1,14 +1,16 @@
-import { App } from 'vue'
 import TimePicker from './src/time-picker'
 import CommonPicker from './src/common/picker.vue'
 import TimePickPanel from './src/time-picker-com/panel-time-pick.vue'
+import type { SFCWithInstall } from '@element-plus/utils/types'
 export * from './src/common/date-utils'
 export * from './src/common/constant'
 export * from './src/common/props'
 
-TimePicker.install = (app: App): void => {
-  app.component(TimePicker.name, TimePicker)
+const _TimePicker: SFCWithInstall<typeof TimePicker> = TimePicker as SFCWithInstall<typeof TimePicker>
+
+_TimePicker.install = app => {
+  app.component(_TimePicker.name, _TimePicker)
 }
 
 export { CommonPicker, TimePickPanel }
-export default TimePicker
+export default _TimePicker

--- a/packages/utils/types.ts
+++ b/packages/utils/types.ts
@@ -1,4 +1,4 @@
-import { App } from 'vue'
+import type { App } from 'vue'
 
 type OptionalKeys<T extends Record<string, unknown>> = {
   [K in keyof T]: T extends Record<K, T[K]>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

close #1301 #1410 

The generated `.d.ts` file is same as [fix: app.use(comp.vue) type is not compatible](https://github.com/element-plus/element-plus/pull/1067). example:

befor

```ts
import Col from './src/col';
export default Col;
```

after

```ts
import Col from './src/col';
import type { SFCWithInstall } from '../utils/types';
declare const _Col: SFCWithInstall<typeof Col>;
export default _Col;
```