### PR TITLE
fix: row shrink width in flex box(#2319)

### DIFF
--- a/packages/theme-chalk/src/row.scss
+++ b/packages/theme-chalk/src/row.scss
@@ -4,6 +4,7 @@
 
 @include b(row) {
   display: flex;
+  width: 100%;
   flex-wrap: wrap;
   position: relative;
   box-sizing: border-box;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

fixed #2319 

The reason of this issues is: at this pr #2270 , it changed display of form `block` to `flex`, and then make `el-row` width shrink.  This pr will fix `el-row` width is not full in flex box.