### PR TITLE
refactor: button/radio/input size by sass map

### DIFF
--- a/packages/theme-chalk/src/button.scss
+++ b/packages/theme-chalk/src/button.scss
@@ -1,4 +1,5 @@
 @charset "UTF-8";
+@use "sass:map";
 @import "common/var";
 @import "mixins/button";
 @import "mixins/mixins";
@@ -7,7 +8,7 @@
 @include b(button) {
   display: inline-block;
   line-height: 1;
-  min-height: $--input-height;
+  min-height: map.get($--input-height, 'default');
   white-space: nowrap;
   cursor: pointer;
   background: $--button-default-background-color;
@@ -26,7 +27,7 @@
     margin-left: 10px;
   }
 
-  @include button-size($--button-padding-vertical, $--button-padding-horizontal, $--button-font-size, $--button-border-radius);
+  @include button-size(map.get($--button-padding-vertical, 'default'), map.get($--button-padding-horizontal, 'default'), map.get($--button-font-size, 'default'), map.get($--button-border-radius, 'default'));
 
   &:hover,
   &:focus {
@@ -120,7 +121,7 @@
   }
   @include when(circle) {
     border-radius: 50%;
-    padding: $--button-padding-vertical;
+    padding: map.get($--button-padding-vertical, 'default');
   }
   @include m(primary) {
     @include button-variant($--button-primary-font-color, $--button-primary-background-color, $--button-primary-border-color);
@@ -137,30 +138,18 @@
   @include m(info) {
     @include button-variant($--button-info-font-color, $--button-info-background-color, $--button-info-border-color);
   }
-  @include m(medium) {
-    min-height: $--input-medium-height;
 
-    @include button-size($--button-medium-padding-vertical, $--button-medium-padding-horizontal, $--button-medium-font-size, $--button-medium-border-radius);
-    @include when(circle) {
-      padding: $--button-medium-padding-vertical;
+  @each $size in (medium, small, mini) {
+    @include m($size) {
+      min-height: map.get($--input-height, $size);
+
+      @include button-size(map.get($--button-padding-vertical, $size), map.get($--button-padding-horizontal, $size), map.get($--button-font-size, $size), map.get($--button-border-radius, $size));
+      @include when(circle) {
+        padding: map.get($--button-padding-horizontal, $size);
+      }
     }
   }
-  @include m(small) {
-    min-height: $--input-small-height;
 
-    @include button-size($--button-small-padding-vertical, $--button-small-padding-horizontal, $--button-small-font-size, $--button-small-border-radius);
-    @include when(circle) {
-      padding: $--button-small-padding-vertical;
-    }
-  }
-  @include m(mini) {
-    min-height: $--input-mini-height;
-
-    @include button-size($--button-mini-padding-vertical, $--button-mini-padding-horizontal, $--button-mini-font-size, $--button-mini-border-radius);
-    @include when(circle) {
-      padding: $--button-mini-padding-vertical;
-    }
-  }
   @include m(text) {
     border-color: transparent;
     color: $--color-primary;
@@ -208,10 +197,10 @@
       border-bottom-left-radius: 0;
     }
     &:first-child:last-child {
-      border-top-right-radius: $--button-border-radius;
-      border-bottom-right-radius: $--button-border-radius;
-      border-top-left-radius: $--button-border-radius;
-      border-bottom-left-radius: $--button-border-radius;
+      border-top-right-radius: map.get($--button-border-radius, 'default');
+      border-bottom-right-radius: map.get($--button-border-radius, 'default');
+      border-top-left-radius: map.get($--button-border-radius, 'default');
+      border-bottom-left-radius: map.get($--button-border-radius, 'default');
 
       &.is-round {
         border-radius: 20px;

--- a/packages/theme-chalk/src/cascader.scss
+++ b/packages/theme-chalk/src/cascader.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @import "mixins/mixins";
 @import "common/var";
 @import "./input";
@@ -9,7 +11,7 @@
   display: inline-block;
   position: relative;
   font-size: $--font-size-base;
-  line-height: $--input-height;
+  line-height: map.get($--input-height, 'default');
   outline: none;
 
   &:not(.is-disabled):hover {
@@ -50,19 +52,11 @@
     }
   }
 
-  @include m(medium) {
-    font-size: $--input-medium-font-size;
-    line-height: $--input-medium-height;
-  }
-
-  @include m(small) {
-    font-size: $--input-small-font-size;
-    line-height: $--input-small-height;
-  }
-
-  @include m(mini) {
-    font-size: $--input-mini-font-size;
-    line-height: $--input-mini-height;
+  @each $size in (medium, small, mini) {
+    @include m($size) {
+      font-size: map.get($--input-font-size, $size);
+      line-height: map.get($--input-height, $size);
+    }
   }
 
   @include when(disabled) {

--- a/packages/theme-chalk/src/checkbox.scss
+++ b/packages/theme-chalk/src/checkbox.scss
@@ -1,7 +1,9 @@
-@import "common/var";
-@import "mixins/mixins";
-@import "mixins/_button";
-@import "mixins/utils";
+@use "sass:map";
+
+@import 'common/var';
+@import 'mixins/mixins';
+@import 'mixins/_button';
+@import 'mixins/utils';
 
 :root {
   --el-checkbox-font-size: 14px;
@@ -13,12 +15,18 @@
   --el-checkbox-background-color: var(--el-color-white);
   --el-checkbox-input-border: var(--el-border-base);
 
+  --el-checkbox-medium-line-height: 17px;
+  --el-checkbox-small-line-height: 15px;
+  --el-checkbox-mini-line-height: 12px;
+
   --el-checkbox-disabled-border-color: var(--el-border-color-base);
   --el-checkbox-disabled-input-fill: #edf2fc;
   --el-checkbox-disabled-icon-color: var(--el-color-text-placeholder);
 
   --el-checkbox-disabled-checked-input-fill: var(--el-border-color-extra-light);
-  --el-checkbox-disabled-checked-input-border-color: var(--el-border-color-base);
+  --el-checkbox-disabled-checked-input-border-color: var(
+    --el-border-color-base
+  );
   --el-checkbox-disabled-checked-icon-color: var(--el-color-text-placeholder);
 
   --el-checkbox-checked-font-color: var(--el-color-primary);
@@ -79,56 +87,28 @@
       margin-left: 10px;
     }
 
-    &.#{$namespace}-checkbox--medium {
-      padding: var(--el-checkbox-bordered-medium-padding);
-      border-radius: $--button-medium-border-radius;
-      height: var(--el-checkbox-bordered-medium-height);
 
-      .#{$namespace}-checkbox__label {
-        line-height: 17px;
-        font-size: $--button-medium-font-size;
-      }
+    @each $size in (medium, small, mini) {
+      &.#{$namespace}-checkbox--#{size} {
+        padding: var(--el-checkbox-bordered-#{$size}-padding);
+        border-radius: map.get($--button-border-radius, $size);
+        height: var(--el-checkbox-bordered-#{$size}-height);
 
-      .#{$namespace}-checkbox__inner {
-        height: var(--el-checkbox-bordered-medium-input-height);
-        width: var(--el-checkbox-bordered-medium-input-width);
-      }
-    }
+        .#{$namespace}-checkbox__label {
+          line-height: var(--el-checkox-#{size}-line-height);
+          font-size: map.get($--button-font-size, $size);
+        }
 
-    &.#{$namespace}-checkbox--small {
-      padding: var(--el-checkbox-bordered-small-padding);
-      border-radius: $--button-small-border-radius;
-      height: var(--el-checkbox-bordered-small-height);
-
-      .#{$namespace}-checkbox__label {
-        line-height: 15px;
-        font-size: $--button-small-font-size;
-      }
-
-      .#{$namespace}-checkbox__inner {
-        height: var(--el-checkbox-bordered-small-input-height);
-        width: var(--el-checkbox-bordered-small-input-width);
-
-        &::after {
-          height: 6px;
-          width: 2px;
+        .#{$namespace}-checkbox__inner {
+          height: var(--el-checkbox-bordered-#{size}-input-height);
+          width: var(--el-checkbox-bordered-#{size}-input-width);
         }
       }
     }
 
-    &.#{$namespace}-checkbox--mini {
-      padding: var(--el-checkbox-bordered-mini-padding);
-      border-radius: $--button-mini-border-radius;
-      height: var(--el-checkbox-bordered-mini-height);
 
-      .#{$namespace}-checkbox__label {
-        line-height: 12px;
-        font-size: $--button-mini-font-size;
-      }
-
+    &.#{$namespace}-checkbox--small, &.#{$namespace}-checkbox--mini {
       .#{$namespace}-checkbox__inner {
-        height: var(--el-checkbox-bordered-mini-input-height);
-        width: var(--el-checkbox-bordered-mini-input-width);
         &::after {
           height: 6px;
           width: 2px;
@@ -205,7 +185,8 @@
         color: var(--el-checkbox-checked-font-color);
       }
     }
-    @include when(focus) { /*focus时 视觉上区分*/
+    @include when(focus) {
+      /*focus时 视觉上区分*/
       .#{$namespace}-checkbox__inner {
         border-color: var(--el-checkbox-input-border-color-hover);
       }
@@ -243,8 +224,8 @@
     height: var(--el-checkbox-input-height);
     background-color: var(--el-checkbox-background-color);
     z-index: var(--el-index-normal);
-    transition: border-color .25s cubic-bezier(.71,-.46,.29,1.46),
-    background-color .25s cubic-bezier(.71,-.46,.29,1.46);
+    transition: border-color 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46),
+      background-color 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46);
 
     &:hover {
       border-color: var(--el-checkbox-input-border-color-hover);
@@ -252,7 +233,7 @@
 
     &::after {
       box-sizing: content-box;
-      content: "";
+      content: '';
       border: 1px solid var(--el-checkbox-checked-icon-color);
       border-left: 0;
       border-top: 0;
@@ -262,7 +243,7 @@
       top: 1px;
       transform: rotate(45deg) scaleY(0);
       width: 3px;
-      transition: transform .15s ease-in .05s;
+      transition: transform 0.15s ease-in 0.05s;
       transform-origin: center;
     }
   }
@@ -313,13 +294,13 @@
     transition: $--all-transition;
     @include utils-user-select(none);
 
-    @include button-size($--button-padding-vertical, $--button-padding-horizontal, $--button-font-size, 0);
+    @include button-size(map.get($--button-padding-vertical, 'default'), map.get($--button-padding-horizontal, 'default'), map.get($--button-font-size, 'default'), 0);
 
     &:hover {
       color: var(--el-color-primary);
     }
 
-    & [class*="#{$namespace}-icon-"] {
+    & [class*='#{$namespace}-icon-'] {
       line-height: 0.9;
 
       & + span {
@@ -382,19 +363,16 @@
     }
   }
 
-  @include m(medium) {
-    .#{$namespace}-checkbox-button__inner {
-      @include button-size($--button-medium-padding-vertical, $--button-medium-padding-horizontal, $--button-medium-font-size, 0);
-    }
-  }
-  @include m(small) {
-    .#{$namespace}-checkbox-button__inner {
-      @include button-size($--button-small-padding-vertical, $--button-small-padding-horizontal, $--button-small-font-size, 0);
-    }
-  }
-  @include m(mini) {
-    .#{$namespace}-checkbox-button__inner {
-      @include button-size($--button-mini-padding-vertical, $--button-mini-padding-horizontal, $--button-mini-font-size, 0);
+  @each $size in (medium, small, mini) {
+    @include m($size) {
+      .#{$namespace}-checkbox-button__inner {
+        @include button-size(
+          map.get($--button-padding-vertical, $size),
+          map.get($--button-padding-horizontal, $size),
+          map.get($--button-font-size, $size),
+          0
+        );
+      }
     }
   }
 }

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -1,5 +1,6 @@
 /* Element Chalk Variables */
 @use "sass:math";
