### PR TITLE
fix(components): el-icon root element receives attributes twice

### DIFF
--- a/packages/components/icon/src/index.vue
+++ b/packages/components/icon/src/index.vue
@@ -9,6 +9,7 @@ import { defineComponent, computed } from 'vue'
 import type { CSSProperties } from 'vue'
 export default defineComponent({
   name: 'ElIcon',
+  inheritAttrs: false,
   props: {
     size: {
       type: Number,


### PR DESCRIPTION
- Fix attributes incorrectly inherited twice.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
