### PR TITLE
fix(alert carousel switch): v-enter(vue2) to v-enter-from(vue3)

### DIFF
--- a/packages/theme-chalk/src/alert.scss
+++ b/packages/theme-chalk/src/alert.scss
@@ -141,7 +141,7 @@
   }
 }
 
-.#{$namespace}-alert-fade-enter,
+.#{$namespace}-alert-fade-enter-from,
 .#{$namespace}-alert-fade-leave-active {
   opacity: 0;
 }

--- a/packages/theme-chalk/src/carousel.scss
+++ b/packages/theme-chalk/src/carousel.scss
@@ -148,13 +148,13 @@
   }
 }
 
-.carousel-arrow-left-enter,
+.carousel-arrow-left-enter-from,
 .carousel-arrow-left-leave-active {
   transform: translateY(-50%) translateX(-10px);
   opacity: 0;
 }
 
-.carousel-arrow-right-enter,
+.carousel-arrow-right-enter-from,
 .carousel-arrow-right-leave-active {
   transform: translateY(-50%) translateX(10px);
   opacity: 0;

--- a/packages/theme-chalk/src/switch.scss
+++ b/packages/theme-chalk/src/switch.scss
@@ -113,7 +113,7 @@
     }
   }
 
-  & .label-fade-enter,
+  & .label-fade-enter-from,
   & .label-fade-leave-active {
     opacity: 0;
   }


### PR DESCRIPTION

When I used alert, I found that there was no transition when I made it appear through v-show, and then I found the syntax of vue2 that was still used in the code, and I found that there was also v-enter, a vue2 formulation, in carousel switch.