### PR TITLE
refactor: upgrade vue & remove `@vue/compiler-sfc`

### DIFF
--- a/build/types-definitions.ts
+++ b/build/types-definitions.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import fs from 'fs/promises'
-import * as vueCompiler from '@vue/compiler-sfc'
+import * as vueCompiler from 'vue/compiler-sfc'
 import { Project } from 'ts-morph'
 import glob from 'fast-glob'
 import { bold } from 'chalk'

--- a/docs/.vitepress/config/plugins.ts
+++ b/docs/.vitepress/config/plugins.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import fs from 'fs'
-import { parse } from '@vue/compiler-sfc'
+import { parse } from 'vue/compiler-sfc'
 import MarkdownIt from 'markdown-it'
 import mdContainer from 'markdown-it-container'
 import { highlight } from '../utils/highlight'

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "@types/sass": "1.43.1",
     "@typescript-eslint/eslint-plugin": "5.8.1",
     "@typescript-eslint/parser": "5.8.1",
-    "@vue/compiler-sfc": "3.2.26",
     "@vue/test-utils": "2.0.0-rc.16",
     "chalk": "4.1.2",
     "components-helper": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ts-jest": "26.5.6",
     "ts-morph": "13.0.2",
     "typescript": "4.5.4",
-    "vue": "3.2.24",
+    "vue": "3.2.26",
     "vue-jest": "5.0.0-alpha.10",
     "vue-router": "4.0.12",
     "vue-tsc": "0.29.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ importers:
       ts-jest: 26.5.6
       ts-morph: 13.0.2
       typescript: 4.5.4
-      vue: 3.2.24
+      vue: 3.2.26
       vue-jest: 5.0.0-alpha.10
       vue-router: 4.0.12
       vue-tsc: 0.29.8
@@ -77,14 +77,14 @@ importers:
       '@element-plus/components': link:packages/components
       '@element-plus/directives': link:packages/directives
       '@element-plus/hooks': link:packages/hooks
-      '@element-plus/icons-vue': 0.2.4_vue@3.2.24
+      '@element-plus/icons-vue': 0.2.4_vue@3.2.26
       '@element-plus/locale': link:packages/locale
       '@element-plus/test-utils': link:packages/test-utils
       '@element-plus/theme-chalk': link:packages/theme-chalk
       '@element-plus/tokens': link:packages/tokens
       '@element-plus/utils': link:packages/utils
       '@popperjs/core': 2.10.2
-      '@vueuse/core': 7.3.0_vue@3.2.24
+      '@vueuse/core': 7.3.0_vue@3.2.26
       async-validator: 4.0.7
       dayjs: 1.10.7
       lodash: 4.17.21
@@ -107,7 +107,7 @@ importers:
       '@types/sass': 1.43.1
       '@typescript-eslint/eslint-plugin': 5.8.1_3a47348159e115370aa4cba56aba33b6
       '@typescript-eslint/parser': 5.8.1_eslint@8.5.0+typescript@4.5.4
-      '@vue/test-utils': 2.0.0-rc.16_vue@3.2.24
+      '@vue/test-utils': 2.0.0-rc.16_vue@3.2.26
       chalk: 4.1.2
       components-helper: 1.0.5
       csstype: 2.6.19
@@ -140,9 +140,9 @@ importers:
       ts-jest: 26.5.6_jest@26.6.3+typescript@4.5.4
       ts-morph: 13.0.2
       typescript: 4.5.4
-      vue: 3.2.24
-      vue-jest: 5.0.0-alpha.10_3b18aa28652cc4f87e0fcc3078cb9f71
-      vue-router: 4.0.12_vue@3.2.24
+      vue: 3.2.26
+      vue-jest: 5.0.0-alpha.10_15b9510143ae033e391d483938a228de
+      vue-router: 4.0.12_vue@3.2.26
       vue-tsc: 0.29.8_typescript@4.5.4
 
   docs:
@@ -163,10 +163,10 @@ importers:
       vite-plugin-windicss: 1.6.1
       vitepress: 0.20.10
     dependencies:
