### PR TITLE
fix(col): col should hidden when span is zero

### DIFF
--- a/packages/col/src/col.ts
+++ b/packages/col/src/col.ts
@@ -66,8 +66,9 @@ const ElCol = defineComponent({
       const pos = ['span', 'offset', 'pull', 'push'] as const
       pos.forEach(prop => {
         const size = props[prop]
-        if (typeof size === 'number' && size > 0) {
-          ret.push(prop !== 'span' ? `el-col-${prop}-${props[prop]}` : `el-col-${props[prop]}`)
+        if (typeof size === 'number') {
+          if(prop === 'span') ret.push(`el-col-${props[prop]}`)
+          else if(size > 0) ret.push(`el-col-${prop}-${props[prop]}`)
         }
       })
       const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
According to https://github.com/element-plus/element-plus/issues/1509#issuecomment-814106078

col should be hidden when span is 0, otherwise will show padding

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
