### PR TITLE
fix(time-picker): replace `it.only` with `it` in test

### DIFF
--- a/packages/time-picker/__tests__/time-picker.spec.ts
+++ b/packages/time-picker/__tests__/time-picker.spec.ts
@@ -144,7 +144,7 @@ describe('TimePicker', () => {
     expect(secondsDom).toBeUndefined()
   })
 
-  it.only('event change, focus, blur', async () => {
+  it('event change, focus, blur', async () => {
     const changeHandler = jest.fn()
     const focusHandler = jest.fn()
     const blurHandler = jest.fn()


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

Other test cases should not be skipped.
