### PR TITLE
chore(project): avoid staging workflow running through fork

### DIFF
--- a/.github/workflows/staging-preview.yml
+++ b/.github/workflows/staging-preview.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'dev'
-      - 'fix/*'
 
 jobs:
   build:

--- a/.github/workflows/staging-preview.yml
+++ b/.github/workflows/staging-preview.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'element-plus' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/staging-preview.yml
+++ b/.github/workflows/staging-preview.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'dev'
+      - 'fix/*'
 
 jobs:
   build:


### PR DESCRIPTION
Avoid staging workflow running through fork

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
