### PR TITLE
[Refactor] Refactor Plan

### DIFF
--- a/packages/components/popover/__tests__/directive.spec.ts
+++ b/packages/components/popover/__tests__/directive.spec.ts
@@ -1,7 +1,7 @@
 import { h, nextTick, Fragment, withDirectives, ref } from 'vue'
 import makeMount from '@element-plus/test-utils/make-mount'
 import { rAF } from '@element-plus/test-utils/tick'
-import Popover from '../src/index.vue'
+import Popover from '../src'
 import PopoverDirective, { VPopover } from '../src/directive'
 
 import type { ComponentPublicInstance } from 'vue'

--- a/packages/components/popover/__tests__/popover.spec.ts
+++ b/packages/components/popover/__tests__/popover.spec.ts
@@ -1,7 +1,7 @@
 import { ref, nextTick, h, createSlots } from 'vue'
 import PopupManager from '@element-plus/utils/popup-manager'
 import makeMount from '@element-plus/test-utils/make-mount'
-import Popover from '../src/index.vue'
+import Popover from '../src'
 
 const AXIOM = 'Rem is the best girl'
 

--- a/packages/components/popover/index.ts
+++ b/packages/components/popover/index.ts
@@ -1,4 +1,4 @@
-import Popover from './src/index.vue'
+import Popover from './src'
 import PopoverDirective, { VPopover } from './src/directive'
 
 import type { App } from 'vue'

--- a/packages/components/popover/src/directive.ts
+++ b/packages/components/popover/src/directive.ts
@@ -1,9 +1,9 @@
-import { on } from '@element-plus/utils/dom'
+import { useEventListener } from '@vueuse/core'
 
 import type { DirectiveBinding, VNode, ObjectDirective } from 'vue'
 
 interface PopoverInstance {
-  events: Record<string, EventListenerOrEventListenerObject>
+  events: Record<string, EventListener>
   triggerRef: HTMLElement
   tabindex: string | number
 }
@@ -14,13 +14,13 @@ const attachEvents = (
   vnode: VNode
 ) => {
   const _ref = binding.arg || binding.value
-  const popover = vnode.dirs[0].instance.$refs[_ref] as PopoverInstance
+  const popover = vnode.dirs?.[0].instance?.$refs[_ref] as PopoverInstance
   if (popover) {
     popover.triggerRef = el
     el.setAttribute('tabindex', popover.tabindex as string)
     // because v-popover cannot modify the vnode itself due to it has already been
     Object.entries(popover.events).forEach(([eventName, e]) => {
-      on(el, eventName.toLowerCase().slice(2), e)
+      useEventListener(el, eventName.toLowerCase().slice(2), e)
     })
   }
 }

