### PR TITLE
fix(docs): fix link gitee sites confirm keep appearing

### DIFF
--- a/docs/.vitepress/vitepress/components/vp-app.vue
+++ b/docs/.vitepress/vitepress/components/vp-app.vue
@@ -55,7 +55,7 @@ onMounted(async () => {
   )
 
   if (lang.value === 'zh-CN') {
-    if (location.href.startsWith('https://element-plus.gitee.io')) return
+    if (location.host === 'element-plus.gitee.io') return
     try {
       await ElMessageBox.confirm(
         '建议大陆用户访问部署在国内的站点，是否跳转？',

--- a/docs/.vitepress/vitepress/components/vp-app.vue
+++ b/docs/.vitepress/vitepress/components/vp-app.vue
@@ -55,6 +55,7 @@ onMounted(async () => {
   )
 
   if (lang.value === 'zh-CN') {
+    if (location.href.startsWith('https://element-plus.gitee.io')) return
     try {
       await ElMessageBox.confirm(
         '建议大陆用户访问部署在国内的站点，是否跳转？',


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

When I  visit the site https://element-plus.org/， the confirm link to domestic site appear. After I click link, the confirm will appear. Such cycle...