### PR TITLE
fix(table): fix bug in render column structure

### DIFF
--- a/packages/table/src/table-column/index.ts
+++ b/packages/table/src/table-column/index.ts
@@ -214,7 +214,7 @@ export default defineComponent({
   render () {
     let children = []
     try {
-      const renderDefault = this.$slots.default?.()
+      const renderDefault = this.$slots.default?.({ row: {}, column: {}, $index: -1 })
       if (renderDefault instanceof Array) {
         for (const childNode of renderDefault) {
           if (childNode.type?.name === 'ElTableColumn' || childNode.shapeFlag !== 36) {


### PR DESCRIPTION
When the slots in template, using row will report an error, resulting in column data exception

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
