### PR TITLE
docs: fix theme-chalk path

### DIFF
--- a/docs/en-US/component/layout.md
+++ b/docs/en-US/component/layout.md
@@ -79,7 +79,7 @@ certain conditions. These classes can be added to any DOM elements or custom com
 You need to import the following CSS file to use these classes:
 
 ```js
-import 'element-plus/lib/theme-chalk/display.css'
+import 'element-plus/theme-chalk/display.css'
 ```
 
 The classes are:


### PR DESCRIPTION
我这半吊子英文，自己都看不懂，基于断点的隐藏类引用组件(路径)是错的，把/lib去掉就好了。

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
