### PR TITLE
feat(click-outside):  return mousedown event

### DIFF
--- a/packages/directives/__tests__/click-outside.spec.ts
+++ b/packages/directives/__tests__/click-outside.spec.ts
@@ -4,7 +4,15 @@ import ClickOutside from '../click-outside'
 const AXIOM = 'Rem is the best girl'
 const TRIGGER = 'trigger'
 const OTHER_CLASS = 'other-class'
-const handler = jest.fn()
+
+// init some local variables
+let mousedownObject
+let mouseupObject
+// mock handler with implementations which makes assignment to the local variable that we registered above.
+const handler = jest.fn((eMouseup, eMousedown) => {
+  mouseupObject = eMouseup
+  mousedownObject = eMousedown
+})
 const Component = {
   template: `
   <div>
@@ -52,6 +60,9 @@ describe('Directives.vue', () => {
     const mouseup = document.createEvent('MouseEvents')
     mouseup.initMouseEvent('mouseup', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null)
     document.dispatchEvent(mouseup)
-    expect(handler).toHaveBeenCalledTimes(1)
+    // here is the different part
+    // we test the existence of the local variable.
+    expect(mousedownObject).toBeDefined()
+    expect(mouseupObject).toBeDefined()
   })
 })

--- a/packages/directives/__tests__/click-outside.spec.ts
+++ b/packages/directives/__tests__/click-outside.spec.ts
@@ -37,6 +37,10 @@ const _mount = () => mount(Component, {
 
 describe('Directives.vue', () => {
   beforeEach(() => {
+    // clear the previously assigned event object
+    mousedownObject = null
+    mouseupObject = null
+
     handler.mockClear()
   })
   test('render test', () => {
@@ -55,11 +59,12 @@ describe('Directives.vue', () => {
 
     const mousedown = document.createEvent('MouseEvents')
     mousedown.initMouseEvent('mousedown', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null)
-
     document.dispatchEvent(mousedown)
+
     const mouseup = document.createEvent('MouseEvents')
     mouseup.initMouseEvent('mouseup', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null)
     document.dispatchEvent(mouseup)
+
     // here is the different part
     // we test the existence of the local variable.
     expect(mousedownObject).toBeDefined()

--- a/packages/directives/click-outside/index.ts
+++ b/packages/directives/click-outside/index.ts
@@ -71,7 +71,7 @@ function createDocumentHandler(
     ) {
       return
     }
-    binding.value(mousedown)
+    binding.value(mouseup, mousedown)
   }
 }
 

--- a/packages/directives/click-outside/index.ts
+++ b/packages/directives/click-outside/index.ts
@@ -71,7 +71,7 @@ function createDocumentHandler(
     ) {
       return
     }
-    binding.value()
+    binding.value(mousedown)
   }
 }
 


### PR DESCRIPTION
Return mousedown event for binding function.

Sometimes it is necessary to prevent the click event for which components append to body or outside container.
```js
handleClickOutside(e) {
   const target = e.target
    if (target.closest('.ow-flow__handle')) return false

    this.$emit('update:visible', false)
}
```

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