+@use "sass:map";
 
 @import "../mixins/config";
 
@@ -171,20 +172,31 @@ $--radio-checked-icon-color: $--color-primary !default;
 
 $--radio-input-border-color-hover: $--color-primary !default;
 
-$--radio-bordered-height: 40px !default;
-$--radio-bordered-padding: 12px 20px 0 10px !default;
-$--radio-bordered-medium-padding: 10px 20px 0 10px !default;
-$--radio-bordered-small-padding: 8px 15px 0 10px !default;
-$--radio-bordered-mini-padding: 6px 15px 0 10px !default;
-$--radio-bordered-medium-input-height: 14px !default;
-$--radio-bordered-medium-input-width: 14px !default;
-$--radio-bordered-medium-height: 36px !default;
-$--radio-bordered-small-input-height: 12px !default;
-$--radio-bordered-small-input-width: 12px !default;
-$--radio-bordered-small-height: 32px !default;
-$--radio-bordered-mini-input-height: 12px !default;
-$--radio-bordered-mini-input-width: 12px !default;
-$--radio-bordered-mini-height: 28px !default;
+$--radio-bordered-padding: (
+  'default': 12px 20px 0 10px,
+  'medium': 10px 20px 0 10px,
+  'small': 8px 15px 0 10px,
+  'mini': 6px 15px 0 10px,
+);
+
+$--radio-bordered-input-height: (
+  'medium': 14px,
+  'small': 12px,
+  'mini': 12px
+);
+
+$--radio-bordered-input-width: (
+  'medium': 14px,
+  'small': 12px,
+  'mini': 12px
+);
+
+$--radio-bordered-height: (
+  'default': 40px,
+  'medium': 36px,
+  'small': 32px,
+  'mini': 28px
+);
 
 /// color||Color|0
 $--radio-button-checked-background-color: $--color-primary !default;
