### PR TITLE
fix(switch): indicator overflowed

### DIFF
--- a/packages/theme-chalk/src/switch.scss
+++ b/packages/theme-chalk/src/switch.scss
@@ -98,7 +98,7 @@
       border-color: var(--el-switch-on-color);
       background-color: var(--el-switch-on-color);
       .#{$namespace}-switch__action {
-        left: 100%;
+        left: calc(100% - var(--el-switch-button-size));
         margin-left: calc(0px - var(--el-switch-button-size) - 1px);
         color: var(--el-switch-on-color);
       }


### PR DESCRIPTION
When `el-switch` was turned on, the `left` value will be set to `100%`, so the rounded indicator went outside the switch box.
Fixed it by changing `left: 100%` to `left: calc(100% - var(--el-switch-button-size))`.

Please make sure these boxes are checked before submitting your PR, thank you!

* [-] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [-] Make sure you are merging your commits to `dev` branch.
* [-] Add some descriptions and refer to relative issues for your PR.
