### PR TITLE
fix(theme-chalk): Put back !optional to @extend

### DIFF
--- a/packages/theme-chalk/src/image.scss
+++ b/packages/theme-chalk/src/image.scss
@@ -17,7 +17,7 @@
   }
 
   @include e(placeholder) {
-    @extend %size;
+    @extend %size !optional;
     background: var(--el-bg-color);
   }
 


### PR DESCRIPTION
Reintroduces an `!optional` to `@extend` to prevent a sass error. It was fixed in #4388 but it seems like there was a regression in #4615. 

Related issue: #4303

Recommended by sass official documentation https://sass-lang.com/documentation/at-rules/extend#mandatory-and-optional-extends

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
