### PR TITLE
fix(style): fix table use with fixed="right", summary not display

### DIFF
--- a/packages/components/table/src/table-footer/style-helper.ts
+++ b/packages/components/table/src/table-footer/style-helper.ts
@@ -27,7 +27,7 @@ function useStyle<T>(props: TableFooter<T>) {
     columns: TableColumnCtx<T>[],
     column: TableColumnCtx<T>
   ) => {
-    if (props.fixed || props.fixed === 'left') {
+    if (props.fixed === 'left') {
       return index >= leftFixedLeafCount.value
     } else if (props.fixed === 'right') {
       let before = 0


### PR DESCRIPTION
fix table use with fixed="right", summary not display

fix #4550
In the original case,the property, either left or right, will go through the first if, which causes the bug.And the case is showed.

<img width="815" alt="image" src="https://user-images.githubusercontent.com/57524062/143883981-e1beb3a3-7bc6-4506-8ef5-685d2546ea54.png">
