### PR TITLE
chore: fix the source value error in web-types

### DIFF
--- a/build/helper.ts
+++ b/build/helper.ts
@@ -20,9 +20,11 @@ const reDocUrl: InstallOptions['reDocUrl'] = (fileName, header) => {
 }
 
 const reWebTypesSource: InstallOptions['reWebTypesSource'] = (title) => {
-  const symbol = `El${title.replace(/-/g, ' ').replace(/^\w|\s+\w/g, (item) => {
-    return item.trim().toUpperCase()
-  })}`
+  const symbol = `El${title
+    .replaceAll(/-/g, ' ')
+    .replaceAll(/^\w|\s+\w/g, (item) => {
+      return item.trim().toUpperCase()
+    })}`
 
   return { symbol }
 }

--- a/build/helper.ts
+++ b/build/helper.ts
@@ -20,7 +20,7 @@ const reDocUrl: InstallOptions['reDocUrl'] = (fileName, header) => {
 }
 
 const reWebTypesSource: InstallOptions['reWebTypesSource'] = (title) => {
-  const symbol = `El${title.replace(/-/, ' ').replace(/^\w|\s+\w/g, (item) => {
+  const symbol = `El${title.replace(/-/g, ' ').replace(/^\w|\s+\w/g, (item) => {
     return item.trim().toUpperCase()
   })}`
 

--- a/build/helper.ts
+++ b/build/helper.ts
@@ -19,6 +19,14 @@ const reDocUrl: InstallOptions['reDocUrl'] = (fileName, header) => {
   return docs + fileName + (_header ? `#${_header}` : '')
 }
 
+const reWebTypesSource: InstallOptions['reWebTypesSource'] = (title) => {
+  const symbol = `EL${title.replace(/-/, ' ').replace(/^\w|\s+\w/g, (item) => {
+    return item.trim().toUpperCase()
+  })}`
+
+  return { symbol }
+}
+
 const reAttribute: InstallOptions['reAttribute'] = (value, key) => {
   const _value = value.match(/^\*\*(.*)\*\*$/)
   const str = _value ? _value[1] : value
@@ -69,6 +77,7 @@ export const buildHelper: TaskFunction = (done) => {
     outDir: epOutput,
     reComponentName,
     reDocUrl,
+    reWebTypesSource,
     reAttribute,
     props: 'Attributes',
     propsName: 'Attribute',

--- a/build/helper.ts
+++ b/build/helper.ts
@@ -20,7 +20,7 @@ const reDocUrl: InstallOptions['reDocUrl'] = (fileName, header) => {
 }
 
 const reWebTypesSource: InstallOptions['reWebTypesSource'] = (title) => {
-  const symbol = `EL${title.replace(/-/, ' ').replace(/^\w|\s+\w/g, (item) => {
+  const symbol = `El${title.replace(/-/, ' ').replace(/^\w|\s+\w/g, (item) => {
     return item.trim().toUpperCase()
   })}`
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix the source value error in web-types, ensure that in theory you can jump to the type definition files by the components name in the webstorm. 

```diff
- "source": {"symbol": "Affix"},
+ "source": {"symbol": "ElAffix"},
```