@@ -361,22 +373,25 @@ $--input-disabled-border: $--disabled-border-base !default;
 $--input-disabled-color: $--disabled-color-base !default;
 $--input-disabled-placeholder-color: $--color-text-placeholder !default;
 
-/// fontSize||Font|1
-$--input-font-size: $--font-size-base !default;
-/// height||Other|4
-$--input-height: 40px !default;
-/// fontSize||Font|1
-$--input-medium-font-size: 14px !default;
-/// height||Other|4
-$--input-medium-height: 36px !default;
-/// fontSize||Font|1
-$--input-small-font-size: 13px !default;
-/// height||Other|4
-$--input-small-height: 32px !default;
-/// fontSize||Font|1
-$--input-mini-font-size: 12px !default;
-/// height||Other|4
-$--input-mini-height: 28px !default;
+$--input-font-size: (
+  'default': $--font-size-base,
+  'medium': 14px,
+  'small': 13px,
+  'mini': 12px,
+);
+
+$--input-height: (
+  'default': 40px,
+  'medium': 36px,
+  'small': 32px,
+  'mini': 28px
+);
+
+$--input-line-height: (
+  'medium': 28px,
+  'small': 24px,
+  'mini': 20px
+);
 
 /* Cascader
 -------------------------- */
@@ -396,40 +411,36 @@ $--cascader-tag-background: #f0f2f5 !default;
 
 /* Button
 -------------------------- */
