### PR TITLE
[Form]: ensure form validation always triggers callback

### DIFF
--- a/packages/components/form/src/form.vue
+++ b/packages/components/form/src/form.vue
@@ -187,7 +187,6 @@ export default defineComponent({
         callback(true)
       }
       let valid = true
-      let count = 0
       let invalidFields = {}
       let firstInvalidFields
       for (const field of fields) {
@@ -197,11 +196,10 @@ export default defineComponent({
             firstInvalidFields || (firstInvalidFields = field)
           }
           invalidFields = { ...invalidFields, ...field }
-          if (++count === fields.length) {
-            callback(valid, invalidFields)
-          }
         })
       }
+      callback(valid, invalidFields)
+
       if (!valid && props.scrollToError) {
         scrollToField(Object.keys(firstInvalidFields)[0])
       }


### PR DESCRIPTION
ensures the callback is always called, no need to the keep track of an internal counter and call the callback inside the loop (which somehow didnt work in my project)

failing use-case: https://codesandbox.io/s/vue-3-element-pro-form-validation-error-c3qnx?file=/src/components/HelloWorld.vue

> notice there arent any `console.logs` either `valid` or `invalid` 

This PR fixes this bug

- [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
