### PR TITLE
fix(theme-chalk): Added !optional to @extend

### DIFF
--- a/packages/theme-chalk/src/image.scss
+++ b/packages/theme-chalk/src/image.scss
@@ -12,17 +12,17 @@
   overflow: hidden;
 
   @include e(inner) {
-    @extend %size;
+    @extend %size !optional;
     vertical-align: top;
   }
 
   @include e(placeholder) {
-    @extend %size;
+    @extend %size !optional;
     background: $background-color-base;
   }
 
   @include e(error) {
-    @extend %size;
+    @extend %size !optional;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/packages/theme-chalk/src/mixins/mixins.scss
+++ b/packages/theme-chalk/src/mixins/mixins.scss
@@ -171,7 +171,7 @@
 }
 
 @mixin extend-rule($name) {
-  @extend #{'%shared-' + $name};
+  @extend #{'%shared-' + $name} !optional;
 }
 
 @mixin share-rule($name) {


### PR DESCRIPTION
Added ``!optional`` to ``@extend`` To prevent this error of sass 

![Sass Error](https://i.imgur.com/H26Y88f.png)
Recommended by sass official documentation https://sass-lang.com/documentation/at-rules/extend#mandatory-and-optional-extends

Closes #4303
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
