### PR TITLE
fix: table lazy rows can't expand at the first time

### DIFF
--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -77,11 +77,10 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
       const oldTreeData = unref(treeData)
       const rootLazyRowKeys = []
       const getExpanded = (oldValue, key) => {
-        if (expandRowKeys.value) {
-          return ifExpandAll || expandRowKeys.value.includes(key)
-        } else {
-          return !!(ifExpandAll || oldValue?.expanded)
-        }
+        const included =
+          ifExpandAll ||
+          (expandRowKeys.value && expandRowKeys.value.indexOf(key) !== -1)
+        return !!((oldValue && oldValue.expanded) || included)
       }
       // 合并 expanded 与 display，确保数据刷新后，状态不变
       keys.forEach((key) => {

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -67,6 +67,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
   }
 
   const updateTreeData = (
+    ifChangeExpandRowKeys = false,
     ifExpandAll = instance.store?.states.defaultExpandAll.value
   ) => {
     const nested = normalizedData.value
@@ -77,10 +78,18 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
       const oldTreeData = unref(treeData)
       const rootLazyRowKeys = []
       const getExpanded = (oldValue, key) => {
-        const included =
-          ifExpandAll ||
-          (expandRowKeys.value && expandRowKeys.value.indexOf(key) !== -1)
-        return !!((oldValue && oldValue.expanded) || included)
+        if (ifChangeExpandRowKeys) {
+          if (expandRowKeys.value) {
+            return ifExpandAll || expandRowKeys.value.includes(key)
+          } else {
+            return !!(ifExpandAll || oldValue?.expanded)
+          }
+        } else {
+          const included =
+            ifExpandAll ||
+            (expandRowKeys.value && expandRowKeys.value.indexOf(key) !== -1)
+          return !!((oldValue && oldValue.expanded) || included)
+        }
       }
       // 合并 expanded 与 display，确保数据刷新后，状态不变
       keys.forEach((key) => {
@@ -124,6 +133,13 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     treeData.value = newTreeData
     instance.store?.updateTableScrollY()
   }
+
+  watch(
+    () => expandRowKeys.value,
+    () => {
+      updateTreeData(true)
+    }
+  )
 
   watch(
     () => normalizedData.value,

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -87,7 +87,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
         } else {
           const included =
             ifExpandAll ||
-            (expandRowKeys.value && expandRowKeys.value.indexOf(key) !== -1)
+            (expandRowKeys.value && expandRowKeys.value.includes(key))
           return !!((oldValue && oldValue.expanded) || included)
         }
       }

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -88,7 +88,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
           const included =
             ifExpandAll ||
             (expandRowKeys.value && expandRowKeys.value.includes(key))
-          return !!((oldValue && oldValue.expanded) || included)
+          return !!(oldValue?.expanded || included)
         }
       }
       // 合并 expanded 与 display，确保数据刷新后，状态不变


### PR DESCRIPTION
fix: #3653 
fix: #3857 
出现这个问题主要是lazy加载之后会更新一次表格视图，这次更新根据`expandRowKeys`行展开，导致之前点击的lazy行未被展开。
此pr添加针对`expandRowKeys`改变的单独监视，在非`expandRowKeys`导致的`updateTreeData()`时仍以原先的逻辑进行判断

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
