### PR TITLE
feat(docs): add support for copying svg content

### DIFF
--- a/docs/.vitepress/vitepress/components/globals/icons.vue
+++ b/docs/.vitepress/vitepress/components/globals/icons.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { hyphenate } from '@vue/shared'
 import clipboardCopy from 'clipboard-copy'
 import { ElMessage } from 'element-plus'
@@ -9,14 +9,11 @@ import localeData from '../../../i18n/component/icons.json'
 
 const lang = useLang()
 const locale = computed(() => localeData[lang.value])
+const copyIcon = ref(true)
 
-const copySvgIcon = async (svg) => {
+const copyContent = async (content) => {
   try {
-    await clipboardCopy(
-      `<el-icon>
-        <${hyphenate(svg)} />
-      </el-icon>`
-    )
+    await clipboardCopy(content)
 
     ElMessage({
       showClose: true,
@@ -31,15 +28,33 @@ const copySvgIcon = async (svg) => {
     })
   }
 }
+
+const copySvgIcon = async (name, refs) => {
+  if (copyIcon.value) {
+    await copyContent(`<el-icon><${hyphenate(name)} /></el-icon>`)
+  } else {
+    const content = refs[name].querySelector('svg')?.outerHTML ?? ''
+    await copyContent(content)
+  }
+}
 </script>
 
 <template>
+  <div style="text-align: right">
+    <el-switch
+      v-model="copyIcon"
+      active-text="Copy Icon Code"
+      inactive-text="Copy Svg Content"
+    >
+    </el-switch>
+  </div>
   <ul class="demo-icon-list">
     <li
       v-for="component in Icons"
       :key="component"
+      :ref="component.name"
       class="icon-item"
-      @click="copySvgIcon(component.name)"
+      @click="copySvgIcon(component.name, $refs)"
     >
       <span class="demo-svg-icon">
         <ElIcon :size="20">


### PR DESCRIPTION
You can choose to copy the icon code or svg content.

If you select the **icon code**, you can get:

```vue
<el-icon><arrow-left /></el-icon>
```

If you select the **svg content**, you can get:
```vue
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" data-v-9c92db9c=""><path fill="currentColor" d="M609.408 149.376 277.76 489.6a32 32 0 0 0 0 44.672l331.648 340.352a29.12 29.12 0 0 0 41.728 0 30.592 30.592 0 0 0 0-42.752L339.264 511.936l311.872-319.872a30.592 30.592 0 0 0 0-42.688 29.12 29.12 0 0 0-41.728 0z"></path></svg>
```

Preview: https://preview-4169-element-plus.surge.sh/en-US/component/icon.html#svg-icons-collection-available-1-0-2-beta-66

![image](https://user-images.githubusercontent.com/29560987/139785825-8f17d7ce-09b8-45b8-bd9f-bf856d54f6e8.png)





Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
