### PR TITLE
perf(scrollbar): add min-size prop

### DIFF
--- a/packages/scrollbar/__tests__/scrollbar.spec.ts
+++ b/packages/scrollbar/__tests__/scrollbar.spec.ts
@@ -12,7 +12,7 @@ const _mount = (template: string) => mount({
 
 describe('ScrollBar', () => {
   test('vertical', async () => {
-    const outerHeight = 200
+    const outerHeight = 204
     const innerHeight = 500
     const wrapper = _mount(`
       <el-scrollbar style="height: ${outerHeight}px">
@@ -22,19 +22,19 @@ describe('ScrollBar', () => {
 
     const scrollDom = wrapper.find('.el-scrollbar__wrap').element
 
-    const clientHeightRestore = defineGetter(scrollDom, 'clientHeight', outerHeight)
+    const offsetHeightRestore = defineGetter(scrollDom, 'offsetHeight', outerHeight)
     const scrollHeightRestore = defineGetter(scrollDom, 'scrollHeight', innerHeight)
 
     await makeScroll(scrollDom, 'scrollTop', 100)
-    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 40%; transform: translateY(50%); webkit-transform: translateY(50%)')
+    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 80px; transform: translateY(50%); webkit-transform: translateY(50%)')
     await makeScroll(scrollDom, 'scrollTop', 300)
-    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 40%; transform: translateY(150%); webkit-transform: translateY(150%)')
-    clientHeightRestore()
+    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 80px; transform: translateY(150%); webkit-transform: translateY(150%)')
+    offsetHeightRestore()
     scrollHeightRestore()
   })
 
   test('horizontal', async () => {
-    const outerWidth = 200
+    const outerWidth = 204
     const innerWidth = 500
     const wrapper = _mount(`
       <el-scrollbar style="height: 100px; width: ${outerWidth}px">
@@ -44,21 +44,21 @@ describe('ScrollBar', () => {
 
     const scrollDom = wrapper.find('.el-scrollbar__wrap').element
 
-    const clientWidthRestore = defineGetter(scrollDom, 'clientWidth', outerWidth)
+    const offsetWidthRestore = defineGetter(scrollDom, 'offsetWidth', outerWidth)
     const scrollWidthRestore = defineGetter(scrollDom, 'scrollWidth', innerWidth)
 
     await makeScroll(scrollDom, 'scrollLeft', 100)
-    expect(wrapper.find('.is-horizontal div').attributes('style')).toContain('width: 40%; transform: translateX(50%); webkit-transform: translateX(50%)')
+    expect(wrapper.find('.is-horizontal div').attributes('style')).toContain('width: 80px; transform: translateX(50%); webkit-transform: translateX(50%)')
     await makeScroll(scrollDom, 'scrollLeft', 300)
-    expect(wrapper.find('.is-horizontal div').attributes('style')).toContain('width: 40%; transform: translateX(150%); webkit-transform: translateX(150%)')
-    clientWidthRestore()
+    expect(wrapper.find('.is-horizontal div').attributes('style')).toContain('width: 80px; transform: translateX(150%); webkit-transform: translateX(150%)')
+    offsetWidthRestore()
     scrollWidthRestore()
   })
 
   test('both vertical and horizontal', async () => {
-    const outerHeight = 200
+    const outerHeight = 204
     const innerHeight = 500
-    const outerWidth = 200
+    const outerWidth = 204
     const innerWidth = 500
     const wrapper = _mount(`
       <el-scrollbar style="height: ${outerHeight}px; width: ${outerWidth}px;">
@@ -68,28 +68,28 @@ describe('ScrollBar', () => {
 
     const scrollDom = wrapper.find('.el-scrollbar__wrap').element
 
-    const clientHeightRestore = defineGetter(scrollDom, 'clientHeight', outerHeight)
+    const offsetHeightRestore = defineGetter(scrollDom, 'offsetHeight', outerHeight)
     const scrollHeightRestore = defineGetter(scrollDom, 'scrollHeight', innerHeight)
-    const clientWidthRestore = defineGetter(scrollDom, 'clientWidth', outerWidth)
+    const offsetWidthRestore = defineGetter(scrollDom, 'offsetWidth', outerWidth)
     const scrollWidthRestore = defineGetter(scrollDom, 'scrollWidth', innerWidth)
 
     await makeScroll(scrollDom, 'scrollTop', 100)
     await makeScroll(scrollDom, 'scrollLeft', 100)
-    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 40%; transform: translateY(50%); webkit-transform: translateY(50%)')
-    expect(wrapper.find('.is-horizontal div').attributes('style')).toContain('width: 40%; transform: translateX(50%); webkit-transform: translateX(50%)')
+    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 80px; transform: translateY(50%); webkit-transform: translateY(50%)')
+    expect(wrapper.find('.is-horizontal div').attributes('style')).toContain('width: 80px; transform: translateX(50%); webkit-transform: translateX(50%)')
     await makeScroll(scrollDom, 'scrollTop', 300)
     await makeScroll(scrollDom, 'scrollLeft', 300)
-    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 40%; transform: translateY(150%); webkit-transform: translateY(150%)')
-    expect(wrapper.find('.is-horizontal div').attributes('style')).toContain('width: 40%; transform: translateX(150%); webkit-transform: translateX(150%)')
+    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 80px; transform: translateY(150%); webkit-transform: translateY(150%)')
+    expect(wrapper.find('.is-horizontal div').attributes('style')).toContain('width: 80px; transform: translateX(150%); webkit-transform: translateX(150%)')
 
-    clientHeightRestore()
+    offsetHeightRestore()
     scrollHeightRestore()
-    clientWidthRestore()
+    offsetWidthRestore()
     scrollWidthRestore()
   })
 
   test('should render height props', async () => {
-    const outerHeight = 200
+    const outerHeight = 204
     const innerHeight = 500
     const wrapper = _mount(`
       <el-scrollbar height="${outerHeight}px">
@@ -97,11 +97,11 @@ describe('ScrollBar', () => {
       </el-scrollbar>
     `)
 
-    expect(wrapper.find('.el-scrollbar__wrap').attributes('style')).toContain('height: 200px;')
+    expect(wrapper.find('.el-scrollbar__wrap').attributes('style')).toContain('height: 204px;')
   })
 
   test('should render max-height props', async () => {
-    const outerHeight = 200
+    const outerHeight = 204
     const innerHeight = 100
     const wrapper = _mount(`
       <el-scrollbar max-height="${outerHeight}px">
@@ -109,11 +109,11 @@ describe('ScrollBar', () => {
       </el-scrollbar>
     `)
 
-    expect(wrapper.find('.el-scrollbar__wrap').attributes('style')).toContain('max-height: 200px;')
+    expect(wrapper.find('.el-scrollbar__wrap').attributes('style')).toContain('max-height: 204px;')
   })
 
   test('should render always props', async () => {
-    const outerHeight = 200
+    const outerHeight = 204
     const innerHeight = 500
     const wrapper = _mount(`
       <el-scrollbar height="${outerHeight}px" always>
@@ -125,9 +125,9 @@ describe('ScrollBar', () => {
   })
 
   test('set scrollTop & scrollLeft', async () => {
-    const outerHeight = 200
+    const outerHeight = 204
     const innerHeight = 500
-    const outerWidth = 200
+    const outerWidth = 204
     const innerWidth = 500
     const wrapper = _mount(`
       <el-scrollbar ref="scrollbar" style="height: ${outerHeight}px; width: ${outerWidth}px;">
@@ -138,9 +138,9 @@ describe('ScrollBar', () => {
     const scrollbar = wrapper.vm.$refs.scrollbar as any
     const scrollDom = wrapper.find('.el-scrollbar__wrap').element
 
-    const clientHeightRestore = defineGetter(scrollDom, 'clientHeight', outerHeight)
+    const offsetHeightRestore = defineGetter(scrollDom, 'offsetHeight', outerHeight)
     const scrollHeightRestore = defineGetter(scrollDom, 'scrollHeight', innerHeight)
-    const clientWidthRestore = defineGetter(scrollDom, 'clientWidth', outerWidth)
+    const offsetWidthRestore = defineGetter(scrollDom, 'offsetWidth', outerWidth)
     const scrollWidthRestore = defineGetter(scrollDom, 'scrollWidth', innerWidth)
 
     scrollbar.setScrollTop(100)
@@ -148,17 +148,17 @@ describe('ScrollBar', () => {
     scrollbar.setScrollLeft(100)
     await nextTick()
 
-    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 40%; transform: translateY(0%); webkit-transform: translateY(0%);')
-    expect(wrapper.find('.is-horizontal div').attributes('style')).toContain('width: 40%; transform: translateX(0%); webkit-transform: translateX(0%);')
+    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 80px; transform: translateY(0%); webkit-transform: translateY(0%);')
+    expect(wrapper.find('.is-horizontal div').attributes('style')).toContain('width: 80px; transform: translateX(0%); webkit-transform: translateX(0%);')
 
-    clientHeightRestore()
+    offsetHeightRestore()
     scrollHeightRestore()
-    clientWidthRestore()
+    offsetWidthRestore()
     scrollWidthRestore()
   })
 
   test('should render min-size props', async () => {
-    const outerHeight = 200
+    const outerHeight = 204
     const innerHeight = 10000
     const wrapper = _mount(`
       <el-scrollbar style="height: ${outerHeight}px">
@@ -168,12 +168,12 @@ describe('ScrollBar', () => {
 
     const scrollDom = wrapper.find('.el-scrollbar__wrap').element
 
-    const clientHeightRestore = defineGetter(scrollDom, 'clientHeight', outerHeight)
+    const offsetHeightRestore = defineGetter(scrollDom, 'offsetHeight', outerHeight)
     const scrollHeightRestore = defineGetter(scrollDom, 'scrollHeight', innerHeight)
 
     await makeScroll(scrollDom, 'scrollTop', 0)
-    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 10%; transform: translateY(0%); webkit-transform: translateY(0%);')
-    clientHeightRestore()
+    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 20px; transform: translateY(0%); webkit-transform: translateY(0%);')
+    offsetHeightRestore()
     scrollHeightRestore()
   })
 })

--- a/packages/scrollbar/__tests__/scrollbar.spec.ts
+++ b/packages/scrollbar/__tests__/scrollbar.spec.ts
@@ -156,4 +156,24 @@ describe('ScrollBar', () => {
     clientWidthRestore()
     scrollWidthRestore()
   })
+
+  test('should render min-size props', async () => {
+    const outerHeight = 200
+    const innerHeight = 10000
+    const wrapper = _mount(`
+      <el-scrollbar style="height: ${outerHeight}px">
+        <div style="height: ${innerHeight}px;"></div>
+      </el-scrollbar>
+    `)
+
+    const scrollDom = wrapper.find('.el-scrollbar__wrap').element
+
+    const clientHeightRestore = defineGetter(scrollDom, 'clientHeight', outerHeight)
+    const scrollHeightRestore = defineGetter(scrollDom, 'scrollHeight', innerHeight)
+
+    await makeScroll(scrollDom, 'scrollTop', 0)
+    expect(wrapper.find('.is-vertical div').attributes('style')).toContain('height: 10%; transform: translateY(0%); webkit-transform: translateY(0%);')
+    clientHeightRestore()
+    scrollHeightRestore()
+  })
 })

--- a/packages/scrollbar/src/bar.vue
+++ b/packages/scrollbar/src/bar.vue
@@ -45,6 +45,8 @@ export default defineComponent({
     let onselectstartStore = null
 
     const offsetRatio = computed(() => {
+      // offsetRatioX = original width of thumb / current width of thumb / ratioX
+      // offsetRatioY = original height of thumb / current height of thumb / ratioY
       return wrap.value[bar.value.offset] ** 2 / wrap.value[bar.value.scrollSize] / props.ratio / thumb.value[bar.value.offset]
     })
 

--- a/packages/scrollbar/src/bar.vue
+++ b/packages/scrollbar/src/bar.vue
@@ -29,6 +29,7 @@ export default defineComponent({
     vertical: Boolean,
     size: String,
     move: Number,
+    ratio: Number,
     always: Boolean,
   },
   setup(props) {
@@ -42,6 +43,10 @@ export default defineComponent({
     const cursorLeave = ref(null)
     const visible = ref(false)
     let onselectstartStore = null
+
+    const offsetRatio = computed(() => {
+      return wrap.value[bar.value.offset] ** 2 / wrap.value[bar.value.scrollSize] / props.ratio / thumb.value[bar.value.offset]
+    })
 
     const clickThumbHandler = (e: MouseEvent) => {
       // prevent click event of middle and right button
@@ -57,7 +62,7 @@ export default defineComponent({
     const clickTrackHandler = (e: MouseEvent) => {
       const offset = Math.abs((e.target as HTMLElement).getBoundingClientRect()[bar.value.direction] - e[bar.value.client])
       const thumbHalf = (thumb.value[bar.value.offset] / 2)
-      const thumbPositionPercentage = ((offset - thumbHalf) * 100 / instance.value[bar.value.offset])
+      const thumbPositionPercentage = ((offset - thumbHalf) * 100 * offsetRatio.value / instance.value[bar.value.offset])
 
       wrap.value[bar.value.scroll] = (thumbPositionPercentage * wrap.value[bar.value.scrollSize] / 100)
     }
@@ -79,7 +84,7 @@ export default defineComponent({
 
       const offset = ((instance.value.getBoundingClientRect()[bar.value.direction] - e[bar.value.client]) * -1)
       const thumbClickPosition = (thumb.value[bar.value.offset] - prevPage)
-      const thumbPositionPercentage = ((offset - thumbClickPosition) * 100 / instance.value[bar.value.offset])
+      const thumbPositionPercentage = ((offset - thumbClickPosition) * 100 * offsetRatio.value / instance.value[bar.value.offset])
       wrap.value[bar.value.scroll] = (thumbPositionPercentage * wrap.value[bar.value.scrollSize] / 100)
     }
 

--- a/packages/scrollbar/src/bar.vue
+++ b/packages/scrollbar/src/bar.vue
@@ -47,7 +47,8 @@ export default defineComponent({
     const offsetRatio = computed(() => {
       // offsetRatioX = original width of thumb / current width of thumb / ratioX
       // offsetRatioY = original height of thumb / current height of thumb / ratioY
-      return wrap.value[bar.value.offset] ** 2 / wrap.value[bar.value.scrollSize] / props.ratio / thumb.value[bar.value.offset]
+      // instance height = wrap height - GAP
+      return instance.value[bar.value.offset] ** 2 / wrap.value[bar.value.scrollSize] / props.ratio / thumb.value[bar.value.offset]
     })
 
     const clickThumbHandler = (e: MouseEvent) => {

--- a/packages/scrollbar/src/index.vue
+++ b/packages/scrollbar/src/index.vue
@@ -79,6 +79,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    minSize: {
+      type: Number,
+      default: 20,
+    },
   },
   emits: ['scroll'],
   setup(props, { emit }) {
@@ -89,6 +93,8 @@ export default defineComponent({
     const scrollbar = ref(null)
     const wrap = ref(null)
     const resize = ref(null)
+    const ratioY = ref(1)
+    const ratioX = ref(1)
 
     const SCOPE = 'ElScrollbar'
 
@@ -97,16 +103,16 @@ export default defineComponent({
 
     const handleScroll = () => {
       if (wrap.value) {
-        moveY.value = (wrap.value.scrollTop * 100) / wrap.value.clientHeight
-        moveX.value = (wrap.value.scrollLeft * 100) / wrap.value.clientWidth
+        moveY.value = (wrap.value.scrollTop * 100) / wrap.value.clientHeight * ratioY.value
+        moveX.value = (wrap.value.scrollLeft * 100) / wrap.value.clientWidth * ratioX.value
         emit('scroll', {
-          scrollLeft: moveX.value,
-          scrollTop: moveY.value,
+          scrollTop: wrap.value.scrollTop,
+          scrollLeft: wrap.value.scrollLeft,
         })
       }
     }
 
-    const setScrollTop = (value: string) => {
+    const setScrollTop = (value: number) => {
       if (!isNumber(value)) {
         if (process.env.NODE_ENV !== 'production') {
           warn(SCOPE, 'value must be a number')
@@ -116,7 +122,7 @@ export default defineComponent({
       wrap.value.scrollTop = value
     }
 
-    const setScrollLeft = (value: string) => {
+    const setScrollLeft = (value: number) => {
       if (!isNumber(value)) {
         if (process.env.NODE_ENV !== 'production') {
           warn(SCOPE, 'value must be a number')
@@ -129,8 +135,16 @@ export default defineComponent({
     const update = () => {
       if (!wrap.value) return
 
-      const heightPercentage = (wrap.value.clientHeight * 100) / wrap.value.scrollHeight
-      const widthPercentage = (wrap.value.clientWidth * 100) / wrap.value.scrollWidth
+      const realHeightPercentage = (wrap.value.clientHeight * 100) / wrap.value.scrollHeight
+      const realWidthPercentage = (wrap.value.clientWidth * 100) / wrap.value.scrollWidth
+      const minHeightPercentage = props.minSize * 100 / wrap.value.clientHeight
+      const minWidthPercentage = props.minSize * 100 / wrap.value.clientWidth
+      const heightPercentage = Math.max(realHeightPercentage, minHeightPercentage)
+      const widthPercentage = Math.max(realWidthPercentage, minWidthPercentage)
+
+      ratioY.value = realHeightPercentage / heightPercentage
+      ratioX.value = realWidthPercentage / widthPercentage
+      console.log(ratioY.value)
 
       sizeHeight.value = heightPercentage < 100 ? heightPercentage + '%' : ''
       sizeWidth.value = widthPercentage < 100 ? widthPercentage + '%' : ''

--- a/packages/scrollbar/src/index.vue
+++ b/packages/scrollbar/src/index.vue
@@ -20,9 +20,15 @@
       </component>
     </div>
     <template v-if="!native">
-      <bar :move="moveX" :size="sizeWidth" :always="always" />
+      <bar
+        :move="moveX"
+        :ratio="ratioX"
+        :size="sizeWidth"
+        :always="always"
+      />
       <bar
         :move="moveY"
+        :ratio="ratioY"
         :size="sizeHeight"
         vertical
         :always="always"
@@ -135,15 +141,20 @@ export default defineComponent({
     const update = () => {
       if (!wrap.value) return
 
-      const realHeightPercentage = (wrap.value.clientHeight * 100) / wrap.value.scrollHeight
-      const realWidthPercentage = (wrap.value.clientWidth * 100) / wrap.value.scrollWidth
+      const originalHeightPercentage = (wrap.value.clientHeight * 100) / wrap.value.scrollHeight
+      const originalWidthPercentage = (wrap.value.clientWidth * 100) / wrap.value.scrollWidth
       const minHeightPercentage = props.minSize * 100 / wrap.value.clientHeight
       const minWidthPercentage = props.minSize * 100 / wrap.value.clientWidth
-      const heightPercentage = Math.max(realHeightPercentage, minHeightPercentage)
-      const widthPercentage = Math.max(realWidthPercentage, minWidthPercentage)
+      const heightPercentage = Math.max(originalHeightPercentage, minHeightPercentage)
+      const widthPercentage = Math.max(originalWidthPercentage, minWidthPercentage)
 
-      ratioY.value = realHeightPercentage / heightPercentage
-      ratioX.value = realWidthPercentage / widthPercentage
+      const originalHeight = originalHeightPercentage / 100 * wrap.value.clientHeight
+      const originalWidth = originalWidthPercentage / 100 * wrap.value.clientWidth
+      const height = heightPercentage / 100 * wrap.value.clientHeight
+      const width = widthPercentage / 100 * wrap.value.clientWidth
+
+      ratioY.value = (originalHeight / (wrap.value.clientHeight - originalHeight)) / (height / (wrap.value.clientHeight - height))
+      ratioX.value = (originalWidth / (wrap.value.clientWidth - originalWidth)) / (width / (wrap.value.clientWidth - width))
 
       sizeHeight.value = heightPercentage < 100 ? heightPercentage + '%' : ''
       sizeWidth.value = widthPercentage < 100 ? widthPercentage + '%' : ''
@@ -182,6 +193,8 @@ export default defineComponent({
     return {
       moveX,
       moveY,
+      ratioX,
+      ratioY,
       sizeWidth,
       sizeHeight,
       style,

--- a/packages/scrollbar/src/index.vue
+++ b/packages/scrollbar/src/index.vue
@@ -144,7 +144,6 @@ export default defineComponent({
 
       ratioY.value = realHeightPercentage / heightPercentage
       ratioX.value = realWidthPercentage / widthPercentage
-      console.log(ratioY.value)
 
       sizeHeight.value = heightPercentage < 100 ? heightPercentage + '%' : ''
       sizeWidth.value = widthPercentage < 100 ? widthPercentage + '%' : ''

--- a/packages/scrollbar/src/index.vue
+++ b/packages/scrollbar/src/index.vue
@@ -157,8 +157,8 @@ export default defineComponent({
       ratioY.value = (originalHeight / (offsetHeight - originalHeight)) / (height / (offsetHeight - height))
       ratioX.value = (originalWidth / (offsetWidth - originalWidth)) / (width / (offsetWidth - width))
 
-      sizeHeight.value = height < offsetHeight ? height + 'px' : ''
-      sizeWidth.value = width < offsetWidth ? width + 'px' : ''
+      sizeHeight.value = height + GAP < offsetHeight ? height + 'px' : ''
+      sizeWidth.value = width + GAP < offsetWidth ? width + 'px' : ''
     }
 
     const style = computed(() => {

--- a/packages/scrollbar/src/index.vue
+++ b/packages/scrollbar/src/index.vue
@@ -103,14 +103,19 @@ export default defineComponent({
     const ratioX = ref(1)
 
     const SCOPE = 'ElScrollbar'
+    const GAP = 4 // top 2 + bottom 2 of bar instance
 
     provide('scrollbar', scrollbar)
     provide('scrollbar-wrap', wrap)
 
     const handleScroll = () => {
       if (wrap.value) {
-        moveY.value = (wrap.value.scrollTop * 100) / wrap.value.clientHeight * ratioY.value
-        moveX.value = (wrap.value.scrollLeft * 100) / wrap.value.clientWidth * ratioX.value
+        const offsetHeight = wrap.value.offsetHeight - GAP
+        const offsetWidth = wrap.value.offsetWidth - GAP
+
+        moveY.value = (wrap.value.scrollTop * 100) / offsetHeight * ratioY.value
+        moveX.value = (wrap.value.scrollLeft * 100) / offsetWidth * ratioX.value
+
         emit('scroll', {
           scrollTop: wrap.value.scrollTop,
           scrollLeft: wrap.value.scrollLeft,
@@ -141,23 +146,19 @@ export default defineComponent({
     const update = () => {
       if (!wrap.value) return
 
-      const originalHeightPercentage = (wrap.value.clientHeight * 100) / wrap.value.scrollHeight
-      const originalWidthPercentage = (wrap.value.clientWidth * 100) / wrap.value.scrollWidth
-      const minHeightPercentage = props.minSize * 100 / wrap.value.clientHeight
-      const minWidthPercentage = props.minSize * 100 / wrap.value.clientWidth
-      const heightPercentage = Math.max(originalHeightPercentage, minHeightPercentage)
-      const widthPercentage = Math.max(originalWidthPercentage, minWidthPercentage)
+      const offsetHeight = wrap.value.offsetHeight - GAP
+      const offsetWidth = wrap.value.offsetWidth - GAP
 
-      const originalHeight = originalHeightPercentage / 100 * wrap.value.clientHeight
-      const originalWidth = originalWidthPercentage / 100 * wrap.value.clientWidth
-      const height = heightPercentage / 100 * wrap.value.clientHeight
-      const width = widthPercentage / 100 * wrap.value.clientWidth
+      const originalHeight = offsetHeight ** 2 / wrap.value.scrollHeight
+      const originalWidth = offsetWidth ** 2 / wrap.value.scrollWidth
+      const height = Math.max(originalHeight, props.minSize)
+      const width = Math.max(originalWidth, props.minSize)
 
-      ratioY.value = (originalHeight / (wrap.value.clientHeight - originalHeight)) / (height / (wrap.value.clientHeight - height))
-      ratioX.value = (originalWidth / (wrap.value.clientWidth - originalWidth)) / (width / (wrap.value.clientWidth - width))
+      ratioY.value = (originalHeight / (offsetHeight - originalHeight)) / (height / (offsetHeight - height))
+      ratioX.value = (originalWidth / (offsetWidth - originalWidth)) / (width / (offsetWidth - width))
 
-      sizeHeight.value = heightPercentage < 100 ? heightPercentage + '%' : ''
-      sizeWidth.value = widthPercentage < 100 ? widthPercentage + '%' : ''
+      sizeHeight.value = height < offsetHeight ? height + 'px' : ''
+      sizeWidth.value = width < offsetWidth ? width + 'px' : ''
     }
 
     const style = computed(() => {

--- a/website/docs/en-US/scrollbar.md
+++ b/website/docs/en-US/scrollbar.md
@@ -122,6 +122,7 @@ Used to replace the browser's native scrollbar.
 | noresize  | do not respond to container size changes, if the container size does not change, it is better to set it to optimize performance    | boolean  |    —  |  false |
 | tag  | element tag of the view    | string  |    —  |  div |
 | always  | always show scrollbar    | boolean  |    —  |  false |
+| min-size  | minimum size of scrollbar    | number  |    —  |  20 |
 
 ### Scrollbar Events
 

--- a/website/docs/es/scrollbar.md
+++ b/website/docs/es/scrollbar.md
@@ -122,6 +122,7 @@ Used to replace the browser's native scrollbar.
 | noresize  | do not respond to container size changes, if the container size does not change, it is better to set it to optimize performance    | boolean  |    —  |  false |
 | tag  | element tag of the view    | string  |    —  |  div |
 | always  | always show scrollbar    | boolean  |    —  |  false |
+| min-size  | minimum size of scrollbar    | number  |    —  |  20 |
 
 ### Scrollbar Events
 

--- a/website/docs/fr-FR/scrollbar.md
+++ b/website/docs/fr-FR/scrollbar.md
@@ -122,6 +122,7 @@ Used to replace the browser's native scrollbar.
 | noresize  | do not respond to container size changes, if the container size does not change, it is better to set it to optimize performance    | boolean  |    —  |  false |
 | tag  | element tag of the view    | string  |    —  |  div |
 | always  | always show scrollbar    | boolean  |    —  |  false |
+| min-size  | minimum size of scrollbar    | number  |    —  |  20 |
 
 ### Scrollbar Events
 

--- a/website/docs/jp/scrollbar.md
+++ b/website/docs/jp/scrollbar.md
@@ -122,6 +122,7 @@ Used to replace the browser's native scrollbar.
 | noresize  | do not respond to container size changes, if the container size does not change, it is better to set it to optimize performance    | boolean  |    —  |  false |
 | tag  | element tag of the view    | string  |    —  |  div |
 | always  | always show scrollbar    | boolean  |    —  |  false |
+| min-size  | minimum size of scrollbar    | number  |    —  |  20 |
 
 ### Scrollbar Events
 

--- a/website/docs/zh-CN/scrollbar.md
+++ b/website/docs/zh-CN/scrollbar.md
@@ -122,6 +122,7 @@
 | noresize  | 不响应容器尺寸变化，如果容器尺寸不会发生变化，最好设置它可以优化性能    | boolean  |    —  |  false |
 | tag  | 视图的元素标签    | string  |    —  |  div |
 | always  | 滚动条总是显示    | boolean  |    —  |  false |
+| min-size  | 滚动条最小尺寸    | number  |    —  |  20 |
 
 ### Scrollbar Events
 


### PR DESCRIPTION
## min-size prop

When using scrollbar with long elements, the thumb will be very short. So the `min-size` prop will solve this problem.

re #2906

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
