### PR TITLE
fix(style): allow custom alone color sass var

### DIFF
--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -40,14 +40,14 @@ $--colors: map.deep-merge(
   $--colors
 );
 
-$--color-white: map.get($--colors, 'white');
-$--color-black: map.get($--colors, 'black');
-$--color-primary: map.get($--colors, 'primary', 'base');
-$--color-success: map.get($--colors, 'success', 'base');
-$--color-warning: map.get($--colors, 'warning', 'base');
-$--color-danger: map.get($--colors, 'danger', 'base');
-$--color-error: map.get($--colors, 'error', 'base');
-$--color-info: map.get($--colors, 'info', 'base');
+$--color-white: map.get($--colors, 'white') !default;
+$--color-black: map.get($--colors, 'black') !default;
+$--color-primary: map.get($--colors, 'primary', 'base') !default;
+$--color-success: map.get($--colors, 'success', 'base') !default;
+$--color-warning: map.get($--colors, 'warning', 'base') !default;
+$--color-danger: map.get($--colors, 'danger', 'base') !default;
+$--color-error: map.get($--colors, 'error', 'base') !default;
+$--color-info: map.get($--colors, 'info', 'base') !default;
 
 // https://sass-lang.com/documentation/values/maps#immutability
 @mixin set-color-type-light($type, $number) {


### PR DESCRIPTION
- allow custom alone color sass var
  - `$--color-primary` (default is `map.get($--colors, 'primary', 'base')`)

---

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
