### PR TITLE
fix(build): marking side effects for webpack importing styles

### DIFF
--- a/packages/element-plus/package.json
+++ b/packages/element-plus/package.json
@@ -10,7 +10,11 @@
   "style": "dist/index.css",
   "unpkg": "dist/index.full.js",
   "jsdevlivr": "dist/index.full.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "dist/*",
+    "theme-chalk/*.css",
+    "theme-chalk/src/*.scss"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/element-plus/element-plus.git"


### PR DESCRIPTION
- Marking file under `dist` and `theme-chalk/*.css` `theme-chalk/*.scss`
- Closes #3081

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
