### PR TITLE
docs: fix el-switch `before-change` code examples

### DIFF
--- a/website/docs/en-US/switch.md
+++ b/website/docs/en-US/switch.md
@@ -134,12 +134,12 @@ Switch is used for switching between two opposing states.
 
 ### prevent switching
 
-:::demo set the `beforeChange` property, If `false` is returned or a `Promise` is returned and then is rejected, will stop switching.
+:::demo set the `before-change` property, If `false` is returned or a `Promise` is returned and then is rejected, will stop switching.
 
 ```html
-<el-switch v-model="value1" :loading="loading1" :beforeChange="beforeChange1">
+<el-switch v-model="value1" :loading="loading1" :before-change="beforeChange1">
 </el-switch>
-<el-switch v-model="value2" :loading="loading2" :beforeChange="beforeChange2">
+<el-switch v-model="value2" :loading="loading2" :before-change="beforeChange2">
 </el-switch>
 <script>
   import { reactive, toRefs } from 'vue'

--- a/website/docs/es/switch.md
+++ b/website/docs/es/switch.md
@@ -134,12 +134,12 @@ Switch es utilizado para realizar cambios entre dos estados opuestos.
 
 ### prevent switching
 
-:::demo set the `beforeChange` property, If `false` is returned or a `Promise` is returned and then is rejected, will stop switching.
+:::demo set the `before-change` property, If `false` is returned or a `Promise` is returned and then is rejected, will stop switching.
 
 ```html
-<el-switch v-model="value1" :loading="loading1" :beforeChange="beforeChange1">
+<el-switch v-model="value1" :loading="loading1" :before-change="beforeChange1">
 </el-switch>
-<el-switch v-model="value2" :loading="loading2" :beforeChange="beforeChange2">
+<el-switch v-model="value2" :loading="loading2" :before-change="beforeChange2">
 </el-switch>
 <script>
   import { reactive, toRefs } from 'vue'

--- a/website/docs/fr-FR/switch.md
+++ b/website/docs/fr-FR/switch.md
@@ -134,12 +134,12 @@ Switch est utilisé pour choisir entre deux états opposés.
 
 ### Empêcher la commutation
 
-:::demo Définissez la propriété `beforeChange`. Si elle renvoie false ou renvoie une promesse et est rejetée, le commutateur s'arrêtera.
+:::demo Définissez la propriété `before-change`. Si elle renvoie false ou renvoie une promesse et est rejetée, le commutateur s'arrêtera.
 
 ```html
-<el-switch v-model="value1" :loading="loading1" :beforeChange="beforeChange1">
+<el-switch v-model="value1" :loading="loading1" :before-change="beforeChange1">
 </el-switch>
-<el-switch v-model="value2" :loading="loading2" :beforeChange="beforeChange2">
+<el-switch v-model="value2" :loading="loading2" :before-change="beforeChange2">
 </el-switch>
 <script>
   import { reactive, toRefs } from 'vue'

--- a/website/docs/jp/switch.md
+++ b/website/docs/jp/switch.md
@@ -134,12 +134,12 @@
 
 ### 切り替えを防ぐ
 
-:::demo `beforeChange`プロパティを設定します。false を返すか、Promise を返し、拒否された場合は、切り替えを停止します。
+:::demo `before-change`プロパティを設定します。false を返すか、Promise を返し、拒否された場合は、切り替えを停止します。
 
 ```html
-<el-switch v-model="value1" :loading="loading1" :beforeChange="beforeChange1">
+<el-switch v-model="value1" :loading="loading1" :before-change="beforeChange1">
 </el-switch>
-<el-switch v-model="value2" :loading="loading2" :beforeChange="beforeChange2">
+<el-switch v-model="value2" :loading="loading2" :before-change="beforeChange2">
 </el-switch>
 <script>
   import { reactive, toRefs } from 'vue'

--- a/website/docs/zh-CN/switch.md
+++ b/website/docs/zh-CN/switch.md
@@ -127,12 +127,12 @@
 
 ### 阻止切换
 
-:::demo 设置`beforeChange`属性，若返回 false 或者返回 Promise 且被 reject，则停止切换。
+:::demo 设置`before-change`属性，若返回 false 或者返回 Promise 且被 reject，则停止切换。
 
 ```html
-<el-switch v-model="value1" :loading="loading1" :beforeChange="beforeChange1">
+<el-switch v-model="value1" :loading="loading1" :before-change="beforeChange1">
 </el-switch>
-<el-switch v-model="value2" :loading="loading2" :beforeChange="beforeChange2">
+<el-switch v-model="value2" :loading="loading2" :before-change="beforeChange2">
 </el-switch>
 <script>
   import { reactive, toRefs } from 'vue'


### PR DESCRIPTION
Previously, code examples for switch didn't work since they used the `beforeChange` html attribute, instead of the properly spelled `before-change`