### PR TITLE
fix  sideEffects at package.json

### DIFF
--- a/packages/element-plus/package.json
+++ b/packages/element-plus/package.json
@@ -20,7 +20,9 @@
   "sideEffects": [
     "dist/*",
     "theme-chalk/*.css",
-    "theme-chalk/src/*.scss"
+    "theme-chalk/src/*.scss",
+    "es/components/*/style/*",
+    "lib/components/*/style/*"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi,
Because webpack build on production mode will tree shaking css file. For example: 
```javascript
// This will not import on production mode.
import 'element-plus/lib/components/button/style/css'
```
And plugin  [unplugin-element-plus](https://element-plus.org/en-US/guide/quickstart.html#manually-import) also not work.

I fixed sideEffects at package.json, then user can manually import css file, like:

```javascript
import { ElButton } from 'element-plus'
import 'element-plus/lib/components/button/style/css'
```
please have a look  😃  . 

===============

UPDATED BY Jeremy

- Closes #3712 


Please make sure these boxes are checked before submitting your PR, thank you!
- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