-/// fontSize||Font|1
-$--button-font-size: $--font-size-base !default;
 /// fontWeight||Font|1
 $--button-font-weight: $--font-weight-primary !default;
-/// borderRadius||Border|2
-$--button-border-radius: $--border-radius-base !default;
-/// padding||Spacing|3
-$--button-padding-vertical: 12px !default;
-/// padding||Spacing|3
-$--button-padding-horizontal: 20px !default;
 
-/// fontSize||Font|1
-$--button-medium-font-size: $--font-size-base !default;
-/// borderRadius||Border|2
-$--button-medium-border-radius: $--border-radius-base !default;
-/// padding||Spacing|3
-$--button-medium-padding-vertical: 10px !default;
-/// padding||Spacing|3
-$--button-medium-padding-horizontal: 20px !default;
+$--button-font-size: (
+  'default': $--font-size-base,
+  'medium': $--font-size-base,
+  'small': 12px,
+  'mini': 12px,
+);
 
-/// fontSize||Font|1
-$--button-small-font-size: 12px !default;
-$--button-small-border-radius: #{$--border-radius-base - 1} !default;
-/// padding||Spacing|3
-$--button-small-padding-vertical: 9px !default;
-/// padding||Spacing|3
-$--button-small-padding-horizontal: 15px !default;
-/// fontSize||Font|1
-$--button-mini-font-size: 12px !default;
-$--button-mini-border-radius: #{$--border-radius-base - 1} !default;
-/// padding||Spacing|3
-$--button-mini-padding-vertical: 7px !default;
-/// padding||Spacing|3
-$--button-mini-padding-horizontal: 15px !default;
+$--button-border-radius: (
+  'default': $--border-radius-base,
+  'medium': $--border-radius-base,
+  'small': #{$--border-radius-base - 1},
+  'mini': #{$--border-radius-base - 1}
+);
+
+$--button-padding-vertical: (
+  'default': 12px,
+  'medium': 10px,
+  'small': 9px,
+  'mini': 7px
+);
+
+$--button-padding-horizontal: (
+  'default': 20px,
+  'medium': 20px,
+  'small': 15px,
+  'mini': 15px
+);
 
 /// color||Color|0
 $--button-default-font-color: $--color-text-regular !default;

--- a/packages/theme-chalk/src/date-picker/picker.scss
+++ b/packages/theme-chalk/src/date-picker/picker.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @import "../mixins/mixins";
 @import "../common/var";
 @import "../common/transition";
