### PR TITLE
Utils: fix isScroll

### DIFF
--- a/packages/utils/dom.ts
+++ b/packages/utils/dom.ts
@@ -166,7 +166,7 @@ export const isScroll = (
       ? getStyle(el, 'overflow-y')
       : getStyle(el, 'overflow-x')
 
-  return overflow.match(/(scroll|auto)/)
+  return overflow.match(/(scroll|auto|overlay)/)
 }
 
 export const getScrollContainer = (


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

`overlay` behaves the same as `auto`, but now `isScroll` method can't match the scroll wrap with `overlay`.

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
