### PR TITLE
Added an example of the popconfirm button click event

### DIFF
--- a/website/docs/en-US/popconfirm.md
+++ b/website/docs/en-US/popconfirm.md
@@ -40,6 +40,44 @@ You can customise Popconfirm like:
 ```
 :::
 
+### Trigger event
+Click the button to trigger the event
+
+:::demo
+
+```html
+<template>
+<el-popconfirm
+  confirmButtonText='Yes'
+  cancelButtonText='No'
+  icon="el-icon-info"
+  iconColor="red"
+  title="Are you sure to delete this?"
+  @confirm="confirmEvent"
+  @cancel="cancelEvent"       
+>
+<template #reference>
+  <el-button>Delete</el-button>
+  </template>
+</el-popconfirm>
+</template>
+
+<script>
+  export default {
+      methods: {
+          confirmEvent() {
+              console.log("confirm!");
+          },
+          cancelEvent() {
+              console.log("cancel!");
+          }
+      }
+  }
+</script>
+```
+
+:::
+
 ### Attributes
 | Attribute      | Description          | Type      | Accepted Values       | Default  |
 |--------------------|----------------------------------------------------------|-------------------|-------------|--------|

--- a/website/docs/en-US/popconfirm.md
+++ b/website/docs/en-US/popconfirm.md
@@ -47,32 +47,32 @@ Click the button to trigger the event
 
 ```html
 <template>
-<el-popconfirm
-  confirmButtonText='Yes'
-  cancelButtonText='No'
-  icon="el-icon-info"
-  iconColor="red"
-  title="Are you sure to delete this?"
-  @confirm="confirmEvent"
-  @cancel="cancelEvent"       
->
-<template #reference>
-  <el-button>Delete</el-button>
-  </template>
-</el-popconfirm>
+  <el-popconfirm
+    confirmButtonText="Yes"
+    cancelButtonText="No"
+    icon="el-icon-info"
+    iconColor="red"
+    title="Are you sure to delete this?"
+    @confirm="confirmEvent"
+    @cancel="cancelEvent"
+  >
+    <template #reference>
+      <el-button>Delete</el-button>
+    </template>
+  </el-popconfirm>
 </template>
 
 <script>
-  export default {
-      methods: {
-          confirmEvent() {
-              console.log("confirm!");
-          },
-          cancelEvent() {
-              console.log("cancel!");
-          }
-      }
-  }
+export default {
+  methods: {
+    confirmEvent() {
+      console.log("confirm!");
+    },
+    cancelEvent() {
+      console.log("cancel!");
+    },
+  },
+};
 </script>
 ```
 

--- a/website/docs/es/popconfirm.md
+++ b/website/docs/es/popconfirm.md
@@ -20,6 +20,7 @@ Popconfirm is similar to Popover. So for some duplicated attributes, please refe
 ````
 :::
 
+
 ### Customise
 You can customise Popconfirm like:
 :::demo
@@ -38,6 +39,44 @@ You can customise Popconfirm like:
 </el-popconfirm>
 </template>
 ```
+:::
+
+### Trigger event
+Click the button to trigger the event
+
+:::demo
+
+```html
+<template>
+<el-popconfirm
+  confirmButtonText='Yes'
+  cancelButtonText='No'
+  icon="el-icon-info"
+  iconColor="red"
+  title="Are you sure to delete this?"
+  @confirm="confirmEvent"
+  @cancel="cancelEvent"       
+>
+<template #reference>
+  <el-button>Delete</el-button>
+  </template>
+</el-popconfirm>
+</template>
+
+<script>
+  export default {
+      methods: {
+          confirmEvent() {
+              console.log("confirm!");
+          },
+          cancelEvent() {
+              console.log("cancel!");
+          }
+      }
+  }
+</script>
+```
+
 :::
 
 ### Attributes

--- a/website/docs/es/popconfirm.md
+++ b/website/docs/es/popconfirm.md
@@ -48,32 +48,32 @@ Click the button to trigger the event
 
 ```html
 <template>
-<el-popconfirm
-  confirmButtonText='Yes'
-  cancelButtonText='No'
-  icon="el-icon-info"
-  iconColor="red"
-  title="Are you sure to delete this?"
-  @confirm="confirmEvent"
-  @cancel="cancelEvent"       
->
-<template #reference>
-  <el-button>Delete</el-button>
-  </template>
-</el-popconfirm>
+  <el-popconfirm
+    confirmButtonText="Yes"
+    cancelButtonText="No"
+    icon="el-icon-info"
+    iconColor="red"
+    title="Are you sure to delete this?"
+    @confirm="confirmEvent"
+    @cancel="cancelEvent"
+  >
+    <template #reference>
+      <el-button>Delete</el-button>
+    </template>
+  </el-popconfirm>
 </template>
 
 <script>
-  export default {
-      methods: {
-          confirmEvent() {
-              console.log("confirm!");
-          },
-          cancelEvent() {
-              console.log("cancel!");
-          }
-      }
-  }
+export default {
+  methods: {
+    confirmEvent() {
+      console.log("confirm!");
+    },
+    cancelEvent() {
+      console.log("cancel!");
+    },
+  },
+};
 </script>
 ```
 

