### PR TITLE
Added an example of the popconfirm button click event

### DIFF
--- a/网站/博士/ZH-CN/popconfirm.md
+++ b/网站/博士/ZH-CN/popconfirm.md
@@ -40,6 +40,43 @@ Popconfirm 的属性与 Popover 很类似，因此对于重复属性，请参考
 ```
 :::
 
+### 触发事件
+
+点击按钮触发事件
+
+:::demo
+```html
+<template>
+<el-popconfirm
+  confirmButtonText='确定'
+  cancelButtonText='取消'
+  icon="el-icon-info"
+  iconColor="red"
+  title="这是一段内容确定删除吗？"
+  @confirm="confirmEvent"
+  @cancel="cancelEvent"       
+>
+<template #reference>
+  <el-button>删除</el-button>
+  </template>
+</el-popconfirm>
+</template>
+
+<script>
+  export default {
+      methods: {
+          confirmEvent() {
+              console.log("confirm!");
+          },
+          cancelEvent() {
+              console.log("cancel!");
+          }
+      }
+  }
+</script>
+```
+:::
+
 ### Attributes
 | 参数               | 说明                                                     | 类型              | 可选值      | 默认值 |
 |--------------------|----------------------------------------------------------|-------------------|-------------|--------|


### PR DESCRIPTION
在使用到Popconfirm时，发现官方文档没有关于Popconfirm的例子，帮助更多人使用它。