-      '@vueuse/core': 7.4.1_vue@3.2.24
+      '@vueuse/core': 7.4.1_vue@3.2.26
       axios: 0.24.0
       clipboard-copy: 4.0.1
-      element-plus: 1.2.0-beta.6_vue@3.2.24
+      element-plus: 1.2.0-beta.6_vue@3.2.26
       normalize.css: 8.0.1
       nprogress: 0.2.0
     devDependencies:
@@ -202,9 +202,9 @@ importers:
       vue-router: ^4.0.0
     dependencies:
       '@ctrl/tinycolor': 3.4.0
-      '@element-plus/icons-vue': 0.2.4_vue@3.2.24
+      '@element-plus/icons-vue': 0.2.4_vue@3.2.26
       '@popperjs/core': 2.10.2
-      '@vueuse/core': 7.3.0_vue@3.2.24
+      '@vueuse/core': 7.3.0_vue@3.2.26
       async-validator: 4.0.7
       dayjs: 1.10.7
       lodash: 4.17.21
@@ -213,7 +213,7 @@ importers:
     devDependencies:
       '@types/node': 16.11.6
       csstype: 2.6.18
-      vue-router: 4.0.12_vue@3.2.24
+      vue-router: 4.0.12_vue@3.2.26
 
   packages/hooks:
     specifiers: {}
@@ -258,10 +258,10 @@ importers:
       vite: 2.7.7
       vite-plugin-inspect: 0.3.11
     dependencies:
-      '@element-plus/icons-vue': 0.2.4_vue@3.2.24
+      '@element-plus/icons-vue': 0.2.4_vue@3.2.26
     devDependencies:
-      '@vitejs/plugin-vue': 2.0.1_vite@2.7.7+vue@3.2.24
-      unplugin-vue-components: 0.17.11_dfab8b9f4248661e03532af181b99639
+      '@vitejs/plugin-vue': 2.0.1_vite@2.7.7+vue@3.2.26
+      unplugin-vue-components: 0.17.11_e0e5be33efeabc7efb6c27985da73f4c
       vite: 2.7.7_sass@1.45.1
       vite-plugin-inspect: 0.3.11_vite@2.7.7
 
@@ -984,12 +984,12 @@ packages:
       - '@algolia/client-search'
     dev: true
 
-  /@element-plus/icons-vue/0.2.4_vue@3.2.24:
+  /@element-plus/icons-vue/0.2.4_vue@3.2.26:
     resolution: {integrity: sha512-RsJNyL58rwxtsjeMy34o8txkL6UlME1stWsUlRpTac6UE9Bx9gdJvnDXbIKhOJqBLX17fBjmposdrn6VTqim2w==}
     peerDependencies:
       vue: ^3.2.0
     dependencies:
-      vue: 3.2.24
+      vue: 3.2.26
     dev: false
 
   /@emmetio/abbreviation/2.2.2:
@@ -2036,17 +2036,6 @@ packages:
       eslint-visitor-keys: 3.1.0
     dev: true
 
