### PR TITLE
fix(image-viewer): fix image src attribute error #1791

### DIFF
--- a/packages/image-viewer/src/index.vue
+++ b/packages/image-viewer/src/index.vue
@@ -51,7 +51,7 @@
           v-show="i === index"
           ref="img"
           :key="url"
-          :src="currentImg"
+          :src="url"
           :style="imgStyle"
           class="el-image-viewer__img"
           @load="handleImgLoad"


### PR DESCRIPTION
set image src attribute according to url-list, instead of `currentImg` state.

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
