### PR TITLE
fix(locale): improve Indonesian (Bahasa) translations and fix typo

### DIFF
--- a/docs/examples/button/custom.vue
+++ b/docs/examples/button/custom.vue
@@ -1,6 +1,6 @@
 <template>
   <el-row>
-    <el-button color="#626aef" style="color: white">Cutsom</el-button>
-    <el-button color="#626aef" plain>Cutsom</el-button>
+    <el-button color="#626aef" style="color: white">Custom</el-button>
+    <el-button color="#626aef" plain>Custom</el-button>
   </el-row>
 </template>

--- a/packages/locale/lang/id.ts
+++ b/packages/locale/lang/id.ts
@@ -34,7 +34,7 @@ export default {
       month10: 'Oktober',
       month11: 'November',
       month12: 'Desember',
-      // week: 'minggu',
+      week: 'Minggu',
       weeks: {
         sun: 'Min',
         mon: 'Sen',
@@ -73,9 +73,11 @@ export default {
     },
     pagination: {
       goto: 'Pergi ke',
-      pagesize: '/laman',
+      pagesize: '/halaman',
       total: 'Total {total}',
       pageClassifier: '',
+      deprecationWarning:
+        'Penggunaan yang tidak akan digunakan lagi terdeteksi, silakan lihat dokumentasi el-pagination untuk lebih jelasnya',
     },
     messagebox: {
       title: 'Pesan',
@@ -94,7 +96,7 @@ export default {
       confirmFilter: 'Konfirmasi',
       resetFilter: 'Atur ulang',
       clearFilter: 'Semua',
-      sumText: 'Jml',
+      sumText: 'Jumlah',
     },
     tree: {
       emptyText: 'Tidak ada data',
@@ -102,9 +104,9 @@ export default {
     transfer: {
       noMatch: 'Tidak ada data yg cocok',
       noData: 'Tidak ada data',
-      titles: ['Senarai 1', 'Senarai 2'],
+      titles: ['Daftar 1', 'Daftar 2'],
       filterPlaceholder: 'Masukan kata kunci',
-      noCheckedFormat: '{total} butir',
+      noCheckedFormat: '{total} item',
       hasCheckedFormat: '{checked}/{total} terpilih',
     },
     image: {


### PR DESCRIPTION
I speak with Indonesia (Bahasa) as native language, this pull request contain some improvement on that language
In this commit I fix some typo for example button documentation

These boxes are checked before submitting current PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
