### PR TITLE
improvement(tabs): optimize tab-bar offset calc

### DIFF
--- a/packages/tabs/__tests__/tabs.spec.ts
+++ b/packages/tabs/__tests__/tabs.spec.ts
@@ -473,6 +473,49 @@ describe('Tabs.vue', () => {
     expect(tabsWrapper.find('.el-tabs__nav').classes('is-stretch')).toBe(false)
   })
 
+  test('tab active bar offset', async () => {
+    const wrapper = mount({
+      components: {
+        'el-tabs': Tabs,
+        'el-tab-pane': TabPane,
+      },
+      template: `
+      <el-tabs ref="tabs" stretch :tab-position="tabPosition">
+        <el-tab-pane label="label-1" name="A">A</el-tab-pane>
+        <el-tab-pane label="label-2" name="B">B</el-tab-pane>
+        <el-tab-pane label="label-3" name="C">C</el-tab-pane>
+        <el-tab-pane label="label-4" name="D">D</el-tab-pane>
+      </el-tabs>
+      `,
+      data() {
+        return {
+          tabPosition: 'bottom',
+        }
+      },
+    })
+
+    const tabsWrapper = wrapper.findComponent(Tabs)
+    await nextTick()
+    const mockCRect = jest.spyOn(wrapper.find('#tab-C').element, 'getBoundingClientRect').mockReturnValue({ left: 300 } as DOMRect)
+    const mockComputedStyle = jest.spyOn(window, 'getComputedStyle').mockReturnValue({ paddingLeft: '0px' } as CSSStyleDeclaration)
+    await wrapper.find('#tab-C').trigger('click')
+
+    expect(tabsWrapper.find('.el-tabs__active-bar').attributes().style).toMatch('translateX(300px)')
+
+    wrapper.vm.tabPosition = 'left'
+    await nextTick()
+    const mockCYRect = jest.spyOn(wrapper.find('#tab-C').element, 'getBoundingClientRect').mockReturnValue({ top: 200 } as DOMRect)
+    await wrapper.find('#tab-A').trigger('click')
+    await wrapper.find('#tab-C').trigger('click')
+
+    expect(tabsWrapper.find('.el-tabs__active-bar').attributes().style).toMatch('translateY(200px)')
+
+    mockCRect.mockRestore()
+    mockCYRect.mockRestore()
+    mockComputedStyle.mockRestore()
+    wrapper.unmount()
+  })
+
   test('horizonal-scrollable', async () => {
     // TODO: jsdom not support `clientWidth`.
   })

--- a/packages/tabs/src/tab-bar.vue
+++ b/packages/tabs/src/tab-bar.vue
@@ -36,11 +36,11 @@ export default defineComponent({
         let $el = instance.parent.refs?.[`tab-${tab.paneName}`] as Element
         if (!$el) { return false }
         if (!tab.active) {
-          offset += $el[`client${capitalize(sizeName)}`]
           return true
         } else {
           tabSize = $el[`client${capitalize(sizeName)}`]
-
+          const position = sizeDir === 'x' ? 'left' : 'top'
+          offset = $el.getBoundingClientRect()[position] - $el.parentElement.getBoundingClientRect()[position]
           const tabStyles = window.getComputedStyle($el)
 
           if (sizeName === 'width') {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

Now the `tab-bar` offset just calculate `tab-item` clientWidth.
Consider the situation https://jsfiddle.net/tu8a3pLy/7/ ，if `tab-nav` style is `justify-content: space-around` and `tab-item`  is `flex: 0 0 auto`, offset will error.
So i optimized the tab-bar offset calculate logic