### PR TITLE
fix(components): [table-column, time-picker] improve typings

### DIFF
--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -40,7 +40,7 @@ interface TableColumnCtx<T> {
     column: TableColumnCtx<T>,
     cellValue,
     index: number
-  ) => VNode
+  ) => VNode | string
   selectable: (row: T, index: number) => boolean
   reserveSelection: boolean
   filterMethod: FilterMethods<T>

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -211,7 +211,7 @@ const parser = function (
   return day.isValid() ? day : undefined
 }
 
-const formatter = function (date: Date, format: string, lang: string) {
+const formatter = function (date: number | Date, format: string, lang: string) {
   return isEmpty(format) ? date : dayjs(date).locale(lang).format(format)
 }
 

--- a/packages/components/time-picker/src/common/props.ts
+++ b/packages/components/time-picker/src/common/props.ts
@@ -61,7 +61,7 @@ export const timePickerDefaultProps = {
     default: () => ({}),
   },
   modelValue: {
-    type: [Date, Array, String] as PropType<string | Date | Date[]>,
+    type: [Date, Array, String] as PropType<string | Date | (number | Date)[]>,
     default: '',
   },
   rangeSeparator: {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

1. 让 table-column 的 formatter 属性的返回值接受字符串类型。绝大多数情况都只需要字符串就够了，但是现在只接受 VNode，
2. 让 time-picker 的 modelValue 接受 number[] 类型。因为JSON不能表示Date类型，所以和后端通讯时都是传时间戳的。

纯类型改动，求合 😭 