### PR TITLE
fix(date-picker): color-text has been renamed to text-color

### DIFF
--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -892,10 +892,10 @@ $--rate: map.merge(
 $--datepicker: () !default;
 $--datepicker: map.merge(
   (
-    'font-color': var(--el-color-text-regular),
-    'off-font-color': var(--el-color-text-placeholder),
-    'header-font-color': var(--el-color-text-regular),
-    'icon-color': var(--el-color-text-primary),
+    'font-color': var(--el-text-color-regular),
+    'off-font-color': var(--el-text-color-placeholder),
+    'header-font-color': var(--el-text-color-regular),
+    'icon-color': var(--el-text-color-primary),
     'border-color': var(--el-disabled-border-base),
     'inner-border-color': #e4e4e4,
     'inrange-background-color': var(--el-border-color-extra-light),


### PR DESCRIPTION
- fix date-picker default var (`color-text` has been renamed to `text-color`)

---

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
