### PR TITLE
docs: [el-upload]add example of setting on-exceed to cover the old file

### DIFF
--- a/docs/en-US/component/upload.md
+++ b/docs/en-US/component/upload.md
@@ -15,6 +15,14 @@ upload/basic
 
 :::
 
+## Cover previous file
+
+:::demo Set `limit` and `on-exceed` to automatically replace the previous file when select a new file.
+
+upload/limit-cover
+
+:::
+
 ## User avatar upload
 
 Use `before-upload` hook to limit the upload file format and size.
@@ -123,8 +131,9 @@ upload/manual
 
 ## Methods
 
-| Methods Name | Description                                                                             | Parameters                  |
-| ------------ | --------------------------------------------------------------------------------------- | --------------------------- |
-| clearFiles   | clear the uploaded file list (this method is not supported in the `before-upload` hook) | —                           |
-| abort        | cancel upload request                                                                   | （ file: fileList's item ） |
-| submit       | upload the file list manually                                                           | —                           |
+| Methods Name | Description                                                                     | Parameters                                                                    | Default                                   |
+| ------------ | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------- |
+| clearFiles   | clear the file list (this method is not supported in the `before-upload` hook). | UploadStatus[] (UploadStatus = 'ready' \| 'uploading' \| 'success' \| 'fail') | ['ready', 'uploading', 'success', 'fail'] |
+| abort        | cancel upload request                                                           | ( file: fileList's item )                                                     |                                           |
+| submit       | upload the file list manually                                                   | —                                                                             |                                           |
+| handleStart  | select the file manually                                                        | ( file: files' item)                                                          |                                           |

--- a/docs/examples/upload/limit-cover.vue
+++ b/docs/examples/upload/limit-cover.vue
@@ -30,7 +30,7 @@ import { ref } from 'vue'
 const upload = ref()
 
 const handleExceed = (files) => {
-  upload.value.clearFiles(['ready', 'success', 'fail', 'uploading'])
+  upload.value.clearFiles()
   upload.value.handleStart(files[0])
 }
 const submitUpload = () => {

--- a/docs/examples/upload/limit-cover.vue
+++ b/docs/examples/upload/limit-cover.vue
@@ -1,0 +1,39 @@
+<template>
+  <el-upload
+    ref="upload"
+    class="upload-demo"
+    action="https://jsonplaceholder.typicode.com/posts/"
+    :limit="1"
+    :on-exceed="handleExceed"
+    :auto-upload="false"
+  >
+    <template #trigger>
+      <el-button size="small" type="primary">select file</el-button>
+    </template>
+    <el-button
+      style="margin-left: 10px"
+      size="small"
+      type="success"
+      @click="submitUpload"
+      >upload to server</el-button
+    >
+    <template #tip>
+      <div class="el-upload__tip" style="color: red">
+        limit 1 file, new file will cover the old file
+      </div>
+    </template>
+  </el-upload>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+const upload = ref()
+
+const handleExceed = (files) => {
+  upload.value.clearFiles(['ready', 'success', 'fail', 'uploading'])
+  upload.value.handleStart(files[0])
+}
+const submitUpload = () => {
+  upload.value.submit()
+}
+</script>

--- a/packages/components/upload/src/useHandlers.ts
+++ b/packages/components/upload/src/useHandlers.ts
@@ -34,7 +34,9 @@ export default (props: IUseHandlersProps) => {
     uploadRef.value.abort(file)
   }
 
-  function clearFiles(status: UploadStatus[] = ['success', 'fail']) {
+  function clearFiles(
+    status: UploadStatus[] = ['ready', 'uploading', 'success', 'fail']
+  ) {
     uploadFiles.value = uploadFiles.value.filter((row) => {
       return status.indexOf(row.status) === -1
     })

--- a/packages/components/upload/src/useHandlers.ts
+++ b/packages/components/upload/src/useHandlers.ts
@@ -38,7 +38,7 @@ export default (props: IUseHandlersProps) => {
     status: UploadStatus[] = ['ready', 'uploading', 'success', 'fail']
   ) {
     uploadFiles.value = uploadFiles.value.filter((row) => {
-      return status.indexOf(row.status) === -1
+      return !status.includes(row.status)
     })
   }
 


### PR DESCRIPTION
Add a example of setting `limit` and `on-exceed` to automatically replace the previous file when select a new file
Add guidance on how to use  `clearFiles()`
fix: #4655 
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
