### PR TITLE
refactor(color): css var for border-color & simplify border-color docs

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -26,6 +26,7 @@ const scopes = [
   'deploy',
   'other',
   'typography',
+  'color',
 ]
 
 module.exports = {

--- a/packages/theme-chalk/src/autocomplete.scss
+++ b/packages/theme-chalk/src/autocomplete.scss
@@ -12,7 +12,7 @@
   @include e(popper) {
     @include picker-popper(
       $--color-white,
-      1px solid $--border-color-light,
+      1px solid var(--el-border-color-light),
       $--box-shadow-light
     );
   }

--- a/packages/theme-chalk/src/color-picker.scss
+++ b/packages/theme-chalk/src/color-picker.scss
@@ -396,7 +396,7 @@
     border-radius: $--border-radius-base;
     box-shadow: $--dropdown-menu-box-shadow;
     &.#{$namespace}-popper {
-      border: 1px solid $--border-color-lighter;
+      border: 1px solid var(--el-border-color-lighter);
     }
   }
 }

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -108,13 +108,17 @@ $--color-text-secondary: #909399 !default;
 /// color|1|Font Color|2
 $--color-text-placeholder: #c0c4cc !default;
 /// color|1|Border Color|3
-$--border-color-base: #dcdfe6 !default;
-/// color|1|Border Color|3
-$--border-color-light: #e4e7ed !default;
-/// color|1|Border Color|3
-$--border-color-lighter: #ebeef5 !default;
-/// color|1|Border Color|3
-$--border-color-extra-light: #f2f6fc !default;
+
+$--border-color: () !default;
+$--border-color: map.merge(
+  (
+    'base': #dcdfe6,
+    'light': #e4e7ed,
+    'lighter': #ebeef5,
+    'extra-light': #f2f6fc,
+  ),
+  $--border-color
+);
 
 // Background
 /// color|1|Background Color|4
@@ -130,7 +134,8 @@ $--link-hover-color: $--color-primary !default;
 $--border-width-base: 1px !default;
 $--border-style-base: solid !default;
 $--border-color-hover: $--color-text-placeholder !default;
-$--border-base: $--border-width-base $--border-style-base $--border-color-base !default;
+$--border-base: $--border-width-base $--border-style-base
+  map.get($--border-color, 'base') !default;
 /// borderRadius|1|Radius|0
 $--border-radius-base: 4px !default;
 /// borderRadius|1|Radius|0
@@ -178,7 +183,7 @@ $--font-line-height-primary: 24px !default;
 -------------------------- */
 $--disabled-fill-base: $--background-color-base !default;
 $--disabled-color-base: $--color-text-placeholder !default;
-$--disabled-border-base: $--border-color-light !default;
+$--disabled-border-base: map.get($--border-color, 'light') !default;
 
 /* Checkbox
 -------------------------- */
@@ -202,7 +207,7 @@ $--radio-input-border-radius: $--border-radius-circle !default;
 $--radio-input-background-color: $--color-white !default;
 $--radio-input-border: $--border-base !default;
 /// color||Color|0
-$--radio-input-border-color: $--border-color-base !default;
+$--radio-input-border-color: map.get($--border-color, 'base') !default;
 
 $--radio-disabled-input-border-color: $--disabled-border-base !default;
 $--radio-disabled-input-fill: $--disabled-fill-base !default;
@@ -253,7 +258,10 @@ $--radio-button-checked-background-color: $--color-primary !default;
 $--radio-button-checked-font-color: $--color-white !default;
 /// color||Color|0
 $--radio-button-checked-border-color: $--color-primary !default;
-$--radio-button-disabled-checked-fill: $--border-color-extra-light !default;
+$--radio-button-disabled-checked-fill: map.get(
+  $--border-color,
+  'extra-light'
+) !default;
 
 /* Select
 -------------------------- */
@@ -289,7 +297,7 @@ $--select-dropdown-empty-color: #999 !default;
 $--select-dropdown-max-height: 274px !default;
 $--select-dropdown-padding: 6px 0 !default;
 $--select-dropdown-empty-padding: 10px 0 !default;
-$--select-dropdown-border: solid 1px $--border-color-light !default;
+$--select-dropdown-border: solid 1px map.get($--border-color, 'light') !default;
 
 /* Alert
 -------------------------- */
@@ -368,7 +376,7 @@ $--notification-padding: 14px 26px 14px 13px !default;
 $--notification-radius: 8px !default;
 $--notification-shadow: $--box-shadow-light !default;
 /// color||Color|0
-$--notification-border-color: $--border-color-lighter !default;
+$--notification-border-color: map.get($--border-color, 'lighter') !default;
 $--notification-icon-size: 24px !default;
 $--notification-close-font-size: $--message-close-size !default;
 $--notification-group-margin-left: 13px !default;
@@ -402,7 +410,7 @@ $--notification-danger-icon-color: $--color-danger !default;
 $--input-font-color: $--color-text-regular !default;
 
 $--input-border: $--border-base !default;
-$--input-border-color: $--border-color-base !default;
+$--input-border-color: map.get($--border-color, 'base') !default;
 /// borderRadius||Border|2
 $--input-border-radius: $--border-radius-base !default;
 /// color||Color|0
@@ -457,7 +465,7 @@ $--cascader-menu-selected-font-color: $--color-primary !default;
 $--cascader-menu-fill: $--fill-base !default;
 $--cascader-menu-font-size: map.get($--font-size, 'base') !default;
 $--cascader-menu-radius: $--border-radius-base !default;
