### PR TITLE
refactor(button): migrate css var

### DIFF
--- a/packages/theme-chalk/src/button.scss
+++ b/packages/theme-chalk/src/button.scss
@@ -1,9 +1,37 @@
 @charset "UTF-8";
 @use "sass:map";
+
 @import 'common/var';
 @import 'mixins/button';
 @import 'mixins/mixins';
 @import 'mixins/utils';
+
+$--button: () !default;
+
+@each $type in (primary, success, warning, danger, info) {
+  $--button: map.deep-merge(
+    $--button,
+    (
+      'border-color': (
+        $type: map.get($--colors, $type, 'base'),
+      ),
+      'font-color': (
+        $type: map.get($--colors, 'white'),
+      ),
+      'background-color': (
+        $type: map.get($--colors, $type, 'base'),
+      ),
+    )
+  ) !global;
+}
+
+:root {
+  @each $type in (primary, success, warning, danger, info) {
+    --el-button-#{$type}-border-color: var(--el-color-#{$type});
+  }
+
+  --el-button-divide-border-color: #{rgba($--color-white, 0.5)};
+}
 
 @include b(button) {
   display: inline-block;
@@ -11,17 +39,17 @@
   min-height: map.get($--input-height, 'default');
   white-space: nowrap;
   cursor: pointer;
-  background: $--button-default-background-color;
-  border: $--border-base;
-  border-color: $--button-default-border-color;
-  color: $--button-default-font-color;
+  background: var(--el-button-default-background-color);
+  border: var(--el-border-base);
+  border-color: var(--el-button-default-border-color);
+  color: var(--el-button-default-font-color);
   -webkit-appearance: none;
   text-align: center;
   box-sizing: border-box;
   outline: none;
   margin: 0;
   transition: 0.1s;
-  font-weight: $--button-font-weight;
+  font-weight: var(--el-button-font-weight);
   @include utils-user-select(none);
   & + & {
     margin-left: 10px;
@@ -36,7 +64,7 @@
 
   &:hover,
   &:focus {
-    color: $--color-primary;
+    color: var(--el-color-primary);
     border-color: map.get($--colors, 'primary', 'light-7');
     background-color: map.get($--colors, 'primary', 'light-9');
   }
@@ -68,13 +96,13 @@
   @include when(plain) {
     &:hover,
     &:focus {
-      background: $--color-white;
-      border-color: $--color-primary;
-      color: $--color-primary;
+      background: var(--el-color-white);
+      border-color: var(--el-color-primary);
+      color: var(--el-color-primary);
     }
 
     &:active {
-      background: $--color-white;
+      background: var(--el-color-white);
       border-color: mix(
         $--color-black,
         $--color-primary,
@@ -106,11 +134,11 @@
     &,
     &:hover,
     &:focus {
-      color: $--button-disabled-font-color;
+      color: var(--el-button-disabled-font-color);
       cursor: not-allowed;
       background-image: none;
-      background-color: $--button-disabled-background-color;
-      border-color: $--button-disabled-border-color;
+      background-color: var(--el-button-disabled-background-color);
+      border-color: var(--el-button-disabled-border-color);
     }
 
     &.#{$namespace}-button--text {
@@ -121,9 +149,9 @@
       &,
       &:hover,
       &:focus {
-        background-color: $--color-white;
-        border-color: $--button-disabled-border-color;
-        color: $--button-disabled-font-color;
+        background-color: var(--el-color-white);
+        border-color: var(--el-button-disabled-border-color);
+        color: var(--el-button-disabled-font-color);
       }
     }
   }
@@ -152,40 +180,15 @@
     border-radius: 50%;
     padding: map.get($--button-padding-vertical, 'default');
   }
-  @include m(primary) {
-    @include button-variant(
-      $--button-primary-font-color,
-      $--button-primary-background-color,
-      $--button-primary-border-color
-    );
-  }
-  @include m(success) {
-    @include button-variant(
-      $--button-success-font-color,
-      $--button-success-background-color,
-      $--button-success-border-color
-    );
-  }
-  @include m(warning) {
-    @include button-variant(
-      $--button-warning-font-color,
-      $--button-warning-background-color,
-      $--button-warning-border-color
-    );
-  }
-  @include m(danger) {
-    @include button-variant(
-      $--button-danger-font-color,
-      $--button-danger-background-color,
-      $--button-danger-border-color
-    );
-  }
-  @include m(info) {
-    @include button-variant(
-      $--button-info-font-color,
-      $--button-info-background-color,
-      $--button-info-border-color
-    );
+
+  @each $type in (primary, success, warning, danger, info) {
+    @include m($type) {
+      @include button-variant(
+        map.get($--button, 'font-color', $type),
+        map.get($--button, 'background-color', $type),
+        map.get($--button, 'border-color', $type)
+      );
+    }
   }
 
   @each $size in (medium, small, mini) {
@@ -206,7 +209,7 @@
 
   @include m(text) {
     border-color: transparent;
-    color: $--color-primary;
+    color: var(--el-color-primary);
     background: transparent;
     padding-left: 0;
     padding-right: 0;
@@ -294,21 +297,21 @@
     & > .#{$namespace}-button {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
-      border-left-color: rgba($--color-white, 0.5);
+      border-left-color: var(--el-button-divide-border-color);
     }
   }
 
   @each $type in (primary, success, warning, danger, info) {
     .#{$namespace}-button--#{$type} {
       &:first-child {
-        border-right-color: rgba($--color-white, 0.5);
+        border-right-color: var(--el-button-divide-border-color);
       }
       &:last-child {
-        border-left-color: rgba($--color-white, 0.5);
+        border-left-color: var(--el-button-divide-border-color);
       }
       &:not(:first-child):not(:last-child) {
-        border-left-color: rgba($--color-white, 0.5);
-        border-right-color: rgba($--color-white, 0.5);
+        border-left-color: var(--el-button-divide-border-color);
+        border-right-color: var(--el-button-divide-border-color);
       }
     }
   }

--- a/packages/theme-chalk/src/checkbox.scss
+++ b/packages/theme-chalk/src/checkbox.scss
@@ -280,10 +280,10 @@
     white-space: nowrap;
     vertical-align: middle;
     cursor: pointer;
-    background: $--button-default-background-color;
+    background: var(--el-button-default-background-color);
     border: $--border-base;
     border-left: 0;
-    color: $--button-default-font-color;
+    color: var(--el-button-default-font-color);
     -webkit-appearance: none;
     text-align: center;
     box-sizing: border-box;
@@ -335,15 +335,15 @@
 
   &.is-disabled {
     & .#{$namespace}-checkbox-button__inner {
-      color: $--button-disabled-font-color;
+      color: var(--el-button-disabled-font-color);
       cursor: not-allowed;
       background-image: none;
-      background-color: $--button-disabled-background-color;
-      border-color: $--button-disabled-border-color;
+      background-color: var(--el-button-disabled-background-color);
+      border-color: var(--el-button-disabled-border-color);
       box-shadow: none;
     }
     &:first-child .#{$namespace}-checkbox-button__inner {
-      border-left-color: $--button-disabled-border-color;
+      border-left-color: var(--el-button-disabled-border-color);
     }
   }
 

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -393,9 +393,6 @@ $--input-number-width: (
 
 /* Button
 -------------------------- */
-/// fontWeight||Font|1
-$--button-font-weight: $--font-weight-primary !default;
-
 $--button-font-size: (
   'default': map.get($--font-size, 'base'),
   'medium': map.get($--font-size, 'base'),
@@ -424,50 +421,8 @@ $--button-padding-horizontal: (
   'mini': 15px,
 );
 
-/// color||Color|0
-$--button-default-font-color: $--color-text-regular !default;
-/// color||Color|0
-$--button-default-background-color: $--color-white !default;
-/// color||Color|0
+// need mix
 $--button-default-border-color: map.get($--border-color, 'base') !default;
-
-/// color||Color|0
-$--button-disabled-font-color: $--color-text-placeholder !default;
-/// color||Color|0
-$--button-disabled-background-color: $--color-white !default;
-/// color||Color|0
-$--button-disabled-border-color: map.get($--border-color, 'lighter') !default;
-
-/// color||Color|0
-$--button-primary-border-color: $--color-primary !default;
-/// color||Color|0
-$--button-primary-font-color: $--color-white !default;
-/// color||Color|0
-$--button-primary-background-color: $--color-primary !default;
-/// color||Color|0
-$--button-success-border-color: $--color-success !default;
-/// color||Color|0
-$--button-success-font-color: $--color-white !default;
-/// color||Color|0
-$--button-success-background-color: $--color-success !default;
-/// color||Color|0
-$--button-warning-border-color: $--color-warning !default;
-/// color||Color|0
-$--button-warning-font-color: $--color-white !default;
-/// color||Color|0
-$--button-warning-background-color: $--color-warning !default;
-/// color||Color|0
-$--button-danger-border-color: $--color-danger !default;
-/// color||Color|0
-$--button-danger-font-color: $--color-white !default;
-/// color||Color|0
-$--button-danger-background-color: $--color-danger !default;
-/// color||Color|0
-$--button-info-border-color: $--color-info !default;
-/// color||Color|0
-$--button-info-font-color: $--color-white !default;
-/// color||Color|0
-$--button-info-background-color: $--color-info !default;
 
 $--button-hover-tint-percent: 20% !default;
 $--button-active-shade-percent: 10% !default;

--- a/packages/theme-chalk/src/radio-button.scss
+++ b/packages/theme-chalk/src/radio-button.scss
@@ -14,11 +14,11 @@
     line-height: 1;
     white-space: nowrap;
     vertical-align: middle;
-    background: $--button-default-background-color;
+    background: var(--el-button-default-background-color);
     border: $--border-base;
-    font-weight: $--button-font-weight;
+    font-weight: var(--el-button-font-weight);
     border-left: 0;
-    color: $--button-default-font-color;
+    color: var(--el-button-default-font-color);
     -webkit-appearance: none;
     text-align: center;
     box-sizing: border-box;
@@ -73,11 +73,11 @@
 
     &:disabled {
       & + .#{$namespace}-radio-button__inner {
-        color: $--button-disabled-font-color;
+        color: var(--el-button-disabled-font-color);
         cursor: not-allowed;
         background-image: none;
-        background-color: $--button-disabled-background-color;
-        border-color: $--button-disabled-border-color;
+        background-color: var(--el-button-disabled-background-color);
+        border-color: var(--el-button-disabled-border-color);
         box-shadow: none;
       }
       &:checked + .#{$namespace}-radio-button__inner {

--- a/packages/theme-chalk/src/var.scss
+++ b/packages/theme-chalk/src/var.scss
@@ -77,6 +77,16 @@
   --el-disabled-border-base: var(--el-border-color-light);
 
   // some var for component, but because they are used in many places, need to be global
+  // button
+  --el-button-font-weight: var(--el-font-weight-primary);
+
+  --el-button-default-font-color: var(--el-color-text-regular);
+  --el-button-default-background-color: var(--el-color-white);
+  --el-button-default-border-color: var(--el-border-color-base);
+  --el-button-disabled-font-color: var(--el-color-text-placeholder);
+  --el-button-disabled-background-color: var(--el-color-white);
+  --el-button-disabled-border-color: var(--el-border-color-light);
+
   // message
   --el-message-close-size: 16px;
 }


### PR DESCRIPTION
Migrate `button` css var.

- Some variables need to be mixed, and the migration method needs to be considered
- add `--el-button-divide-border-color` to represent the color of the button group dividing line
- `sass:map` for `border-color` `font-color` `background-color`

---

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
