### PR TITLE
 fix(components): [el-image] image load error

### DIFF
--- a/packages/components/image/__tests__/image.spec.ts
+++ b/packages/components/image/__tests__/image.spec.ts
@@ -50,6 +50,24 @@ describe('Image.vue', () => {
     expect(wrapper.find('img').exists()).toBe(false)
     expect(wrapper.find('.el-image__error').exists()).toBe(true)
   })
+  
+  test('image load sequence success test', async () => {
+    const wrapper = mount(Image, {
+      props: {
+        src: IMAGE_FAIL,
+      },
+    })
+    wrapper.setProps({
+      src: IMAGE_SUCCESS,
+    })
+    expect(wrapper.find('.el-image__placeholder').exists()).toBe(true)
+    await doubleWait()
+    expect(wrapper.emitted('error')).toBeUndefined()
+    expect(wrapper.find('.el-image__inner').exists()).toBe(true)
+    expect(wrapper.find('img').exists()).toBe(true)
+    expect(wrapper.find('.el-image__placeholder').exists()).toBe(false)
+    expect(wrapper.find('.el-image__error').exists()).toBe(false)
+  })
 
   test('imageStyle fit test', async () => {
     const fits = ['fill', 'contain', 'cover', 'none', 'scale-down']

--- a/packages/components/image/__tests__/image.spec.ts
+++ b/packages/components/image/__tests__/image.spec.ts
@@ -50,7 +50,7 @@ describe('Image.vue', () => {
     expect(wrapper.find('img').exists()).toBe(false)
     expect(wrapper.find('.el-image__error').exists()).toBe(true)
   })
-  
+
   test('image load sequence success test', async () => {
     const wrapper = mount(Image, {
       props: {

--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -115,8 +115,21 @@ export default defineComponent({
       hasLoadError.value = false
 
       const img = new Image()
-      img.addEventListener('load', (e) => handleLoad(e, img))
-      img.addEventListener('error', handleError)
+      const currentImageSrc = props.src
+
+      // load & error callbacks are only responsible for currentImageSrc
+      img.addEventListener('load', (e) => {
+        if (currentImageSrc !== props.src) {
+          return
+        }
+        handleLoad(e, img)
+      })
+      img.addEventListener('error', (e) => {
+        if (currentImageSrc !== props.src) {
+          return
+        }
+        handleError(e)
+      })
 
       // bind html attrs
       // so it can behave consistently
@@ -125,7 +138,7 @@ export default defineComponent({
         if (key.toLowerCase() === 'onload') return
         img.setAttribute(key, value as string)
       })
-      img.src = props.src
+      img.src = currentImageSrc
     }
 
     function handleLoad(e: Event, img: HTMLImageElement) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

-----------
image 的 load 和 error 回调没有考虑到 src 变化的时序，这导致在边界场景：
* 先设置 src1，其对应的图片会加载失败
* 再设置 src2，其对应的图片会加载成功
* src2 的成功回调先于 src1 的失败回调执行  

此时，el-image 组件会显示为加载失败

具体 demo 见： https://codepen.io/holynewbie-the-sasster/pen/dyVNXoR

PS： **由于图片没有缓存，所以第一次不会触发 bug，当 codepen 加载完成之后刷新一次，即可复现 bug**
