### PR TITLE
fix: el-image-viewer drag have problem

### DIFF
--- a/packages/components/image-viewer/src/index.vue
+++ b/packages/components/image-viewer/src/index.vue
@@ -256,7 +256,7 @@ export default defineComponent({
         }
       })
       on(document, 'mousemove', _dragHandler)
-      on(document, 'mouseup', (e: any) => {
+      on(document, 'mouseup', (e: MouseEvent) => {
         const mouseX = e.pageX
         const mouseY = e.pageY
         if (mouseX < divLeft || mouseX > divRight || mouseY < divTop || mouseY > divBottom){

--- a/packages/components/image-viewer/src/index.vue
+++ b/packages/components/image-viewer/src/index.vue
@@ -242,6 +242,12 @@ export default defineComponent({
       const { offsetX, offsetY } = transform.value
       const startX = e.pageX
       const startY = e.pageY
+
+      const divLeft = wrapper.value.clientLeft
+      const divRight = wrapper.value.clientLeft + wrapper.value.clientWidth
+      const divTop = wrapper.value.clientTop
+      const divBottom = wrapper.value.clientTop + wrapper.value.clientHeight
+
       _dragHandler = rafThrottle(ev => {
         transform.value = {
           ...transform.value,
@@ -250,7 +256,12 @@ export default defineComponent({
         }
       })
       on(document, 'mousemove', _dragHandler)
-      on(document, 'mouseup', () => {
+      on(document, 'mouseup', (e: any) => {
+        const mouseX = e.pageX
+        const mouseY = e.pageY
+        if (mouseX < divLeft || mouseX > divRight || mouseY < divTop || mouseY > divBottom){
+          reset()
+        }
         off(document, 'mousemove', _dragHandler)
       })
 


### PR DESCRIPTION
fix issue[#3115](https://github.com/element-plus/element-plus/issues/3115),
by reset the image-viewer when mouse drag it out of the area of page

Please make sure these boxes are checked before submitting your PR, thank you!

* [√ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ √] Make sure you are merging your commits to `dev` branch.
* [√ ] Add some descriptions and refer to relative issues for your PR.
