### PR TITLE
fix(select): tag can't close if the option is disabled

### DIFF
--- a/packages/select/__tests__/select.spec.ts
+++ b/packages/select/__tests__/select.spec.ts
@@ -862,7 +862,7 @@ describe('Select', () => {
 
   test('tag of disabled option is not closable', async () => {
     const wrapper = _mount(`
-    <el-select v-model="vendors" multiple :collapse-tags="isCollapsed" placeholder="Select Business Unit">
+    <el-select v-model="vendors" multiple :collapse-tags="isCollapsed" :clearable="isClearable" placeholder="Select Business Unit">
     <el-option
       v-for="(vendor, index) in options"
       :key="index"
@@ -874,6 +874,7 @@ describe('Select', () => {
   </el-select>`, () => ({
       vendors: [2, 3, 4],
       isCollapsed: false,
+      isClearable: false,
       options: [
         { name: 'Test 1', isDisabled: false },
         { name: 'Test 2', isDisabled: true },
@@ -883,17 +884,41 @@ describe('Select', () => {
     }))
     const vm = wrapper.vm as any
     await vm.$nextTick()
+    const selectVm = wrapper.findComponent({ name: 'ElSelect' }).vm as any
     expect(wrapper.findAll('.el-tag').length).toBe(3)
     const tagCloseIcons = wrapper.findAll('.el-tag__close')
     expect(tagCloseIcons.length).toBe(1)
     await tagCloseIcons[0].trigger('click')
     expect(wrapper.findAll('.el-tag__close').length).toBe(0)
     expect(wrapper.findAll('.el-tag').length).toBe(2)
+
+    //test if is clearable
+    vm.isClearable = true
+    vm.vendors = [2, 3, 4]
+    await vm.$nextTick()
+    selectVm.inputHovering = true
+    await selectVm.$nextTick()
+    const iconClear = wrapper.find('.el-input__icon.el-icon-circle-close')
+    expect(wrapper.findAll('.el-tag').length).toBe(3)
+    await iconClear.trigger('click')
+    expect(wrapper.findAll('.el-tag').length).toBe(2)
+
     // test for collapse select
     vm.vendors = [1, 2, 4]
     vm.isCollapsed = true
+    vm.isClearable = false
     await vm.$nextTick()
     expect(wrapper.findAll('.el-tag').length).toBe(2)
+    await wrapper.find('.el-tag__close').trigger('click')
+    expect(wrapper.findAll('.el-tag').length).toBe(2)
+    expect(wrapper.findAll('.el-tag__close').length).toBe(0)
+
+    // test for collapse select if is clearable
+    vm.vendors = [1, 2, 4]
+    vm.isCollapsed = true
+    vm.isClearable = true
+    await vm.$nextTick()
+    expect(wrapper.findAll('.el-tag__close').length).toBe(1)
     await wrapper.find('.el-tag__close').trigger('click')
     expect(wrapper.findAll('.el-tag').length).toBe(2)
     expect(wrapper.findAll('.el-tag__close').length).toBe(0)

--- a/packages/select/__tests__/select.spec.ts
+++ b/packages/select/__tests__/select.spec.ts
@@ -115,6 +115,7 @@ describe('Select', () => {
   afterEach(() => {
     document.body.innerHTML = ''
   })
+
   test('create', async () => {
     const wrapper = _mount(`<el-select v-model="value"></el-select>`, () => ({ value: '' }))
     expect(wrapper.classes()).toContain('el-select')
@@ -165,7 +166,6 @@ describe('Select', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.el-input__inner').element.value).toBe('双皮奶')
   })
-
 
   test('sync set value and options', async () => {
     const wrapper = _mount(`
@@ -858,5 +858,44 @@ describe('Select', () => {
     options[2].click()
     await nextTick()
     expect(vm.value).toBe('Shanghai')
+  })
+
+  test('tag of disabled option is not closable', async () => {
+    const wrapper = _mount(`
+    <el-select v-model="vendors" multiple :collapse-tags="isCollapsed" placeholder="Select Business Unit">
+    <el-option
+      v-for="(vendor, index) in options"
+      :key="index"
+      :value="index + 1"
+      :label="vendor.name"
+      :disabled="vendor.isDisabled"
+    >
+    </el-option>
+  </el-select>`, () => ({
+      vendors: [2, 3, 4],
+      isCollapsed: false,
+      options: [
+        { name: 'Test 1', isDisabled: false },
+        { name: 'Test 2', isDisabled: true },
+        { name: 'Test 3', isDisabled: false },
+        { name: 'Test 4', isDisabled: true },
+      ],
+    }))
+    const vm = wrapper.vm as any
+    await vm.$nextTick()
+    expect(wrapper.findAll('.el-tag').length).toBe(3)
+    const tagCloseIcons = wrapper.findAll('.el-tag__close')
+    expect(tagCloseIcons.length).toBe(1)
+    await tagCloseIcons[0].trigger('click')
+    expect(wrapper.findAll('.el-tag__close').length).toBe(0)
+    expect(wrapper.findAll('.el-tag').length).toBe(2)
+    // test for collapse select
+    vm.vendors = [1, 2, 4]
+    vm.isCollapsed = true
+    await vm.$nextTick()
+    expect(wrapper.findAll('.el-tag').length).toBe(2)
+    await wrapper.find('.el-tag__close').trigger('click')
+    expect(wrapper.findAll('.el-tag').length).toBe(2)
+    expect(wrapper.findAll('.el-tag__close').length).toBe(0)
   })
 })

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -56,7 +56,7 @@
                 <el-tag
                   v-for="item in selected"
                   :key="getValueKey(item)"
-                  :closable="!selectDisabled"
+                  :closable="!selectDisabled && !item.isDisabled"
                   :size="collapseTagSize"
                   :hit="item.hitState"
                   type="info"

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -31,7 +31,7 @@
           >
             <span v-if="collapseTags && selected.length">
               <el-tag
-                :closable="!selectDisabled"
+                :closable="!selectDisabled && !selected[0].isDisabled"
                 :size="collapseTagSize"
                 :hit="selected[0].hitState"
                 type="info"

--- a/packages/select/src/useSelect.ts
+++ b/packages/select/src/useSelect.ts
@@ -384,6 +384,7 @@ export const useSelect = (props, states: States, ctx) => {
         option = {
           value,
           currentLabel: cachedOption.currentLabel,
+          isDisabled: cachedOption.isDisabled,
         }
         break
       }

--- a/packages/select/src/useSelect.ts
+++ b/packages/select/src/useSelect.ts
@@ -470,6 +470,11 @@ export const useSelect = (props, states: States, ctx) => {
   const deleteSelected = event => {
     event.stopPropagation()
     const value = props.multiple ? [] : ''
+    if (typeof value !== 'string') {
+      for (const item of states.selected) {
+        if (item.isDisabled) value.push(item.value)
+      }
+    }
     ctx.emit(UPDATE_MODEL_EVENT, value)
     emitChange(value)
     states.visible = false


### PR DESCRIPTION
re #1594, #1595

tag shouldn't be able to close if the option is disabled
![1Jnhv.png](https://img.ams1.imgbed.xyz/2021/03/10/1Jnhv.png)
![1JHqH.png](https://img.ams1.imgbed.xyz/2021/03/10/1JHqH.png)

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
