### PR TITLE
perf(components): avoid unnecessary tab switch rerender

### DIFF
--- a/packages/components/tabs/src/tab-pane.vue
+++ b/packages/components/tabs/src/tab-pane.vue
@@ -22,6 +22,7 @@ import {
   markRaw,
   reactive,
 } from 'vue'
+import { eagerComputed } from '@vueuse/core'
 import { tabsRootContextKey } from '@element-plus/tokens'
 import { throwError } from '@element-plus/utils/error'
 import { tabPaneProps } from './tab-pane'
@@ -39,11 +40,11 @@ export default defineComponent({
     const index = ref<string>()
     const loaded = ref(false)
     const isClosable = computed(() => props.closable || tabsRoot.props.closable)
-    const active = computed(
+    const active = eagerComputed(
       () => tabsRoot.currentName.value === (props.name || index.value)
     )
     const paneName = computed(() => props.name || index.value)
-    const shouldBeRender = computed(
+    const shouldBeRender = eagerComputed(
       () => !props.lazy || loaded.value || active.value
     )
 


### PR DESCRIPTION
Tab Pane Components depends on `active` computed property and `active` computed property depends on `tabsRoot.currentName`. `tabsRoot.currentName` changes whenever user clicks the new tab pane.

By default, computed property is lazily evaluated, therefore all the tab panes have to be rerendered since the dep is dirty, it will cause performance issue if the size of tab panes is large.

The fix is using eagerComupted function from vueuse, as a result, only 2 tab panes have to be rerendered.

In our user case, we have 14 tab panes and in each tab pane we have a table with multiple columns. Before this change, the switch costs 2000ms. After this change (using v-memo with v-for at the same time), the switch only costs 200ms