### PR TITLE
Revert "[Form]: ensure form validation always triggers callback"

### DIFF
--- a/packages/components/form/src/form.vue
+++ b/packages/components/form/src/form.vue
@@ -184,6 +184,7 @@ export default defineComponent({
         callback(true)
       }
       let valid = true
+      let count = 0
       let invalidFields = {}
       let firstInvalidFields
       for (const field of fields) {
@@ -193,10 +194,11 @@ export default defineComponent({
             firstInvalidFields || (firstInvalidFields = field)
           }
           invalidFields = { ...invalidFields, ...field }
+          if (++count === fields.length) {
+            callback(valid, invalidFields)
+          }
         })
       }
-      callback(valid, invalidFields)
-
       if (!valid && props.scrollToError) {
         scrollToField(Object.keys(firstInvalidFields)[0])
       }


### PR DESCRIPTION
Reverts element-plus/element-plus#3294
So sorry the change does not handle asynchronous field checking. We have to revert it.