### PR TITLE
docs: button-group add type attribute

### DIFF
--- a/docs/en-US/component/button.md
+++ b/docs/en-US/component/button.md
@@ -111,9 +111,10 @@ button/custom
 
 ## Button-Group Attributes
 
-| Attribute | Description                                      | Type   | Accepted Values       | Default |
-| --------- | ------------------------------------------------ | ------ | --------------------- | ------- |
-| size      | control the size of buttons in this button-group | string | medium / small / mini | —       |
+| Attribute | Description                                      | Type   | Accepted Values             | Default |
+| --------- | ------------------------------------------------ | ------ | --------------------------- | ------- |
+| size      | control the size of buttons in this button-group | string | medium / small / mini       | —       |
+| type      | control the type of buttons in this button-group | string | primary / success / warning | —       |
 
 ## Button-Group Slots
 


### PR DESCRIPTION
button-group have type Attributes but docs not have

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
