### PR TITLE
更新骨架屏自定义模板时的key值

### DIFF
--- a/packages/skeleton/src/index.vue
+++ b/packages/skeleton/src/index.vue
@@ -2,7 +2,7 @@
   <template v-if="uiLoading">
     <div :class="['el-skeleton', animated ? 'is-animated' : '', ]" v-bind="$attrs">
       <template v-for="i in count" :key="i">
-        <slot v-if="loading" name="template" :key="i">
+        <slot v-if="loading" :key="i" name="template">
           <el-skeleton-item class="is-first" variant="p" />
           <el-skeleton-item
             v-for="item in rows"

--- a/packages/skeleton/src/index.vue
+++ b/packages/skeleton/src/index.vue
@@ -2,7 +2,7 @@
   <template v-if="uiLoading">
     <div :class="['el-skeleton', animated ? 'is-animated' : '', ]" v-bind="$attrs">
       <template v-for="i in count" :key="i">
-        <slot v-if="loading" name="template">
+        <slot v-if="loading" name="template" :key="i">
           <el-skeleton-item class="is-first" variant="p" />
           <el-skeleton-item
             v-for="item in rows"


### PR DESCRIPTION
之前骨架屏自定义模板时key都是0，因为没有传入模板作用域。现在把count循环的i传入作用域，解决该问题

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
