### PR TITLE
fix: popover repeat when exist fixed column in table

### DIFF
--- a/packages/components/table/src/table-body/render-helper.ts
+++ b/packages/components/table/src/table-body/render-helper.ts
@@ -28,6 +28,7 @@ function useRender<T>(props: Partial<TableBodyProps<T>>) {
     getCellClass,
     getSpan,
     getColspanRealWidth,
+    isColumnHidden,
   } = useStyles(props)
   const firstDefaultColumnIndex = computed(() => {
     return props.store.states.columns.value.findIndex(
@@ -103,6 +104,7 @@ function useRender<T>(props: Partial<TableBodyProps<T>>) {
         }
         const baseKey = `${$index},${cellIndex}`
         const patchKey = columnData.columnKey || columnData.rawColumnKey || ''
+        const tdChildren = cellChildren(cellIndex, column, data)
         return h(
           'td',
           {
@@ -115,10 +117,17 @@ function useRender<T>(props: Partial<TableBodyProps<T>>) {
               handleCellMouseEnter($event, { ...row, tooltipEffect }),
             onMouseleave: handleCellMouseLeave,
           },
-          [column.renderCell(data)]
+          [tdChildren]
         )
       })
     )
+  }
+  const cellChildren = (cellIndex, column, data) => {
+    if (!isColumnHidden(cellIndex)) {
+      return column.renderCell(data)
+    } else {
+      return
+    }
   }
   const wrappedRowRender = (row: T, $index: number) => {
     const store = props.store

--- a/packages/components/table/src/table-body/render-helper.ts
+++ b/packages/components/table/src/table-body/render-helper.ts
@@ -123,11 +123,7 @@ function useRender<T>(props: Partial<TableBodyProps<T>>) {
     )
   }
   const cellChildren = (cellIndex, column, data) => {
-    if (!isColumnHidden(cellIndex)) {
-      return column.renderCell(data)
-    } else {
-      return
-    }
+    return isColumnHidden(cellIndex) ? null : column.renderCell(data)
   }
   const wrappedRowRender = (row: T, $index: number) => {
     const store = props.store


### PR DESCRIPTION
fix issue #2953 
The reason for this issue is that when the `fixed `column function is implemented, the entire table is actually recreated, including the `popover `in the column. You hide the cells that you don’t want to display through `class="is-hidden"`, but Nothing prevents popover from creating multiple copies. When clicking the button and `visible=true`, three identical popovers (controlled by the same attribute--`visible`) are displayed.
This pr is mainly to no longer render the subtags of cells that are judged to be is-hidden

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