-$--cascader-menu-border: solid 1px $--border-color-light !default;
+$--cascader-menu-border: solid 1px map.get($--border-color, 'light') !default;
 $--cascader-menu-shadow: $--box-shadow-light !default;
 $--cascader-node-background-hover: $--background-color-base !default;
 $--cascader-node-color-disabled: $--color-text-placeholder !default;
@@ -502,14 +510,14 @@ $--button-default-font-color: $--color-text-regular !default;
 /// color||Color|0
 $--button-default-background-color: $--color-white !default;
 /// color||Color|0
-$--button-default-border-color: $--border-color-base !default;
+$--button-default-border-color: map.get($--border-color, 'base') !default;
 
 /// color||Color|0
 $--button-disabled-font-color: $--color-text-placeholder !default;
 /// color||Color|0
 $--button-disabled-background-color: $--color-white !default;
 /// color||Color|0
-$--button-disabled-border-color: $--border-color-lighter !default;
+$--button-disabled-border-color: map.get($--border-color, 'lighter') !default;
 
 /// color||Color|0
 $--button-primary-border-color: $--color-primary !default;
@@ -550,7 +558,7 @@ $--button-active-shade-percent: 10% !default;
 /// color||Color|0
 $--switch-on-color: $--color-primary !default;
 /// color||Color|0
-$--switch-off-color: $--border-color-base !default;
+$--switch-off-color: map.get($--border-color, 'base') !default;
 /// fontSize||Font|1
 $--switch-font-size: map.get($--font-size, 'base') !default;
 $--switch-core-border-radius: 10px !default;
@@ -577,7 +585,7 @@ $--dialog-padding-primary: 20px !default;
 /* Table
 -------------------------- */
 /// color||Color|0
-$--table-border-color: $--border-color-lighter !default;
+$--table-border-color: map.get($--border-color, 'lighter') !default;
 $--table-border: 1px solid $--table-border-color !default;
 /// color||Color|0
 $--table-font-color: $--color-text-regular !default;
@@ -630,7 +638,7 @@ $--popover-background-color: $--color-white !default;
 /// fontSize||Font|1
 $--popover-font-size: map.get($--font-size, 'base') !default;
 /// color||Color|0
-$--popover-border-color: $--border-color-lighter !default;
+$--popover-border-color: map.get($--border-color, 'lighter') !default;
 /// padding||Spacing|3
 $--popover-padding: 12px !default;
 $--popover-padding-large: 18px 20px !default;
@@ -706,7 +714,7 @@ $--badge-size: 18px !default;
 /* Card
 --------------------------*/
 /// color||Color|0
-$--card-border-color: $--border-color-lighter !default;
+$--card-border-color: map.get($--border-color, 'lighter') !default;
 $--card-border-radius: 4px !default;
 /// padding||Spacing|3
 $--card-padding: 20px !default;
@@ -716,7 +724,7 @@ $--card-padding: 20px !default;
 /// color||Color|0
 $--slider-main-background-color: $--color-primary !default;
 /// color||Color|0
-$--slider-runway-background-color: $--border-color-light !default;
+$--slider-runway-background-color: map.get($--border-color, 'light') !default;
 $--slider-stop-background-color: $--color-white !default;
 $--slider-disable-color: $--color-text-placeholder !default;
 $--slider-margin: 16px 0 !default;
@@ -761,9 +769,15 @@ $--datepicker-icon-color: $--color-text-primary !default;
 $--datepicker-border-color: $--disabled-border-base !default;
 $--datepicker-inner-border-color: #e4e4e4 !default;
 /// color||Color|0
-$--datepicker-inrange-background-color: $--border-color-extra-light !default;
+$--datepicker-inrange-background-color: map.get(
+  $--border-color,
+  'extra-light'
+) !default;
 /// color||Color|0
-$--datepicker-inrange-hover-background-color: $--border-color-extra-light !default;
+$--datepicker-inrange-hover-background-color: map.get(
+  $--border-color,
+  'extra-light'
+) !default;
 /// color||Color|0
 $--datepicker-active-color: $--color-primary !default;
 /// color||Color|0
@@ -802,7 +816,7 @@ $--carousel-indicator-out-color: $--border-color-hover !default;
 /* Collapse
 --------------------------*/
 /// color||Color|0
-$--collapse-border-color: $--border-color-lighter !default;
+$--collapse-border-color: map.get($--border-color, 'lighter') !default;
 /// height||Other|4
 $--collapse-header-height: 48px !default;
 /// color||Color|0
@@ -820,7 +834,7 @@ $--collapse-content-font-color: $--color-text-primary !default;
 
 /* Transfer
 --------------------------*/
-$--transfer-border-color: $--border-color-lighter !default;
+$--transfer-border-color: map.get($--border-color, 'lighter') !default;
 $--transfer-border-radius: $--border-radius-base !default;
 /// height||Other|4
 $--transfer-panel-width: 200px !default;
@@ -841,7 +855,7 @@ $--transfer-filter-height: 32px !default;
 --------------------------*/
 $--timeline-node-size-normal: 12px !default;
 $--timeline-node-size-large: 14px !default;
-$--timeline-node-color: $--border-color-light !default;
+$--timeline-node-color: map.get($--border-color, 'light') !default;
 
 /* Backtop
 --------------------------*/
@@ -850,7 +864,10 @@ $--backtop-background-color: $--color-white !default;
 /// color||Color|0
 $--backtop-font-color: $--color-primary !default;
 /// color||Color|0
-$--backtop-hover-background-color: $--border-color-extra-light !default;
+$--backtop-hover-background-color: map.get(
+  $--border-color,
+  'extra-light'
+) !default;
 
 /* Link
 --------------------------*/
@@ -920,7 +937,7 @@ $--empty-bottom-margin-top: 20px !default;
 -------------------------- */
 $--descriptions-header-margin-bottom: 20px !default;
 $--descriptions-title-font-size: 16px !default;
