### PR TITLE
fix(select): options display fix when allow-create, also empty & entered #2826 #2854

### DIFF
--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -1,6 +1,6 @@
 <template>
   <li
-    v-show="visible"
+    v-show="visible || created"
     class="el-select-dropdown__item"
     :class="{
       'selected': itemSelected,

--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -1,6 +1,6 @@
 <template>
   <li
-    v-show="visible || created"
+    v-show="visible"
     class="el-select-dropdown__item"
     :class="{
       'selected': itemSelected,

--- a/packages/select/src/useOption.ts
+++ b/packages/select/src/useOption.ts
@@ -81,16 +81,10 @@ export function useOption(props, states) {
   }
 
   const queryChange = (query: string) => {
-    // not in filtering, just show original options only
-    if (!query) {
-      states.visible = !props.created
-    } else {
-      // in filtering, do filter by RegExp
-      const regexp = new RegExp(escapeRegexpString(query), 'i')
-      states.visible = regexp.test(currentLabel.value)
-      if (!states.visible && !props.created) {
-        select.filteredOptionsCount--
-      }
+    const regexp = new RegExp(escapeRegexpString(query), 'i')
+    states.visible = regexp.test(currentLabel.value) || props.created
+    if (!states.visible) {
+      select.filteredOptionsCount--
     }
   }
 


### PR DESCRIPTION
fix https://github.com/element-plus/element-plus/issues/2826 by always showing the created option in option list with `v-show="visible || created"`

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
