### PR TITLE
fix: checkbox label auto convert to bool when label is empty (#2287)

### DIFF
--- a/packages/checkbox/__tests__/checkbox.spec.ts
+++ b/packages/checkbox/__tests__/checkbox.spec.ts
@@ -125,7 +125,7 @@ describe('Checkbox', () => {
     expect(vm.checkList).toEqual(['a'])
   })
 
-  test('true false lable', async () => {
+  test('true false label', async () => {
     const wrapper = _mount(
       `<el-checkbox true-label="a" :false-label="3" v-model="checked"></el-checkbox>`,
       () => ({
@@ -154,6 +154,27 @@ describe('Checkbox', () => {
     ) as any
     expect(wrapper.vm.checked).toBe(true)
     expect(wrapper.vm.checklist).toEqual(['a'])
+  })
+
+  test('label', async() => {
+    const wrapper = _mount(
+      `
+      <div>
+        <el-checkbox-group v-model="checklist">
+          <el-checkbox label="">all</el-checkbox>
+          <el-checkbox label="a">a</el-checkbox>
+          <el-checkbox label="b">b</el-checkbox>
+        </el-checkbox-group>
+      </div>
+      `,
+      () => ({
+        checked: false,
+        checklist: [],
+      }),
+    )
+    const checkbox = wrapper.find('.el-checkbox')
+    await checkbox.trigger('click')
+    expect(wrapper.vm.checklist[0]).toEqual('')
   })
 })
 

--- a/packages/checkbox/src/checkbox.vue
+++ b/packages/checkbox/src/checkbox.vue
@@ -75,7 +75,7 @@ export default defineComponent({
       default: () => undefined,
     },
     label: {
-      type: [Boolean, Number, String],
+      type: [String, Boolean, Number],
     },
     indeterminate: Boolean,
     disabled: Boolean,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

bugfix #2287 

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

Edited by jeremy:

- fix: #2287 
Note: Please use `fix: #issue_number` statement for a better UI lookup next time, GitHub only recognizes this keyword and handles it correctly.