### PR TITLE
fix(cascader-panel): no loaded nodes should not be checked

### DIFF
--- a/packages/cascader-panel/__tests__/cascader-panel.spec.ts
+++ b/packages/cascader-panel/__tests__/cascader-panel.spec.ts
@@ -622,8 +622,11 @@ describe('CascaderPanel.vue', () => {
     const secondMenu = wrapper.findAll(MENU)[1]
     expect(secondMenu.exists()).toBe(true)
     expect(firstMenu.find(CHECKBOX).classes('is-checked')).toBe(true)
+    expect(firstMenu.find(CHECKBOX).classes('is-indeterminate')).toBe(true)
     expect(secondMenu.findAll(CHECKBOX)[0].classes('is-checked')).toBe(false)
+    expect(secondMenu.findAll(CHECKBOX)[0].classes('is-indeterminate')).toBe(false)
     expect(secondMenu.findAll(CHECKBOX)[1].classes('is-checked')).toBe(true)
+    expect(secondMenu.findAll(CHECKBOX)[1].classes('is-indeterminate')).toBe(false)
   })
 
   test('getCheckedNodes and clearCheckedNodes', () => {

--- a/packages/cascader-panel/__tests__/cascader-panel.spec.ts
+++ b/packages/cascader-panel/__tests__/cascader-panel.spec.ts
@@ -621,7 +621,7 @@ describe('CascaderPanel.vue', () => {
 
     const secondMenu = wrapper.findAll(MENU)[1]
     expect(secondMenu.exists()).toBe(true)
-    expect(firstMenu.find(CHECKBOX).classes('is-checked')).toBe(true)
+    expect(firstMenu.find(CHECKBOX).classes('is-checked')).toBe(false)
     expect(firstMenu.find(CHECKBOX).classes('is-indeterminate')).toBe(true)
     expect(secondMenu.findAll(CHECKBOX)[0].classes('is-checked')).toBe(false)
     expect(secondMenu.findAll(CHECKBOX)[0].classes('is-indeterminate')).toBe(false)

--- a/packages/cascader-panel/__tests__/cascader-panel.spec.ts
+++ b/packages/cascader-panel/__tests__/cascader-panel.spec.ts
@@ -578,6 +578,54 @@ describe('CascaderPanel.vue', () => {
     expect(wrapper.find(`.is-active`).text()).toBe('option2')
   })
 
+  test('no loaded nodes should not be checked', async () => {
+    const wrapper = _mount({
+      template: `
+        <cascader-panel
+          :props="props"
+        />
+      `,
+      data() {
+        return {
+          props: {
+            multiple: true,
+            lazy: true,
+            lazyLoad (node, resolve) {
+              const { level } = node
+              setTimeout(() => {
+                const nodes = Array.from({ length: level + 1 })
+                  .map(() => {
+                    ++id
+                    return {
+                      value: id,
+                      label: `option${id}`,
+                      leaf: id === 3,
+                    }
+                  })
+                resolve(nodes)
+              }, 1000)
+            },
+          },
+        }
+      },
+    })
+    jest.runAllTimers()
+    await nextTick()
+    const firstMenu = wrapper.findAll(MENU)[0]
+    const firstOption = wrapper.find(NODE)
+    await firstOption.trigger('click')
+    jest.runAllTimers()
+    await nextTick()
+
+    await firstMenu.find(CHECKBOX).find('input').trigger('click')
+
+    const secondMenu = wrapper.findAll(MENU)[1]
+    expect(secondMenu.exists()).toBe(true)
+    expect(firstMenu.find(CHECKBOX).classes('is-checked')).toBe(true)
+    expect(secondMenu.findAll(CHECKBOX)[0].classes('is-checked')).toBe(false)
+    expect(secondMenu.findAll(CHECKBOX)[1].classes('is-checked')).toBe(true)
+  })
+
   test('getCheckedNodes and clearCheckedNodes', () => {
     const wrapper = mount(CascaderPanel, {
       props: {

--- a/packages/cascader-panel/src/node.ts
+++ b/packages/cascader-panel/src/node.ts
@@ -147,8 +147,8 @@ export default class Node {
       return c + num
     }, 0)
 
-    this.checked = checked
-    this.indeterminate = checkedNum !== totalNum && checkedNum > 0
+    this.checked = this.loaded && checked
+    this.indeterminate = this.loaded && checkedNum !== totalNum && checkedNum > 0
   }
 
   doCheck(checked: boolean) {

--- a/packages/cascader-panel/src/node.ts
+++ b/packages/cascader-panel/src/node.ts
@@ -147,7 +147,7 @@ export default class Node {
       return c + num
     }, 0)
 
-    this.checked = this.loaded && checked
+    this.checked = this.loaded && this.children.every(child => child.loaded && child.checked) && checked
     this.indeterminate = this.loaded && checkedNum !== totalNum && checkedNum > 0
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

Reproduce link: https://codesandbox.io/s/element-plus-spa-forked-xnwop?file=/src/App.vue

Reproduce step:
1. Click first menu to load children.
2. Click first checkbox twice (this may be another bug) of first menu to select the `Option 3`, at the same time, the `Option 2` will be selected too, but it is not leaf node.

Expected:
The `Option 2` is not leaf node and it should not be `checked`.

Actual:
The `Option 2` is checked too.
