### PR TITLE
refactor(badge/card/dropdown/rate): migrate css var & use sass:map

### DIFF
--- a/packages/theme-chalk/src/badge.scss
+++ b/packages/theme-chalk/src/badge.scss
@@ -1,7 +1,16 @@
 @use "sass:math";
+@use "sass:map";
 
 @import 'mixins/mixins';
 @import 'common/var';
+
+:root {
+  --el-badge-background-color: var(--el-color-danger);
+
+  @each $attribute, $value in $--badge {
+    --el-badge-#{$attribute}: #{$value};
+  }
+}
 
 @include b(badge) {
   position: relative;
@@ -9,22 +18,22 @@
   display: inline-block;
 
   @include e(content) {
-    background-color: $--badge-background-color;
-    border-radius: $--badge-radius;
-    color: $--color-white;
+    background-color: var(--el-badge-background-color);
+    border-radius: var(--el-badge-radius);
+    color: var(--el-color-white);
     display: inline-block;
-    font-size: $--badge-font-size;
-    height: $--badge-size;
-    line-height: $--badge-size;
-    padding: 0 $--badge-padding;
+    font-size: var(--el-badge-font-size);
+    height: var(--el-badge-size);
+    line-height: var(--el-badge-size);
+    padding: 0 var(--el-badge-padding);
     text-align: center;
     white-space: nowrap;
-    border: 1px solid $--color-white;
+    border: 1px solid var(--el-color-white);
 
     @include when(fixed) {
       position: absolute;
       top: 0;
-      right: #{1 + math.div($--badge-size, 2)};
+      right: calc(1px + var(--el-badge-size) / 2);
       transform: translateY(-50%) translateX(100%);
 
       @include when(dot) {

--- a/packages/theme-chalk/src/badge.scss
+++ b/packages/theme-chalk/src/badge.scss
@@ -2,14 +2,11 @@
 @use "sass:map";
 
 @import 'mixins/mixins';
+@import 'mixins/var';
 @import 'common/var';
 
 :root {
-  --el-badge-background-color: var(--el-color-danger);
-
-  @each $attribute, $value in $--badge {
-    --el-badge-#{$attribute}: #{$value};
-  }
+  @include set-component-css-var('badge', $--badge);
 }
 
 @include b(badge) {

--- a/packages/theme-chalk/src/card.scss
+++ b/packages/theme-chalk/src/card.scss
@@ -1,9 +1,14 @@
 @import 'mixins/mixins';
+@import 'mixins/var';
 @import 'common/var';
 
+:root {
+  @include set-component-css-var('card', $--card);
+}
+
 @include b(card) {
-  border-radius: $--card-border-radius;
-  border: 1px solid $--card-border-color;
+  border-radius: var(--el-card-border-radius);
+  border: 1px solid var(--el-card-border-color);
   background-color: $--color-white;
   overflow: hidden;
   color: var(--el-text-color-primary);
@@ -21,12 +26,12 @@
   }
 
   @include e(header) {
-    padding: #{$--card-padding - 2 $--card-padding};
-    border-bottom: 1px solid $--card-border-color;
+    padding: calc(var(--el-card-padding) - 2px) var(--el-card-padding);
+    border-bottom: 1px solid var(--el-card-border-color);
     box-sizing: border-box;
   }
 
   @include e(body) {
-    padding: $--card-padding;
+    padding: var(--el-card-padding);
   }
 }

--- a/packages/theme-chalk/src/color-picker.scss
+++ b/packages/theme-chalk/src/color-picker.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @import 'mixins/mixins';
 @import 'common/var';
 @import './input.scss';
@@ -396,7 +398,7 @@
     box-sizing: content-box;
     background-color: $--color-white;
     border-radius: var(--el-border-radius-base);
-    box-shadow: $--dropdown-menu-box-shadow;
+    box-shadow: map.get($--dropdown, 'menu-box-shadow');
     &.#{$namespace}-popper {
       border: 1px solid var(--el-border-color-lighter);
     }

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -516,6 +516,7 @@ $--dropdown-menu-index: 10 !default;
 $--badge: () !default;
 $--badge: map.merge(
   (
+    'background-color': var(--el-color-danger),
     'radius': 10px,
     'font-size': 12px,
     'padding': 6px,
@@ -556,14 +557,17 @@ $--slider-button-wrapper-offset: -15px !default;
 
 /* Rate
 --------------------------*/
-$--rate-height: 20px !default;
-/// fontSize||Font|1
-$--rate-font-size: map.get($--font-size, 'base') !default;
-/// height||Other|3
-$--rate-icon-size: 18px !default;
-/// margin||Spacing|2
-$--rate-icon-margin: 6px !default;
-$--rate-icon-color: var(--el-text-color-placeholder) !default;
+$--rate: () !default;
+$--rate: map.merge(
+  (
+    'height': 20px,
+    'font-size': var(--el-font-size-base),
+    'icon-size': 18px,
+    'icon-margin': 6px,
+    'icon-color': var(--el-text-color-placeholder),
+  ),
+  $--rate
+);
 
 /* DatePicker
 --------------------------*/

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -512,15 +512,17 @@ $--dropdown-menu-index: 10 !default;
 
 /* Badge
 -------------------------- */
-/// color||Color|0
-$--badge-background-color: $--color-danger !default;
-$--badge-radius: 10px !default;
-/// fontSize||Font|1
-$--badge-font-size: 12px !default;
-/// padding||Spacing|3
-$--badge-padding: 6px !default;
-/// height||Other|4
-$--badge-size: 18px !default;
+// Css3 var in packages/theme-chalk/src/badge.scss
+$--badge: () !default;
+$--badge: map.merge(
+  (
+    'radius': 10px,
+    'font-size': 12px,
+    'padding': 6px,
+    'size': 18px,
+  ),
+  $--badge
+);
 
 /* Card
 --------------------------*/

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -527,11 +527,16 @@ $--badge: map.merge(
 
 /* Card
 --------------------------*/
-/// color||Color|0
-$--card-border-color: map.get($--border-color, 'lighter') !default;
-$--card-border-radius: 4px !default;
-/// padding||Spacing|3
-$--card-padding: 20px !default;
+$--card: () !default;
+$--card: map.merge(
+  (
+    'border-color':
+      var(--el-border-color-light, map.get($--border-color, 'lighter')),
+    'border-radius': 4px,
+    'padding': 20px,
+  ),
+  $--card
+);
 
 /* Slider
 --------------------------*/

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -501,14 +501,16 @@ $--button-active-shade-percent: 10% !default;
 
 /* Dropdown
 -------------------------- */
-$--dropdown-menu-box-shadow: var(--el-box-shadow-light) !default;
-$--dropdown-menuItem-hover-fill: map.get(
-  $--colors,
-  'primary',
-  'light-9'
-) !default;
-$--dropdown-menuItem-hover-color: $--link-color !default;
-$--dropdown-menu-index: 10 !default;
+$--dropdown: () !default;
+$--dropdown: map.merge(
+  (
+    'menu-box-shadow': var(--el-box-shadow-light),
+    'menuItem-hover-fill': var(--el-color-primary-light-9),
+    'menuItem-hover-color': var(--el-link-color),
+    'menu-index': 10,
+  ),
+  $--dropdown
+);
 
 /* Badge
 -------------------------- */

--- a/packages/theme-chalk/src/dropdown.scss
+++ b/packages/theme-chalk/src/dropdown.scss
@@ -1,7 +1,12 @@
 @import 'mixins/mixins';
+@import 'mixins/var';
 @import 'common/var';
 @import 'button';
 @import 'popper';
+
+:root {
+  @include set-component-css-var('dropdown', $--dropdown);
+}
 
 @include b(dropdown) {
   display: inline-block;
@@ -16,7 +21,7 @@
     @include picker-popper(
       $--color-white,
       1px solid var(--el-border-color-light),
-      $--dropdown-menu-box-shadow
+      var(--el-dropdown-menu-box-shadow)
     );
 
     .#{$namespace}-dropdown-menu {
@@ -28,7 +33,7 @@
     }
 
     @include b(scrollbar__bar) {
-      z-index: #{$--dropdown-menu-index + 1};
+      z-index: calc(var(--el-dropdown-menu-index + 1));
     }
 
     @include b(dropdown__list) {
@@ -96,7 +101,7 @@
   position: relative;
   top: 0;
   left: 0;
-  z-index: $--dropdown-menu-index;
+  z-index: var(--el-dropdown-menu-index);
   padding: 10px 0;
   margin: 0;
   background-color: $--color-white;
@@ -115,8 +120,8 @@
     outline: none;
     &:not(.is-disabled):hover,
     &:focus {
-      background-color: $--dropdown-menuItem-hover-fill;
-      color: $--dropdown-menuItem-hover-color;
+      background-color: var(--el-dropdown-menuItem-hover-fill);
+      color: var(--el-dropdown-menuItem-hover-color);
     }
 
     i {

--- a/packages/theme-chalk/src/mixins/_var.scss
+++ b/packages/theme-chalk/src/mixins/_var.scss
@@ -13,3 +13,10 @@
 @mixin set-css-var-type($name, $type, $--variables) {
   --el-#{$name}-#{$type}: #{map.get($--variables, $type)};
 }
+
+// set all css var for component by map
+@mixin set-component-css-var($name, $--variables) {
+  @each $attribute, $value in $--variables {
+    --el-#{$name}-#{$attribute}: #{$value};
+  }
+}

--- a/packages/theme-chalk/src/rate.scss
+++ b/packages/theme-chalk/src/rate.scss
@@ -1,8 +1,15 @@
+@use "sass:map";
+
 @import 'mixins/mixins';
+@import 'mixins/var';
 @import 'common/var';
 
+:root {
+  @include set-component-css-var('rate', $--rate);
+}
+
 @include b(rate) {
-  height: $--rate-height;
+  height: var(--el-rate-height);
   line-height: 1;
 
   &:focus,
@@ -20,9 +27,9 @@
   @include e(icon) {
     position: relative;
     display: inline-block;
-    font-size: $--rate-icon-size;
-    margin-right: $--rate-icon-margin;
-    color: $--rate-icon-color;
+    font-size: var(--el-rate-icon-size);
+    margin-right: var(--el-rate-icon-margin);
+    color: var(--el-rate-icon-color);
     transition: var(--el-transition-duration);
     &.hover {
       transform: scale(1.15);
@@ -44,7 +51,7 @@
   }
 
   @include e(text) {
-    font-size: $--rate-font-size;
+    font-size: var(--el-rate-font-size);
     vertical-align: middle;
   }
 }

--- a/packages/theme-chalk/src/table-column.scss
+++ b/packages/theme-chalk/src/table-column.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @import 'mixins/mixins';
 @import 'checkbox';
 @import 'tag';
@@ -16,7 +18,7 @@
   border: solid 1px var(--el-border-color-lighter);
   border-radius: 2px;
   background-color: $--color-white;
-  box-shadow: $--dropdown-menu-box-shadow;
+  box-shadow: map.get($--dropdown, 'menu-box-shadow');
   box-sizing: border-box;
   margin: 2px 0;
 
@@ -35,8 +37,8 @@
     font-size: var(--el-font-size-base);
 
     &:hover {
-      background-color: $--dropdown-menuItem-hover-fill;
-      color: $--dropdown-menuItem-hover-color;
+      background-color: map.get($--dropdown, 'menuItem-hover-fill');
+      color: map.get($--dropdown, 'menuItem-hover-color');
     }
 
     @include when(active) {


### PR DESCRIPTION
- migrate `badge` `dropdown` `rate` `card` css var
- I'm trying to provide a new way for users to override variables using `sass` or `css var` at the same time.
 
WTDY

---

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
