### PR TITLE
fix(build): fix imports in mjs files

### DIFF
--- a/packages/components/autocomplete/src/index.vue
+++ b/packages/components/autocomplete/src/index.vue
@@ -100,7 +100,7 @@ import {
   watch,
 } from 'vue'
 import { NOOP } from '@vue/shared'
-import debounce from 'lodash/debounce'
+import debounce from 'lodash/debounce.js'
 import { useAttrs } from '@element-plus/hooks'
 import { ClickOutside } from '@element-plus/directives'
 import { generateId, isArray } from '@element-plus/utils/util'

--- a/packages/components/calendar/src/date-table.vue
+++ b/packages/components/calendar/src/date-table.vue
@@ -39,7 +39,7 @@
 <script lang="ts">
 import { computed, defineComponent, ref } from 'vue'
 import dayjs from 'dayjs'
-import localeData from 'dayjs/plugin/localeData'
+import localeData from 'dayjs/plugin/localeData.js'
 import { useLocaleInject } from '@element-plus/hooks'
 import { rangeArr } from '@element-plus/components/time-picker'
 import type { Dayjs } from 'dayjs'

--- a/packages/components/carousel/src/main.vue
+++ b/packages/components/carousel/src/main.vue
@@ -74,7 +74,7 @@ import {
   watch,
   nextTick,
 } from 'vue'
