### PR TITLE
fix(input): amend tabindex prop type (#2127)

### DIFF
--- a/packages/input/src/index.vue
+++ b/packages/input/src/index.vue
@@ -210,7 +210,7 @@ export default defineComponent({
       type: String,
     },
     tabindex: {
-      type: String,
+      type: Number,
     },
     validateEvent: {
       type: Boolean,


### PR DESCRIPTION
Fix bug: [#2127](https://github.com/element-plus/element-plus/issues/2127)

1. Bug's reason: prop  ``tabindex``  in the Input component is defined as ``String`` type,  but should be ``Number`` type.
2. Fix plan: amend ``tabindex``  type to be ``Number``, also refer MDN document：  [It accepts an integer as a value](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)



Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