-  /@vitejs/plugin-vue/2.0.1_vite@2.7.7+vue@3.2.24:
-    resolution: {integrity: sha512-wtdMnGVvys9K8tg+DxowU1ytTrdVveXr3LzdhaKakysgGXyrsfaeds2cDywtvujEASjWOwWL/OgWM+qoeM8Plg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      vite: ^2.5.10
-      vue: ^3.2.25
-    dependencies:
-      vite: 2.7.7_sass@1.45.1
-      vue: 3.2.24
-    dev: true
-
   /@vitejs/plugin-vue/2.0.1_vite@2.7.7+vue@3.2.26:
     resolution: {integrity: sha512-wtdMnGVvys9K8tg+DxowU1ytTrdVveXr3LzdhaKakysgGXyrsfaeds2cDywtvujEASjWOwWL/OgWM+qoeM8Plg==}
     engines: {node: '>=12.0.0'}
@@ -2101,9 +2090,9 @@ packages:
       '@volar/code-gen': 0.29.8
       '@volar/shared': 0.29.8
       '@volar/source-map': 0.29.8
-      '@vue/compiler-core': 3.2.24
-      '@vue/compiler-dom': 3.2.24
-      '@vue/shared': 3.2.24
+      '@vue/compiler-core': 3.2.26
+      '@vue/compiler-dom': 3.2.26
+      '@vue/shared': 3.2.26
       upath: 2.0.1
     dev: true
 
@@ -2118,15 +2107,6 @@ packages:
       vscode-uri: 2.1.2
     dev: true
 
-  /@vue/compiler-core/3.2.24:
-    resolution: {integrity: sha512-A0SxB2HAggKzP57LDin5gfgWOTwFyGCtQ5MTMNBADnfQYALWnYuC8kMI0DhRSplGTWRvn9Z2DAnG8f35BnojuA==}
-    dependencies:
-      '@babel/parser': 7.16.4
-      '@vue/shared': 3.2.24
-      estree-walker: 2.0.2
-      source-map: 0.6.1
-    dev: true
-
   /@vue/compiler-core/3.2.26:
     resolution: {integrity: sha512-N5XNBobZbaASdzY9Lga2D9Lul5vdCIOXvUMd6ThcN8zgqQhPKfCV+wfAJNNJKQkSHudnYRO2gEB+lp0iN3g2Tw==}
     dependencies:
@@ -2136,33 +2116,11 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /@vue/compiler-dom/3.2.24:
-    resolution: {integrity: sha512-KQEm8r0JFsrNNIfbD28pcwMvHpcJcwjVR1XWFcD0yyQ8eREd7IXhT7J6j7iNCSE/TIo78NOvkwbyX+lnIm836w==}
-    dependencies:
-      '@vue/compiler-core': 3.2.24
-      '@vue/shared': 3.2.24
-    dev: true
-
   /@vue/compiler-dom/3.2.26:
     resolution: {integrity: sha512-smBfaOW6mQDxcT3p9TKT6mE22vjxjJL50GFVJiI0chXYGU/xzC05QRGrW3HHVuJrmLTLx5zBhsZ2dIATERbarg==}
     dependencies:
       '@vue/compiler-core': 3.2.26
       '@vue/shared': 3.2.26
-    dev: true
-
-  /@vue/compiler-sfc/3.2.24:
-    resolution: {integrity: sha512-YGPcIvVJp2qTPkuT6kT43Eo1xjstyY4bmuiSV31my4bQMBFVR26ANmifUSt759Blok71gK0WzfIZHbcOKYOeKA==}
-    dependencies:
-      '@babel/parser': 7.16.4
-      '@vue/compiler-core': 3.2.24
-      '@vue/compiler-dom': 3.2.24
-      '@vue/compiler-ssr': 3.2.24
-      '@vue/ref-transform': 3.2.24
-      '@vue/shared': 3.2.24
-      estree-walker: 2.0.2
-      magic-string: 0.25.7
-      postcss: 8.4.4
-      source-map: 0.6.1
     dev: true
 
   /@vue/compiler-sfc/3.2.26:
@@ -2176,15 +2134,8 @@ packages:
       '@vue/shared': 3.2.26
       estree-walker: 2.0.2
       magic-string: 0.25.7
-      postcss: 8.4.4
+      postcss: 8.4.5
       source-map: 0.6.1
-    dev: true
-
-  /@vue/compiler-ssr/3.2.24:
-    resolution: {integrity: sha512-E1HHShNsGVWXxs68LDOUuI+Bzak9W/Ier/366aKDBFuwvfwgruwq6abhMfj6pSDZpwZ/PXnfliyl/m7qBSq6gw==}
-    dependencies:
-      '@vue/compiler-dom': 3.2.24
-      '@vue/shared': 3.2.24
     dev: true
 
   /@vue/compiler-ssr/3.2.26:
@@ -2208,33 +2159,10 @@ packages:
       magic-string: 0.25.7
     dev: true
 
-  /@vue/reactivity/3.2.24:
-    resolution: {integrity: sha512-5eVsO9wfQ5erCMSRBjpqLkkI+LglJS7E0oLZJs2gsChpvOjH2Uwt3Hk1nVv0ywStnWg71Ykn3SyQwtnl7PknOQ==}
-    dependencies:
-      '@vue/shared': 3.2.24
-    dev: true
-
   /@vue/reactivity/3.2.26:
     resolution: {integrity: sha512-h38bxCZLW6oFJVDlCcAiUKFnXI8xP8d+eO0pcDxx+7dQfSPje2AO6M9S9QO6MrxQB7fGP0DH0dYQ8ksf6hrXKQ==}
     dependencies:
       '@vue/shared': 3.2.26
-    dev: true
-
-  /@vue/ref-transform/3.2.24:
-    resolution: {integrity: sha512-j6oNbsGLvea2rF8GQB9w6q7UFL1So7J+t6ducaMeWPSyjYZ+slWpwPVK6mmyghg5oGqC41R+HC5BV036Y0KhXQ==}
-    dependencies:
-      '@babel/parser': 7.16.4
-      '@vue/compiler-core': 3.2.24
-      '@vue/shared': 3.2.24
-      estree-walker: 2.0.2
-      magic-string: 0.25.7
-    dev: true
-
-  /@vue/runtime-core/3.2.24:
-    resolution: {integrity: sha512-ReI06vGgYuW0G8FlOcAOzMklVDJSxKuRhYzT8j+a8BTfs1945kxo1Th28BPvasyYx8J+LMeZ0HqpPH9yGXvWvg==}
-    dependencies:
-      '@vue/reactivity': 3.2.24
-      '@vue/shared': 3.2.24
     dev: true
 
   /@vue/runtime-core/3.2.26:
@@ -2244,30 +2172,12 @@ packages:
       '@vue/shared': 3.2.26
     dev: true
 
-  /@vue/runtime-dom/3.2.24:
-    resolution: {integrity: sha512-piqsabtIEUKkMGSJlOyKUonZEDtdwOpR6teQ8EKbH8PX9sxfAt9snLnFJldUhhyYrLIyDtnjwajfJ7/XtpD4JA==}
-    dependencies:
-      '@vue/runtime-core': 3.2.24
-      '@vue/shared': 3.2.24
-      csstype: 2.6.19
-    dev: true
-
   /@vue/runtime-dom/3.2.26:
     resolution: {integrity: sha512-dY56UIiZI+gjc4e8JQBwAifljyexfVCkIAu/WX8snh8vSOt/gMSEGwPRcl2UpYpBYeyExV8WCbgvwWRNt9cHhQ==}
     dependencies:
       '@vue/runtime-core': 3.2.26
       '@vue/shared': 3.2.26
       csstype: 2.6.19
-    dev: true
-
-  /@vue/server-renderer/3.2.24_vue@3.2.24:
-    resolution: {integrity: sha512-DqiCRDxTbv67Hw5ImiqnLIQbPGtIwWLLfEcVHoEnu1f21EMTB6LfoS69EQddd8VyfN5kfX3Fmz27/hrFPpRaMQ==}
-    peerDependencies:
-      vue: 3.2.24
-    dependencies:
-      '@vue/compiler-ssr': 3.2.24
-      '@vue/shared': 3.2.24
-      vue: 3.2.24
     dev: true
 
   /@vue/server-renderer/3.2.26_vue@3.2.26:
@@ -2280,23 +2190,19 @@ packages:
       vue: 3.2.26
     dev: true
 
-  /@vue/shared/3.2.24:
-    resolution: {integrity: sha512-BUgRiZCkCrqDps5aQ9av05xcge3rn092ztKIh17tHkeEFgP4zfXMQWBA2zfdoCdCEdBL26xtOv+FZYiOp9RUDA==}
-    dev: true
-
   /@vue/shared/3.2.26:
     resolution: {integrity: sha512-vPV6Cq+NIWbH5pZu+V+2QHE9y1qfuTq49uNWw4f7FDEeZaDU2H2cx5jcUZOAKW7qTrUS4k6qZPbMy1x4N96nbA==}
     dev: true
 
-  /@vue/test-utils/2.0.0-rc.16_vue@3.2.24:
+  /@vue/test-utils/2.0.0-rc.16_vue@3.2.26:
     resolution: {integrity: sha512-TubikDVkI2LuRKRPSLv3lYpbpvvucT2DIcGqfBVpvYs4W19u0EBTJEdmfwmSuLY7H1TyAr9Stur3PI1sWWvTGQ==}
     peerDependencies:
       vue: ^3.0.1
     dependencies:
-      vue: 3.2.24
+      vue: 3.2.26
     dev: true
 
-  /@vueuse/core/7.3.0_vue@3.2.24:
+  /@vueuse/core/7.3.0_vue@3.2.26:
     resolution: {integrity: sha512-gPJyMMAquva9Qwqz63qGQT122m5hWI8Kuy8kfPV/JLQU7m01CXooyv8FIrX9TV8OxVcHBTPXPJHY0oyUiFoNgw==}
     peerDependencies:
       '@vue/composition-api': ^1.1.0
@@ -2307,12 +2213,12 @@ packages:
       vue:
         optional: true
     dependencies:
-      '@vueuse/shared': 7.3.0_vue@3.2.24
-      vue: 3.2.24
-      vue-demi: 0.11.4_vue@3.2.24
+      '@vueuse/shared': 7.3.0_vue@3.2.26
+      vue: 3.2.26
+      vue-demi: 0.11.4_vue@3.2.26
     dev: false
 
-  /@vueuse/core/7.4.1_vue@3.2.24:
+  /@vueuse/core/7.4.1_vue@3.2.26:
     resolution: {integrity: sha512-8UeLPCAieeQLXFHF1/28SIEK6ILLPb/4hp03hR+xkXF00gB/YUp0CEVcRAL9uQ8HTZa3S2T/jTISMc1ZjilM0A==}
     peerDependencies:
       '@vue/composition-api': ^1.1.0
@@ -2323,12 +2229,12 @@ packages:
       vue:
         optional: true
     dependencies:
-      '@vueuse/shared': 7.4.1_vue@3.2.24
-      vue: 3.2.24
-      vue-demi: 0.11.4_vue@3.2.24
+      '@vueuse/shared': 7.4.1_vue@3.2.26
+      vue: 3.2.26
+      vue-demi: 0.11.4_vue@3.2.26
     dev: false
 
-  /@vueuse/shared/7.3.0_vue@3.2.24:
+  /@vueuse/shared/7.3.0_vue@3.2.26:
     resolution: {integrity: sha512-vOAeI84tIXKVkzm8s/Mxbrzhj0QN6NyVc/sC6LrW0AjVNdvpD8sB1dZiDn9yh8T77WJmloCEt4zZVIppeq7I+w==}
     peerDependencies:
       '@vue/composition-api': ^1.1.0
@@ -2339,11 +2245,11 @@ packages:
       vue:
         optional: true
     dependencies:
-      vue: 3.2.24
-      vue-demi: 0.11.4_vue@3.2.24
+      vue: 3.2.26
+      vue-demi: 0.11.4_vue@3.2.26
     dev: false
 
-  /@vueuse/shared/7.4.1_vue@3.2.24:
+  /@vueuse/shared/7.4.1_vue@3.2.26:
     resolution: {integrity: sha512-Pzb7XoHIcgPwwBJ5Ow9lZb0HTDyaLDV3pgxKauPGTMN9qvEylG06kUG+VTjJXkPsRtiGu46di8XyFeMw2dongA==}
     peerDependencies:
       '@vue/composition-api': ^1.1.0
@@ -2354,8 +2260,8 @@ packages:
       vue:
         optional: true
     dependencies:
-      vue: 3.2.24
-      vue-demi: 0.11.4_vue@3.2.24
+      vue: 3.2.26
+      vue-demi: 0.11.4_vue@3.2.26
     dev: false
 
   /@windicss/config/1.6.1:
@@ -4119,20 +4025,20 @@ packages:
     resolution: {integrity: sha512-2jtSwgyiRzybHRxrc2nKI+39wH3AwQgn+sogQ+q814gv8hIFwrcZbV07Ea9f8AmK0ufPVZUvvAG1uZJ+obV4Jw==}
     dev: true
 
-  /element-plus/1.2.0-beta.6_vue@3.2.24:
+  /element-plus/1.2.0-beta.6_vue@3.2.26:
     resolution: {integrity: sha512-8EdSIR/5/FHcSB8w1diAh+gJMHgxIvxuZoayY99k6taAR1QyEFHuPTgFccZLopJ1+iP4UEsZFz49l57qS08Utw==}
     peerDependencies:
       vue: ^3.2.0
     dependencies:
-      '@element-plus/icons-vue': 0.2.4_vue@3.2.24
+      '@element-plus/icons-vue': 0.2.4_vue@3.2.26
       '@popperjs/core': 2.11.0
-      '@vueuse/core': 7.4.1_vue@3.2.24
+      '@vueuse/core': 7.4.1_vue@3.2.26
       async-validator: 4.0.7
       dayjs: 1.10.7
       lodash: 4.17.21
       memoize-one: 6.0.0
       normalize-wheel-es: 1.1.1
-      vue: 3.2.24
+      vue: 3.2.26
     transitivePeerDependencies:
       - '@vue/composition-api'
     dev: false
@@ -8399,15 +8305,6 @@ packages:
       source-map-js: 0.6.2
     dev: true
 
-  /postcss/8.4.4:
-    resolution: {integrity: sha512-joU6fBsN6EIer28Lj6GDFoC/5yOZzLCfn0zHAn/MYXI7aPt4m4hK5KC5ovEZXy+lnCjmYIbQWngvju2ddyEr8Q==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.1.30
-      picocolors: 1.0.0
-      source-map-js: 1.0.1
-    dev: true
-
   /postcss/8.4.5:
     resolution: {integrity: sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -10250,7 +10147,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /unplugin-vue-components/0.17.11_dfab8b9f4248661e03532af181b99639:
+  /unplugin-vue-components/0.17.11_e0e5be33efeabc7efb6c27985da73f4c:
     resolution: {integrity: sha512-u5MQ0TbikszRelCt6EA/HskGtGkGLDxi7tQ4/4tcEPWkH3yXSZRJCOeLF5MSdxN1SiGjaJ0I9zeHjoZFC3FvRw==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -10273,7 +10170,7 @@ packages:
       minimatch: 3.0.4
       resolve: 1.20.0
       unplugin: 0.2.21_rollup@2.62.0+vite@2.7.7
-      vue: 3.2.24
+      vue: 3.2.26
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -10644,8 +10541,8 @@ packages:
       '@volar/transforms': 0.29.8
       '@volar/vue-code-gen': 0.29.8
       '@vscode/emmet-helper': 2.8.2
-      '@vue/reactivity': 3.2.24
-      '@vue/shared': 3.2.24
+      '@vue/reactivity': 3.2.26
+      '@vue/shared': 3.2.26
       request-light: 0.5.4
       upath: 2.0.1
       vscode-css-languageservice: 5.1.7
@@ -10657,7 +10554,7 @@ packages:
       vscode-typescript-languageservice: 0.29.8
     dev: true
 
-  /vue-demi/0.11.4_vue@3.2.24:
+  /vue-demi/0.11.4_vue@3.2.26:
     resolution: {integrity: sha512-/3xFwzSykLW2HiiLie43a+FFgNOcokbBJ+fzvFXd0r2T8MYohqvphUyDQ8lbAwzQ3Dlcrb1c9ykifGkhSIAk6A==}
     engines: {node: '>=12'}
     hasBin: true
@@ -10669,7 +10566,7 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
-      vue: 3.2.24
+      vue: 3.2.26
     dev: false
 
   /vue-eslint-parser/8.0.1_eslint@8.5.0:
@@ -10690,7 +10587,7 @@ packages:
       - supports-color
     dev: true
 
-  /vue-jest/5.0.0-alpha.10_3b18aa28652cc4f87e0fcc3078cb9f71:
+  /vue-jest/5.0.0-alpha.10_15b9510143ae033e391d483938a228de:
     resolution: {integrity: sha512-iN62cTi4AL0UsgxEyVeJtHG6qXEv+8Ci2wX1vP3b/dAZvyBRmqy5aJHQrP6VCEuio+HgHQ1LAZ+ccM2pouBmlg==}
     peerDependencies:
       '@babel/core': 7.x
@@ -10714,18 +10611,18 @@ packages:
       ts-jest: 26.5.6_jest@26.6.3+typescript@4.5.4
       tsconfig: 7.0.0
       typescript: 4.5.4
-      vue: 3.2.24
+      vue: 3.2.26
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vue-router/4.0.12_vue@3.2.24:
+  /vue-router/4.0.12_vue@3.2.26:
     resolution: {integrity: sha512-CPXvfqe+mZLB1kBWssssTiWg4EQERyqJZes7USiqfW9B5N2x+nHlnsM1D3b5CaJ6qgCvMmYJnz+G0iWjNCvXrg==}
     peerDependencies:
       vue: ^3.0.0
     dependencies:
       '@vue/devtools-api': 6.0.0-beta.19
-      vue: 3.2.24
+      vue: 3.2.26
     dev: true
 
   /vue-tsc/0.29.8_typescript@4.5.4:
@@ -10737,16 +10634,6 @@ packages:
       '@volar/shared': 0.29.8
       typescript: 4.5.4
       vscode-vue-languageservice: 0.29.8
-    dev: true
-
-  /vue/3.2.24:
-    resolution: {integrity: sha512-PvCklXNfcUMyeP/a9nME27C32IipwUDoS45rDyKn5+RQrWyjL+0JAJtf98HL6y9bfqQRTlYjSowWEB1nXxvG5Q==}
-    dependencies:
-      '@vue/compiler-dom': 3.2.24
-      '@vue/compiler-sfc': 3.2.24
-      '@vue/runtime-dom': 3.2.24
-      '@vue/server-renderer': 3.2.24_vue@3.2.24
-      '@vue/shared': 3.2.24
     dev: true
 
   /vue/3.2.26:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,6 @@ importers:
       '@types/sass': 1.43.1
       '@typescript-eslint/eslint-plugin': 5.8.1
       '@typescript-eslint/parser': 5.8.1
-      '@vue/compiler-sfc': 3.2.26
       '@vue/test-utils': 2.0.0-rc.16
       '@vueuse/core': ^7.3.0
       async-validator: ^4.0.7
@@ -108,7 +107,6 @@ importers:
       '@types/sass': 1.43.1
       '@typescript-eslint/eslint-plugin': 5.8.1_3a47348159e115370aa4cba56aba33b6
       '@typescript-eslint/parser': 5.8.1_eslint@8.5.0+typescript@4.5.4
-      '@vue/compiler-sfc': 3.2.26
       '@vue/test-utils': 2.0.0-rc.16_vue@3.2.24
       chalk: 4.1.2
       components-helper: 1.0.5
@@ -136,7 +134,7 @@ importers:
       rollup-plugin-css-only: 3.1.0_rollup@2.62.0
       rollup-plugin-esbuild: 4.8.1_esbuild@0.14.8+rollup@2.62.0
       rollup-plugin-filesize: 9.1.1
-      rollup-plugin-vue: 6.0.0_@vue+compiler-sfc@3.2.26
+      rollup-plugin-vue: 6.0.0
       sass: 1.45.1
       sucrase: 3.20.3
       ts-jest: 26.5.6_jest@26.6.3+typescript@4.5.4
@@ -9084,12 +9082,11 @@ packages:
       - supports-color
     dev: true
 
-  /rollup-plugin-vue/6.0.0_@vue+compiler-sfc@3.2.26:
+  /rollup-plugin-vue/6.0.0:
     resolution: {integrity: sha512-oVvUd84d5u73M2HYM3XsMDLtZRIA/tw2U0dmHlXU2UWP5JARYHzh/U9vcxaN/x/9MrepY7VH3pHFeOhrWpxs/Q==}
     peerDependencies:
       '@vue/compiler-sfc': '*'
     dependencies:
-      '@vue/compiler-sfc': 3.2.26
       debug: 4.3.2
       hash-sum: 2.0.0
       rollup-pluginutils: 2.8.2


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


https://github.com/vuejs/vue-next/tree/master/packages/compiler-sfc

> Note: as of 3.2.13+, this package is included as a dependency of the main vue package and can be accessed as vue/compiler-sfc. This means you no longer need to explicitly install this package and ensure its version match that of vue's. Just use the main vue/compiler-sfc deep import instead.

