### PR TITLE
[quickstart.md] Fix wrong method name in documentation

### DIFF
--- a/website/docs/en-US/quickstart.md
+++ b/website/docs/en-US/quickstart.md
@@ -129,7 +129,7 @@ export default defineConfig({
       libs: [{
         libraryName: 'element-plus',
         resolveStyle: (name) => {
-          name = name.splice(3)
+          name = name.slice(3)
           return `element-plus/packages/theme-chalk/src/${name}.scss`;
         },
         resolveComponent: (name) => {


### PR DESCRIPTION
Hi! There is a mistake in doc's, you used the wrong method, method `slice` will be correct.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
