### PR TITLE
fix(date-picker): default-time does not work when type is datetime

### DIFF
--- a/packages/date-picker/__tests__/date-time-picker.spec.ts
+++ b/packages/date-picker/__tests__/date-time-picker.spec.ts
@@ -264,6 +264,33 @@ describe('Datetime Picker', () => {
       .map(node => Number(node.textContent))
     expect(disabledMinutes.length).toBe(19)
   })
+
+  it('defaultTime takes effect when the type is datetime', async () => {
+    const wrapper = _mount(`<el-date-picker
+        v-model="value"
+        type="datetime"
+        :default-time="defaultTime"
+    />`, () => ({
+      value: '',
+      defaultTime: new Date(2000, 1, 1, 12, 24, 48),
+    }))
+
+    const input = wrapper.find('input')
+    input.trigger('blur')
+    input.trigger('focus')
+    await nextTick()
+    const someDateTd = document.querySelector('.el-picker-panel__content tr:nth-child(3) td:nth-child(4)')
+    const timeInput = document.querySelector('.el-date-picker__time-header > span:nth-child(2) input');
+    (someDateTd as HTMLElement).click();
+    (timeInput as HTMLElement).focus()
+    await nextTick()
+    expect((timeInput as HTMLInputElement).value).toBe('12:24:48')
+    // time spinner highlight is correct
+    const spinners = document.querySelectorAll('.el-time-spinner ul li.active') as any
+    expect(spinners[0].textContent).toBe('12')
+    expect(spinners[1].textContent).toBe('24')
+    expect(spinners[2].textContent).toBe('48')
+  })
 })
 
 describe('Datetimerange', () => {

--- a/packages/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -223,11 +223,11 @@ export default defineComponent({
         : true
     }
     const formatEmit = (emitDayjs: Dayjs) => {
-      if (showTime.value) return emitDayjs.millisecond(0)
       if (defaultTime) {
         const defaultTimeD = dayjs(defaultTime)
         return defaultTimeD.year(emitDayjs.year()).month(emitDayjs.month()).date(emitDayjs.date())
       }
+      if (showTime.value) return emitDayjs.millisecond(0)
       return emitDayjs.startOf('day')
     }
     const emit = (value, ...args) => {


### PR DESCRIPTION
修复当type为datetime时default-time不工作的问题。
并添加一个相关的test。

fix #1915

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
