### PR TITLE
fix(pagination): Fix that current-page and page-size do not support hyphen style when using v-model

### DIFF
--- a/packages/pagination/src/index.ts
+++ b/packages/pagination/src/index.ts
@@ -122,8 +122,8 @@ export default defineComponent({
     const { t } = useLocaleInject()
     const vnodeProps = getCurrentInstance().vnode.props || {}
     // we can find @xxx="xxx" props on `vnodeProps` to check if user bind corresponding events
-    const hasCurrentPageListener = 'onUpdate:currentPage' in vnodeProps || 'onCurrentChange' in vnodeProps
-    const hasPageSizeListener = 'onUpdate:pageSize' in vnodeProps || 'onSizeChange' in vnodeProps
+    const hasCurrentPageListener = 'onUpdate:currentPage' in vnodeProps || 'onUpdate:current-page' || 'onCurrentChange' in vnodeProps
+    const hasPageSizeListener = 'onUpdate:pageSize' in vnodeProps || 'onUpdate:page-size' in vnodeProps || 'onSizeChange' in vnodeProps
     const assertValidUsage = computed(() => {
       // Users have to set either one, otherwise count of pages cannot be determined
       if (isAbsent(props.total) && isAbsent(props.pageCount)) return false

--- a/packages/pagination/src/index.ts
+++ b/packages/pagination/src/index.ts
@@ -122,7 +122,7 @@ export default defineComponent({
     const { t } = useLocaleInject()
     const vnodeProps = getCurrentInstance().vnode.props || {}
     // we can find @xxx="xxx" props on `vnodeProps` to check if user bind corresponding events
-    const hasCurrentPageListener = 'onUpdate:currentPage' in vnodeProps || 'onUpdate:current-page' || 'onCurrentChange' in vnodeProps
+    const hasCurrentPageListener = 'onUpdate:currentPage' in vnodeProps || 'onUpdate:current-page' in vnodeProps || 'onCurrentChange' in vnodeProps
     const hasPageSizeListener = 'onUpdate:pageSize' in vnodeProps || 'onUpdate:page-size' in vnodeProps || 'onSizeChange' in vnodeProps
     const assertValidUsage = computed(() => {
       // Users have to set either one, otherwise count of pages cannot be determined


### PR DESCRIPTION
在Pagination组件的使用过程中，发现了一些关于`v-model`的问题。

在vue的官方文档中，是有类似于`v-model:current-page`的写法的，
但在Pagination组件中，只能使用`v-model:currentPage`的驼峰写法，
如果使用`v-model:current-page`的连字符风格会导致组件不渲染，并在控制台只输出了一个很简单的`warning`。
（希望官方能为warning添加更详细的提示）

此次PR的改动目的是兼容两种写法，同时感谢一位叫“废鸭”的网友提供的帮助。
