### PR TITLE
fix(style): ensure that the loading icon is inline

### DIFF
--- a/packages/theme-chalk/src/loading.scss
+++ b/packages/theme-chalk/src/loading.scss
@@ -52,6 +52,7 @@
   }
 
   .circular {
+    display: inline;
     height: $--loading-spinner-size;
     width: $--loading-spinner-size;
     animation: loading-rotate 2s linear infinite;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

When using some frameworks that include CSS reset, the svg element will be set to block, which will cause the style problem of the loading icon.
![screenshot](https://user-images.githubusercontent.com/16174159/125881859-b58f882c-b8e6-4fe5-aef3-89584af0d8f7.png)
