### PR TITLE
fix: not generate code hint files when publish-npm

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,6 +30,8 @@ yarn build:locale-umd
 
 yarn build:theme
 
+yarn build:helper
+
 # Post build clean up
 
 rm ./es.gz


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

@JeremyWuuuuu I find the #1749 not generate code hint files when publish-npm