### PR TITLE
fix(cascader-panel): click checkbox should works after lazy node loaded

### DIFF
--- a/packages/cascader-panel/__tests__/cascader-panel.spec.ts
+++ b/packages/cascader-panel/__tests__/cascader-panel.spec.ts
@@ -560,6 +560,37 @@ describe('CascaderPanel.vue', () => {
     expect(wrapper.vm.value).toEqual([1, 2])
   })
 
+  test('click checkbox should works after lazy node loaded', async () => {
+    const wrapper = _mount({
+      template: `
+        <cascader-panel
+          v-model="value"
+          :props="props"
+        />
+      `,
+      data() {
+        return {
+          value: [],
+          props: {
+            multiple: true,
+            lazy: true,
+            lazyLoad,
+          },
+        }
+      },
+    })
+    jest.runAllTimers()
+    await nextTick()
+    const firstCheckbox = wrapper.find(CHECKBOX)
+
+    await firstCheckbox.find('input').trigger('click')
+    jest.runAllTimers()
+    await nextTick()
+    await firstCheckbox.find('input').trigger('click')
+
+    expect(firstCheckbox.classes('is-checked')).toBe(true)
+  })
+
   test('lazy load with default value', async () => {
     const wrapper = mount(CascaderPanel, {
       props: {

--- a/packages/cascader-panel/__tests__/cascader-panel.spec.ts
+++ b/packages/cascader-panel/__tests__/cascader-panel.spec.ts
@@ -407,6 +407,34 @@ describe('CascaderPanel.vue', () => {
     expect(bjCheckbox.classes('is-checked')).toBe(true)
   })
 
+  test('clicking the option should always check it in single node', async () => {
+    const wrapper = _mount({
+      template: `
+        <cascader-panel
+          v-model="value"
+          :options="options"
+        />
+      `,
+      data() {
+        return {
+          value: [],
+          options: NORMAL_OPTIONS,
+        }
+      },
+    })
+
+    const options = wrapper.findAll(NODE)
+    const [bjNode] = options
+
+    await bjNode.trigger('click')
+    expect(bjNode.find('.el-icon-check').exists()).toBe(true)
+    expect(wrapper.vm.value).toEqual(['beijing'])
+
+    await bjNode.trigger('click')
+    expect(bjNode.find('.el-icon-check').exists()).toBe(true)
+    expect(wrapper.vm.value).toEqual(['beijing'])
+  })
+
   test('check strictly in single mode', async () => {
     const wrapper = _mount({
       template: `

--- a/packages/cascader-panel/__tests__/cascader-panel.spec.ts
+++ b/packages/cascader-panel/__tests__/cascader-panel.spec.ts
@@ -435,6 +435,35 @@ describe('CascaderPanel.vue', () => {
     expect(wrapper.vm.value).toEqual(['beijing'])
   })
 
+  test('clicking on checked option should keep opening in single node', async () => {
+    const handleClose = jest.fn()
+    const wrapper = _mount({
+      template: `
+        <cascader-panel
+          v-model="value"
+          :options="options"
+          @close="handleClose"
+        />
+      `,
+      data() {
+        return {
+          value: [],
+          options: NORMAL_OPTIONS,
+          handleClose,
+        }
+      },
+    })
+
+    const options = wrapper.findAll(NODE)
+    const [bjNode] = options
+
+    await bjNode.trigger('click')
+    expect(handleClose).toBeCalledTimes(1)
+
+    await bjNode.trigger('click')
+    expect(handleClose).toBeCalledTimes(1)
+  })
+
   test('check strictly in single mode', async () => {
     const wrapper = _mount({
       template: `

--- a/packages/cascader-panel/src/node.vue
+++ b/packages/cascader-panel/src/node.vue
@@ -121,7 +121,7 @@ export default defineComponent({
 
     const doCheck = () => {
       const { node } = props
-      panel.handleCheckChange(node, !node.checked)
+      panel.handleCheckChange(node, multiple.value ? !node.checked : true)
     }
 
     const doLoad = () => {

--- a/packages/cascader-panel/src/node.vue
+++ b/packages/cascader-panel/src/node.vue
@@ -119,10 +119,9 @@ export default defineComponent({
       panel.expandNode(props.node)
     }
 
-    const doCheck = (checked: boolean) => {
+    const doCheck = () => {
       const { node } = props
-      if (checked === node.checked) return
-      panel.handleCheckChange(node, checked)
+      panel.handleCheckChange(node, !node.checked)
     }
 
     const doLoad = () => {
@@ -148,17 +147,17 @@ export default defineComponent({
       if (isHoverMenu.value && !isLeaf.value) return
 
       if (isLeaf.value && !isDisabled.value && !checkStrictly.value && !multiple.value) {
-        handleCheck(true)
+        handleCheck()
       } else {
         handleExpand()
       }
     }
 
-    const handleCheck = (checked: boolean) => {
+    const handleCheck = () => {
       if (!props.node.loaded) {
         doLoad()
       } else {
-        doCheck(checked)
+        doCheck()
         !checkStrictly.value && doExpand()
       }
     }

--- a/packages/cascader-panel/src/node.vue
+++ b/packages/cascader-panel/src/node.vue
@@ -121,7 +121,9 @@ export default defineComponent({
 
     const doCheck = () => {
       const { node } = props
-      panel.handleCheckChange(node, multiple.value ? !node.checked : true, multiple.value || !node.checked)
+      const newCheckedState = multiple.value ? !node.checked : true
+      const shouldEmitClose = newCheckedState !== node.checked
+      panel.handleCheckChange(node, newCheckedState, shouldEmitClose)
     }
 
     const doLoad = () => {

--- a/packages/cascader-panel/src/node.vue
+++ b/packages/cascader-panel/src/node.vue
@@ -121,7 +121,7 @@ export default defineComponent({
 
     const doCheck = () => {
       const { node } = props
-      panel.handleCheckChange(node, multiple.value ? !node.checked : true)
+      panel.handleCheckChange(node, multiple.value ? !node.checked : true, multiple.value || !node.checked)
     }
 
     const doLoad = () => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

Reproduce link: https://codesandbox.io/s/element-plus-spa-forked-vnzbv?file=/src/App.vue

Reproduce step:

1. Click the `Option - 1's *checkbox*` to load children.
2. Wait one second.
2. Click the checkbox again.

Expected:
It should be checked/indeterminate.

Actual:
Nothing happened. But if you click the checkbox again, it works.

This is due to the Cascader Panel's Checkbox use [one-way binding](https://github.com/element-plus/element-plus/blob/dev/packages/cascader-panel/src/node.vue#L24-L28), and the first click event is for expand/load children rather than change the checked state.