### PR TITLE
fix(docs): notification documentation with types demo icon missing

### DIFF
--- a/docs/examples/notification/different-types.vue
+++ b/docs/examples/notification/different-types.vue
@@ -31,6 +31,7 @@ export default defineComponent({
       ElNotification({
         title: 'Info',
         message: 'This is an info message',
+        type: 'info',
       })
     }
 
@@ -38,6 +39,7 @@ export default defineComponent({
       ElNotification({
         title: 'Error',
         message: 'This is an error message',
+        type: 'error',
       })
     }
     return {


### PR DESCRIPTION
fix notification documentation with types demo icon missing

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
