### PR TITLE
fix(components): [el-table] BUG 修复：设置固定列时窗口宽度变大滚动条消失的事件循环中固定列高度没有更新

### DIFF
--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -96,10 +96,10 @@ function useStyle<T>(
   })
 
   const doLayout = () => {
+    layout.updateColumnsWidth()
     if (shouldUpdateHeight.value) {
       layout.updateElsHeight()
     }
-    layout.updateColumnsWidth()
     syncPostion()
   }
   onMounted(async () => {


### PR DESCRIPTION
问题描述：使用 `el-table` 时，用 `fixed` 属性将列固定后，缩小窗口宽度使滚动条出现后，再放大窗口宽度使滚动条消失的瞬间（操作1：直接最大化窗口，操作2：逐像素拖动），`table` 组件的高度恢复，但是固定列的高度没有恢复（高度少 17px）。
问题定位：窗口 `resize` 过程中，`table` 组件 `style-helper` 中的 `doLayout` 方法执行存在问题，`layout.updateElsHeight()` 方法负责固定列高度的计算，固定列高度又受控于 `scrollX` 的状态，`layout.updateColumnsWidth()` 方法中会去更新 `scrollX` 的状态；滚动条消失的瞬间 `scrollX` 状态 为 `true`，先执行 `layout.updateElsHeight()` 方法固定列高度为 `tableHeight - gutterWidth`，再执行 `layout.updateColumnsWidth()` 方法更新 `scrollX` 状态为 `false`，导致页面出现固定列高度比列表高度少 17px 的问题。
解决方案：先执行 `layout.updateColumnsWidth()` 方法更新 `scrollX` 状态，再执行 `layout.updateElsHeight()` 方法计算相关高度。

![QQ截图20211009164928](https://user-images.githubusercontent.com/8801357/136651444-2e9dc6fb-3c3d-453d-9b86-bbe3f802109a.png)

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
