### PR TITLE
fix(theme-chalk): checkbox inline-height issue

### DIFF
--- a/packages/theme-chalk/src/checkbox.scss
+++ b/packages/theme-chalk/src/checkbox.scss
@@ -250,7 +250,6 @@ $--checkbox-bordered-height: map.merge(
   @include e(label) {
     display: inline-block;
     padding-left: 10px;
-    line-height: 1;
     font-size: var(--el-checkbox-font-size);
   }
 


### PR DESCRIPTION
`line-height: 1` causes the checkbox to not inherit the correct line-height

eg:
![image](https://user-images.githubusercontent.com/26672484/131107894-f4c54533-ab7f-4dda-81ce-686b4f79e035.png)


Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