@@ -121,69 +123,25 @@
     }
   }
 
-  @include m(medium) {
-    line-height: $--input-medium-height;
+  @each $size in (medium, small, mini) {
+    line-height: map.get($--input-height, $size);
 
     &.#{$namespace}-input__inner {
-      height: $--input-medium-height;
+      height: map.get($--input-height, $size);
     }
 
     .#{$namespace}-range-separator {
-      line-height: 28px;
-      font-size: $--input-medium-font-size;
+      line-height: map.get($--input-line-height, $size);
+      font-size: map.get($--input-font-size, $size);
     }
 
     .#{$namespace}-range-input {
-      font-size: $--input-medium-font-size;
+      font-size: map.get($--input-font-size, $size);
     }
 
     .#{$namespace}-range__icon,
     .#{$namespace}-range__close-icon {
-      line-height: 28px;
-    }
-  }
-
-  @include m(small) {
-    line-height: $--input-small-height;
-
-    &.#{$namespace}-input__inner {
-      height: $--input-small-height;
-    }
-
-    .#{$namespace}-range-separator {
-      line-height: 24px;
-      font-size: $--input-small-font-size;
-    }
-
-    .#{$namespace}-range-input {
-      font-size: $--input-small-font-size;
-    }
-
-    .#{$namespace}-range__icon,
-    .#{$namespace}-range__close-icon {
-      line-height: 24px;
-    }
-  }
-
-  @include m(mini) {
-    line-height: $--input-mini-height;
-
-    &.#{$namespace}-input__inner {
-      height: $--input-mini-height;
-    }
-
-    .#{$namespace}-range-separator {
-      line-height: 20px;
-      font-size: $--input-mini-font-size;
-    }
-
-    .#{$namespace}-range-input {
-      font-size: $--input-mini-font-size;
-    }
-
-    .#{$namespace}-range__icon,
-    .#{$namespace}-range__close-icon {
-      line-height: 20px;
+      line-height: map.get($--input-line-height, $size);
     }
   }
 

--- a/packages/theme-chalk/src/input-number.scss
+++ b/packages/theme-chalk/src/input-number.scss
@@ -1,4 +1,5 @@
 @use "sass:math";
+@use "sass:map";
 
 @import "mixins/mixins";
 @import "common/var";
@@ -8,15 +9,15 @@
   position: relative;
   display: inline-block;
   width: 180px;
-  line-height: #{$--input-height - 2};
+  line-height: #{map.get($--input-height, 'default') - 2};
 
   .#{$namespace}-input {
     display: block;
 
     &__inner {
       -webkit-appearance: none;
-      padding-left: #{$--input-height + 10};
-      padding-right: #{$--input-height + 10};
+      padding-left: #{map.get($--input-height, 'default') + 10};
+      padding-right: #{map.get($--input-height, 'default') + 10};
       text-align: center;
     }
   }
@@ -25,7 +26,7 @@
     position: absolute;
     z-index: 1;
     top: 1px;
-    width: $--input-height;
+    width: map.get($--input-height, 'default');
     height: auto;
     text-align: center;
     background: $--background-color-base;
@@ -71,56 +72,41 @@
     }
   }
 
-  @include m(medium) {
-    width: 200px;
-    line-height: #{$--input-medium-height - 2};
+  @each $size in (medium, small, mini) {
+    line-height: #{map.get($--input-height, $size) - 2};
 
     @include e((increase, decrease)) {
-      width: $--input-medium-height;
-      font-size: $--input-medium-font-size;
+      width: map.get($--input-height, $size);
+      font-size: map.get($--input-font-size, $size);
     }
 
     .#{$namespace}-input__inner {
-      padding-left: #{$--input-medium-height + 7};
-      padding-right: #{$--input-medium-height + 7};
+      padding-left: #{map.get($--input-height, $size) + 7};
+      padding-right: #{map.get($--input-height, $size) + 7};
     }
+  }
+
+  @include m(medium) {
+    width: 200px;
   }
 
   @include m(small) {
     width: 130px;
-    line-height: #{$--input-small-height - 2};
 
     @include e((increase, decrease)) {
-      width: $--input-small-height;
-      font-size: $--input-small-font-size;
-
       [class*=#{$namespace}-icon] {
         transform: scale(.9);
       }
-    }
-
-    .#{$namespace}-input__inner {
-      padding-left: #{$--input-small-height + 7};
-      padding-right: #{$--input-small-height + 7};
     }
   }
 
   @include m(mini) {
     width: 130px;
-    line-height: #{$--input-mini-height - 2};
 
     @include e((increase, decrease)) {
-      width: $--input-mini-height;
-      font-size: $--input-mini-font-size;
-
       [class*=#{$namespace}-icon] {
         transform: scale(.8);
       }
-    }
-
-    .#{$namespace}-input__inner {
-      padding-left: #{$--input-mini-height + 7};
-      padding-right: #{$--input-mini-height + 7};
     }
   }
 
