### PR TITLE
fix(style): input inner padding right when has suffix

### DIFF
--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       'vue',
+      'markdown-it',
       'clipboard-copy',
       '@vueuse/core',
       'axios',

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -263,6 +263,10 @@
         padding-right: 55px;
       }
     }
+
+    .#{$namespace}-input__inner {
+      padding-right: 30px;
+    }
   }
 
   @include m(prefix) {


### PR DESCRIPTION
- fix input inner `padding-right` when has suffix (e.g. clearable)

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
