### PR TITLE
fix(components): lazy image is not work when it changes src

### DIFF
--- a/packages/components/image/src/index.vue
+++ b/packages/components/image/src/index.vue
@@ -301,12 +301,17 @@ export default defineComponent({
       emit('switch', val)
     }
 
-    watch(
-      () => props.src,
-      () => {
+    watch(() => props.src, () => {
+      if (props.lazy) {
+        // reset status
+        loading.value = true
+        hasLoadError.value = false
+        removeLazyLoadListener()
+        nextTick(addLazyLoadListener)
+      } else {
         loadImage()
       }
-    )
+    })
 
     onMounted(() => {
       if (props.lazy) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

el-image has a problem.
image opens lazy props , if i do not trigger lazy-load of image ,  i change src of image , picture will load immediately. lazy loading is not work.
