### PR TITLE
fix(drawer): fix/1695-drawer-close-button-outline

### DIFF
--- a/packages/theme-chalk/src/drawer.scss
+++ b/packages/theme-chalk/src/drawer.scss
@@ -115,6 +115,12 @@ $directions: rtl, ltr, ttb, btt;
     font-size: $--font-size-extra-large;
     color: inherit;
     background-color: transparent;
+    outline: none;
+    &:hover {
+      i {
+        color: $--color-primary;
+      }
+    }
   }
 
   &__body {


### PR DESCRIPTION
- Fix drawer close button outline issue when focusing. Close #1695.
- Fix drawer close button not highlighted when hovering.
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
