### PR TITLE
fix(message): iconClass correctly replaces the default icon

### DIFF
--- a/packages/message/src/index.vue
+++ b/packages/message/src/index.vue
@@ -15,7 +15,7 @@
       @mouseenter="clearTimer"
       @mouseleave="startTimer"
     >
-      <i v-if="type || iconClass" :class="[typeClass, iconClass]"></i>
+      <i v-if="type || iconClass" :class="['el-message__icon', iconClass || typeClass ]"></i>
       <slot>
         <p v-if="!dangerouslyUseHTMLString" class="el-message__content">{{ message }}</p>
         <!-- Caution here, message could've been compromised, never use user's input as message -->
@@ -65,7 +65,7 @@ export default defineComponent({
     const typeClass = computed(() => {
       const type = props.type
       return type && TypeMap[type]
-        ? `el-message__icon el-icon-${TypeMap[type]}`
+        ? `el-icon-${TypeMap[type]}`
         : ''
     })
     const customStyle = computed(() => {


### PR DESCRIPTION
-  "**el-message__icon**" is decoupled from **typeClass**
-  **iconClass** and **typeClass** are mutually exclusive 
- **iconClass** has a higher priority

---
Please make sure these boxes are checked before submitting your PR, thank you!

 [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
 [x] Make sure you are merging your commits to `dev` branch.
 [x] Add some descriptions and refer to relative issues for your PR.