--- a/packages/components/popover/src/index.ts
+++ b/packages/components/popover/src/index.ts
@@ -1,0 +1,167 @@
+import {
+  defineComponent,
+  Fragment,
+  createTextVNode,
+  renderSlot,
+  toDisplayString,
+  createCommentVNode,
+  withDirectives,
+  Teleport,
+  h,
+  reactive,
+  toRef,
+} from 'vue'
+import { ClickOutside } from '@element-plus/directives'
+import {
+  popperProps,
+  Effect,
+  renderArrow,
+  renderPopper,
+  renderTrigger,
+} from '@element-plus/components/popper'
+import { debugWarn } from '@element-plus/utils/error'
+import { renderIf, PatchFlags } from '@element-plus/utils/vnode'
+import { buildProp } from '@element-plus/utils/props'
+import usePopover, { SHOW_EVENT, HIDE_EVENT } from './usePopover'
+
+import type { ExtractPropTypes, Ref } from 'vue'
+import type { TriggerType } from '@element-plus/components/popper'
+import type { ElementType } from '@element-plus/components/popper/src/use-popper'
+
+const popoverProps = {
+  ...popperProps,
+  trigger: buildProp<TriggerType>({
+    type: String,
+    default: 'click',
+  }),
+  title: {
+    type: String,
+  },
+  transition: {
+    type: String,
+    default: 'fade-in-linear',
+  },
+  width: buildProp<string | number>({
+    type: [String, Number],
+    default: 150,
+  }),
+  appendToBody: {
+    type: Boolean,
+    default: true,
+  },
+  tabindex: buildProp<string | number>({
+    type: [String, Number],
+  }),
+} as const
+const emits = [
+  'update:visible',
+  'after-enter',
+  'after-leave',
+  SHOW_EVENT,
+  HIDE_EVENT,
+]
+const NAME = 'ElPopover'
+
+const _hoist = { key: 0, class: 'el-popover__title', role: 'title' }
+
+export type PopoverProps = ExtractPropTypes<typeof popoverProps>
+
+export default defineComponent({
+  name: NAME,
+
+  props: popoverProps,
+  emits,
+
+  setup(props, ctx) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      props.visible &&
+      !ctx.slots.reference
+    )
+      debugWarn(NAME, 'You cannot init popover without given reference')
+
+    const popover = usePopover(props, ctx)
+
+    ctx.expose({
+      events: popover.events,
+      triggerRef: popover.triggerRef,
+      tabindex: toRef(props, 'tabindex'),
+    })
+
+    return () => {
+      const { slots } = ctx
+      const trigger = slots.reference?.() ?? null
+
+      const title = renderIf(
+        !!props.title,
+        'div',
+        _hoist,
+        toDisplayString(props.title),
+        PatchFlags.TEXT
+      )
+
+      const content = renderSlot(slots, 'default', {}, () => [
+        createTextVNode(toDisplayString(props.content), PatchFlags.TEXT),
+      ])
+
+      const {
+        events,
+        onAfterEnter,
+        onAfterLeave,
+        onPopperMouseEnter,
+        onPopperMouseLeave,
+        popperStyle,
+        popperId,
+        visibility,
+      } = reactive(popover)
+
+      const kls = [
+        props.content ? 'el-popover--plain' : '',
+        'el-popover',
+        props.popperClass,
+      ].join(' ')
+
+      const vPopover = renderPopper(
+        {
+          effect: Effect.LIGHT,
+          name: props.transition,
+          popperClass: kls,
+          popperStyle,
+          popperId,
+          visibility,
+          onMouseenter: onPopperMouseEnter,
+          onMouseleave: onPopperMouseLeave,
+          onAfterEnter,
+          onAfterLeave,
+          stopPopperMouseEvent: false,
+        },
+        [title, content, renderArrow(props.showArrow)]
+      )
+
+      // when user uses popover directively, trigger will be null so that we only
+      // render a popper window for displaying contents
+      const _trigger = trigger
+        ? renderTrigger(trigger, {
+            ariaDescribedby: popperId,
+            ref: popover.triggerRef as Ref<ElementType>,
+            tabindex: props.tabindex,
+            ...events,
+          })
+        : createCommentVNode('v-if', true)
+
+      return h(Fragment, null, [
+        props.trigger === 'click'
+          ? withDirectives(_trigger, [[ClickOutside, popover.hide]])
+          : _trigger,
+        h(
+          Teleport,
+          {
+            disabled: !props.appendToBody,
+            to: 'body',
+          },
+          [vPopover]
+        ),
+      ])
+    }
+  },
+})

--- a/packages/components/popover/src/usePopover.ts
+++ b/packages/components/popover/src/usePopover.ts
@@ -3,28 +3,26 @@ import { isString } from '@element-plus/utils/util'
 import { usePopper } from '@element-plus/components/popper'
 import PopupManager from '@element-plus/utils/popup-manager'
 
