### PR TITLE
fix(select-v2): adjust the trigger conditions of focus and blur event

### DIFF
--- a/packages/select-v2/src/useSelect.ts
+++ b/packages/select-v2/src/useSelect.ts
@@ -221,8 +221,8 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
       // if (expanded.value) {
       //   expanded.value = false
       // }
+      if (states.isComposing) states.softFocus = true
       expanded.value = !expanded.value
-      states.softFocus = true
       inputRef.value?.focus?.()
       // }
     }
@@ -388,14 +388,9 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
       states.selectedLabel = option.label
       update(option.value)
       expanded.value = false
+      states.isComposing = false
+      states.isSilentBlur = byClick
     }
-    states.isComposing = false
-    states.isSilentBlur = byClick
-    // setSoftFocus()
-    if (expanded.value) return
-    nextTick(() => {
-      // scrollToOption(option)
-    })
   }
 
   const deleteTag = (event: MouseEvent, tag: Option) => {
@@ -423,15 +418,14 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
   }
 
   const handleFocus = (event: FocusEvent) => {
+    const focused = states.isComposing
     states.isComposing = true
     if (!states.softFocus) {
       if (props.automaticDropdown || props.filterable) {
         expanded.value = true
-        // if (props.filterable) {
-        //   states.menuVisibleOnFocus = true
-        // }
       }
-      emit('focus', event)
+      // If already in the focus state, shouldn't trigger event
+      if (!focused) emit('focus', event)
     } else {
       states.softFocus = false
     }
@@ -444,7 +438,6 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
       }
     }
 
-    states.isComposing = false
     states.softFocus = false
 
     // reset input value when blurred
@@ -454,7 +447,6 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
       if (calculatorRef.value) {
         states.calculatedWidth = calculatorRef.value.getBoundingClientRect().width
       }
-
       if (states.isSilentBlur) {
         states.isSilentBlur = false
       } else {
@@ -462,6 +454,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
           emit('blur')
         }
       }
+      states.isComposing = false
     })
 
   }


### PR DESCRIPTION
The following issues were fixed:

* Blur event can not be triggered
* Focus event in the focus state can still be repeatedly triggered
* The isComposing state is set to false after selecting one in multiple mode
* The focus event is triggered multiple times when selecting in multiple mode

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
