### PR TITLE
fix: upgrade @element-plus/icons-vue to currentColor

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@element-plus/components": "workspace:*",
     "@element-plus/directives": "workspace:*",
     "@element-plus/hooks": "workspace:*",
-    "@element-plus/icons-vue": "^0.2.2",
+    "@element-plus/icons-vue": "^0.2.4",
     "@element-plus/locale": "workspace:*",
     "@element-plus/test-utils": "workspace:*",
     "@element-plus/theme-chalk": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
       '@element-plus/components': workspace:*
       '@element-plus/directives': workspace:*
       '@element-plus/hooks': workspace:*
-      '@element-plus/icons-vue': ^0.2.2
+      '@element-plus/icons-vue': ^0.2.4
       '@element-plus/locale': workspace:*
       '@element-plus/test-utils': workspace:*
       '@element-plus/theme-chalk': workspace:*
@@ -75,7 +75,7 @@ importers:
       '@element-plus/components': link:packages/components
       '@element-plus/directives': link:packages/directives
       '@element-plus/hooks': link:packages/hooks
-      '@element-plus/icons-vue': 0.2.2_vue@3.2.23
+      '@element-plus/icons-vue': 0.2.4_vue@3.2.23
       '@element-plus/locale': link:packages/locale
       '@element-plus/test-utils': link:packages/test-utils
       '@element-plus/theme-chalk': link:packages/theme-chalk
@@ -929,6 +929,14 @@ packages:
       vue: ^3.2.0
     dependencies:
       '@element-plus/icons-svg': 0.2.2
+      vue: 3.2.23
+    dev: false
+
+  /@element-plus/icons-vue/0.2.4_vue@3.2.23:
+    resolution: {integrity: sha512-RsJNyL58rwxtsjeMy34o8txkL6UlME1stWsUlRpTac6UE9Bx9gdJvnDXbIKhOJqBLX17fBjmposdrn6VTqim2w==}
+    peerDependencies:
+      vue: ^3.2.0
+    dependencies:
       vue: 3.2.23
     dev: false
 


### PR DESCRIPTION
change fill='#333' to fill='currentColor', inherit from currentColor

> https://github.com/element-plus/element-plus-icons/commit/d9b1d31f4747d7b09bb0e1c60e72f8b232a9d8e2

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
