### PR TITLE
fix: Table Attributes expand-row-keys has changed, but fold not work

### DIFF
--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -80,7 +80,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
         if (expandRowKeys.value) {
           return ifExpandAll || expandRowKeys.value.indexOf(key) !== -1
         } else {
-          return !!(ifExpandAll || (oldValue && oldValue.expanded))
+          return !!(ifExpandAll || oldValue?.expanded)
         }
       }
       // 合并 expanded 与 display，确保数据刷新后，状态不变

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -77,10 +77,11 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
       const oldTreeData = unref(treeData)
       const rootLazyRowKeys = []
       const getExpanded = (oldValue, key) => {
-        const included =
-          ifExpandAll ||
-          (expandRowKeys.value && expandRowKeys.value.indexOf(key) !== -1)
-        return !!((oldValue && oldValue.expanded) || included)
+        if (expandRowKeys.value) {
+          return ifExpandAll || expandRowKeys.value.indexOf(key) !== -1
+        } else {
+          return !!(ifExpandAll || (oldValue && oldValue.expanded))
+        }
       }
       // 合并 expanded 与 display，确保数据刷新后，状态不变
       keys.forEach((key) => {

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -78,7 +78,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
       const rootLazyRowKeys = []
       const getExpanded = (oldValue, key) => {
         if (expandRowKeys.value) {
-          return ifExpandAll || expandRowKeys.value.indexOf(key) !== -1
+          return ifExpandAll || expandRowKeys.value.includes(key)
         } else {
           return !!(ifExpandAll || oldValue?.expanded)
         }


### PR DESCRIPTION
fix: #3653 
My opinion is that if the user sets `expand-row-keys`,  it should overridde `oldValue.expanded`

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
