### PR TITLE
fix(time-picker): update oldValue when visible change

### DIFF
--- a/packages/time-picker/__tests__/time-picker.spec.ts
+++ b/packages/time-picker/__tests__/time-picker.spec.ts
@@ -128,6 +128,49 @@ describe('TimePicker', () => {
     expect(vm.value instanceof Date).toBeTruthy()
   })
 
+  it('should update oldValue when visible change', async () => {
+    const wrapper = _mount(`<el-time-picker
+        v-model="value"
+      />`, () => ({ value: new Date(2016, 9, 10, 18, 40) }))
+
+    // show picker panel
+    const input = wrapper.find('input')
+    input.trigger('blur')
+    input.trigger('focus')
+    await nextTick()
+
+    // select time
+    const list = document.querySelectorAll('.el-time-spinner__list')
+    const hoursEl = list[0]
+    const minutesEl = list[1]
+    const secondsEl = list[2]
+    const hourEl = hoursEl.querySelectorAll('.el-time-spinner__item')[4] as any
+    const minuteEl = minutesEl.querySelectorAll('.el-time-spinner__item')[36] as any
+    const secondEl = secondsEl.querySelectorAll('.el-time-spinner__item')[20] as any
+    hourEl.click()
+    await nextTick()
+    minuteEl.click()
+    await nextTick()
+    secondEl.click()
+    await nextTick();
+
+    // click confirm button
+    (document.querySelector('.el-time-panel__btn.confirm') as any).click()
+    const date = (wrapper.vm as any).value
+    expect(date.getHours()).toBe(4)
+    expect(date.getMinutes()).toBe(36)
+    expect(date.getSeconds()).toBe(20)
+
+    // show picker panel and click cancel button
+    input.trigger('blur')
+    input.trigger('focus')
+    await nextTick();
+    (document.querySelector('.el-time-panel__btn.cancel') as any).click()
+    expect(date.getHours()).toBe(4)
+    expect(date.getMinutes()).toBe(36)
+    expect(date.getSeconds()).toBe(20)
+  })
+
   it('set format', async () => {
     const wrapper = _mount(`<el-time-picker
         v-model="value"

--- a/packages/time-picker/src/time-picker-com/panel-time-pick.vue
+++ b/packages/time-picker/src/time-picker-com/panel-time-pick.vue
@@ -42,7 +42,6 @@ import {
   defineComponent,
   ref,
   computed,
-  watch,
   inject,
   PropType,
 } from 'vue'
@@ -50,7 +49,7 @@ import { EVENT_CODE } from '@element-plus/utils/aria'
 import { t } from '@element-plus/locale'
 import TimeSpinner from './basic-time-spinner.vue'
 import dayjs, { Dayjs } from 'dayjs'
-import { getAvaliableArrs } from './useTimePicker'
+import { getAvaliableArrs, useOldValue } from './useTimePicker'
 
 export default defineComponent({
   components: {
@@ -80,7 +79,7 @@ export default defineComponent({
   setup(props, ctx) {
     // data
     const selectionRange = ref([0, 2])
-    const oldValue = ref(props.parsedValue)
+    const oldValue = useOldValue(props)
     // computed
     const transitionName = computed(() => {
       return props.actualVisible === undefined ? 'el-zoom-in-top' : ''
@@ -92,12 +91,6 @@ export default defineComponent({
       if (props.format.includes('A')) return 'A'
       if (props.format.includes('a')) return 'a'
       return ''
-    })
-    // watch
-    watch(() => props.visible, val => {
-      if (!val) {
-        oldValue.value = props.parsedValue
-      }
     })
     // method
     const isValidValue = _date => {

--- a/packages/time-picker/src/time-picker-com/panel-time-pick.vue
+++ b/packages/time-picker/src/time-picker-com/panel-time-pick.vue
@@ -42,6 +42,7 @@ import {
   defineComponent,
   ref,
   computed,
+  watch,
   inject,
   PropType,
 } from 'vue'
@@ -91,6 +92,12 @@ export default defineComponent({
       if (props.format.includes('A')) return 'A'
       if (props.format.includes('a')) return 'a'
       return ''
+    })
+    // watch
+    watch(() => props.visible, val => {
+      if (!val) {
+        oldValue.value = props.parsedValue
+      }
     })
     // method
     const isValidValue = _date => {

--- a/packages/time-picker/src/time-picker-com/panel-time-range.vue
+++ b/packages/time-picker/src/time-picker-com/panel-time-range.vue
@@ -71,6 +71,7 @@ import {
   defineComponent,
   ref,
   computed,
+  watch,
   PropType,
   inject,
 } from 'vue'
@@ -124,6 +125,13 @@ export default defineComponent({
 
     const minSelectableRange = ref([])
     const maxSelectableRange = ref([])
+
+    // watch
+    watch(() => props.visible, val => {
+      if (!val) {
+        oldValue.value = props.parsedValue
+      }
+    })
 
     const handleConfirm = (visible = false) => {
       ctx.emit('pick', [minDate.value, maxDate.value], visible)

--- a/packages/time-picker/src/time-picker-com/panel-time-range.vue
+++ b/packages/time-picker/src/time-picker-com/panel-time-range.vue
@@ -71,7 +71,6 @@ import {
   defineComponent,
   ref,
   computed,
-  watch,
   PropType,
   inject,
 } from 'vue'
@@ -80,7 +79,7 @@ import union from 'lodash/union'
 import { t } from '@element-plus/locale'
 import { EVENT_CODE } from '@element-plus/utils/aria'
 import TimeSpinner from './basic-time-spinner.vue'
-import { getAvaliableArrs } from './useTimePicker'
+import { getAvaliableArrs, useOldValue } from './useTimePicker'
 
 const makeSelectRange = (start, end) => {
   const result = []
@@ -110,7 +109,7 @@ export default defineComponent({
   setup(props, ctx) {
     const minDate = computed(() => props.parsedValue[0])
     const maxDate = computed(() => props.parsedValue[1])
-    const oldValue = ref(props.parsedValue)
+    const oldValue = useOldValue(props)
     const handleCancel = () => {
       ctx.emit('pick', oldValue.value, null)
     }
@@ -125,13 +124,6 @@ export default defineComponent({
 
     const minSelectableRange = ref([])
     const maxSelectableRange = ref([])
-
-    // watch
-    watch(() => props.visible, val => {
-      if (!val) {
-        oldValue.value = props.parsedValue
-      }
-    })
 
     const handleConfirm = (visible = false) => {
       ctx.emit('pick', [minDate.value, maxDate.value], visible)

--- a/packages/time-picker/src/time-picker-com/useTimePicker.ts
+++ b/packages/time-picker/src/time-picker-com/useTimePicker.ts
@@ -1,3 +1,6 @@
+import { ref, watch } from 'vue'
+import { Dayjs } from 'dayjs'
+
 const makeList = (total, method, methodFunc) => {
   const arr = []
   const disabledArr = method && methodFunc()
@@ -60,4 +63,19 @@ export const getAvaliableArrs = (disabledHours, disabledMinutes, disabledSeconds
     getAvaliableMinutes,
     getAvaliableSeconds,
   }
+}
+
+export const useOldValue = (props: {
+  parsedValue?: string | Dayjs | Dayjs[]
+  visible: boolean
+}) => {
+  const oldValue = ref(props.parsedValue)
+
+  watch(() => props.visible, val => {
+    if (!val) {
+      oldValue.value = props.parsedValue
+    }
+  })
+
+  return oldValue
 }


### PR DESCRIPTION
fix #1561

I found #1633 was trying to solve the same problem. I prefer to use watch to update oldValue. Because in the current version, there is more than one place that needs to do this operation. For example, click on the outside of pick panel.

In addition, range mode also had this problem. So I fixed it together.


* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
