### PR TITLE
build: bump sass from 1.26.10 to 1.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.27.3",
     "rollup-plugin-vue": "^6.0.0-beta.11",
-    "sass": "^1.26.10",
+    "sass": "^1.34.0",
     "sass-loader": "^10.0.1",
     "sinon": "^9.0.3",
     "style-loader": "^1.2.1",

--- a/packages/theme-chalk/src/badge.scss
+++ b/packages/theme-chalk/src/badge.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "mixins/mixins";
 @import "common/var";
 
@@ -22,7 +24,7 @@
     @include when(fixed) {
       position: absolute;
       top: 0;
-      right: #{1 + $--badge-size / 2};
+      right: #{1 + math.div($--badge-size, 2)};
       transform: translateY(-50%) translateX(100%);
 
       @include when(dot) {

--- a/packages/theme-chalk/src/carousel.scss
+++ b/packages/theme-chalk/src/carousel.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "mixins/mixins";
 @import "common/var";
 
@@ -122,7 +124,7 @@
       padding: $--carousel-indicator-padding-horizontal $--carousel-indicator-padding-vertical;
       .#{$namespace}-carousel__button {
         width: $--carousel-indicator-height;
-        height: #{$--carousel-indicator-width / 2};
+        height: #{math.div($--carousel-indicator-width, 2)};
       }
     }
 

--- a/packages/theme-chalk/src/col.scss
+++ b/packages/theme-chalk/src/col.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import './common/var.scss';
 @import './mixins/mixins.scss';
 
@@ -20,22 +22,22 @@
 
 @for $i from 0 through 24 {
   .#{$namespace}-col-#{$i} {
-    max-width: (1 / 24 * $i * 100) * 1%;
-    flex: 0 0 (1 / 24 * $i * 100) * 1%;
+    max-width: (math.div(1, 24) * $i * 100) * 1%;
+    flex: 0 0 (math.div(1, 24) * $i * 100) * 1%;
   }
 
   .#{$namespace}-col-offset-#{$i} {
-    margin-left: (1 / 24 * $i * 100) * 1%;
+    margin-left: (math.div(1, 24) * $i * 100) * 1%;
   }
 
   .#{$namespace}-col-pull-#{$i} {
     position: relative;
-    right: (1 / 24 * $i * 100) * 1%;
+    right: (math.div(1, 24) * $i * 100) * 1%;
   }
 
   .#{$namespace}-col-push-#{$i} {
     position: relative;
-    left: (1 / 24 * $i * 100) * 1%;
+    left: (math.div(1, 24) * $i * 100) * 1%;
   }
 }
 
@@ -51,22 +53,22 @@
       @if $i != 0 {
         display: block;
       }
-      max-width: (1 / 24 * $i * 100) * 1%;
-      flex: 0 0 (1 / 24 * $i * 100) * 1%;
+      max-width: (math.div(1, 24) * $i * 100) * 1%;
+      flex: 0 0 (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-xs-offset-#{$i} {
-      margin-left: (1 / 24 * $i * 100) * 1%;
+      margin-left: (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-xs-pull-#{$i} {
       position: relative;
-      right: (1 / 24 * $i * 100) * 1%;
+      right: (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-xs-push-#{$i} {
       position: relative;
-      left: (1 / 24 * $i * 100) * 1%;
+      left: (math.div(1, 24) * $i * 100) * 1%;
     }
   }
 }
@@ -83,22 +85,22 @@
       @if $i != 0 {
         display: block;
       }
-      max-width: (1 / 24 * $i * 100) * 1%;
-      flex: 0 0 (1 / 24 * $i * 100) * 1%;
+      max-width: (math.div(1, 24) * $i * 100) * 1%;
+      flex: 0 0 (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-sm-offset-#{$i} {
-      margin-left: (1 / 24 * $i * 100) * 1%;
+      margin-left: (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-sm-pull-#{$i} {
       position: relative;
-      right: (1 / 24 * $i * 100) * 1%;
+      right: (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-sm-push-#{$i} {
       position: relative;
-      left: (1 / 24 * $i * 100) * 1%;
+      left: (math.div(1, 24) * $i * 100) * 1%;
     }
   }
 }
