### PR TITLE
docs(other): missing style tag problem

### DIFF
--- a/website/components/demo-block.vue
+++ b/website/components/demo-block.vue
@@ -201,11 +201,15 @@ export default {
   ${this.displayDemoCode}
 ${'</sc' + 'ript>'}
 `
+        const innerStyle = this.codepen.style && this.codepen.style.trim() ? `<style>
+  ${this.codepen.style}
+</style>
+` : ''
         hlcode.innerHTML = sanitizeHTML(`<template>
   ${this.codepen.html}
 </template>
 
-${this.displayDemoCode ? innerScript : ''}`)
+${this.displayDemoCode ? innerScript : ''}${innerStyle}`)
 
         nextTick(() => {
           if (this.$el.getElementsByClassName('description').length === 0) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

Fix the documentation demo code is missing the style tag problem.

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
