### PR TITLE
refactor(typography): add css var for typography & simplify example code

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -25,6 +25,7 @@ const scopes = [
   'build',
   'deploy',
   'other',
+  'typography',
 ]
 
 module.exports = {

--- a/packages/theme-chalk/src/autocomplete.scss
+++ b/packages/theme-chalk/src/autocomplete.scss
@@ -39,7 +39,7 @@
     line-height: 34px;
     cursor: pointer;
     color: $--color-text-regular;
-    font-size: $--font-size-base;
+    font-size: var(--el-font-size-base);
     list-style: none;
     text-align: left;
     white-space: nowrap;

--- a/packages/theme-chalk/src/cascader.scss
+++ b/packages/theme-chalk/src/cascader.scss
@@ -10,7 +10,7 @@
 @include b(cascader) {
   display: inline-block;
   position: relative;
-  font-size: $--font-size-base;
+  font-size: var(--el-font-size-base);
   line-height: map.get($--input-height, 'default');
   outline: none;
 
@@ -127,7 +127,7 @@
     max-height: 204px;
     margin: 0;
     padding: 6px 0;
-    font-size: $--font-size-base;
+    font-size: var(--el-font-size-base);
     color: $--cascader-menu-font-color;
     text-align: center;
   }

--- a/packages/theme-chalk/src/check-tag.scss
+++ b/packages/theme-chalk/src/check-tag.scss
@@ -9,8 +9,8 @@
   color: $--color-info;
   cursor: pointer;
   display: inline-block;
-  font-size: $--font-size-base;
-  line-height: $--font-size-base;
+  font-size: var(--el-font-size-base);
+  line-height: var(--el-font-size-base);
   padding: 7px 15px;
   transition: $--all-transition;
   font-weight: bold;

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -155,18 +155,20 @@ $--fill-base: $--color-white !default;
 -------------------------- */
 $--font-path: 'fonts' !default;
 $--font-display: 'auto' !default;
-/// fontSize|1|Font Size|0
-$--font-size-extra-large: 20px !default;
-/// fontSize|1|Font Size|0
-$--font-size-large: 18px !default;
-/// fontSize|1|Font Size|0
-$--font-size-medium: 16px !default;
-/// fontSize|1|Font Size|0
-$--font-size-base: 14px !default;
-/// fontSize|1|Font Size|0
-$--font-size-small: 13px !default;
-/// fontSize|1|Font Size|0
-$--font-size-extra-small: 12px !default;
+
+$--font-size: () !default;
+$--font-size: map.merge(
+  (
+    'extra-large': 20px,
+    'large': 18px,
+    'medium': 16px,
+    'base': 14px,
+    'small': 13px,
+    'extra-small': 12px,
+  ),
+  $--font-size
+);
+
 /// fontWeight|1|Font Weight|1
 $--font-weight-primary: 500 !default;
 /// fontLineHeight|1|Line Height|2
@@ -187,7 +189,7 @@ $--disabled-border-base: $--border-color-light !default;
 /* Radio
 -------------------------- */
 /// fontSize||Font|1
-$--radio-font-size: $--font-size-base !default;
+$--radio-font-size: map.get($--font-size, 'base') !default;
 /// fontWeight||Font|1
 $--radio-font-weight: $--font-weight-primary !default;
 /// color||Color|0
@@ -258,7 +260,7 @@ $--radio-button-disabled-checked-fill: $--border-color-extra-light !default;
 $--select-border-color-hover: $--border-color-hover !default;
 $--select-disabled-border: $--disabled-border-base !default;
 /// fontSize||Font|1
-$--select-font-size: $--font-size-base !default;
+$--select-font-size: map.get($--font-size, 'base') !default;
 $--select-close-hover-color: $--color-text-secondary !default;
 
 $--select-input-color: $--color-text-placeholder !default;
@@ -320,9 +322,9 @@ $--messagebox-title-color: $--color-text-primary !default;
 $--messagebox-width: 420px !default;
 $--messagebox-border-radius: 4px !default;
 /// fontSize||Font|1
-$--messagebox-font-size: $--font-size-large !default;
+$--messagebox-font-size: map.get($--font-size, 'large') !default;
 /// fontSize||Font|1
-$--messagebox-content-font-size: $--font-size-base !default;
+$--messagebox-content-font-size: map.get($--font-size, 'base') !default;
 /// color||Color|0
 $--messagebox-content-color: $--color-text-regular !default;
 /// fontSize||Font|1
@@ -372,7 +374,7 @@ $--notification-close-font-size: $--message-close-size !default;
 $--notification-group-margin-left: 13px !default;
 $--notification-group-margin-right: 8px !default;
 /// fontSize||Font|1
-$--notification-content-font-size: $--font-size-base !default;
+$--notification-content-font-size: map.get($--font-size, 'base') !default;
 /// color||Color|0
 $--notification-content-color: $--color-text-regular !default;
 /// fontSize||Font|1
@@ -421,7 +423,7 @@ $--input-disabled-color: $--disabled-color-base !default;
 $--input-disabled-placeholder-color: $--color-text-placeholder !default;
 
 $--input-font-size: (
-  'default': $--font-size-base,
+  'default': map.get($--font-size, 'base'),
   'medium': 14px,
   'small': 13px,
   'mini': 12px,
@@ -453,7 +455,7 @@ $--cascader-menu-font-color: $--color-text-regular !default;
 /// color||Color|0
 $--cascader-menu-selected-font-color: $--color-primary !default;
 $--cascader-menu-fill: $--fill-base !default;
-$--cascader-menu-font-size: $--font-size-base !default;
+$--cascader-menu-font-size: map.get($--font-size, 'base') !default;
 $--cascader-menu-radius: $--border-radius-base !default;
 $--cascader-menu-border: solid 1px $--border-color-light !default;
 $--cascader-menu-shadow: $--box-shadow-light !default;
@@ -468,8 +470,8 @@ $--cascader-tag-background: #f0f2f5 !default;
 $--button-font-weight: $--font-weight-primary !default;
 
 $--button-font-size: (
-  'default': $--font-size-base,
-  'medium': $--font-size-base,
+  'default': map.get($--font-size, 'base'),
+  'medium': map.get($--font-size, 'base'),
   'small': 12px,
   'mini': 12px,
 );
@@ -550,7 +552,7 @@ $--switch-on-color: $--color-primary !default;
 /// color||Color|0
 $--switch-off-color: $--border-color-base !default;
 /// fontSize||Font|1
-$--switch-font-size: $--font-size-base !default;
+$--switch-font-size: map.get($--font-size, 'base') !default;
 $--switch-core-border-radius: 10px !default;
 // height||Other|4
 $--switch-width: 40px !default;
@@ -564,7 +566,7 @@ $--switch-button-size: 16px !default;
 $--dialog-background-color: $--color-white !default;
 $--dialog-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3) !default;
 /// fontSize||Font|1
-$--dialog-title-font-size: $--font-size-large !default;
+$--dialog-title-font-size: map.get($--font-size, 'large') !default;
 /// fontSize||Font|1
 $--dialog-content-font-size: 14px !default;
 /// fontLineHeight||LineHeight|2
@@ -626,7 +628,7 @@ $--popup-modal-opacity: 0.5 !default;
 /// color||Color|0
 $--popover-background-color: $--color-white !default;
 /// fontSize||Font|1
-$--popover-font-size: $--font-size-base !default;
+$--popover-font-size: map.get($--font-size, 'base') !default;
 /// color||Color|0
 $--popover-border-color: $--border-color-lighter !default;
 /// padding||Spacing|3
@@ -729,7 +731,7 @@ $--slider-button-wrapper-offset: -15px !default;
 /* Menu
 --------------------------*/
 /// fontSize||Font|1
-$--menu-item-font-size: $--font-size-base !default;
+$--menu-item-font-size: map.get($--font-size, 'base') !default;
 /// color||Color|0
 $--menu-item-font-color: $--color-text-primary !default;
 /// color||Color|0
@@ -741,7 +743,7 @@ $--menu-border-color: #e6e6e6 !default;
 --------------------------*/
 $--rate-height: 20px !default;
 /// fontSize||Font|1
-$--rate-font-size: $--font-size-base !default;
+$--rate-font-size: map.get($--font-size, 'base') !default;
 /// height||Other|3
 $--rate-icon-size: 18px !default;
 /// margin||Spacing|2
@@ -865,7 +867,7 @@ $--backtop-hover-background-color: $--border-color-extra-light !default;
 /* Link
 --------------------------*/
 /// fontSize||Font|1
-$--link-font-size: $--font-size-base !default;
+$--link-font-size: map.get($--font-size, 'base') !default;
 /// fontWeight||Font|1
 $--link-font-weight: $--font-weight-primary !default;
 /// color||Color|0
@@ -895,7 +897,7 @@ $--calendar-cell-width: 85px !default;
 /* Form
 -------------------------- */
 /// fontSize||Font|1
-$--form-label-font-size: $--font-size-base !default;
+$--form-label-font-size: map.get($--font-size, 'base') !default;
 
 /* Avatar
 --------------------------*/

--- a/packages/theme-chalk/src/date-picker/picker.scss
+++ b/packages/theme-chalk/src/date-picker/picker.scss
@@ -74,7 +74,7 @@
     padding: 0;
     width: 39%;
     text-align: center;
-    font-size: $--font-size-base;
+    font-size: var(--el-font-size-base);
     color: $--color-text-regular;
 
     &::placeholder {

--- a/packages/theme-chalk/src/descriptions.scss
+++ b/packages/theme-chalk/src/descriptions.scss
@@ -4,7 +4,7 @@
 
 @include b(descriptions) {
   box-sizing: border-box;
-  font-size: $--font-size-base;
+  font-size: var(--el-font-size-base);
   color: $--color-text-primary;
 
   @include e(header) {

--- a/packages/theme-chalk/src/drawer.scss
+++ b/packages/theme-chalk/src/drawer.scss
@@ -112,7 +112,7 @@ $directions: rtl, ltr, ttb, btt;
   &__close-btn {
     border: none;
     cursor: pointer;
-    font-size: $--font-size-extra-large;
+    font-size: var(--el-font-size-extra-large);
     color: inherit;
     background-color: transparent;
     outline: none;

--- a/packages/theme-chalk/src/dropdown.scss
+++ b/packages/theme-chalk/src/dropdown.scss
@@ -7,7 +7,7 @@
   display: inline-block;
   position: relative;
   color: $--color-text-regular;
-  font-size: $--font-size-base;
+  font-size: var(--el-font-size-base);
   line-height: 1;
 
   @include e(popper) {
@@ -109,7 +109,7 @@
     line-height: 36px;
     padding: 0 20px;
     margin: 0;
-    font-size: $--font-size-base;
+    font-size: var(--el-font-size-base);
     color: $--color-text-regular;
     cursor: pointer;
     outline: none;

--- a/packages/theme-chalk/src/empty.scss
+++ b/packages/theme-chalk/src/empty.scss
@@ -34,7 +34,7 @@
 
     p {
       margin: 0;
-      font-size: $--font-size-base;
+      font-size: var(--el-font-size-base);
       color: $--color-text-secondary;
     }
   }

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -8,7 +8,7 @@
   display: inline-block;
   width: 100%;
   vertical-align: bottom;
-  font-size: $--font-size-base;
+  font-size: var(--el-font-size-base);
 
   @include e(inner) {
     display: block;
@@ -75,7 +75,7 @@
 
 @include b(input) {
   position: relative;
-  font-size: $--font-size-base;
+  font-size: var(--el-font-size-base);
   display: inline-block;
   width: 100%;
   line-height: map.get($--input-height, 'default');

--- a/packages/theme-chalk/src/mixins/_var.scss
+++ b/packages/theme-chalk/src/mixins/_var.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @mixin set-css-color-primary($i) {
   --el-color-primary-light-#{$i}: #{map.get($--colors, 'primary', 'light-#{$i}')};
 }

--- a/packages/theme-chalk/src/mixins/_var.scss
+++ b/packages/theme-chalk/src/mixins/_var.scss
@@ -1,0 +1,13 @@
+@mixin set-css-color-primary($i) {
+  --el-color-primary-light-#{$i}: #{map.get($--colors, 'primary', 'light-#{$i}')};
+}
+
+@mixin set-css-color-type($type) {
+  --el-color-#{$type}: #{map.get($--colors, $type, 'base')};
+  --el-color-#{$type}-light: #{map.get($--colors, $type, 'light')};
+  --el-color-#{$type}-lighter: #{map.get($--colors, $type, 'lighter')};
+}
+
+@mixin set-css-var-type($name, $type, $--variables) {
+  --el-#{$name}-#{$type}: #{map.get($--variables, $type)};
+}

--- a/packages/theme-chalk/src/pagination.scss
+++ b/packages/theme-chalk/src/pagination.scss
@@ -105,7 +105,7 @@ $--pagination-line-height-extra-small: $--pagination-height-extra-small !default
     .#{$namespace}-pager li.btn-quickprev,
     .#{$namespace}-pager li:last-child {
       border-color: transparent;
-      font-size: $--font-size-extra-small;
+      font-size: var(--el-font-size-extra-small);
       line-height: $--pagination-line-height-extra-small;
       height: $--pagination-height-extra-small;
       min-width: 22px;

--- a/packages/theme-chalk/src/radio.scss
+++ b/packages/theme-chalk/src/radio.scss
@@ -14,7 +14,7 @@
   display: inline-block;
   white-space: nowrap;
   outline: none;
-  font-size: $--font-size-base;
+  font-size: var(--el-font-size-base);
   margin-right: 30px;
   @include utils-user-select(none);
 

--- a/packages/theme-chalk/src/reset.scss
+++ b/packages/theme-chalk/src/reset.scss
@@ -4,7 +4,7 @@ body {
   font-family: 'Helvetica Neue', Helvetica, 'PingFang SC', 'Hiragino Sans GB',
     'Microsoft YaHei', '微软雅黑', Arial, sans-serif;
   font-weight: 400;
-  font-size: $--font-size-base;
+  font-size: var(--el-font-size-base);
   color: $--color-black;
   -webkit-font-smoothing: antialiased;
 }
@@ -46,15 +46,15 @@ h6 {
 }
 
 h1 {
-  font-size: #{$--font-size-base + 6px};
+  font-size: #{var(--el-font-size-base) + 6px};
 }
 
 h2 {
-  font-size: #{$--font-size-base + 4px};
+  font-size: #{var(--el-font-size-base) + 4px};
 }
 
 h3 {
-  font-size: #{$--font-size-base + 2px};
+  font-size: #{var(--el-font-size-base) + 2px};
 }
 
 h4,
@@ -78,11 +78,11 @@ p {
 
 sup,
 sub {
-  font-size: #{$--font-size-base - 1px};
+  font-size: #{var(--el-font-size-base) - 1px};
 }
 
 small {
-  font-size: #{$--font-size-base - 2px};
+  font-size: #{var(--el-font-size-base) - 2px};
 }
 
 hr {

--- a/packages/theme-chalk/src/result.scss
+++ b/packages/theme-chalk/src/result.scss
@@ -33,7 +33,7 @@
 
     p {
       margin: 0;
-      font-size: $--font-size-base;
+      font-size: var(--el-font-size-base);
       color: $--color-text-regular;
       line-height: 1.3;
     }

--- a/packages/theme-chalk/src/skeleton-item.scss
+++ b/packages/theme-chalk/src/skeleton-item.scss
@@ -48,23 +48,23 @@
 
   @include e(text) {
     width: 100%;
-    height: $--font-size-small;
+    height: var(--el-font-size-small);
   }
 
   @include e(caption) {
-    height: $--font-size-extra-small;
+    height: var(--el-font-size-extra-small);
   }
 
   @include e(h1) {
-    height: $--font-size-extra-large;
+    height: var(--el-font-size-extra-large);
   }
 
   @include e(h3) {
-    height: $--font-size-large;
+    height: var(--el-font-size-large);
   }
 
   @include e(h5) {
-    height: $--font-size-medium;
+    height: var(--el-font-size-medium);
   }
 
   @include e(image) {

--- a/packages/theme-chalk/src/table-column.scss
+++ b/packages/theme-chalk/src/table-column.scss
@@ -32,7 +32,7 @@
     line-height: 36px;
     padding: 0 10px;
     cursor: pointer;
-    font-size: $--font-size-base;
+    font-size: var(--el-font-size-base);
 
     &:hover {
       background-color: $--dropdown-menuItem-hover-fill;
@@ -58,7 +58,7 @@
       border: none;
       color: $--color-text-regular;
       cursor: pointer;
-      font-size: $--font-size-small;
+      font-size: var(--el-font-size-small);
       padding: 0 3px;
 
       &:hover {

--- a/packages/theme-chalk/src/timeline-item.scss
+++ b/packages/theme-chalk/src/timeline-item.scss
@@ -20,7 +20,7 @@
 
   @include e(icon) {
     color: $--color-white;
-    font-size: $--font-size-small;
+    font-size: var(--el-font-size-small);
   }
 
   @include e(node) {
@@ -73,7 +73,7 @@
   @include e(timestamp) {
     color: $--color-text-secondary;
     line-height: 1;
-    font-size: $--font-size-small;
+    font-size: var(--el-font-size-small);
 
     @include when(top) {
       margin-bottom: 8px;

--- a/packages/theme-chalk/src/timeline.scss
+++ b/packages/theme-chalk/src/timeline.scss
@@ -3,7 +3,7 @@
 
 @include b(timeline) {
   margin: 0;
-  font-size: $--font-size-base;
+  font-size: var(--el-font-size-base);
   list-style: none;
 
   & .#{$namespace}-timeline-item:last-child {

--- a/packages/theme-chalk/src/transfer.scss
+++ b/packages/theme-chalk/src/transfer.scss
@@ -9,7 +9,7 @@
 @import 'checkbox-group';
 
 @include b(transfer) {
-  font-size: $--font-size-base;
+  font-size: var(--el-font-size-base);
 
   @include e(buttons) {
     display: inline-block;

--- a/packages/theme-chalk/src/tree.scss
+++ b/packages/theme-chalk/src/tree.scss
@@ -23,7 +23,7 @@
     top: 50%;
     transform: translate(-50%, -50%);
     color: $--color-text-secondary;
-    font-size: $--font-size-base;
+    font-size: var(--el-font-size-base);
   }
 
   @include e(drop-indicator) {
@@ -100,12 +100,12 @@
   }
 
   @include e(label) {
-    font-size: $--font-size-base;
+    font-size: var(--el-font-size-base);
   }
 
   @include e(loading-icon) {
     margin-right: 8px;
-    font-size: $--font-size-base;
+    font-size: var(--el-font-size-base);
     color: $--tree-expand-icon-color;
   }
 

--- a/packages/theme-chalk/src/var.scss
+++ b/packages/theme-chalk/src/var.scss
@@ -2,16 +2,7 @@
 
 // CSS3 var
 @import 'common/var';
-
-@mixin set-css-color-primary($i) {
-  --el-color-primary-light-#{$i}: #{map.get($--colors, 'primary', 'light-#{$i}')};
-}
-
-@mixin set-css-color-type($type) {
-  --el-color-#{$type}: #{map.get($--colors, $type, 'base')};
-  --el-color-#{$type}-light: #{map.get($--colors, $type, 'light')};
-  --el-color-#{$type}-lighter: #{map.get($--colors, $type, 'lighter')};
-}
+@import 'mixins/var';
 
 :root {
   --el-color-primary: #{$--color-primary};
@@ -64,12 +55,10 @@
   --el-fill-base: var(--el-color-white);
 
   // Typography
-  --el-font-size-extra-large: #{$--font-size-extra-large};
-  --el-font-size-large: #{$--font-size-large};
-  --el-font-size-medium: #{$--font-size-medium};
-  --el-font-size-base: #{$--font-size-base};
-  --el-font-size-small: #{$--font-size-small};
-  --el-font-size-extra-small: #{$--font-size-extra-small};
+  @each $type in (extra-large, large, medium, base, small, extra-small) {
+    @include set-css-var-type('font-size', $type, $--font-size);
+  }
+
   --el-font-weight-primary: #{$--font-weight-primary};
   --el-line-height-primary: #{$--font-line-height-primary};
   --el-font-color-disabled-base: #bbb;

--- a/website/docs/en-US/typography.md
+++ b/website/docs/en-US/typography.md
@@ -1,59 +1,45 @@
 <script>
-  import bus from '../../bus';
-  const varMap = [
-    '$--font-size-extra-large',
-    '$--font-size-large',
-    '$--font-size-medium',
-    '$--font-size-base',
-    '$--font-size-small',
-    '$--font-size-extra-small'
-  ];
-  const original = {
-    'font_size_extra_large': '20px',
-    'font_size_large': '18px',
-    'font_size_medium': '16px',
-    'font_size_base': '14px',
-    'font_size_small': '13px',
-    'font_size_extra_small': '12px'
-  }
+  const fontSizes = [
+    {
+      level: 'Supplementary text',
+      type: 'extra-small',
+      size: '12px',
+    },
+    {
+      level: 'Body (small)',
+      type: 'small',
+      size: '13px',
+    },
+    {
+      level: 'Body',
+      type: 'base',
+      size: '14px',
+    },
+    {
+      level: 'Small Title',
+      type: 'medium',
+      size: '16px',
+    },
+    {
+      level: 'Title',
+      type: 'large',
+      size: '18px',
+    },
+    {
+      level: 'Main Title',
+      type: 'extra-large',
+      size: '20px',
+    },
+  ]
   export default {
-    mounted() {
-      this.setGlobal();
-    },
-    methods: {
-      tintColor(color, tint) {
-        return tintColor(color, tint);
-      },
-      setGlobal() {
-        if (window.userThemeConfig) {
-          this.global = window.userThemeConfig.global;
-        }
-      }
-    },
     data() {
       return {
-        global: {},
-        'font_size_extra_large': '',
-        'font_size_large': '',
-        'font_size_medium': '',
-        'font_size_base': '',
-        'font_size_small': '',
-        'font_size_extra_small': ''
+        fontSizes
       }
     },
-    watch: {
-      global: {
-        immediate: true,
-        handler(value) {
-          varMap.forEach((v) => {
-            const key = v.replace('$--', '').replace(/-/g, '_')
-            if (value[v]) {
-              this[key] = value[v]
-            } else {
-              this[key] = original[key]
-            }
-          });
-        }
+    methods: {
+      formatType(type) {
+        return type.split('-').map(item => item.charAt(0).toUpperCase() + item.slice(1)).join(' ');
       }
     },
   }
@@ -64,6 +50,7 @@
 We create a font convention to ensure the best presentation across different platforms.
 
 ### Font
+
 <div class="demo-term-box">
 <img src="../../assets/images/term-pingfang.png" alt="">
 <img src="../../assets/images/term-hiragino.png" alt="">
@@ -83,46 +70,9 @@ We create a font convention to ensure the best presentation across different pla
       <td>Font Size</td>
       <td class="color-dark-light">Demo</td>
     </tr>
-    <tr
-    :style="{ fontSize: font_size_extra_small }"
-    >
-      <td>Supplementary text</td>
-      <td class="color-dark-light">{{font_size_extra_small}} Extra Small</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_small }"
-    >
-      <td>Body (small)</td>
-      <td class="color-dark-light">{{font_size_small}} Small</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_base }"
-    >
-      <td>Body</td>
-      <td class="color-dark-light">{{font_size_base}} Base</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_medium }"
-    >
-      <td >Small Title</td>
-      <td class="color-dark-light">{{font_size_medium}} Medium</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_large }"
-    >
-      <td>Title</td>
-      <td class="color-dark-light">{{font_size_large}} large</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_extra_large }"
-    >
-      <td>Main Title</td>
-      <td class="color-dark-light">{{font_size_extra_large}} Extra large</td>
+    <tr v-for="(fontSize, i) in fontSizes" :key="i" :style="`font-size: var(--el-font-size-${fontSize.type})`">
+      <td>{{ fontSize.level }}</td>
+      <td>{{ fontSize.size + ' ' + formatType(fontSize.type) }}</td>
       <td>Build with Element</td>
     </tr>
   </tbody>
@@ -143,5 +93,6 @@ We create a font convention to ensure the best presentation across different pla
 ### Font-family
 
 ```css
-font-family: "Helvetica Neue",Helvetica,"PingFang SC","Hiragino Sans GB","Microsoft YaHei","微软雅黑",Arial,sans-serif;
+font-family: 'Helvetica Neue', Helvetica, 'PingFang SC', 'Hiragino Sans GB',
+  'Microsoft YaHei', '微软雅黑', Arial, sans-serif;
 ```

--- a/website/docs/es/typography.md
+++ b/website/docs/es/typography.md
@@ -1,59 +1,45 @@
 <script>
-  import bus from '../../bus';
-  const varMap = [
-    '$--font-size-extra-large',
-    '$--font-size-large',
-    '$--font-size-medium',
-    '$--font-size-base',
-    '$--font-size-small',
-    '$--font-size-extra-small'
-  ];
-  const original = {
-    'font_size_extra_large': '20px',
-    'font_size_large': '18px',
-    'font_size_medium': '16px',
-    'font_size_base': '14px',
-    'font_size_small': '13px',
-    'font_size_extra_small': '12px'
-  }
+  const fontSizes = [
+    {
+      level: 'Supplementary text',
+      type: 'extra-small',
+      size: '12px',
+    },
+    {
+      level: 'Body (small)',
+      type: 'small',
+      size: '13px',
+    },
+    {
+      level: 'Body',
+      type: 'base',
+      size: '14px',
+    },
+    {
+      level: 'Small Title',
+      type: 'medium',
+      size: '16px',
+    },
+    {
+      level: 'Title',
+      type: 'large',
+      size: '18px',
+    },
+    {
+      level: 'Main Title',
+      type: 'extra-large',
+      size: '20px',
+    },
+  ]
   export default {
-    mounted() {
-      this.setGlobal();
-    },
-    methods: {
-      tintColor(color, tint) {
-        return tintColor(color, tint);
-      },
-      setGlobal() {
-        if (window.userThemeConfig) {
-          this.global = window.userThemeConfig.global;
-        }
-      }
-    },
     data() {
       return {
-        global: {},
-        'font_size_extra_large': '',
-        'font_size_large': '',
-        'font_size_medium': '',
-        'font_size_base': '',
-        'font_size_small': '',
-        'font_size_extra_small': ''
+        fontSizes
       }
     },
-    watch: {
-      global: {
-        immediate: true,
-        handler(value) {
-          varMap.forEach((v) => {
-            const key = v.replace('$--', '').replace(/-/g, '_')
-            if (value[v]) {
-              this[key] = value[v]
-            } else {
-              this[key] = original[key]
-            }
-          });
-        }
+    methods: {
+      formatType(type) {
+        return type.split('-').map(item => item.charAt(0).toUpperCase() + item.slice(1)).join(' ');
       }
     },
   }
@@ -64,6 +50,7 @@
 Creamos una convención de fuentes para asegurar la mejor presentación en diferentes plataformas.
 
 ### Fuente
+
 <div class="demo-term-box">
 <img src="../../assets/images/term-pingfang.png" alt="">
 <img src="../../assets/images/term-hiragino.png" alt="">
@@ -83,46 +70,9 @@ Creamos una convención de fuentes para asegurar la mejor presentación en difer
       <td>Font Size</td>
       <td class="color-dark-light">Demo</td>
     </tr>
-    <tr
-    :style="{ fontSize: font_size_extra_small }"
-    >
-      <td>Supplementary text</td>
-      <td class="color-dark-light">{{font_size_extra_small}} Extra Small</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_small }"
-    >
-      <td>Body (small)</td>
-      <td class="color-dark-light">{{font_size_small}} Small</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_base }"
-    >
-      <td>Body</td>
-      <td class="color-dark-light">{{font_size_base}} Base</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_medium }"
-    >
-      <td >Small Title</td>
-      <td class="color-dark-light">{{font_size_medium}} Medium</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_large }"
-    >
-      <td>Title</td>
-      <td class="color-dark-light">{{font_size_large}} large</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_extra_large }"
-    >
-      <td>Main Title</td>
-      <td class="color-dark-light">{{font_size_extra_large}} Extra large</td>
+    <tr v-for="(fontSize, i) in fontSizes" :key="i" :style="`font-size: var(--el-font-size-${fontSize.type})`">
+      <td>{{ fontSize.level }}</td>
+      <td>{{ fontSize.size + ' ' + formatType(fontSize.type) }}</td>
       <td>Build with Element</td>
     </tr>
   </tbody>
@@ -143,5 +93,6 @@ Creamos una convención de fuentes para asegurar la mejor presentación en difer
 ### Font-family
 
 ```css
-font-family: "Helvetica Neue",Helvetica,"PingFang SC","Hiragino Sans GB","Microsoft YaHei","微软雅黑",Arial,sans-serif;
+font-family: 'Helvetica Neue', Helvetica, 'PingFang SC', 'Hiragino Sans GB',
+  'Microsoft YaHei', '微软雅黑', Arial, sans-serif;
 ```

--- a/website/docs/fr-FR/typography.md
+++ b/website/docs/fr-FR/typography.md
@@ -1,59 +1,45 @@
 <script>
-  import bus from '../../bus';
-  const varMap = [
-    '$--font-size-extra-large',
-    '$--font-size-large',
-    '$--font-size-medium',
-    '$--font-size-base',
-    '$--font-size-small',
-    '$--font-size-extra-small'
-  ];
-  const original = {
-    'font_size_extra_large': '20px',
-    'font_size_large': '18px',
-    'font_size_medium': '16px',
-    'font_size_base': '14px',
-    'font_size_small': '13px',
-    'font_size_extra_small': '12px'
-  }
+  const fontSizes = [
+    {
+      level: 'Supplementary text',
+      type: 'extra-small',
+      size: '12px',
+    },
+    {
+      level: 'Body (small)',
+      type: 'small',
+      size: '13px',
+    },
+    {
+      level: 'Body',
+      type: 'base',
+      size: '14px',
+    },
+    {
+      level: 'Small Title',
+      type: 'medium',
+      size: '16px',
+    },
+    {
+      level: 'Title',
+      type: 'large',
+      size: '18px',
+    },
+    {
+      level: 'Main Title',
+      type: 'extra-large',
+      size: '20px',
+    },
+  ]
   export default {
-    mounted() {
-      this.setGlobal();
-    },
-    methods: {
-      tintColor(color, tint) {
-        return tintColor(color, tint);
-      },
-      setGlobal() {
-        if (window.userThemeConfig) {
-          this.global = window.userThemeConfig.global;
-        }
-      }
-    },
     data() {
       return {
-        global: {},
-        'font_size_extra_large': '',
-        'font_size_large': '',
-        'font_size_medium': '',
-        'font_size_base': '',
-        'font_size_small': '',
-        'font_size_extra_small': ''
+        fontSizes
       }
     },
-    watch: {
-      global: {
-        immediate: true,
-        handler(value) {
-          varMap.forEach((v) => {
-            const key = v.replace('$--', '').replace(/-/g, '_')
-            if (value[v]) {
-              this[key] = value[v]
-            } else {
-              this[key] = original[key]
-            }
-          });
-        }
+    methods: {
+      formatType(type) {
+        return type.split('-').map(item => item.charAt(0).toUpperCase() + item.slice(1)).join(' ');
       }
     },
   }
@@ -84,46 +70,9 @@ Nous avons créé une convention de police d'écriture afin d'assurer la meilleu
       <td>Font Size</td>
       <td class="color-dark-light">Demo</td>
     </tr>
-    <tr
-    :style="{ fontSize: font_size_extra_small }"
-    >
-      <td>Supplementary text</td>
-      <td class="color-dark-light">{{font_size_extra_small}} Extra Small</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_small }"
-    >
-      <td>Body (small)</td>
-      <td class="color-dark-light">{{font_size_small}} Small</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_base }"
-    >
-      <td>Body</td>
-      <td class="color-dark-light">{{font_size_base}} Base</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_medium }"
-    >
-      <td >Small Title</td>
-      <td class="color-dark-light">{{font_size_medium}} Medium</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_large }"
-    >
-      <td>Title</td>
-      <td class="color-dark-light">{{font_size_large}} large</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_extra_large }"
-    >
-      <td>Main Title</td>
-      <td class="color-dark-light">{{font_size_extra_large}} Extra large</td>
+    <tr v-for="(fontSize, i) in fontSizes" :key="i" :style="`font-size: var(--el-font-size-${fontSize.type})`">
+      <td>{{ fontSize.level }}</td>
+      <td>{{ fontSize.size + ' ' + formatType(fontSize.type) }}</td>
       <td>Build with Element</td>
     </tr>
   </tbody>
@@ -144,5 +93,6 @@ Nous avons créé une convention de police d'écriture afin d'assurer la meilleu
 ### Font-family
 
 ```css
-font-family: "Helvetica Neue",Helvetica,"PingFang SC","Hiragino Sans GB","Microsoft YaHei","微软雅黑",Arial,sans-serif;
+font-family: 'Helvetica Neue', Helvetica, 'PingFang SC', 'Hiragino Sans GB',
+  'Microsoft YaHei', '微软雅黑', Arial, sans-serif;
 ```

--- a/website/docs/jp/typography.md
+++ b/website/docs/jp/typography.md
@@ -1,59 +1,45 @@
 <script>
-  import bus from '../../bus';
-  const varMap = [
-    '$--font-size-extra-large',
-    '$--font-size-large',
-    '$--font-size-medium',
-    '$--font-size-base',
-    '$--font-size-small',
-    '$--font-size-extra-small'
-  ];
-  const original = {
-    'font_size_extra_large': '20px',
-    'font_size_large': '18px',
-    'font_size_medium': '16px',
-    'font_size_base': '14px',
-    'font_size_small': '13px',
-    'font_size_extra_small': '12px'
-  }
+  const fontSizes = [
+    {
+      level: 'Supplementary text',
+      type: 'extra-small',
+      size: '12px',
+    },
+    {
+      level: 'Body (small)',
+      type: 'small',
+      size: '13px',
+    },
+    {
+      level: 'Body',
+      type: 'base',
+      size: '14px',
+    },
+    {
+      level: 'Small Title',
+      type: 'medium',
+      size: '16px',
+    },
+    {
+      level: 'Title',
+      type: 'large',
+      size: '18px',
+    },
+    {
+      level: 'Main Title',
+      type: 'extra-large',
+      size: '20px',
+    },
+  ]
   export default {
-    mounted() {
-      this.setGlobal();
-    },
-    methods: {
-      tintColor(color, tint) {
-        return tintColor(color, tint);
-      },
-      setGlobal() {
-        if (window.userThemeConfig) {
-          this.global = window.userThemeConfig.global;
-        }
-      }
-    },
     data() {
       return {
-        global: {},
-        'font_size_extra_large': '',
-        'font_size_large': '',
-        'font_size_medium': '',
-        'font_size_base': '',
-        'font_size_small': '',
-        'font_size_extra_small': ''
+        fontSizes
       }
     },
-    watch: {
-      global: {
-        immediate: true,
-        handler(value) {
-          varMap.forEach((v) => {
-            const key = v.replace('$--', '').replace(/-/g, '_')
-            if (value[v]) {
-              this[key] = value[v]
-            } else {
-              this[key] = original[key]
-            }
-          });
-        }
+    methods: {
+      formatType(type) {
+        return type.split('-').map(item => item.charAt(0).toUpperCase() + item.slice(1)).join(' ');
       }
     },
   }
@@ -64,6 +50,7 @@
 私たちは、さまざまなプラットフォームで最高のプレゼンテーションを実現するために、フォントの規約を作成します。
 
 ### Font
+
 <div class="demo-term-box">
 <img src="../../assets/images/term-pingfang.png" alt="">
 <img src="../../assets/images/term-hiragino.png" alt="">
@@ -83,46 +70,9 @@
       <td>Font Size</td>
       <td class="color-dark-light">Demo</td>
     </tr>
-    <tr
-    :style="{ fontSize: font_size_extra_small }"
-    >
-      <td>Supplementary text</td>
-      <td class="color-dark-light">{{font_size_extra_small}} Extra Small</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_small }"
-    >
-      <td>Body (small)</td>
-      <td class="color-dark-light">{{font_size_small}} Small</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_base }"
-    >
-      <td>Body</td>
-      <td class="color-dark-light">{{font_size_base}} Base</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_medium }"
-    >
-      <td >Small Title</td>
-      <td class="color-dark-light">{{font_size_medium}} Medium</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_large }"
-    >
-      <td>Title</td>
-      <td class="color-dark-light">{{font_size_large}} large</td>
-      <td>Build with Element</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_extra_large }"
-    >
-      <td>Main Title</td>
-      <td class="color-dark-light">{{font_size_extra_large}} Extra large</td>
+    <tr v-for="(fontSize, i) in fontSizes" :key="i" :style="`font-size: var(--el-font-size-${fontSize.type})`">
+      <td>{{ fontSize.level }}</td>
+      <td>{{ fontSize.size + ' ' + formatType(fontSize.type) }}</td>
       <td>Build with Element</td>
     </tr>
   </tbody>
@@ -143,5 +93,6 @@
 ### フォントファミリー
 
 ```css
-font-family: "Helvetica Neue",Helvetica,"PingFang SC","Hiragino Sans GB","Microsoft YaHei","微软雅黑",Arial,sans-serif;
+font-family: 'Helvetica Neue', Helvetica, 'PingFang SC', 'Hiragino Sans GB',
+  'Microsoft YaHei', '微软雅黑', Arial, sans-serif;
 ```

--- a/website/docs/zh-CN/typography.md
+++ b/website/docs/zh-CN/typography.md
@@ -1,59 +1,45 @@
 <script>
-  import bus from '../../bus';
-  const varMap = [
-    '$--font-size-extra-large',
-    '$--font-size-large',
-    '$--font-size-medium',
-    '$--font-size-base',
-    '$--font-size-small',
-    '$--font-size-extra-small'
-  ];
-  const original = {
-    'font_size_extra_large': '20px',
-    'font_size_large': '18px',
-    'font_size_medium': '16px',
-    'font_size_base': '14px',
-    'font_size_small': '13px',
-    'font_size_extra_small': '12px'
-  }
+  const fontSizes = [
+    {
+      level: '辅助文字',
+      type: 'extra-small',
+      size: '12px',
+    },
+    {
+      level: '正文（小）',
+      type: 'small',
+      size: '13px',
+    },
+    {
+      level: '正文',
+      type: 'base',
+      size: '14px',
+    },
+    {
+      level: '小标题',
+      type: 'medium',
+      size: '16px',
+    },
+    {
+      level: '标题',
+      type: 'large',
+      size: '18px',
+    },
+    {
+      level: '主标题',
+      type: 'extra-large',
+      size: '20px',
+    },
+  ]
   export default {
-    mounted() {
-      this.setGlobal();
-    },
-    methods: {
-      tintColor(color, tint) {
-        return tintColor(color, tint);
-      },
-      setGlobal() {
-        if (window.userThemeConfig) {
-          this.global = window.userThemeConfig.global;
-        }
-      }
-    },
     data() {
       return {
-        global: {},
-        'font_size_extra_large': '',
-        'font_size_large': '',
-        'font_size_medium': '',
-        'font_size_base': '',
-        'font_size_small': '',
-        'font_size_extra_small': ''
+        fontSizes
       }
     },
-    watch: {
-      global: {
-        immediate: true,
-        handler(value) {
-          varMap.forEach((v) => {
-            const key = v.replace('$--', '').replace(/-/g, '_')
-            if (value[v]) {
-              this[key] = value[v]
-            } else {
-              this[key] = original[key]
-            }
-          });
-        }
+    methods: {
+      formatType(type) {
+        return type.split('-').map(item => item.charAt(0).toUpperCase() + item.slice(1)).join(' ');
       }
     },
   }
@@ -64,6 +50,7 @@
 我们对字体进行统一规范，力求在各个操作系统下都有最佳展示效果。
 
 ### 字体
+
 <div class="demo-term-box">
 <img src="../../assets/images/term-pingfang.png" alt="">
 <img src="../../assets/images/term-hiragino.png" alt="">
@@ -83,46 +70,9 @@
       <td>字体大小</td>
       <td class="color-dark-light">举例</td>
     </tr>
-    <tr
-    :style="{ fontSize: font_size_extra_small }"
-    >
-      <td>辅助文字</td>
-      <td class="color-dark-light">{{font_size_extra_small}} Extra Small</td>
-      <td>用 Element Plus 快速搭建页面</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_small }"
-    >
-      <td>正文（小）</td>
-      <td class="color-dark-light">{{font_size_small}} Small</td>
-      <td>用 Element Plus 快速搭建页面</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_base }"
-    >
-      <td>正文</td>
-      <td class="color-dark-light">{{font_size_base}} Base</td>
-      <td>用 Element Plus 快速搭建页面</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_medium }"
-    >
-      <td>小标题</td>
-      <td class="color-dark-light">{{font_size_medium}} Medium</td>
-      <td>用 Element Plus 快速搭建页面</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_large }"
-    >
-      <td>标题</td>
-      <td class="color-dark-light">{{font_size_large}} large</td>
-      <td>用 Element Plus 快速搭建页面</td>
-    </tr>
-    <tr
-    :style="{ fontSize: font_size_extra_large }"
-    >
-      <td>主标题</td>
-      <td class="color-dark-light">{{font_size_extra_large}} Extra large</td>
+    <tr v-for="(fontSize, i) in fontSizes" :key="i" :style="`font-size: var(--el-font-size-${fontSize.type})`">
+      <td>{{ fontSize.level }}</td>
+      <td>{{ fontSize.size + ' ' + formatType(fontSize.type) }}</td>
       <td>用 Element Plus 快速搭建页面</td>
     </tr>
   </tbody>
@@ -143,5 +93,6 @@
 ### Font-family 代码
 
 ```css
-font-family: "Helvetica Neue",Helvetica,"PingFang SC","Hiragino Sans GB","Microsoft YaHei","微软雅黑",Arial,sans-serif;
+font-family: 'Helvetica Neue', Helvetica, 'PingFang SC', 'Hiragino Sans GB',
+  'Microsoft YaHei', '微软雅黑', Arial, sans-serif;
 ```


### PR DESCRIPTION
- use `map.get($--font-size, 'small')` instead of `$--font-size-small`
- set `--el-font-size-small: map.get($--font-size, 'small')`
- replace the variables used in each component
- simplify the typography sample document code

---

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