@@ -115,22 +117,22 @@
       @if $i != 0 {
         display: block;
       }
-      max-width: (1 / 24 * $i * 100) * 1%;
-      flex: 0 0 (1 / 24 * $i * 100) * 1%;
+      max-width: (math.div(1, 24) * $i * 100) * 1%;
+      flex: 0 0 (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-md-offset-#{$i} {
-      margin-left: (1 / 24 * $i * 100) * 1%;
+      margin-left: (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-md-pull-#{$i} {
       position: relative;
-      right: (1 / 24 * $i * 100) * 1%;
+      right: (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-md-push-#{$i} {
       position: relative;
-      left: (1 / 24 * $i * 100) * 1%;
+      left: (math.div(1, 24) * $i * 100) * 1%;
     }
   }
 }
@@ -147,22 +149,22 @@
       @if $i != 0 {
         display: block;
       }
-      max-width: (1 / 24 * $i * 100) * 1%;
-      flex: 0 0 (1 / 24 * $i * 100) * 1%;
+      max-width: (math.div(1, 24) * $i * 100) * 1%;
+      flex: 0 0 (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-lg-offset-#{$i} {
-      margin-left: (1 / 24 * $i * 100) * 1%;
+      margin-left: (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-lg-pull-#{$i} {
       position: relative;
-      right: (1 / 24 * $i * 100) * 1%;
+      right: (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-lg-push-#{$i} {
       position: relative;
-      left: (1 / 24 * $i * 100) * 1%;
+      left: (math.div(1, 24) * $i * 100) * 1%;
     }
   }
 }
@@ -179,22 +181,22 @@
       @if $i != 0 {
         display: block;
       }
-      max-width: (1 / 24 * $i * 100) * 1%;
-      flex: 0 0 (1 / 24 * $i * 100) * 1%;
+      max-width: (math.div(1, 24) * $i * 100) * 1%;
+      flex: 0 0 (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-xl-offset-#{$i} {
-      margin-left: (1 / 24 * $i * 100) * 1%;
+      margin-left: (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-xl-pull-#{$i} {
       position: relative;
-      right: (1 / 24 * $i * 100) * 1%;
+      right: (math.div(1, 24) * $i * 100) * 1%;
     }
 
     .#{$namespace}-col-xl-push-#{$i} {
       position: relative;
-      left: (1 / 24 * $i * 100) * 1%;
+      left: (math.div(1, 24) * $i * 100) * 1%;
     }
   }
 }

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -1,4 +1,6 @@
 /* Element Chalk Variables */
+@use "sass:math";
+
 @import "../mixins/config";
 
 // Special comment for theme configurator

--- a/packages/theme-chalk/src/input-number.scss
+++ b/packages/theme-chalk/src/input-number.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "mixins/mixins";
 @import "common/var";
 @import "input";
