### PR TITLE
feat(menu): improve handleItemClick

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
   "license": "MIT",
   "dependencies": {
     "@popperjs/core": "^2.4.4",
-    "@types/lodash": "^4.14.161",
     "async-validator": "^3.4.0",
     "dayjs": "1.x",
     "lodash": "^4.17.20",

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -192,7 +192,7 @@ export default defineComponent({
     }) => {
       const { index, indexPath } = item
       const hasIndex = item.index !== null
-      const emitParams = ['select', index, indexPath.value, item]
+      const emitParams = [index, indexPath.value, item]
 
       if (props.mode === 'horizontal' || props.collapse) {
         openedMenus.value = []
@@ -212,10 +212,10 @@ export default defineComponent({
             }
             return navigationResult
           })
-        ctx.emit.apply(this, emitParams.concat(routerResult))
+        ctx.emit('select', ...emitParams.concat(routerResult))
       } else {
         activeIndex.value = item.index
-        ctx.emit.apply(this, emitParams)
+        ctx.emit('select', ...emitParams)
       }
     }
 

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -192,34 +192,30 @@ export default defineComponent({
     }) => {
       const { index, indexPath } = item
       const hasIndex = item.index !== null
-      const oldActiveIndex = activeIndex.value
-
-      if (hasIndex) {
-        activeIndex.value = item.index
-      }
-
-      ctx.emit('select', index, indexPath.value, item)
+      const emitParams = ['select', index, indexPath.value, item]
 
       if (props.mode === 'horizontal' || props.collapse) {
         openedMenus.value = []
       }
 
-      if (props.router && router && hasIndex) {
-        let route = item.route || item.index
-        router?.push(route)
-          .then(navigationResult => {
-            //vue-router NavigationFailureType duplicated
-            const DUPLICATE_ROUTE = 16
-            if (navigationResult && navigationResult.type !== DUPLICATE_ROUTE) {
-              activeIndex.value = oldActiveIndex
-              throw navigationResult
-            }
-          })
-          .catch(error => {
-            activeIndex.value = oldActiveIndex
-            throw error
-          })
+      if (!hasIndex) {
+        return
+      }
 
+      if (props.router && router) {
+        let route = item.route || item.index
+        const routerResult = router
+          .push(route)
+          .then(navigationResult => {
+            if (!navigationResult) {
+              activeIndex.value = item.index
+            }
+            return navigationResult
+          })
+        ctx.emit.apply(this, emitParams.concat(routerResult))
+      } else {
+        activeIndex.value = item.index
+        ctx.emit.apply(this, emitParams)
       }
     }
 

--- a/website/docs/en-US/menu.md
+++ b/website/docs/en-US/menu.md
@@ -334,7 +334,7 @@ Vertical NavMenu could be collapsed.
 ### Menu Events
 | Event Name | Description | Parameters |
 |---------- |-------- |---------- |
-| select  | callback function when menu is activated | index: index of activated menu, indexPath: index path of activated menu  |
+| select  | callback function when menu is activated | index: index of activated menu, indexPath: index path of activated menu, item: the selected menu item, routeResult: result returned by `vue-router` if `router` is enabled  |
 | open  | callback function when sub-menu expands | index: index of expanded sub-menu, indexPath: index path of expanded sub-menu |
 | close  | callback function when sub-menu collapses | index: index of collapsed sub-menu, indexPath: index path of collapsed sub-menu |
 

--- a/website/docs/es/menu.md
+++ b/website/docs/es/menu.md
@@ -336,7 +336,7 @@ NavMenu vertical puede ser colapsado.
 ### Eventos Menu
 | Nombre de evento | Descripción                              | Parámetros                               |
 | ---------------- | ---------------------------------------- | ---------------------------------------- |
-| select           | callback ejecutado cuando el menú es activado | index: índice del menú activado, indexPath: index path del menú activado |
+| select           | callback ejecutado cuando el menú es activado | index: índice del menú activado, indexPath: index path del menú activado, item: el elemento de menú seleccionado, routeResult: resultado devuelto por `vue-router` si `router` está activado |
 | open             | callback ejecutado cuando sub-menu se expande | index: índice del sub-menu expandido, indexPath: index path del sub-menu expandido |
 | close            | callback ejecutado cuando sub-menu colapsa | index: índice del sub-menu colapsado, indexPath: index path del menú colapsado |
 

--- a/website/docs/fr-FR/menu.md
+++ b/website/docs/fr-FR/menu.md
@@ -337,7 +337,7 @@ Le menu vertical peut être réduit.
 
 | Nom | Description | Paramètres |
 |---------- |-------- |---------- |
-| select  | Fonction de callback pour quand le menu est activé. | index: index du menu activé, indexPath: index path du menu activé.  |
+| select  | Fonction de callback pour quand le menu est activé. | index: index du menu activé, indexPath: index path du menu activé, item : l'élément de menu sélectionné, routeResult : le résultat retourné par `vue-router` si `router` est activé.  |
 | open  | Fonction de callback pour quand le sous-menu s'agrandit. | index: index of expanded sous-menu, indexPath: index path du sous-menu |
 | close  | Fonction de callback pour quand le sous-menu se réduit. | index: index of collapsed sous-menu, indexPath: index path du sous-menu |
 

--- a/website/docs/jp/menu.md
+++ b/website/docs/jp/menu.md
@@ -334,7 +334,7 @@ Vサブメニューのある縦型ナビメニュー。
 ### メニューイベント
 | Event Name | Description | Parameters |
 |---------- |-------- |---------- |
-| select  | メニュー起動時コールバック機能 | index: index of activated menu, indexPath: index path of activated menu  |
+| select  | メニュー起動時コールバック機能 | index: index of activated menu, indexPath: index path of activated menu, item: 選択されたメニュー項目, routeResult: `router` が有効な場合に `vue-router` が返す結果  |
 | open  | サブメニュー展開したときのコールバック関数 | index: index of expanded sub-menu, indexPath: index path of expanded sub-menu |
 | close  | サブメニューを折りたたんだ時のコールバック関数 | index: index of collapsed sub-menu, indexPath: index path of collapsed sub-menu |
 

--- a/website/docs/zh-CN/menu.md
+++ b/website/docs/zh-CN/menu.md
@@ -350,9 +350,9 @@
 ### Menu Events
 | 事件名称 | 说明                | 回调参数                                                                   |
 | -------- | ------------------- | -------------------------------------------------------------------------- |
-| select   | 菜单激活回调        | index: 选中菜单项的 index, indexPath: 选中菜单项的 index path              |
-| open     | sub-menu 展开的回调 | index: 打开的 sub-menu 的 index， indexPath: 打开的 sub-menu 的 index path |
-| close    | sub-menu 收起的回调 | index: 收起的 sub-menu 的 index， indexPath: 收起的 sub-menu 的 index path |
+| select   | 菜单激活回调        | index: 选中菜单项的 index, indexPath: 选中菜单项的 index path, item: 选中菜单项, route: vue-router 的返回值（如果 router 为 true）              |
+| open     | sub-menu 展开的回调 | index: 打开的 sub-menu 的 index, indexPath: 打开的 sub-menu 的 index path |
+| close    | sub-menu 收起的回调 | index: 收起的 sub-menu 的 index, indexPath: 收起的 sub-menu 的 index path |
 
 ### SubMenu Attribute
 | 参数                  | 说明                                                                     | 类型        | 可选值 | 默认值                                 |

--- a/website/docs/zh-CN/menu.md
+++ b/website/docs/zh-CN/menu.md
@@ -350,7 +350,7 @@
 ### Menu Events
 | 事件名称 | 说明                | 回调参数                                                                   |
 | -------- | ------------------- | -------------------------------------------------------------------------- |
-| select   | 菜单激活回调        | index: 选中菜单项的 index, indexPath: 选中菜单项的 index path, item: 选中菜单项, route: vue-router 的返回值（如果 router 为 true）              |
+| select   | 菜单激活回调        | index: 选中菜单项的 index, indexPath: 选中菜单项的 index path, item: 选中菜单项, routeResult: vue-router 的返回值（如果 router 为 true）              |
 | open     | sub-menu 展开的回调 | index: 打开的 sub-menu 的 index, indexPath: 打开的 sub-menu 的 index path |
 | close    | sub-menu 收起的回调 | index: 收起的 sub-menu 的 index, indexPath: 收起的 sub-menu 的 index path |
 


### PR DESCRIPTION
The former & older fix of vue-router in `handleItemClick`  introduced vulnerability to the code. Since from **vue-router v4** DuplicatedNavigation has been removed from error list, the code needn't take a conservative & buggy way to hack it anymore.

I'm introduced the 4th parameter `routeResult` in `handleItemClick` for users to manipulate navigation result by themselves. The implementation is also compatible with **vue-router v3**, users could resolve the promise result (then or catch) when DuplicatedNavigation is still an error.

<img width="762" alt="v4" src="https://user-images.githubusercontent.com/15604293/125444955-40328d5c-97b6-4388-b6f1-0b0ddaabbb15.png">

[In vue-router v4, NavigationFailure is removed from error](https://next.router.vuejs.org/api/#push)
