### PR TITLE
fix(build): memoize-one not found issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "dayjs": "1.x",
     "lodash": "^4.17.21",
     "normalize-wheel": "^1.0.1",
-    "resize-observer-polyfill": "^1.5.1"
+    "resize-observer-polyfill": "^1.5.1",
+    "memoize-one": "^5.2.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",


### PR DESCRIPTION
- Add memoize-one as root package dependency to fix #3555

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