@@ -137,7 +139,7 @@
 
     @include e((increase, decrease)) {
       height: auto;
-      line-height: #{($--input-height - 2) / 2};
+      line-height: #{math.div($--input-height - 2, 2)};
 
       [class*=#{$namespace}-icon] {
         transform: scale(.8);
@@ -161,19 +163,19 @@
 
     &[class*=medium] {
       [class*=increase], [class*=decrease] {
-        line-height: #{($--input-medium-height - 2) / 2};
+        line-height: #{math.div($--input-medium-height - 2, 2)};
       }
     }
 
     &[class*=small] {
       [class*=increase], [class*=decrease] {
-        line-height: #{($--input-small-height - 2) / 2};
+        line-height: #{math.div($--input-small-height - 2, 2)};
       }
     }
 
     &[class*=mini] {
       [class*=increase], [class*=decrease] {
-        line-height: #{($--input-mini-height - 2) / 2};
+        line-height: #{math.div($--input-mini-height - 2, 2)};
       }
     }
   }

--- a/packages/theme-chalk/src/loading.scss
+++ b/packages/theme-chalk/src/loading.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "mixins/mixins";
 @import "common/var";
 
@@ -26,7 +28,7 @@
     position: fixed;
 
     .#{$namespace}-loading-spinner {
-      margin-top: #{- $--loading-fullscreen-spinner-size / 2};
+      margin-top: #{math.div(- $--loading-fullscreen-spinner-size, 2)};
 
       .circular {
         height: $--loading-fullscreen-spinner-size;
@@ -38,7 +40,7 @@
 
 @include b(loading-spinner) {
   top: 50%;
-  margin-top: #{- $--loading-spinner-size / 2};
+  margin-top: #{math.div(- $--loading-spinner-size, 2)};
   width: 100%;
   text-align: center;
   position: absolute;

--- a/packages/theme-chalk/src/transfer.scss
+++ b/packages/theme-chalk/src/transfer.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "mixins/mixins";
 @import "mixins/utils";
 @import "common/var";
@@ -114,7 +116,7 @@
       font-size: 12px;
       display: inline-block;
       box-sizing: border-box;
-      border-radius: #{$--transfer-filter-height / 2};
+      border-radius: #{math.div($--transfer-filter-height, 2)};
       padding-right: 10px;
       padding-left: 30px;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4037,9 +4037,10 @@ chokidar@2.1.8, chokidar@^2.0.0, chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-"chokidar@>=2.0.0 <4.0.0", chokidar@^3.4.1:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
+"chokidar@>=3.0.0 <4.0.0":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
   dependencies:
     anymatch "~3.1.1"
     braces "~3.0.2"
@@ -4047,9 +4048,9 @@ chokidar@2.1.8, chokidar@^2.0.0, chokidar@^2.1.8:
     is-binary-path "~2.1.0"
     is-glob "~4.0.1"
     normalize-path "~3.0.0"
-    readdirp "~3.4.0"
+    readdirp "~3.5.0"
   optionalDependencies:
-    fsevents "~2.1.2"
+    fsevents "~2.3.1"
 
 chokidar@^3.4.0:
   version "3.4.3"
@@ -4063,6 +4064,20 @@ chokidar@^3.4.0:
     is-glob "~4.0.1"
     normalize-path "~3.0.0"
     readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
+chokidar@^3.4.1:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -6364,6 +6379,11 @@ fsevents@^2.1.2, fsevents@~2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
 
+fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -6738,6 +6758,7 @@ gulp-cssmin@^0.2.0:
 gulp-dart-sass@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/gulp-dart-sass/-/gulp-dart-sass-1.0.2.tgz#20e33c236b48d557c91e8dfe67a2aef2b8a2e328"
+  integrity sha512-8fLttA824mbuc0jRVlGs00zWYZXBckat6INawx5kp66Eqsz5srNWTA51t0mbfB4C8a/a/GZ9muYLwXGklgAHlw==
   dependencies:
     chalk "^2.3.0"
     lodash.clonedeep "^4.3.2"
@@ -11580,11 +11601,12 @@ sass-loader@^10.0.1:
     schema-utils "^2.7.1"
     semver "^7.3.2"
 
-sass@^1.26.10, sass@^1.26.3:
-  version "1.26.10"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.26.10.tgz#851d126021cdc93decbf201d1eca2a20ee434760"
+sass@^1.26.3, sass@^1.34.0:
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.34.0.tgz#e46d5932d8b0ecc4feb846d861f26a578f7f7172"
+  integrity sha512-rHEN0BscqjUYuomUEaqq3BMgsXqQfkcMVR7UhscsAVub0/spUrZGBMxQXFS2kfiDsPLZw5yuU9iJEFNC2x38Qw==
   dependencies:
-    chokidar ">=2.0.0 <4.0.0"
+    chokidar ">=3.0.0 <4.0.0"
 
 sax@~1.2.4:
   version "1.2.4"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

reason: #2051 

In this pull request, I bump sass to the latest version(1.34.0).

This will affect those who import and build SCSS source files, they must upgrade (or replace) the SCSS compiler to Dart Sass ^1.33.0 version. 
