### PR TITLE
fix: cascader-empty-slot-is-invalid #4432

### DIFF
--- a/packages/components/cascader-panel/src/menu.vue
+++ b/packages/components/cascader-panel/src/menu.vue
@@ -1,5 +1,6 @@
 <template>
   <el-scrollbar
+    v-show="!isEmpty"
     :key="menuId"
     tag="ul"
     role="menu"
@@ -16,11 +17,8 @@
       :menu-id="menuId"
       @expand="handleExpand"
     />
-    <div v-if="isEmpty" class="el-cascader-menu__empty-text">
-      {{ t('el.cascader.noData') }}
-    </div>
     <svg
-      v-else-if="panel?.isHoverMenu"
+      v-if="panel?.isHoverMenu"
       ref="hoverZone"
       class="el-cascader-menu__hover-zone"
     ></svg>

--- a/packages/components/cascader/src/index.vue
+++ b/packages/components/cascader/src/index.vue
@@ -111,10 +111,11 @@
         @close="togglePopperVisible(false)"
       />
       <el-scrollbar
-        v-if="filterable"
-        v-show="filtering"
+        v-if="filterable || !options.length"
+        v-show="filtering || !options.length"
         ref="suggestionPanel"
         tag="ul"
+        role="menu"
         class="el-cascader__suggestion-panel"
         view-class="el-cascader__suggestion-list"
         @keydown="handleSuggestionKeyDown"


### PR DESCRIPTION
I'm here to fix it Cascader's empty slot is invalid #4432 

![image](https://user-images.githubusercontent.com/39750199/142232419-c38c09d2-b32e-42c4-85fd-486d43edbd6f.png)

![image](https://user-images.githubusercontent.com/39750199/142232454-c3457ddf-cee8-4afd-937c-ec2e60a9c807.png)
