### PR TITLE
fix(avatar): fix src attributes default value

### DIFF
--- a/packages/avatar/src/index.vue
+++ b/packages/avatar/src/index.vue
@@ -38,7 +38,10 @@ export default defineComponent({
       },
     },
     icon: String,
-    src: String,
+    src: {
+      type: String,
+      default: '',
+    },
     alt: String,
     srcSet: String,
     fit: {


### PR DESCRIPTION
A watch source can only be a getter/effect function, a ref, a reactive object, or an array of these types. 