### PR TITLE
docs: add scoped option in example file

### DIFF
--- a/docs/examples/card/simple.vue
+++ b/docs/examples/card/simple.vue
@@ -3,7 +3,7 @@
     <div v-for="o in 4" :key="o" class="text item">{{ 'List item ' + o }}</div>
   </el-card>
 </template>
-<style>
+<style scoped>
 .text {
   font-size: 14px;
 }

--- a/docs/examples/tooltip/basic.vue
+++ b/docs/examples/tooltip/basic.vue
@@ -108,7 +108,7 @@
   </div>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .box {
   width: 400px;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30256102/135409833-7bdf6fcc-b48d-42e4-a18a-060490f2b2fc.png)

Find doc site some css problem.
