### PR TITLE
fix(message): using iconClass causes "el-message__icon" to be lost

### DIFF
--- a/packages/message/__tests__/message.spec.ts
+++ b/packages/message/__tests__/message.spec.ts
@@ -33,7 +33,7 @@ describe('Message.vue', () => {
 
       expect(wrapper.text()).toEqual(AXIOM)
       expect(vm.visible).toBe(true)
-      expect(vm.typeClass).toBe('el-message__icon el-icon-info')
+      expect(vm.typeClass).toBe('el-icon-info')
       expect(vm.customStyle).toEqual({ top: '20px', zIndex: 0 })
     })
 
@@ -100,7 +100,7 @@ describe('Message.vue', () => {
       const type = 'some-type'
       const wrapper = _mount({ props: { type } })
 
-      expect(wrapper.find('.el-message__icon').exists()).toBe(false)
+      expect(wrapper.find(`el-icon-${type}`).exists()).toBe(false)
     })
   })
 

--- a/packages/message/src/index.vue
+++ b/packages/message/src/index.vue
@@ -15,7 +15,7 @@
       @mouseenter="clearTimer"
       @mouseleave="startTimer"
     >
-      <i v-if="type || iconClass" :class="[typeClass, iconClass]"></i>
+      <i v-if="type || iconClass" :class="['el-message__icon', typeClass, iconClass]"></i>
       <slot>
         <p v-if="!dangerouslyUseHTMLString" class="el-message__content">{{ message }}</p>
         <!-- Caution here, message could've been compromised, never use user's input as message -->
@@ -65,7 +65,7 @@ export default defineComponent({
     const typeClass = computed(() => {
       const type = !props.iconClass && props.type
       return type && TypeMap[type]
-        ? `el-message__icon el-icon-${TypeMap[type]}`
+        ? `el-icon-${TypeMap[type]}`
         : ''
     })
     const customStyle = computed(() => {


### PR DESCRIPTION
在最新的代码中，ElMessage 组件在使用 `iconClass` 会导致 <i>标签丢失 `el-message__icon` class，我认为这是一个bug。

In the latest code, the use of `iconClass` in the ElMessage component will cause the ` <i>` to lose the `el-message__icon` class. I think this is a bug. 

---
Please make sure these boxes are checked before submitting your PR, thank you!

[x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
[x] Make sure you are merging your commits to `dev` branch.
[x] Add some descriptions and refer to relative issues for your PR.
