### PR TITLE
chore(project): increase space size to 4GB for staging docs build

### DIFF
--- a/.github/workflows/staging-preview.yml
+++ b/.github/workflows/staging-preview.yml
@@ -48,6 +48,7 @@ jobs:
         run: pnpm docs:build
         env:
           DOC_ENV: staging
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Deploy staging website
         uses: JamesIves/github-pages-deploy-action@4.1.5


### PR DESCRIPTION
After testing, it is found that in Github Action, the default space size of Node.js 16 is limited to **2048MB**.

When a document is built, memory increases a lot (more than 2048MB) if there are five languages, but memory usage is relatively low when there is only one language, which is why preview can be built successfully but staging cannot.

So my solution is to increase the build memory limit of staging to 4096MB. However, due to the lack of a complete test environment, we need further experiments and follow-up.