-$--descriptions-table-border: 1px solid $--border-color-lighter !default;
+$--descriptions-table-border: 1px solid map.get($--border-color, 'lighter') !default;
 $--descriptions-item-bordered-label-background: #fafafa !default;
 
 /* Result

--- a/packages/theme-chalk/src/date-picker/date-picker.scss
+++ b/packages/theme-chalk/src/date-picker/date-picker.scss
@@ -49,7 +49,7 @@
     @include m(bordered) {
       margin-bottom: 0;
       padding-bottom: 12px;
-      border-bottom: solid 1px $--border-color-lighter;
+      border-bottom: solid 1px var(--el-border-color-lighter);
 
       & + .#{$namespace}-picker-panel__content {
         margin-top: 0;

--- a/packages/theme-chalk/src/date-picker/date-table.scss
+++ b/packages/theme-chalk/src/date-picker/date-table.scss
@@ -146,6 +146,6 @@
     padding: 5px;
     color: $--datepicker-header-font-color;
     font-weight: 400;
-    border-bottom: solid 1px $--border-color-lighter;
+    border-bottom: solid 1px var(--el-border-color-lighter);
   }
 }

--- a/packages/theme-chalk/src/date-picker/time-picker.scss
+++ b/packages/theme-chalk/src/date-picker/time-picker.scss
@@ -27,8 +27,8 @@
       box-sizing: border-box;
       padding-top: 6px;
       text-align: left;
-      border-top: 1px solid $--border-color-light;
-      border-bottom: 1px solid $--border-color-light;
+      border-top: 1px solid var(--el-border-color-light);
+      border-bottom: 1px solid var(--el-border-color-light);
     }
 
     &::after {

--- a/packages/theme-chalk/src/divider.scss
+++ b/packages/theme-chalk/src/divider.scss
@@ -2,7 +2,7 @@
 @import 'mixins/mixins';
 
 @include b(divider) {
-  background-color: $--border-color-base;
+  background-color: var(--el-border-color-base);
   position: relative;
 
   @include m(horizontal) {

--- a/packages/theme-chalk/src/dropdown.scss
+++ b/packages/theme-chalk/src/dropdown.scss
@@ -15,7 +15,7 @@
 
     @include picker-popper(
       $--color-white,
-      1px solid $--border-color-light,
+      1px solid var(--el-border-color-light),
       $--dropdown-menu-box-shadow
     );
 
@@ -128,7 +128,7 @@
 
       position: relative;
       margin-top: $divided-offset;
-      border-top: 1px solid $--border-color-lighter;
+      border-top: 1px solid var(--el-border-color-lighter);
 
       &:before {
         content: '';

--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -169,7 +169,7 @@
         top: 0;
         left: 100%;
         z-index: 10;
-        border: 1px solid $--border-color-light;
+        border: 1px solid var(--el-border-color-light);
         border-radius: $--border-radius-small;
         box-shadow: $--box-shadow-light;
       }

--- a/packages/theme-chalk/src/message-box.scss
+++ b/packages/theme-chalk/src/message-box.scss
@@ -12,7 +12,7 @@
   vertical-align: middle;
   background-color: $--color-white;
   border-radius: $--messagebox-border-radius;
-  border: 1px solid $--border-color-lighter;
+  border: 1px solid var(--el-border-color-lighter);
   font-size: $--messagebox-font-size;
   box-shadow: $--box-shadow-light;
   text-align: left;

--- a/packages/theme-chalk/src/message.scss
+++ b/packages/theme-chalk/src/message.scss
@@ -9,7 +9,7 @@
   border-radius: $--border-radius-base;
   border-width: $--border-width-base;
   border-style: $--border-style-base;
-  border-color: $--border-color-lighter;
+  border-color: var(--el-border-color-lighter);
   position: fixed;
   left: 50%;
   top: 20px;

--- a/packages/theme-chalk/src/option-group.scss
+++ b/packages/theme-chalk/src/option-group.scss
@@ -24,7 +24,7 @@
         right: $gap;
         bottom: 12px;
         height: 1px;
-        background: $--border-color-light;
+        background: var(--el-border-color-light);
       }
     }
   }
@@ -35,7 +35,7 @@
       left: $gap;
       right: $gap;
       height: 1px;
-      background: $--border-color-light;
+      background: var(--el-border-color-light);
     }
   }
 

--- a/packages/theme-chalk/src/page-header.scss
+++ b/packages/theme-chalk/src/page-header.scss
@@ -19,7 +19,7 @@
       right: -20px;
       top: 50%;
       transform: translateY(-50%);
-      background-color: $--border-color-base;
+      background-color: var(--el-border-color-base);
     }
 
     @include e(icon) {

--- a/packages/theme-chalk/src/popper.scss
+++ b/packages/theme-chalk/src/popper.scss
@@ -25,10 +25,10 @@
 
   @include when(light) {
     background: $--color-white;
-    border: 1px solid $--border-color-light;
+    border: 1px solid var(--el-border-color-light);
 
     #{$arrow-selector}::before {
-      border: 1px solid $--border-color-light;
+      border: 1px solid var(--el-border-color-light);
       background: $--color-white;
       right: 0;
     }

--- a/packages/theme-chalk/src/progress.scss
+++ b/packages/theme-chalk/src/progress.scss
@@ -97,7 +97,7 @@
   @include e(outer) {
     height: 6px;
     border-radius: 100px;
-    background-color: $--border-color-lighter;
+    background-color: var(--el-border-color-lighter);
     overflow: hidden;
     position: relative;
     vertical-align: middle;

--- a/packages/theme-chalk/src/radio.scss
+++ b/packages/theme-chalk/src/radio.scss
@@ -31,7 +31,7 @@
 
     &.is-disabled {
       cursor: not-allowed;
-      border-color: $--border-color-lighter;
+      border-color: var(--el-border-color-lighter);
     }
 
     & + .#{$namespace}-radio.is-bordered {

--- a/packages/theme-chalk/src/select-v2.scss
+++ b/packages/theme-chalk/src/select-v2.scss
@@ -25,7 +25,7 @@ $--input-inline-start: 7px !default;
     padding-right: 30px;
     padding-top: 1px;
     padding-bottom: 1px;
-    border: 1px solid $--border-color-base;
+    border: 1px solid var(--el-border-color-base);
     border-radius: $--border-radius-base;
     transition: border-color 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
 

--- a/packages/theme-chalk/src/table-column.scss
+++ b/packages/theme-chalk/src/table-column.scss
@@ -13,7 +13,7 @@
 }
 
 @include b(table-filter) {
-  border: solid 1px $--border-color-lighter;
+  border: solid 1px var(--el-border-color-lighter);
   border-radius: 2px;
   background-color: $--color-white;
   box-shadow: $--dropdown-menu-box-shadow;
@@ -50,7 +50,7 @@
   }
 
   @include e(bottom) {
-    border-top: 1px solid $--border-color-lighter;
+    border-top: 1px solid var(--el-border-color-lighter);
     padding: 8px;
 
     button {

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -323,7 +323,7 @@
       bottom: 0;
       width: 100%;
       height: 1px;
-      background-color: $--border-color-lighter;
+      background-color: var(--el-border-color-lighter);
       z-index: 4;
     }
   }

--- a/packages/theme-chalk/src/tabs.scss
+++ b/packages/theme-chalk/src/tabs.scss
@@ -51,7 +51,7 @@
       bottom: 0;
       width: 100%;
       height: 2px;
-      background-color: $--border-color-light;
+      background-color: var(--el-border-color-light);
       z-index: var(--el-index-normal);
     }
 
@@ -145,13 +145,13 @@
   }
   @include m(card) {
     > .#{$namespace}-tabs__header {
-      border-bottom: 1px solid $--border-color-light;
+      border-bottom: 1px solid var(--el-border-color-light);
     }
     > .#{$namespace}-tabs__header .#{$namespace}-tabs__nav-wrap::after {
       content: none;
     }
     > .#{$namespace}-tabs__header .#{$namespace}-tabs__nav {
-      border: 1px solid $--border-color-light;
+      border: 1px solid var(--el-border-color-light);
       border-bottom: none;
       border-radius: 4px 4px 0 0;
       box-sizing: border-box;
@@ -175,7 +175,7 @@
     }
     > .#{$namespace}-tabs__header .#{$namespace}-tabs__item {
       border-bottom: 1px solid transparent;
-      border-left: 1px solid $--border-color-light;
+      border-left: 1px solid var(--el-border-color-light);
       transition: color 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
         padding 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
       &:first-child {
@@ -207,7 +207,7 @@
   }
   @include m(border-card) {
     background: $--color-white;
-    border: 1px solid $--border-color-base;
+    border: 1px solid var(--el-border-color-base);
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.12), 0 0 6px 0 rgba(0, 0, 0, 0.04);
 
     > .#{$namespace}-tabs__content {
@@ -215,7 +215,7 @@
     }
     > .#{$namespace}-tabs__header {
       background-color: $--background-color-base;
-      border-bottom: 1px solid $--border-color-light;
+      border-bottom: 1px solid var(--el-border-color-light);
       margin: 0;
     }
     > .#{$namespace}-tabs__header .#{$namespace}-tabs__nav-wrap::after {
@@ -238,8 +238,8 @@
       &.is-active {
         color: $--color-primary;
         background-color: $--color-white;
-        border-right-color: $--border-color-base;
-        border-left-color: $--border-color-base;
+        border-right-color: var(--el-border-color-base);
+        border-left-color: var(--el-border-color-base);
       }
       &:not(.is-disabled):hover {
         color: $--color-primary;
@@ -287,7 +287,7 @@
     &.#{$namespace}-tabs--border-card {
       .#{$namespace}-tabs__header.is-bottom {
         border-bottom: 0;
-        border-top: 1px solid $--border-color-base;
+        border-top: 1px solid var(--el-border-color-base);
       }
       .#{$namespace}-tabs__nav-wrap.is-bottom {
         margin-top: -1px;
@@ -393,17 +393,17 @@
       }
       .#{$namespace}-tabs__item.is-left {
         border-left: none;
-        border-right: 1px solid $--border-color-light;
+        border-right: 1px solid var(--el-border-color-light);
         border-bottom: none;
-        border-top: 1px solid $--border-color-light;
+        border-top: 1px solid var(--el-border-color-light);
         text-align: left;
       }
       .#{$namespace}-tabs__item.is-left:first-child {
-        border-right: 1px solid $--border-color-light;
+        border-right: 1px solid var(--el-border-color-light);
         border-top: none;
       }
       .#{$namespace}-tabs__item.is-left.is-active {
-        border: 1px solid $--border-color-light;
+        border: 1px solid var(--el-border-color-light);
         border-right-color: #fff;
         border-left: none;
         border-bottom: none;
@@ -418,7 +418,7 @@
 
       .#{$namespace}-tabs__nav {
         border-radius: 4px 0 0 4px;
-        border-bottom: 1px solid $--border-color-light;
+        border-bottom: 1px solid var(--el-border-color-light);
         border-right: none;
       }
 
@@ -468,14 +468,14 @@
       }
       .#{$namespace}-tabs__item.is-right {
         border-bottom: none;
-        border-top: 1px solid $--border-color-light;
+        border-top: 1px solid var(--el-border-color-light);
       }
       .#{$namespace}-tabs__item.is-right:first-child {
-        border-left: 1px solid $--border-color-light;
+        border-left: 1px solid var(--el-border-color-light);
         border-top: none;
       }
       .#{$namespace}-tabs__item.is-right.is-active {
-        border: 1px solid $--border-color-light;
+        border: 1px solid var(--el-border-color-light);
         border-left-color: #fff;
         border-right: none;
         border-bottom: none;
@@ -490,7 +490,7 @@
 
       .#{$namespace}-tabs__nav {
         border-radius: 0 4px 4px 0;
-        border-bottom: 1px solid $--border-color-light;
+        border-bottom: 1px solid var(--el-border-color-light);
         border-left: none;
       }
     }

--- a/packages/theme-chalk/src/var.scss
+++ b/packages/theme-chalk/src/var.scss
@@ -22,10 +22,9 @@
   --el-color-text-secondary: #{$--color-text-secondary};
   --el-color-text-placeholder: #{$--color-text-placeholder};
 
-  --el-border-color-base: #{$--border-color-base};
-  --el-border-color-light: #{$--border-color-light};
-  --el-border-color-lighter: #{$--border-color-lighter};
-  --el-border-color-extra-light: #{$--border-color-extra-light};
+  @each $type in (base, light, lighter, extra-light) {
+    @include set-css-var-type('border-color', $type, $--border-color);
+  }
 
   // Background
   --el-background-color-base: #{$--background-color-base};

--- a/website/components/demo-block.vue
+++ b/website/components/demo-block.vue
@@ -201,11 +201,15 @@ export default {
   ${this.displayDemoCode}
 ${'</sc' + 'ript>'}
 `
+        const innerStyle = this.codepen.style && this.codepen.style.trim() ? `<style>
+  ${this.codepen.style}
+</style>
+` : ''
         hlcode.innerHTML = sanitizeHTML(`<template>
   ${this.codepen.html}
 </template>
 
-${this.displayDemoCode ? innerScript : ''}`)
+${this.displayDemoCode ? innerScript : ''}${innerStyle}`)
 
         nextTick(() => {
           if (this.$el.getElementsByClassName('description').length === 0) {

--- a/website/components/demo/color/border-box.vue
+++ b/website/components/demo/color/border-box.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="demo-color-box-group">
+    <div
+      v-for="(border, i) in borderColors"
+      :key="i"
+      class="demo-color-box demo-color-box-other demo-color-box-lite"
+      :style="{ background: `var(--el-border-color-${border.type})` }"
+    >
+      {{ border.name || formatType(border.type) + ' Border' }}
+      <div class="value">{{ border.color }}</div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { formatType } from '../../../util'
+
+export default {
+  props: {
+    borderColors: {
+      type: Array,
+      default() {
+        return []
+      },
+    },
+  },
+  methods: {
+    formatType,
+  },
+}
+</script>

--- a/website/docs/en-US/color.md
+++ b/website/docs/en-US/color.md
@@ -1,6 +1,7 @@
 <script>
   import bus from '../../bus';
   import { tintColor } from '../../color.js';
+  import BorderBox from "../../components/demo/color/border-box.vue"
   const varMap = {
     'primary': '$--color-primary',
     'success': '$--color-success',
@@ -13,11 +14,27 @@
     'textRegular': '$--color-text-regular',
     'textSecondary': '$--color-text-secondary',
     'textPlaceholder': '$--color-text-placeholder',
-    'borderBase': '$--border-color-base',
-    'borderLight': '$--border-color-light',
-    'borderLighter': '$--border-color-lighter',
-    'borderExtraLight': '$--border-color-extra-light'
   };
+
+  const borderColors = [
+    {
+      type: 'base',
+      color: '#DCDFE6',
+    },
+    {
+      type: 'light',
+      color: '#E4E7ED',
+    },
+    {
+      type: 'lighter',
+      color: '#EBEEF5',
+    },
+    {
+      type: 'extra-light',
+      color: '#F2F6FC',
+    },
+  ]
+
   const original = {
     primary: '#409EFF',
     success: '#67C23A',
@@ -30,12 +47,11 @@
     textRegular: '#606266',
     textSecondary: '#909399',
     textPlaceholder: '#C0C4CC',
-    borderBase: '#DCDFE6',
-    borderLight: '#E4E7ED',
-    borderLighter: '#EBEEF5',
-    borderExtraLight: '#F2F6FC'
   }
   export default {
+    components: {
+      BorderBox
+    },
     mounted() {
       this.setGlobal();
     },
@@ -47,7 +63,7 @@
         if (window.userThemeConfig) {
           this.global = window.userThemeConfig.global;
         }
-      }
+      },
     },
     data() {
       return {
@@ -63,10 +79,7 @@
         textRegular: '',
         textSecondary: '',
         textPlaceholder: '',
-        borderBase: '',
-        borderLight: '',
-        borderLighter: '',
-        borderExtraLight: ''
+        borderColors,
       }
     },
     watch: {
@@ -215,20 +228,7 @@ Neutral colors are for text, background and border colors. You can use different
     </div>
   </el-col>
   <el-col :span="6" :xs="{span: 12}">
-    <div class="demo-color-box-group">
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderBase }"
-      >Base Border<div class="value">{{borderBase}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderLight }"
-      >Light Border<div class="value">{{borderLight}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderLighter }"
-      >Lighter Border<div class="value">{{borderLighter}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderExtraLight }"
-      >Extra Light Border<div class="value">{{borderExtraLight}}</div></div>
-    </div>
+    <border-box :border-colors="borderColors" />
   </el-col>
   <el-col :span="6" :xs="{span: 12}">
     <div class="demo-color-box-group">

--- a/website/docs/es/color.md
+++ b/website/docs/es/color.md
@@ -1,6 +1,30 @@
 <script>
   import bus from '../../bus';
   import { tintColor } from '../../color.js';
+  import BorderBox from "../../components/demo/color/border-box.vue"
+  const borderColors = [
+    {
+      name: 'Borde base',
+      type: 'base',
+      color: '#DCDFE6',
+    },
+    {
+      name: 'Borde ligero',
+      type: 'light',
+      color: '#E4E7ED',
+    },
+    {
+      name: 'Borde claro',
+      type: 'lighter',
+      color: '#EBEEF5',
+    },
+    {
+      name: 'Borde extra claro',
+      type: 'extra-light',
+      color: '#F2F6FC',
+    },
+  ]
+
   const varMap = {
     'primary': '$--color-primary',
     'success': '$--color-success',
@@ -13,10 +37,6 @@
     'textRegular': '$--color-text-regular',
     'textSecondary': '$--color-text-secondary',
     'textPlaceholder': '$--color-text-placeholder',
-    'borderBase': '$--border-color-base',
-    'borderLight': '$--border-color-light',
-    'borderLighter': '$--border-color-lighter',
-    'borderExtraLight': '$--border-color-extra-light'
   };
   const original = {
     primary: '#409EFF',
@@ -30,12 +50,11 @@
     textRegular: '#606266',
     textSecondary: '#909399',
     textPlaceholder: '#C0C4CC',
-    borderBase: '#DCDFE6',
-    borderLight: '#E4E7ED',
-    borderLighter: '#EBEEF5',
-    borderExtraLight: '#F2F6FC'
   }
   export default {
+    components: {
+      BorderBox
+    },
     mounted() {
       this.setGlobal();
     },
@@ -63,10 +82,7 @@
         textRegular: '',
         textSecondary: '',
         textPlaceholder: '',
-        borderBase: '',
-        borderLight: '',
-        borderLighter: '',
-        borderExtraLight: ''
+        borderColors,
       }
     },
     watch: {
@@ -87,6 +103,7 @@
 </script>
 
 ## Color
+
 Element Plus utiliza un conjunto de paletas para especificar colores, y así, proporcionar una apariencia y sensación coherente para los productos que construye.
 
 ### Color principal
@@ -214,20 +231,7 @@ Los colores neutrales son para texto, fondos y bordes. Puede usar diferentes col
     </div>
   </el-col>
   <el-col :span="6" :xs="{span: 12}">
-    <div class="demo-color-box-group">
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderBase }"
-      >Borde base<div class="value">{{borderBase}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderLight }"
-      >Borde ligero<div class="value">{{borderLight}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderLighter }"
-      >Borde claro<div class="value">{{borderLighter}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderExtraLight }"
-      >Borde extra claro<div class="value">{{borderExtraLight}}</div></div>
-    </div>
+    <border-box :border-colors="borderColors" />
   </el-col>
   <el-col :span="6" :xs="{span: 12}">
     <div class="demo-color-box-group">

--- a/website/docs/fr-FR/color.md
+++ b/website/docs/fr-FR/color.md
@@ -1,6 +1,29 @@
 <script>
   import bus from '../../bus';
   import { tintColor } from '../../color.js';
+  import BorderBox from "../../components/demo/color/border-box.vue"
+  const borderColors = [
+    {
+      name: 'Bordure de base',
+      type: 'base',
+      color: '#DCDFE6',
+    },
+    {
+      name: 'Bordure claire',
+      type: 'light',
+      color: '#E4E7ED',
+    },
+    {
+      name: 'Bordure très claire',
+      type: 'lighter',
+      color: '#EBEEF5',
+    },
+    {
+      name: 'Bordure extra claire',
+      type: 'extra-light',
+      color: '#F2F6FC',
+    },
+  ]
   const varMap = {
     'primary': '$--color-primary',
     'success': '$--color-success',
@@ -13,10 +36,6 @@
     'textRegular': '$--color-text-regular',
     'textSecondary': '$--color-text-secondary',
     'textPlaceholder': '$--color-text-placeholder',
-    'borderBase': '$--border-color-base',
-    'borderLight': '$--border-color-light',
-    'borderLighter': '$--border-color-lighter',
-    'borderExtraLight': '$--border-color-extra-light'
   };
   const original = {
     primary: '#409EFF',
@@ -30,12 +49,11 @@
     textRegular: '#606266',
     textSecondary: '#909399',
     textPlaceholder: '#C0C4CC',
-    borderBase: '#DCDFE6',
-    borderLight: '#E4E7ED',
-    borderLighter: '#EBEEF5',
-    borderExtraLight: '#F2F6FC'
   }
   export default {
+    components: {
+      BorderBox
+    },
     mounted() {
       this.setGlobal();
     },
@@ -63,10 +81,7 @@
         textRegular: '',
         textSecondary: '',
         textPlaceholder: '',
-        borderBase: '',
-        borderLight: '',
-        borderLighter: '',
-        borderExtraLight: ''
+        borderColors,
       }
     },
     watch: {
@@ -87,6 +102,7 @@
 </script>
 
 ## Couleur
+
 Element Plus utilise un ensemble de palettes spécifiques afin de fournir un style consistant pour vos produits.
 
 ### Couleur principale
@@ -191,20 +207,7 @@ Les couleurs neutres sont les couleurs du fond, du texte et des bordures. Vous p
     </div>
   </el-col>
   <el-col :span="6" :xs="{span: 12}">
-    <div class="demo-color-box-group">
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderBase }"
-      >Bordure de base<div class="value">{{borderBase}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderLight }"
-      >Bordure claire<div class="value">{{borderLight}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderLighter }"
-      >Bordure très claire<div class="value">{{borderLighter}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderExtraLight }"
-      >Bordure extra claire<div class="value">{{borderExtraLight}}</div></div>
-    </div>
+    <border-box :border-colors="borderColors" />
   </el-col>
   <el-col :span="6" :xs="{span: 12}">
     <div class="demo-color-box-group">

--- a/website/docs/jp/color.md
+++ b/website/docs/jp/color.md
@@ -1,6 +1,25 @@
 <script>
   import bus from '../../bus';
   import { tintColor } from '../../color.js';
+  import BorderBox from "../../components/demo/color/border-box.vue"
+  const borderColors = [
+    {
+      type: 'base',
+      color: '#DCDFE6',
+    },
+    {
+      type: 'light',
+      color: '#E4E7ED',
+    },
+    {
+      type: 'lighter',
+      color: '#EBEEF5',
+    },
+    {
+      type: 'extra-light',
+      color: '#F2F6FC',
+    },
+  ]
   const varMap = {
     'primary': '$--color-primary',
     'success': '$--color-success',
@@ -13,10 +32,6 @@
     'textRegular': '$--color-text-regular',
     'textSecondary': '$--color-text-secondary',
     'textPlaceholder': '$--color-text-placeholder',
-    'borderBase': '$--border-color-base',
-    'borderLight': '$--border-color-light',
-    'borderLighter': '$--border-color-lighter',
-    'borderExtraLight': '$--border-color-extra-light'
   };
   const original = {
     primary: '#409EFF',
@@ -30,12 +45,11 @@
     textRegular: '#606266',
     textSecondary: '#909399',
     textPlaceholder: '#C0C4CC',
-    borderBase: '#DCDFE6',
-    borderLight: '#E4E7ED',
-    borderLighter: '#EBEEF5',
-    borderExtraLight: '#F2F6FC'
   }
   export default {
+    components: {
+      BorderBox
+    },
     mounted() {
       this.setGlobal();
     },
@@ -63,10 +77,7 @@
         textRegular: '',
         textSecondary: '',
         textPlaceholder: '',
-        borderBase: '',
-        borderLight: '',
-        borderLighter: '',
-        borderExtraLight: ''
+        borderColors,
       }
     },
     watch: {
@@ -87,24 +98,26 @@
 </script>
 
 ## カラー
-Element Plusは、特定のパレットセットを用いて色を指定し、プロダクトに一貫した外観と使用感を提供します。
+
+Element Plus は、特定のパレットセットを用いて色を指定し、プロダクトに一貫した外観と使用感を提供します。
 
 ### メインカラー
-Element Plusのメインカラーは明るく親しみやすいブルーです。
+
+Element Plus のメインカラーは明るく親しみやすいブルーです。
 
 <el-row :gutter="12">
   <el-col :span="10" :xs="{span: 12}">
-    <div 
+    <div
       class="demo-color-box"
       :style="{ background: primary }"
     >
       Brand Color<div class="value">#409EFF</div>
-    <div 
+    <div
       class="bg-color-sub"
       :style="{ background: tintColor(primary, 0.9) }"
     >
-    <div 
-      class="bg-blue-sub-item" 
+    <div
+      class="bg-blue-sub-item"
       v-for="(item, key) in Array(8)"
       :key="key"
       :style="{ background: tintColor(primary, (key + 1) / 10) }"
@@ -124,11 +137,11 @@ Element Plusのメインカラーは明るく親しみやすいブルーです�
     <div class="demo-color-box"
     :style="{ background: success }"
     >Success<div class="value">#67C23A</div>
-      <div 
+      <div
         class="bg-color-sub"
       >
-        <div 
-          class="bg-success-sub-item" 
+        <div
+          class="bg-success-sub-item"
           v-for="(item, key) in Array(2)"
           :key="key"
           :style="{ background: tintColor(success, (key + 8) / 10) }"
@@ -141,11 +154,11 @@ Element Plusのメインカラーは明るく親しみやすいブルーです�
     <div class="demo-color-box"
     :style="{ background: warning }"
     >Warning<div class="value">#E6A23C</div>
-      <div 
+      <div
           class="bg-color-sub"
         >
-        <div 
-          class="bg-success-sub-item" 
+        <div
+          class="bg-success-sub-item"
           v-for="(item, key) in Array(2)"
           :key="key"
           :style="{ background: tintColor(warning, (key + 8) / 10) }"
@@ -158,11 +171,11 @@ Element Plusのメインカラーは明るく親しみやすいブルーです�
     <div class="demo-color-box"
     :style="{ background: danger }"
     >Danger<div class="value">#F56C6C</div>
-      <div 
+      <div
           class="bg-color-sub"
         >
-        <div 
-          class="bg-success-sub-item" 
+        <div
+          class="bg-success-sub-item"
           v-for="(item, key) in Array(2)"
           :key="key"
           :style="{ background: tintColor(danger, (key + 8) / 10) }"
@@ -175,11 +188,11 @@ Element Plusのメインカラーは明るく親しみやすいブルーです�
     <div class="demo-color-box"
     :style="{ background: info }"
     >Info<div class="value">#909399</div>
-      <div 
+      <div
           class="bg-color-sub"
         >
-        <div 
-          class="bg-success-sub-item" 
+        <div
+          class="bg-success-sub-item"
           v-for="(item, key) in Array(2)"
           :key="key"
           :style="{ background: tintColor(info, (key + 8) / 10) }"
@@ -213,24 +226,11 @@ Element Plusのメインカラーは明るく親しみやすいブルーです�
     </div>
   </el-col>
   <el-col :span="6" :xs="{span: 12}">
-    <div class="demo-color-box-group">
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderBase }"
-      >Base Border<div class="value">{{borderBase}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderLight }"
-      >Light Border<div class="value">{{borderLight}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderLighter }"
-      >Lighter Border<div class="value">{{borderLighter}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderExtraLight }"
-      >Extra Light Border<div class="value">{{borderExtraLight}}</div></div>
-    </div>
+    <border-box :border-colors="borderColors" />
   </el-col>
   <el-col :span="6" :xs="{span: 12}">
     <div class="demo-color-box-group">
-      <div 
+      <div
       class="demo-color-box demo-color-box-other"
       :style="{ background: black }"
       >Basic Black<div class="value">{{black}}</div></div>

--- a/website/docs/zh-CN/color.md
+++ b/website/docs/zh-CN/color.md
@@ -1,6 +1,29 @@
 <script>
   import bus from '../../bus';
   import { tintColor } from '../../color.js';
+  import BorderBox from "../../components/demo/color/border-box.vue"
+  const borderColors = [
+    {
+      name: '一级边框',
+      type: 'base',
+      color: '#DCDFE6',
+    },
+    {
+      name: '二级边框',
+      type: 'light',
+      color: '#E4E7ED',
+    },
+    {
+      name: '三级边框',
+      type: 'lighter',
+      color: '#EBEEF5',
+    },
+    {
+      name: '四级边框',
+      type: 'extra-light',
+      color: '#F2F6FC',
+    },
+  ]
   const varMap = {
     'primary': '$--color-primary',
     'success': '$--color-success',
@@ -13,10 +36,6 @@
     'textRegular': '$--color-text-regular',
     'textSecondary': '$--color-text-secondary',
     'textPlaceholder': '$--color-text-placeholder',
-    'borderBase': '$--border-color-base',
-    'borderLight': '$--border-color-light',
-    'borderLighter': '$--border-color-lighter',
-    'borderExtraLight': '$--border-color-extra-light'
   };
   const original = {
     primary: '#409EFF',
@@ -30,12 +49,11 @@
     textRegular: '#606266',
     textSecondary: '#909399',
     textPlaceholder: '#C0C4CC',
-    borderBase: '#DCDFE6',
-    borderLight: '#E4E7ED',
-    borderLighter: '#EBEEF5',
-    borderExtraLight: '#F2F6FC'
   }
   export default {
+    components: {
+      BorderBox
+    },
     mounted() {
       this.setGlobal();
     },
@@ -63,10 +81,7 @@
         textRegular: '',
         textSecondary: '',
         textPlaceholder: '',
-        borderBase: '',
-        borderLight: '',
-        borderLighter: '',
-        borderExtraLight: ''
+        borderColors
       }
     },
     watch: {
@@ -208,20 +223,7 @@ Element Plus 主要品牌颜色是鲜艳、友好的蓝色。
     </div>
   </el-col>
   <el-col :span="6" :xs="{span: 12}">
-    <div class="demo-color-box-group">
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderBase }"
-      >一级边框<div class="value">{{borderBase}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderLight }"
-      >二级边框<div class="value">{{borderLight}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderLighter }"
-      >三级边框<div class="value">{{borderLighter}}</div></div>
-      <div class="demo-color-box demo-color-box-other demo-color-box-lite"
-      :style="{ background: borderExtraLight }"
-      >四级边框<div class="value">{{borderExtraLight}}</div></div>
-    </div>
+    <border-box :border-colors="borderColors" />
   </el-col>
   <el-col :span="6" :xs="{span: 12}">
     <div class="demo-color-box-group">

--- a/website/util.js
+++ b/website/util.js
@@ -13,16 +13,12 @@ export function stripTemplate(content) {
   if (!content) {
     return content
   }
-  return content
-    .replace(/<(script|style)[\s\S]+<\/\1>/g, '')
-    .trim()
+  return content.replace(/<(script|style)[\s\S]+<\/\1>/g, '').trim()
 }
 
 const setupCommentGlobalRegx = /<!--[\r?\n|\r]?(<setup>[\s\S]+)-->/g
-export function removeSetup (content) {
-  return content
-    .replace(setupCommentGlobalRegx, '')
-    .trim()
+export function removeSetup(content) {
+  return content.replace(setupCommentGlobalRegx, '').trim()
 }
 
 const setupCommentRegx = /<!--[\r?\n|\r]?(<setup>[\s\S]+)-->/
@@ -32,4 +28,15 @@ export function stripSetup(content) {
   if (!comment) return comment
   const result2 = comment.match(/<(setup)>([\s\S]+)<\/\1>/)
   return result2 && result2[2] ? result2[2].trim() : ''
+}
+
+/**
+ * format kebab-case to PascalCase with space (Pascal Case)
+ * @param {string} type
+ */
+export function formatType(type) {
+  return type
+    .split('-')
+    .map(item => item.charAt(0).toUpperCase() + item.slice(1))
+    .join(' ')
 }


### PR DESCRIPTION
- use `map.get($--border-color, 'light')` instead of `$--border-color-light`
- set `--el-border-color-light`: map.get($--border-color, 'light')
- replace the variables used in each component
- simplify the border-color sample document code
  - a common component `websites/components/demo/color/border-box.vue` is extracted to display the BorderColor, and different languages just need to pass in the corresponding title
  - This helps to ensure uniformity of examples across languages
  - I think some content can also be migrated in this way

---

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