@@ -134,12 +120,12 @@
   @include when(controls-right) {
     .#{$namespace}-input__inner {
       padding-left: 15px;
-      padding-right: #{$--input-height + 10};
+      padding-right: #{map.get($--input-height, 'default') + 10};
     }
 
     @include e((increase, decrease)) {
       height: auto;
-      line-height: #{math.div($--input-height - 2, 2)};
+      line-height: #{math.div(map.get($--input-height, 'default') - 2, 2)};
 
       [class*=#{$namespace}-icon] {
         transform: scale(.8);
@@ -161,21 +147,11 @@
       border-radius: 0 0 $--border-radius-base 0;
     }
 
-    &[class*=medium] {
-      [class*=increase], [class*=decrease] {
-        line-height: #{math.div($--input-medium-height - 2, 2)};
-      }
-    }
-
-    &[class*=small] {
-      [class*=increase], [class*=decrease] {
-        line-height: #{math.div($--input-small-height - 2, 2)};
-      }
-    }
-
-    &[class*=mini] {
-      [class*=increase], [class*=decrease] {
-        line-height: #{math.div($--input-mini-height - 2, 2)};
+    @each $size in (medium, small, mini) {
+      &[class*=#{size}] {
+        [class*=increase], [class*=decrease] {
+          line-height: #{math.div(map.get($--input-height, $size) - 2, 2)};
+        }
       }
     }
   }

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @import "mixins/mixins";
 @import "common/var";
 
@@ -76,12 +78,12 @@
   font-size: $--font-size-base;
   display: inline-block;
   width: 100%;
-  line-height: $--input-height;
+  line-height: map.get($--input-height, 'default');
   @include scroll-bar;
 
   & .#{$namespace}-input__clear {
     color: $--input-icon-color;
-    font-size: $--input-font-size;
+    font-size: map.get($--input-font-size, 'default');
     cursor: pointer;
     transition: $--color-transition-base;
 
@@ -115,8 +117,8 @@
     color: $--input-font-color;
     display: inline-block;
     font-size: inherit;
-    height: $--input-height;
-    line-height: $--input-height;
+    height: map.get($--input-height, 'default');
+    line-height: map.get($--input-height, 'default');
     outline: none;
     padding: 0 15px;
     transition: $--border-transition-base;
@@ -165,7 +167,7 @@
     width: 25px;
     text-align: center;
     transition: all .3s;
-    line-height: $--input-height;
+    line-height: map.get($--input-height, 'default');
 
     &:after {
       content: '';
@@ -234,43 +236,19 @@
     }
   }
 
-  @include m(medium) {
-    font-size: $--input-medium-font-size;
-    line-height: $--input-medium-height;
+  @each $size in (medium, small, mini) {
+    @include m($size) {
+      font-size: map.get($--input-font-size, $size);
+      line-height: map.get($--input-height, $size);
 
-    @include e(inner) {
-      height: $--input-medium-height;
-      line-height: $--input-medium-height;
-    }
+      @include e(inner) {
+        height: map.get($--input-height, $size);
+        line-height: map.get($--input-height, $size);
+      }
 
-    .#{$namespace}-input__icon {
-      line-height: $--input-medium-height;
-    }
-  }
-  @include m(small) {
-    font-size: $--input-small-font-size;
-    line-height: $--input-small-height;
-
-    @include e(inner) {
-      height: $--input-small-height;
-      line-height: $--input-small-height;
-    }
-
-    .#{$namespace}-input__icon {
-      line-height: $--input-small-height;
-    }
-  }
-  @include m(mini) {
-    font-size: $--input-mini-font-size;
-    line-height: $--input-mini-height;
-
-    @include e(inner) {
-      height: $--input-mini-height;
-      line-height: $--input-mini-height;
-    }
-
-    .#{$namespace}-input__icon {
-      line-height: $--input-mini-height;
+      .#{$namespace}-input__icon {
+        line-height: map.get($--input-height, $size);
+      }
     }
   }
 }

