### PR TITLE
fix: [el-table] default-expand-all doesn't work

### DIFF
--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -49,6 +49,9 @@ function useStore<T>() {
       // 没有使用 computed，而是手动更新部分数据 https://github.com/vuejs/vue/issues/6660#issuecomment-331417140
       instance.store.updateCurrentRowData()
       instance.store.updateExpandRows()
+      instance.store.updateTreeData(
+        instance.store.states.defaultExpandAll.value
+      )
       if (unref(states.reserveSelection)) {
         instance.store.assertRowKey()
         instance.store.updateSelectionByRowKey()

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -66,18 +66,19 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     return res
   }
 
-  const updateTreeData = () => {
+  const updateTreeData = (
+    ifExpandAll = instance.store?.states.defaultExpandAll.value
+  ) => {
     const nested = normalizedData.value
     const normalizedLazyNode_ = normalizedLazyNode.value
     const keys = Object.keys(nested)
     const newTreeData = {}
     if (keys.length) {
       const oldTreeData = unref(treeData)
-      const defaultExpandAll = instance.store?.states.defaultExpandAll.value
       const rootLazyRowKeys = []
       const getExpanded = (oldValue, key) => {
         const included =
-          defaultExpandAll ||
+          ifExpandAll ||
           (expandRowKeys.value && expandRowKeys.value.indexOf(key) !== -1)
         return !!((oldValue && oldValue.expanded) || included)
       }
@@ -124,8 +125,18 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     instance.store?.updateTableScrollY()
   }
 
-  watch(() => normalizedData.value, updateTreeData)
-  watch(() => normalizedLazyNode.value, updateTreeData)
+  watch(
+    () => normalizedData.value,
+    () => {
+      updateTreeData()
+    }
+  )
+  watch(
+    () => normalizedLazyNode.value,
+    () => {
+      updateTreeData()
+    }
+  )
 
   const updateTreeExpandKeys = (value: string[]) => {
     expandRowKeys.value = value

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -430,6 +430,7 @@ function useWatcher<T>() {
   const {
     updateTreeExpandKeys,
     toggleTreeExpansion,
+    updateTreeData,
     loadOrToggle,
     states: treeStates,
   } = useTree({
@@ -490,6 +491,7 @@ function useWatcher<T>() {
     updateExpandRows,
     updateCurrentRowData,
     loadOrToggle,
+    updateTreeData,
     states: {
       rowKey,
       data,


### PR DESCRIPTION
fix issue #2776 #3139 .
the reason of this problem is` instance.store.states.defaultExpandAll` is not load when it be first use in `updateTreeData()`


Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
