### PR TITLE
Build: fix build bug cause import path error in xxx.d.ts

### DIFF
--- a/build/gen-type.js
+++ b/build/gen-type.js
@@ -14,7 +14,7 @@ fs.copyFileSync(
 const newIndexPath = path.resolve(__dirname, '../lib/index.d.ts')
 fs.copyFileSync(path.resolve(__dirname, '../lib/element-plus/index.d.ts'), newIndexPath)
 const index = fs.readFileSync(newIndexPath)
-const newIndex = index.toString().replace(/@element-plus\//g, './el-').replace('el-utils', 'utils')
+const newIndex = index.toString().replace(/@element-plus\//g, './el-').replace('el-utils', 'utils').replace('el-locale', 'locale')
 fs.writeFileSync(newIndexPath, newIndex)
 
 // remove ep
@@ -56,7 +56,10 @@ fs.readdirSync(libDirPath).forEach(comp => {
         data.forEach(f => {
           if (!fs.lstatSync(path.resolve(srcPath, f)).isDirectory()) {
             const imp = fs.readFileSync(path.resolve(srcPath, f)).toString()
-            if (imp.includes('@element-plus/')) {
+            if (imp.includes('@element-plus/utils/')) {
+              const newImp = imp.replace(/@element-plus\//g, '../../')
+              fs.writeFileSync(path.resolve(srcPath, f), newImp)
+            } else if (imp.includes('@element-plus/')) {
               const newImp = imp.replace(/@element-plus\//g, '../../el-')
               fs.writeFileSync(path.resolve(srcPath, f), newImp)
             }


### PR DESCRIPTION
Fix build bug.

Original build result, in lib/index.d.ts file and some other xxx.d.ts files,
import errors caused by 'import el-local' and' import el-utils' because local and utils modules don't have el- prefix.