--- a/website/docs/fr-FR/popconfirm.md
+++ b/website/docs/fr-FR/popconfirm.md
@@ -40,6 +40,45 @@ You can customise Popconfirm like:
 ```
 :::
 
+### Trigger event
+Click the button to trigger the event
+
+:::demo
+
+```html
+<template>
+<el-popconfirm
+  confirmButtonText='Yes'
+  cancelButtonText='No'
+  icon="el-icon-info"
+  iconColor="red"
+  title="Are you sure to delete this?"
+  @confirm="confirmEvent"
+  @cancel="cancelEvent"       
+>
+<template #reference>
+  <el-button>Delete</el-button>
+  </template>
+</el-popconfirm>
+</template>
+
+<script>
+  export default {
+      methods: {
+          confirmEvent() {
+              console.log("confirm!");
+          },
+          cancelEvent() {
+              console.log("cancel!");
+          }
+      }
+  }
+</script>
+```
+
+:::
+
+
 ### Attributes
 | Attribute      | Description          | Type      | Accepted Values       | Default  |
 |--------------------|----------------------------------------------------------|-------------------|-------------|--------|

--- a/website/docs/fr-FR/popconfirm.md
+++ b/website/docs/fr-FR/popconfirm.md
@@ -47,32 +47,32 @@ Click the button to trigger the event
 
 ```html
 <template>
-<el-popconfirm
-  confirmButtonText='Yes'
-  cancelButtonText='No'
-  icon="el-icon-info"
-  iconColor="red"
-  title="Are you sure to delete this?"
-  @confirm="confirmEvent"
-  @cancel="cancelEvent"       
->
-<template #reference>
-  <el-button>Delete</el-button>
-  </template>
-</el-popconfirm>
+  <el-popconfirm
+    confirmButtonText="Yes"
+    cancelButtonText="No"
+    icon="el-icon-info"
+    iconColor="red"
+    title="Are you sure to delete this?"
+    @confirm="confirmEvent"
+    @cancel="cancelEvent"
+  >
+    <template #reference>
+      <el-button>Delete</el-button>
+    </template>
+  </el-popconfirm>
 </template>
 
 <script>
-  export default {
-      methods: {
-          confirmEvent() {
-              console.log("confirm!");
-          },
-          cancelEvent() {
-              console.log("cancel!");
-          }
-      }
-  }
+export default {
+  methods: {
+    confirmEvent() {
+      console.log("confirm!");
+    },
+    cancelEvent() {
+      console.log("cancel!");
+    },
+  },
+};
 </script>
 ```
 

--- a/website/docs/jp/popconfirm.md
+++ b/website/docs/jp/popconfirm.md
@@ -48,32 +48,32 @@ popconfirmは以下のようにカスタマイズすることができます。:
 
 ```html
 <template>
-<el-popconfirm
-  confirmButtonText='Yes'
-  cancelButtonText='No'
-  icon="el-icon-info"
-  iconColor="red"
-  title="Are you sure to delete this?"
-  @confirm="confirmEvent"
-  @cancel="cancelEvent"       
->
-<template #reference>
-  <el-button>Delete</el-button>
-  </template>
-</el-popconfirm>
+  <el-popconfirm
+    confirmButtonText="Yes"
+    cancelButtonText="No"
+    icon="el-icon-info"
+    iconColor="red"
+    title="Are you sure to delete this?"
+    @confirm="confirmEvent"
+    @cancel="cancelEvent"
+  >
+    <template #reference>
+      <el-button>Delete</el-button>
+    </template>
+  </el-popconfirm>
 </template>
 
 <script>
