### PR TITLE
fix: input suffix icon center by flex

### DIFF
--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -166,7 +166,7 @@
 
   @include m(feedback) {
     .#{$namespace}-input__validateIcon {
-      display: inline-block;
+      display: inline-flex;
     }
   }
 }

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -204,17 +204,10 @@
   @include e(icon) {
     width: 25px;
     height: inherit;
-    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     transition: all var(--el-transition-duration);
-    vertical-align: middle;
-
-    &:after {
-      content: '';
-      height: 100%;
-      width: 0;
-      display: inline-block;
-      vertical-align: middle;
-    }
   }
 
   @include e(validateIcon) {


### PR DESCRIPTION
Use `display: flex` fix input suffix icon center

Before:

![image](https://user-images.githubusercontent.com/25154432/139667646-94b1c0b9-c45a-443e-942c-0f83e73d734f.png)

After:

![image](https://user-images.githubusercontent.com/25154432/139667666-1a0052ad-4b89-4168-802e-db5bf1ef800c.png)

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