--- a/packages/theme-chalk/src/mixins/_button.scss
+++ b/packages/theme-chalk/src/mixins/_button.scss
@@ -41,7 +41,7 @@
     border-color: mix($--color-white, $border-color, $--button-hover-tint-percent);
     color: $color;
   }
-  
+
   &:active {
     background: mix($--color-black, $background-color, $--button-active-shade-percent);
     border-color: mix($--color-black, $border-color, $--button-active-shade-percent);

--- a/packages/theme-chalk/src/radio-button.scss
+++ b/packages/theme-chalk/src/radio-button.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @import "mixins/mixins";
 @import "mixins/_button";
 @import "common/var";
@@ -26,7 +28,7 @@
     cursor: pointer;
     transition: $--all-transition;
 
-    @include button-size($--button-padding-vertical, $--button-padding-horizontal, $--button-font-size, 0);
+    @include button-size(map.get($--button-padding-vertical, 'default'), map.get($--button-padding-horizontal, 'default'), map.get($--button-font-size, 'default'), 0);
 
     &:hover {
       color: $--color-primary;
@@ -91,19 +93,11 @@
     }
   }
 
-  @include m(medium) {
-    & .#{$namespace}-radio-button__inner {
-      @include button-size($--button-medium-padding-vertical, $--button-medium-padding-horizontal, $--button-medium-font-size, 0);
-    }
-  }
-  @include m(small) {
-    & .#{$namespace}-radio-button__inner {
-      @include button-size($--button-small-padding-vertical, $--button-small-padding-horizontal, $--button-small-font-size, 0);
-    }
-  }
-  @include m(mini) {
-    & .#{$namespace}-radio-button__inner {
-      @include button-size($--button-mini-padding-vertical, $--button-mini-padding-horizontal, $--button-mini-font-size, 0);
+  @each $size in (medium, small, mini) {
+    @include m($size) {
+      & .#{$namespace}-radio-button__inner {
+        @include button-size(map.get($--button-padding-vertical, $size), map.get($--button-padding-horizontal, $size), map.get($--button-font-size, $size), 0);
+      }
     }
   }
 

--- a/packages/theme-chalk/src/radio.scss
+++ b/packages/theme-chalk/src/radio.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @import "mixins/mixins";
 @import "mixins/utils";
 @import 'mixins/button';
@@ -17,11 +19,11 @@
   @include utils-user-select(none);
 
   @include when(bordered) {
-    padding: $--radio-bordered-padding;
+    padding: map.get($--radio-bordered-padding, 'default');
     border-radius: $--border-radius-base;
     border: $--border-base;
     box-sizing: border-box;
-    height: $--radio-bordered-height;
+    height: map.get($--radio-bordered-height, 'default');
 
     &.is-checked {
       border-color: $--color-primary;
@@ -37,45 +39,17 @@
     }
   }
 
-  @include m(medium) {
+  @each $size in (medium, small, mini) {
     &.is-bordered {
-      padding: $--radio-bordered-medium-padding;
-      border-radius: $--button-medium-border-radius;
-      height: $--radio-bordered-medium-height;
+      padding: map.get($--radio-bordered-padding, $size);
+      border-radius: $--border-radius-base;
+      height: map.get($--radio-bordered-height, $size);
       .#{$namespace}-radio__label {
-        font-size: $--button-medium-font-size;
+        font-size: map.get($--button-font-size, $size);
       }
       .#{$namespace}-radio__inner {
-        height: $--radio-bordered-medium-input-height;
-        width: $--radio-bordered-medium-input-width;
-      }
-    }
-  }
-  @include m(small) {
-    &.is-bordered {
-      padding: $--radio-bordered-small-padding;
-      border-radius: $--button-small-border-radius;
-      height: $--radio-bordered-small-height;
-      .#{$namespace}-radio__label {
-        font-size: $--button-small-font-size;
-      }
-      .#{$namespace}-radio__inner {
-        height: $--radio-bordered-small-input-height;
-        width: $--radio-bordered-small-input-width;
-      }
-    }
-  }
-  @include m(mini) {
-    &.is-bordered {
-      padding: $--radio-bordered-mini-padding;
-      border-radius: $--button-mini-border-radius;
-      height: $--radio-bordered-mini-height;
-      .#{$namespace}-radio__label {
-        font-size: $--button-mini-font-size;
-      }
-      .#{$namespace}-radio__inner {
-        height: $--radio-bordered-mini-input-height;
-        width: $--radio-bordered-mini-input-width;
+        height: map.get($--radio-bordered-input-height, $size);
+        width: map.get($--radio-bordered-input-width, $size);
       }
     }
   }