-import type { SetupContext } from 'vue'
-import type { IPopperOptions, EmitType } from '@element-plus/components/popper'
-export interface IUsePopover extends IPopperOptions {
-  width: number | string
-}
+import type { SetupContext, CSSProperties } from 'vue'
+import type { EmitType } from '@element-plus/components/popper'
+import type { PopoverProps } from '.'
 
 export const SHOW_EVENT = 'show'
 export const HIDE_EVENT = 'hide'
 
 export default function usePopover(
-  props: IUsePopover,
+  props: PopoverProps,
   ctx: SetupContext<string[]>
 ) {
   const zIndex = ref(PopupManager.nextZIndex())
   const width = computed(() => {
     if (isString(props.width)) {
-      return props.width as string
+      return props.width
     }
     return `${props.width}px`
   })
 
-  const popperStyle = computed(() => {
+  const popperStyle = computed<CSSProperties>(() => {
     return {
       width: width.value,
       zIndex: zIndex.value,

--- a/packages/components/popper/index.ts
+++ b/packages/components/popper/index.ts
@@ -12,10 +12,8 @@ const _Popper = Popper as SFCWithInstall<typeof Popper>
 export default _Popper
 export const ElPopper = _Popper
 
-export {
-  default as popperDefaultProps,
-  Effect,
-} from './src/use-popper/defaults'
+export { popperProps, Effect } from './src/use-popper/popper.type'
+export type { PopperProps } from './src/use-popper/popper.type'
 export * from './src/renderers'
 export { default as usePopper } from './src/use-popper'
 export type { Placement, Options } from '@popperjs/core'
@@ -24,4 +22,4 @@ export type {
   TriggerType,
   IPopperOptions,
   PopperInstance,
-} from './src/use-popper/defaults'
+} from './src/use-popper/popper.type'

--- a/packages/components/popper/src/index.vue
+++ b/packages/components/popper/src/index.vue
@@ -16,7 +16,7 @@ import { ClickOutside } from '@element-plus/directives'
 import { throwError } from '@element-plus/utils/error'
 
 import usePopper from './use-popper/index'
-import defaultProps from './use-popper/defaults'
+import { popperProps } from './use-popper/popper.type'
 import { renderPopper, renderTrigger, renderArrow } from './renderers'
 
 const compName = 'ElPopper'
@@ -24,7 +24,8 @@ const UPDATE_VISIBLE_EVENT = 'update:visible'
 
 export default defineComponent({
   name: compName,
-  props: defaultProps,
+
+  props: popperProps,
   emits: [
     UPDATE_VISIBLE_EVENT,
     'after-enter',
@@ -32,6 +33,7 @@ export default defineComponent({
     'before-enter',
     'before-leave',
   ],
+
   setup(props, ctx) {
     if (!ctx.slots.trigger) {
       throwError(compName, 'Trigger must be provided')
@@ -102,7 +104,7 @@ export default defineComponent({
       ]
     )
 
-    const _t = $slots.trigger?.()
+    const _t = $slots.trigger?.()!
 
     const triggerProps = {
       'aria-describedby': popperId,

--- a/packages/components/popper/src/renderers/arrow.ts
+++ b/packages/components/popper/src/renderers/arrow.ts
@@ -2,14 +2,10 @@ import { Comment, h } from 'vue'
 
 export default function renderArrow(showArrow: boolean) {
   return showArrow
-    ? h(
-        'div',
-        {
-          ref: 'arrowRef',
-          class: 'el-popper__arrow',
-          'data-popper-arrow': '',
-        },
-        null
-      )
+    ? h('div', {
+        ref: 'arrowRef',
+        class: 'el-popper__arrow',
+        'data-popper-arrow': '',
+      })
     : h(Comment, null, '')
 }

--- a/packages/components/popper/src/renderers/popper.ts
+++ b/packages/components/popper/src/renderers/popper.ts
@@ -3,7 +3,7 @@ import { NOOP } from '@vue/shared'
 import { stop } from '@element-plus/utils/dom'
 
 import type { VNode, Ref, CSSProperties } from 'vue'
-import type { Effect } from '../use-popper/defaults'
+import type { Effect } from '../use-popper/popper.type'
 
 interface IRenderPopperProps {
   effect: Effect

--- a/packages/components/popper/src/renderers/trigger.ts
+++ b/packages/components/popper/src/renderers/trigger.ts
@@ -20,5 +20,5 @@ export default function renderTrigger(
   const firstElement = getFirstValidNode(trigger, 1)
   if (!firstElement)
     throwError('renderTrigger', 'trigger expects single rooted node')
-  return cloneVNode(firstElement, extraProps, true)
+  return cloneVNode(firstElement!, extraProps, true)
 }

--- a/packages/components/popper/src/use-popper/popper-options.ts
+++ b/packages/components/popper/src/use-popper/popper-options.ts
@@ -3,6 +3,7 @@ import buildModifiers from './build-modifiers'
 
 import type { Ref } from 'vue'
 import type { Options, Placement } from '@popperjs/core'
+import type { RefElement } from '.'
 
 interface IUsePopperProps {
   popperOptions: Partial<Options>
@@ -14,28 +15,26 @@ interface IUsePopperProps {
 }
 
 interface IUsePopperState {
-  arrow: Ref<HTMLElement>
+  arrow: Ref<RefElement>
 }
 
 export default function usePopperOptions(
   props: IUsePopperProps,
   state: IUsePopperState
 ) {
-  return computed(() => {
-    return {
-      placement: props.placement,
-      ...props.popperOptions,
-      // Avoiding overriding modifiers.
-      modifiers: buildModifiers(
-        {
-          arrow: state.arrow.value,
-          arrowOffset: props.arrowOffset,
-          offset: props.offset,
-          gpuAcceleration: props.gpuAcceleration,
-          fallbackPlacements: props.fallbackPlacements,
-        },
-        props.popperOptions?.modifiers
-      ),
-    }
-  })
+  return computed(() => ({
+    placement: props.placement,
+    ...props.popperOptions,
+    // Avoiding overriding modifiers.
+    modifiers: buildModifiers(
+      {
+        arrow: state.arrow.value,
+        arrowOffset: props.arrowOffset,
+        offset: props.offset,
+        gpuAcceleration: props.gpuAcceleration,
+        fallbackPlacements: props.fallbackPlacements,
+      },
+      props.popperOptions?.modifiers
+    ),
+  }))
 }

--- a/packages/components/popper/src/use-popper/popper.type.ts
+++ b/packages/components/popper/src/use-popper/popper.type.ts
@@ -1,18 +1,19 @@
-import type { PropType } from 'vue'
+import { buildProp } from '@element-plus/utils/props'
+
+import type { ExtractPropTypes } from 'vue'
 import type {
   Placement,
   PositioningStrategy,
   Instance as PopperInstance,
   Options,
 } from '@popperjs/core'
-import type { Nullable } from '@element-plus/utils/types'
 
 export enum Effect {
   DARK = 'dark',
   LIGHT = 'light',
 }
 
-export type RefElement = Nullable<HTMLElement>
+export type RefElement = HTMLElement | undefined
 export type Offset = [number, number] | number
 
 export type { Placement, PositioningStrategy, PopperInstance, Options }
@@ -21,34 +22,11 @@ export type TriggerType = 'click' | 'hover' | 'focus' | 'manual'
 
 export type Trigger = TriggerType | TriggerType[]
 
-export type IPopperOptions = {
-  arrowOffset: number
-  autoClose: number
-  boundariesPadding: number
-  class: string
-  cutoff: boolean
-  disabled: boolean
-  enterable: boolean
-  hideAfter: number
-  manualMode: boolean
-  offset: number
-  placement: Placement
-  popperOptions: Partial<Options>
-  showAfter: number
-  showArrow: boolean
-  strategy: PositioningStrategy
-  trigger: Trigger
-  visible: boolean
-  stopPopperMouseEvent: boolean
-  gpuAcceleration: boolean
-  fallbackPlacements: Array<Placement>
-}
-
 // duplicate export at index.ts
 // export const DEFAULT_TRIGGER = 'hover'
 const DEFAULT_FALLBACK_PLACEMENTS = []
 
-export default {
+export const popperProps = {
   // the arrow size is an equailateral triangle with 10px side length, the 3rd side length ~ 14.1px
   // adding a offset to the ceil of 4.1 should be 5 this resolves the problem of arrow overflowing out of popper.
   arrowOffset: {
@@ -88,10 +66,11 @@ export default {
     type: Boolean,
     default: false,
   },
-  effect: {
-    type: String as PropType<Effect>,
+  effect: buildProp({
+    type: String,
+    values: Object.values(Effect),
     default: Effect.DARK,
-  },
+  }),
   enterable: {
     type: Boolean,
     default: true,
@@ -108,10 +87,10 @@ export default {
     type: Number,
     default: 12,
   },
-  placement: {
-    type: String as PropType<Placement>,
-    default: 'bottom' as Placement,
-  },
+  placement: buildProp<Placement>({
+    type: String,
+    default: 'bottom',
+  }),
   popperClass: {
     type: String,
     default: '',
@@ -121,30 +100,30 @@ export default {
     default: false,
   },
   // Once this option were given, the entire popper is under the users' control, top priority
-  popperOptions: {
-    type: Object as PropType<Partial<Options>>,
-    default: () => null,
-  },
+  popperOptions: buildProp<Partial<Options>>({
+    type: Object,
+    default: () => ({}),
+  }),
   showArrow: {
     type: Boolean,
     default: true,
   },
-  strategy: {
-    type: String as PropType<PositioningStrategy>,
-    default: 'fixed' as PositioningStrategy,
-  },
+  strategy: buildProp<PositioningStrategy>({
+    type: String,
+    default: 'fixed',
+  }),
   transition: {
     type: String,
     default: 'el-fade-in-linear',
   },
-  trigger: {
-    type: [String, Array] as PropType<Trigger>,
+  trigger: buildProp<Trigger>({
+    type: [String, Array],
     default: 'hover',
-  },
-  visible: {
+  }),
+  visible: buildProp<boolean | undefined>({
     type: Boolean,
     default: undefined,
-  },
+  }),
   stopPopperMouseEvent: {
     type: Boolean,
     default: true,
@@ -153,8 +132,9 @@ export default {
     type: Boolean,
     default: true,
   },
-  fallbackPlacements: {
-    type: Array as PropType<Placement[]>,
-    default: DEFAULT_FALLBACK_PLACEMENTS,
-  },
-}
+  fallbackPlacements: buildProp<Placement[]>({
+    type: Array,
+    default: () => DEFAULT_FALLBACK_PLACEMENTS,
+  }),
+} as const
+export type PopperProps = ExtractPropTypes<typeof popperProps>

--- a/packages/components/slider/__tests__/slider.spec.ts
+++ b/packages/components/slider/__tests__/slider.spec.ts
@@ -72,7 +72,7 @@ describe('Slider', () => {
     })
     const slider = wrapper.vm.$refs.slider as any
     const tooltip = slider.$refs.firstButton.$refs.tooltip
-    expect(tooltip.disabled).toBe(true)
+    expect(tooltip.$props.disabled).toBe(true)
   })
 
   it('format tooltip', async () => {

--- a/packages/components/tooltip/src/index.ts
+++ b/packages/components/tooltip/src/index.ts
@@ -1,11 +1,40 @@
 import { defineComponent, h, ref, cloneVNode } from 'vue'
 import {
   default as ElPopper,
-  popperDefaultProps,
+  popperProps,
 } from '@element-plus/components/popper'
 import { UPDATE_MODEL_EVENT } from '@element-plus/utils/constants'
 import { throwError } from '@element-plus/utils/error'
 import { getFirstValidNode } from '@element-plus/utils/vnode'
+import { buildProp } from '@element-plus/utils/props'
+
+import type { ExtractPropTypes } from 'vue'
+
+const tooltipProps = {
+  ...popperProps,
+  manual: {
+    type: Boolean,
+    default: false,
+  },
+  modelValue: buildProp<boolean | undefined>({
+    type: Boolean,
+    default: undefined,
+  }),
+  // This API should be decaprecate since it's confusing with close-delay
+  openDelay: {
+    type: Number,
+    default: 0,
+  },
+  visibleArrow: {
+    type: Boolean,
+    default: true,
+  },
+  tabindex: buildProp<string | number>({
+    type: [String, Number],
+    default: '0',
+  }),
+} as const
+export type TooltipProps = ExtractPropTypes<typeof tooltipProps>
 
 /**
  * ElTooltip
@@ -15,105 +44,71 @@ import { getFirstValidNode } from '@element-plus/utils/vnode'
  */
 export default defineComponent({
   name: 'ElTooltip',
-  components: {
-    ElPopper,
-  },
-  props: {
-    ...popperDefaultProps,
-    manual: {
-      type: Boolean,
-      default: false,
-    },
-    modelValue: {
-      type: Boolean,
-      validator: (val: unknown) => {
-        return typeof val === 'boolean'
-      },
-      default: undefined,
-    },
-    // This API should be decaprecate since it's confusing with close-delay
-    openDelay: {
-      type: Number,
-      default: 0,
-    },
-    visibleArrow: {
-      type: Boolean,
-      default: true,
-    },
-    tabindex: {
-      type: [String, Number],
-      default: '0',
-    },
-  },
+
+  props: tooltipProps,
   emits: [UPDATE_MODEL_EVENT],
-  setup(props, ctx) {
+
+  setup(props, { emit, slots, expose }) {
     // when manual mode is true, v-model must be passed down
-    if (props.manual && typeof props.modelValue === 'undefined') {
+    if (props.manual && typeof props.modelValue === undefined) {
       throwError(
         '[ElTooltip]',
         'You need to pass a v-model to el-tooltip when `manual` is true'
       )
     }
 
-    const popper = ref(null)
+    const popper = ref()
 
-    const onUpdateVisible = (val) => {
-      ctx.emit(UPDATE_MODEL_EVENT, val)
+    const onUpdateVisible = (val: boolean) => {
+      emit(UPDATE_MODEL_EVENT, val)
     }
 
-    const updatePopper = () => {
-      return popper.value.update()
-    }
+    const updatePopper = () => popper.value.update()
 
-    return {
-      popper,
-      onUpdateVisible,
+    expose({
       updatePopper,
-    }
-  },
-  render() {
-    const {
-      $slots,
-      content,
-      manual,
-      openDelay,
-      onUpdateVisible,
-      showAfter,
-      visibleArrow,
-      modelValue,
-      tabindex,
-    } = this
+    })
 
-    const throwErrorTip = () => {
-      throwError('[ElTooltip]', 'you need to provide a valid default slot.')
-    }
+    return () => {
+      const {
+        content,
+        manual,
+        openDelay,
+        showAfter,
+        visibleArrow,
+        modelValue,
+        tabindex,
+      } = props
 
-    const popper = h(
-      ElPopper,
-      {
-        ...Object.keys(popperDefaultProps).reduce((result, key) => {
-          return { ...result, [key]: this[key] }
-        }, {}),
-        ref: 'popper',
-        manualMode: manual,
-        showAfter: openDelay || showAfter, // this is for mapping API due to we decided to rename the current openDelay API to showAfter for better readability,
-        showArrow: visibleArrow,
-        visible: modelValue,
-        'onUpdate:visible': onUpdateVisible,
-      },
-      {
-        default: () => ($slots.content ? $slots.content() : content),
-        trigger: () => {
-          if ($slots.default) {
-            const firstVnode = getFirstValidNode($slots.default(), 1)
-            if (!firstVnode) throwErrorTip()
-            return cloneVNode(firstVnode, { tabindex }, true)
-          }
-          throwErrorTip()
-        },
+      function throwErrorTip(): never {
+        throwError('[ElTooltip]', 'you need to provide a valid default slot.')
       }
-    )
 
-    return popper
+      return h(
+        ElPopper,
+        {
+          ref: popper,
+          ...Object.fromEntries(
+            Object.entries(popperProps).map(([key]) => [key, props[key]])
+          ),
+          manualMode: manual,
+          showAfter: openDelay || showAfter, // this is for mapping API due to we decided to rename the current openDelay API to showAfter for better readability,
+          showArrow: visibleArrow,
+          visible: modelValue,
+          'onUpdate:visible': onUpdateVisible,
+        },
+        {
+          default: () => slots.content?.() ?? content,
+          trigger: () => {
+            if (slots.default) {
+              const firstVnode = getFirstValidNode(slots.default(), 1)
+              if (!firstVnode) throwErrorTip()
+              return cloneVNode(firstVnode, { tabindex }, true)
+            }
+            throwErrorTip()
+          },
+        }
+      )
+    }
   },
 })


### PR DESCRIPTION
# Refactor

## Summary

- Improve all project typings.
- Drop deprecated APIs.

## Contribute Guide

- Create an PR. e.g `refactor(components): refactor button`
  - Please at`@` me.
  - Please assign to me if you're Element Plus member.
  - Please add PR link to below `Progress` if you have permission.
  - I will review it ASAP.
- 🛠 ❌ **fix ALL TypeScript errors.**
  - ⚠️ Priority: highest
  - Please refer to https://github.com/element-plus/element-plus/pull/3113#issuecomment-967230194
- 🧲 Extract `.vue` props and emits to `.ts`.
  - Philosophy: Write the logical part into ts file as much as possible.
  - add `InstanceType` for each components #4308
- 🎨 Use setup return render method.
  - Use `setup() { return () => { /* code here */ } }`
- 📁 Structure
  - Move `tokens` to `@element-plus/tokens`.
    - Only context type interface
    - Only injection key
- 🔑 Use `withInstall`.
  - Please refer to completed files if you're confused.
- 🪛 Refactor **ALL** APIs in detail.
- 🧱 Do not use SFC(`.vue`), if there is no template.

For more details, please refer to `Task List` and merged pull request below. Thanks for your contribution!

## Task List

### ⭐️ Feature

- [x] `el-check-tag` support `v-model:checked`.
  - https://github.com/element-plus/element-plus/pull/3311
- [ ] `el-menu` add `v-model:opened`
  - https://github.com/element-plus/element-plus/issues/3122

### ♻️ Typing

- [x] 🦾 use typescript `strict` mode, increase code reliability.
- `RefElement` -> use the exact element type.
  - e.g `HTMLDivElement`
- `null` -> prefer `undefined`.
  - e.g `ref<HTMLDivElement>()`. **NOT** `ref(null)`
- Try not to use type assertions.
  - e.g ❌ BAD `inject(foo, {} as FooType)`
- [ ] improve and export props and emits type.
- [ ] add `InstanceType` for each components.
  - https://github.com/element-plus/element-plus/issues/4308
- [ ] add `vue-tsc` checker for unit test.

### 🔨 Utils / Hooks

- [ ] `VueUse`
  - https://github.com/element-plus/element-plus/pull/3370
  - https://github.com/element-plus/element-plus/pull/3374
  - [ ] `useEventListener` (remove `on`, `off`)
  - [ ] `onClickOutside` (remove directive)
  - [ ] `useResizeObserver` (remove directive and `@element-plus/utils/resize-event`)
  - [x] `isClient` (remove `isServer`)
- [x] ~~Use `useFormItem`.~~ Use `useSize` and `useDisabled`
  - https://github.com/element-plus/element-plus/pull/4730

### 👌 Compatibility

- Now only support `Edge` ≥ 79, `Firefox` ≥ 78, `Chrome` ≥ 64, `Safari` ≥ 12
- [x] Docs
  - https://github.com/element-plus/element-plus/pull/3342
- [x] Drop IE support
  - https://github.com/element-plus/element-plus/pull/3304
- [x] Remove `ResizeObserver` polyfill
  - https://github.com/element-plus/element-plus/pull/4058
- [x] Remove CSS prefix e.g `-ms-`
  - https://github.com/element-plus/element-plus/pull/4075

### Naming

- [ ] 📁 unify file naming rules: `kebab-case`.
  - https://github.com/element-plus/element-plus/pull/3113#issuecomment-917482311
- Rename `index.vue` to `[component-name].vue`.
- Unify file naming rules to `kebab-case.{ts,vue}`.

## Progress

Moved to #6114

- [ ] ✅ `vue-tsc` emit no error and add to ci check.
  - ~~`Found 1823 errors.`~~
  - ~~`Found 1773 errors.`~~
  - ~~`Found 1629 errors.`~~
  - ~~`Found 1617 errors.`~~
  - ~~`Found 1614 errors.`~~
  - ~~`Found 1533 errors.`~~
  - ~~`Found 1353 errors.`~~
  - ~~`Found 1292 errors.`~~
  - ~~`Found 1128 errors.` (144 files)~~
  - `Found 1050 errors.`

🚀 Embrace `TypeScript`!