-  export default {
-      methods: {
-          confirmEvent() {
-              console.log("confirm!");
-          },
-          cancelEvent() {
-              console.log("cancel!");
-          }
-      }
-  }
+export default {
+  methods: {
+    confirmEvent() {
+      console.log("confirm!");
+    },
+    cancelEvent() {
+      console.log("cancel!");
+    },
+  },
+};
 </script>
 ```
 

--- a/website/docs/jp/popconfirm.md
+++ b/website/docs/jp/popconfirm.md
@@ -40,6 +40,45 @@ popconfirmは以下のようにカスタマイズすることができます。:
 ```
 :::
 
+### トリガーイベント
+
+ボタンをクリックしてイベントを起動します。
+
+:::demo
+
+```html
+<template>
+<el-popconfirm
+  confirmButtonText='Yes'
+  cancelButtonText='No'
+  icon="el-icon-info"
+  iconColor="red"
+  title="Are you sure to delete this?"
+  @confirm="confirmEvent"
+  @cancel="cancelEvent"       
+>
+<template #reference>
+  <el-button>Delete</el-button>
+  </template>
+</el-popconfirm>
+</template>
+
+<script>
+  export default {
+      methods: {
+          confirmEvent() {
+              console.log("confirm!");
+          },
+          cancelEvent() {
+              console.log("cancel!");
+          }
+      }
+  }
+</script>
+```
+
+:::
+
 ### 属性
 | Attribute      | Description          | Type      | Accepted Values       | Default  |
 |--------------------|----------------------------------------------------------|-------------------|-------------|--------|

--- a/website/docs/zh-CN/popconfirm.md
+++ b/website/docs/zh-CN/popconfirm.md
@@ -40,6 +40,45 @@ Popconfirm 的属性与 Popover 很类似，因此对于重复属性，请参考
 ```
 :::
 
+### 触发事件
+
+点击按钮触发事件
+
+:::demo
+
+```html
+<template>
+<el-popconfirm
+  confirmButtonText='确定'
+  cancelButtonText='取消'
+  icon="el-icon-info"
+  iconColor="red"
+  title="这是一段内容确定删除吗？"
+  @confirm="confirmEvent"
+  @cancel="cancelEvent"       
+>
+<template #reference>
+  <el-button>删除</el-button>
+  </template>
+</el-popconfirm>
+</template>
+
+<script>
+  export default {
+      methods: {
+          confirmEvent() {
+              console.log("confirm!");
+          },
+          cancelEvent() {
+              console.log("cancel!");
+          }
+      }
+  }
+</script>
+```
+
+:::
+
 ### Attributes
 | 参数               | 说明                                                     | 类型              | 可选值      | 默认值 |
 |--------------------|----------------------------------------------------------|-------------------|-------------|--------|

--- a/website/docs/zh-CN/popconfirm.md
+++ b/website/docs/zh-CN/popconfirm.md
@@ -6,6 +6,7 @@
 
 Popconfirm 的属性与 Popover 很类似，因此对于重复属性，请参考 Popover 的文档，在此文档中不做详尽解释。
 :::demo 在 Popconfirm 中，只有 `title` 属性可用，`content` 属性不会被展示。
+
 ```html
 <template>
 <el-popconfirm
@@ -48,32 +49,32 @@ Popconfirm 的属性与 Popover 很类似，因此对于重复属性，请参考
 
 ```html
 <template>
-<el-popconfirm
-  confirmButtonText='确定'
-  cancelButtonText='取消'
-  icon="el-icon-info"
-  iconColor="red"
-  title="这是一段内容确定删除吗？"
-  @confirm="confirmEvent"
-  @cancel="cancelEvent"       
->
-<template #reference>
-  <el-button>删除</el-button>
-  </template>
-</el-popconfirm>
+  <el-popconfirm
+    confirmButtonText="确定"
+    cancelButtonText="取消"
+    icon="el-icon-info"
+    iconColor="red"
+    title="这是一段内容确定删除吗？"
+    @confirm="confirmEvent"
+    @cancel="cancelEvent"
+  >
+    <template #reference>
+      <el-button>删除</el-button>
+    </template>
+  </el-popconfirm>
 </template>
 
 <script>
-  export default {
-      methods: {
-          confirmEvent() {
-              console.log("confirm!");
-          },
-          cancelEvent() {
-              console.log("cancel!");
-          }
-      }
-  }
+export default {
+  methods: {
+    confirmEvent() {
+      console.log("confirm!");
+    },
+    cancelEvent() {
+      console.log("cancel!");
+    },
+  },
+};
 </script>
 ```
 


### PR DESCRIPTION
在使用popconfirm时，发现官方文档中并没有关于按钮点击触发事件的例子，希望增加此例子帮助更多人理解此处。