-import throttle from 'lodash/throttle'
+import throttle from 'lodash/throttle.js'
 import {
   addResizeListener,
   removeResizeListener,

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -25,7 +25,7 @@ import {
   ref,
   watch,
 } from 'vue'
-import isEqual from 'lodash/isEqual'
+import isEqual from 'lodash/isEqual.js'
 import { EVENT_CODE, focusNode, getSibling } from '@element-plus/utils/aria'
 import { UPDATE_MODEL_EVENT, CHANGE_EVENT } from '@element-plus/utils/constants'
 import isServer from '@element-plus/utils/isServer'

--- a/packages/components/cascader-panel/src/store.ts
+++ b/packages/components/cascader-panel/src/store.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash/isEqual'
+import isEqual from 'lodash/isEqual.js'
 import Node from './node'
 
 import type { Nullable } from '@element-plus/utils/types'

--- a/packages/components/cascader/src/index.vue
+++ b/packages/components/cascader/src/index.vue
@@ -156,7 +156,7 @@ import {
   watch,
 } from 'vue'
 import { isPromise } from '@vue/shared'
-import debounce from 'lodash/debounce'
+import debounce from 'lodash/debounce.js'
 
 import ElCascaderPanel, {
   CommonProps,

--- a/packages/components/color-picker/src/index.vue
+++ b/packages/components/color-picker/src/index.vue
@@ -106,7 +106,7 @@ import {
   ref,
   watch,
 } from 'vue'
-import debounce from 'lodash/debounce'
+import debounce from 'lodash/debounce.js'
 import ElButton from '@element-plus/components/button'
 import ElIcon from '@element-plus/components/icon'
 import { ClickOutside } from '@element-plus/directives'

--- a/packages/components/date-picker/src/date-picker.ts
+++ b/packages/components/date-picker/src/date-picker.ts
@@ -1,13 +1,13 @@
 import { defineComponent, h, provide, ref } from 'vue'
 import dayjs from 'dayjs'
-import customParseFormat from 'dayjs/plugin/customParseFormat'
-import advancedFormat from 'dayjs/plugin/advancedFormat'
-import localeData from 'dayjs/plugin/localeData'
-import weekOfYear from 'dayjs/plugin/weekOfYear'
-import weekYear from 'dayjs/plugin/weekYear'
-import dayOfYear from 'dayjs/plugin/dayOfYear'
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
+import customParseFormat from 'dayjs/plugin/customParseFormat.js'
+import advancedFormat from 'dayjs/plugin/advancedFormat.js'
+import localeData from 'dayjs/plugin/localeData.js'
+import weekOfYear from 'dayjs/plugin/weekOfYear.js'
+import weekYear from 'dayjs/plugin/weekYear.js'
+import dayOfYear from 'dayjs/plugin/dayOfYear.js'
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter.js'
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore.js'
 import {
   CommonPicker,
   DEFAULT_FORMATS_DATE,

--- a/packages/components/infinite-scroll/src/index.ts
+++ b/packages/components/infinite-scroll/src/index.ts
@@ -1,6 +1,6 @@
 import { nextTick } from 'vue'
 import { isFunction } from '@vue/shared'
-import throttle from 'lodash/throttle'
+import throttle from 'lodash/throttle.js'
 import {
   getScrollContainer,
   getOffsetTopDistance,

--- a/packages/components/pagination/src/components/sizes.vue
+++ b/packages/components/pagination/src/components/sizes.vue
@@ -19,7 +19,7 @@
 
 <script lang="ts">
 import { defineComponent, watch, computed, ref } from 'vue'
-import isEqual from 'lodash/isEqual'
+import isEqual from 'lodash/isEqual.js'
 import { ElSelect, ElOption } from '@element-plus/components/select'
 import { useLocaleInject } from '@element-plus/hooks'
 import { buildProps, definePropType, mutable } from '@element-plus/utils/props'

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -9,8 +9,8 @@ import {
   onBeforeMount,
 } from 'vue'
 import { isArray, isFunction, isObject } from '@vue/shared'
-import isEqual from 'lodash/isEqual'
-import lodashDebounce from 'lodash/debounce'
+import isEqual from 'lodash/isEqual.js'
+import lodashDebounce from 'lodash/debounce.js'
 import { elFormKey, elFormItemKey } from '@element-plus/tokens'
 import { useLocaleInject } from '@element-plus/hooks'
 import { UPDATE_MODEL_EVENT, CHANGE_EVENT } from '@element-plus/utils/constants'

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -9,8 +9,8 @@ import {
   triggerRef,
 } from 'vue'
 import { isObject, toRawType } from '@vue/shared'
-import lodashDebounce from 'lodash/debounce'
-import isEqual from 'lodash/isEqual'
+import lodashDebounce from 'lodash/debounce.js'
+import isEqual from 'lodash/isEqual.js'
 import { UPDATE_MODEL_EVENT, CHANGE_EVENT } from '@element-plus/utils/constants'
 import { EVENT_CODE } from '@element-plus/utils/aria'
 import { useLocaleInject } from '@element-plus/hooks'

--- a/packages/components/slider/src/useSliderButton.ts
+++ b/packages/components/slider/src/useSliderButton.ts
@@ -1,5 +1,5 @@
 import { computed, inject, nextTick, ref, watch } from 'vue'
-import debounce from 'lodash/debounce'
+import debounce from 'lodash/debounce.js'
 import { UPDATE_MODEL_EVENT } from '@element-plus/utils/constants'
 import { off, on } from '@element-plus/utils/dom'
 

--- a/packages/components/table/src/store/helper.ts
+++ b/packages/components/table/src/store/helper.ts
@@ -1,5 +1,5 @@
 import { watch } from 'vue'
-import debounce from 'lodash/debounce'
+import debounce from 'lodash/debounce.js'
 import useStore from '.'
 
 import type { Store } from '.'

--- a/packages/components/table/src/table-body/events-helper.ts
+++ b/packages/components/table/src/table-body/events-helper.ts
@@ -1,5 +1,5 @@
 import { getCurrentInstance, ref, h } from 'vue'
-import debounce from 'lodash/debounce'
+import debounce from 'lodash/debounce.js'
 import { getStyle, hasClass } from '@element-plus/utils/dom'
 import { createTablePopper, getCell, getColumnByCell } from '../util'
 

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -258,7 +258,7 @@
 
 <script lang="ts">
 import { defineComponent, getCurrentInstance, computed } from 'vue'
-import debounce from 'lodash/debounce'
+import debounce from 'lodash/debounce.js'
 import { Mousewheel } from '@element-plus/directives'
 import { useLocaleInject } from '@element-plus/hooks'
 import { createStore } from './store/helper'

--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -8,7 +8,7 @@ import {
   unref,
   nextTick,
 } from 'vue'
-import throttle from 'lodash/throttle'
+import throttle from 'lodash/throttle.js'
 import {
   addResizeListener,
   removeResizeListener,

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -145,7 +145,7 @@ import {
   provide,
 } from 'vue'
 import dayjs from 'dayjs'
-import isEqual from 'lodash/isEqual'
+import isEqual from 'lodash/isEqual.js'
 import { useLocaleInject } from '@element-plus/hooks'
 import { ClickOutside } from '@element-plus/directives'
 import { elFormKey, elFormItemKey } from '@element-plus/tokens'

--- a/packages/components/time-picker/src/time-picker-com/basic-time-spinner.vue
+++ b/packages/components/time-picker/src/time-picker-com/basic-time-spinner.vue
@@ -76,7 +76,7 @@
 </template>
 <script lang="ts">
 import { defineComponent, ref, nextTick, computed, onMounted, watch } from 'vue'
-import debounce from 'lodash/debounce'
+import debounce from 'lodash/debounce.js'
 import { RepeatClick } from '@element-plus/directives'
 import ElScrollbar from '@element-plus/components/scrollbar'
 import ElIcon from '@element-plus/components/icon'

--- a/packages/components/time-picker/src/time-picker-com/panel-time-range.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-range.vue
@@ -73,7 +73,7 @@
 <script lang="ts">
 import { defineComponent, ref, computed, inject } from 'vue'
 import dayjs from 'dayjs'
-import union from 'lodash/union'
+import union from 'lodash/union.js'
 import { useLocaleInject } from '@element-plus/hooks'
 import { EVENT_CODE } from '@element-plus/utils/aria'
 import TimeSpinner from './basic-time-spinner.vue'

--- a/packages/components/time-picker/src/time-picker.ts
+++ b/packages/components/time-picker/src/time-picker.ts
@@ -1,6 +1,6 @@
 import { defineComponent, h, ref, provide } from 'vue'
 import dayjs from 'dayjs'
-import customParseFormat from 'dayjs/plugin/customParseFormat'
+import customParseFormat from 'dayjs/plugin/customParseFormat.js'
 import { DEFAULT_FORMATS_TIME } from './common/constant'
 import Picker from './common/picker.vue'
 import TimePickPanel from './time-picker-com/panel-time-pick.vue'

--- a/packages/components/upload/src/useHandlers.ts
+++ b/packages/components/upload/src/useHandlers.ts
@@ -1,6 +1,6 @@
 import { ref, watch } from 'vue'
 import { NOOP } from '@vue/shared'
-import cloneDeep from 'lodash/cloneDeep'
+import cloneDeep from 'lodash/cloneDeep.js'
 
 // Inline types
 import type {

--- a/packages/components/virtual-list/src/hooks/use-cache.ts
+++ b/packages/components/virtual-list/src/hooks/use-cache.ts
@@ -1,5 +1,5 @@
 import { computed, getCurrentInstance } from 'vue'
-import memo from 'lodash/memoize'
+import memo from 'lodash/memoize.js'
 import memoOne from 'memoize-one'
 
 import type { VirtualizedProps } from '../props'

--- a/packages/hooks/use-attrs/index.ts
+++ b/packages/hooks/use-attrs/index.ts
@@ -1,5 +1,5 @@
 import { getCurrentInstance, computed } from 'vue'
-import fromPairs from 'lodash/fromPairs'
+import fromPairs from 'lodash/fromPairs.js'
 import { debugWarn } from '@element-plus/utils/error'
 
 import type { ComputedRef } from 'vue'

--- a/packages/utils/props.ts
+++ b/packages/utils/props.ts
@@ -1,6 +1,6 @@
 import { warn } from 'vue'
 import { isObject } from '@vue/shared'
-import fromPairs from 'lodash/fromPairs'
+import fromPairs from 'lodash/fromPairs.js'
 import type { ExtractPropTypes, PropType } from '@vue/runtime-core'
 import type { Mutable } from './types'
 

--- a/packages/utils/util.ts
+++ b/packages/utils/util.ts
@@ -12,7 +12,7 @@ import {
   looseEqual,
   toRawType,
 } from '@vue/shared'
-import isEqualWith from 'lodash/isEqualWith'
+import isEqualWith from 'lodash/isEqualWith.js'
 import isServer from './isServer'
 import { debugWarn, throwError } from './error'
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## description

When import Element-plus, there are some errors about mjs files imports in webpack 5, because some import paths miss extension name.
![image](https://user-images.githubusercontent.com/33826386/141404001-b7bcbe2c-8f14-4f13-b30e-540811f535f7.png)

## environment
- webpack 5.36.2