### PR TITLE
fix(date-picker): date-picker focus end-time resets start-time

### DIFF
--- a/packages/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/date-picker/src/date-picker-com/panel-date-range.vue
@@ -523,6 +523,8 @@ export default defineComponent({
 
       if (!maxDate.value || maxDate.value.isBefore(minDate.value)) {
         maxDate.value = minDate.value
+        rightDate.value = maxDate.value
+        rightDate.value = rightDate.value.add(1, 'month')
       }
     }
 
@@ -539,6 +541,7 @@ export default defineComponent({
 
       if (maxDate.value && maxDate.value.isBefore(minDate.value)) {
         minDate.value = maxDate.value
+        leftDate.value = minDate.value
       }
     }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

element-plus: 1.0.2-beta.48
vue: 3.1.1

Hi~, date-picker has a problem. type is datetimerange. When the start date and the end date are the same day, the first step, I select the start time, and then I prepare to select the end time. When the end time is focused, the end time is reset to the current time, and the start time is reset to the current time, I have to set the start time again...

![before](https://user-images.githubusercontent.com/27729870/122857611-51019c00-d34b-11eb-8a0c-42b6f3cc5277.gif)

