### PR TITLE
docs: fix translation dropdown error

### DIFF
--- a/docs/.vitepress/vitepress/composables/translation.ts
+++ b/docs/.vitepress/vitepress/composables/translation.ts
@@ -29,6 +29,11 @@ export const useTranslation = () => {
     const langsCopy = langs.slice(0)
     langsCopy.splice(langsCopy.indexOf(currentLang), 1)
 
+    // if current language is not zh-CN, then zh-CN needs to be moved to the head.
+    if (currentLang !== 'zh-CN') {
+      langsCopy.splice(langsCopy.indexOf('zh-CN'), 1)
+    }
+
     return currentLang === 'zh-CN' ? langsCopy : ['zh-CN'].concat(langsCopy)
   })
 


### PR DESCRIPTION
- Fix translation dropdown showing `zh-CN` for twice

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