--- a/packages/theme-chalk/src/select-v2.scss
+++ b/packages/theme-chalk/src/select-v2.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @import 'mixins/mixins';
 @import 'mixins/utils';
 @import 'common/var';
@@ -78,13 +80,13 @@ $--input-inline-start: 7px !default;
 
     &,
     #{$selector}__input-wrapper {
-      line-height: $--input-height;
+      line-height: map.get($--input-height, 'default');
       // height: $--input-height;
     }
 
     #{$selector}__input-wrapper input {
-      line-height: $--input-medium-height;
-      height: $--input-medium-height;
+      line-height: map.get($--input-height, 'medium');
+      height: map.get($--input-height, 'medium');
 
       min-width: 4px;
       width: 100%;
@@ -118,48 +120,18 @@ $--input-inline-start: 7px !default;
     );
   }
 
-  @include m(mini) {
-    @include e(wrapper) {
-      &,
-      #{$selector}__input-wrapper {
-        // since there were no 24px predefined, we can only hand write here.
-        line-height: $--input-mini-height;
-        // height: $--input-mini-height;
-      }
+  @each $size in (medium, small, mini) {
+    @include m($size) {
+      @include e(wrapper) {
+        &,
+        #{$selector}__input-wrapper {
+          line-height: map.get($--input-height, $size);
+        }
 
-      #{$selector}__input-wrapper input {
-        line-height: 24px;
-        height: 24px;
-      }
-    }
-  }
-
-  @include m(small) {
-    @include e(wrapper) {
-      &,
-      #{$selector}__input-wrapper {
-        line-height: $--input-small-height;
-        // height: $--input-small-height;
-      }
-
-      #{$selector}__input-wrapper input {
-        line-height: $--input-mini-height;
-        height: $--input-mini-height;
-      }
-    }
-  }
-
-  @include m(medium) {
-    @include e(wrapper) {
-      &,
-      #{$selector}__input-wrapper {
-        line-height: $--input-medium-height;
-        // height: $--input-medium-height;
-      }
-
-      #{$selector}__input-wrapper input {
-        line-height: $--input-small-height;
-        height: $--input-small-height;
+        #{$selector}__input-wrapper input {
+          line-height: map.get($--input-height, $size) - 4px;
+          height: map.get($--input-height, $size) - 4px;
+        }
       }
     }
   }

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @import 'mixins/mixins';
 @import 'mixins/utils';
 @import 'common/var';
@@ -11,7 +13,7 @@
 @include b(select) {
   display: inline-block;
   position: relative;
-  line-height: $--input-height;
+  line-height: map.get($--input-height, 'default');
 
   @include e(popper) {
     @include picker-popper(
@@ -21,16 +23,10 @@
     );
   }
 
-  @include m(mini) {
-    line-height: $--input-mini-height;
-  }
-
-  @include m(small) {
-    line-height: $--input-small-height;
-  }
-
-  @include m(medium) {
-    line-height: $--input-medium-height;
+  @each $size in (medium, small, mini) {
+    @include m($size) {
+      line-height: map.get($--input-height, $size);
+    }
   }
 
   .#{$namespace}-select__tags > span {

--- a/packages/theme-chalk/src/slider.scss
+++ b/packages/theme-chalk/src/slider.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @import "mixins/mixins";
 @import "mixins/utils";
 @import "input-number";
@@ -187,7 +189,7 @@
       transform: translateY(50%);
     }
     &.#{$namespace}-slider--with-input {
-      padding-bottom: #{$--input-medium-height + 22px};
+      padding-bottom: #{map.get($--input-height, 'medium') + 22px};
       .#{$namespace}-slider__input {
         overflow: visible;
         float: none;
@@ -203,7 +205,7 @@
         .#{$namespace}-input-number__decrease,
         .#{$namespace}-input-number__increase
         {
-          top: $--input-small-height;
+          top: map.get($--input-height, 'small');
           margin-top: -1px;
           border: $--input-border;
           line-height: 20px;


### PR DESCRIPTION
Since radio and input also contain button variables, they are refactored into the form of `sass:map`.

The variables are mainly divided into `default/medium/small/mini`.
The use of `@each` greatly reduces the amount of redundant code.

The handwrite of `#{$selector}__input-wrapper input` in select-v2 has been removed. We can calculate it.

---

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
