### PR TITLE
fix(Checkbox): activeStyle boxShadow error

### DIFF
--- a/packages/checkbox/src/checkbox-button.vue
+++ b/packages/checkbox/src/checkbox-button.vue
@@ -88,11 +88,12 @@ export default defineComponent({
     const { checkboxGroup } = useCheckboxGroup()
 
     const activeStyle = computed(() => {
+      const fillValue = checkboxGroup?.fill?.value ?? ''
       return {
-        backgroundColor: checkboxGroup?.fill?.value ?? '',
-        borderColor: checkboxGroup?.fill?.value ?? '',
+        backgroundColor: fillValue,
+        borderColor: fillValue,
         color: checkboxGroup?.textColor?.value ?? '',
-        boxShadow: '-1px 0 0 0 ' + checkboxGroup?.fill?.value ?? '',
+        boxShadow: fillValue ? `-1px 0 0 0 ${fillValue}` : null,
       }
     })
 


### PR DESCRIPTION
`boxShadow: '-1px 0 0 0 ' + checkboxGroup?.fill?.value ?? ''`

由于 + 号 比 ?? 优先级高，所以可能会处理为  `-1px 0 0 0 undefined`,   右边始终不成立。



* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
