### PR TITLE
fix(style): remove chinese comments in checkbox

### DIFF
--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -25,3 +25,11 @@ pnpm link --global element-plus
 ```
 
 > More info see [pnpm link](https://pnpm.io/cli/link).
+
+## Theme
+
+We should not write Chinese comments in scss files.
+
+It will generate warning `@charset "UTF-8";` in the header of css file when built with vite.
+
+> More info see [#3219](https://github.com/element-plus/element-plus/issues/3219).

--- a/packages/theme-chalk/src/checkbox.scss
+++ b/packages/theme-chalk/src/checkbox.scss
@@ -180,7 +180,7 @@ $checkbox-bordered-input-width: map.merge(
       }
     }
     @include when(focus) {
-      /*focus时 视觉上区分*/
+      // Visually distinguish when focus
       .#{$namespace}-checkbox__inner {
         border-color: var(--el-checkbox-input-border-color-hover);
       }


### PR DESCRIPTION
We should not write Chinese comments in scss files.

More info see #3219.

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
