### PR TITLE
fix(components): [el-select] BUG修复：添加filterable属性后，点击小箭头不能将下拉列表收起

### DIFF
--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -164,6 +164,7 @@
                 v-if="iconComponent"
                 v-show="!showClose"
                 :class="['el-select__caret', 'el-input__icon', iconReverse]"
+                @click="handlePickUpSelect"
               >
                 <component :is="iconComponent" />
               </el-icon>
@@ -369,6 +370,7 @@ export default defineComponent({
       blur,
       handleBlur,
       handleClearClick,
+      handlePickUpSelect,
       handleClose,
       toggleMenu,
       selectOption,
@@ -539,6 +541,7 @@ export default defineComponent({
       blur,
       handleBlur,
       handleClearClick,
+      handlePickUpSelect,
       handleClose,
       toggleMenu,
       selectOption,

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -731,6 +731,11 @@ export const useSelect = (props, states: States, ctx) => {
     deleteSelected(event)
   }
 
+  const handlePickUpSelect = (event: Event) => {
+    event.stopPropagation()
+    states.visible = !states.visible
+  }
+
   const handleClose = () => {
     states.visible = false
   }
@@ -835,6 +840,7 @@ export const useSelect = (props, states: States, ctx) => {
     blur,
     handleBlur,
     handleClearClick,
+    handlePickUpSelect,
     handleClose,
     toggleMenu,
     selectOption,


### PR DESCRIPTION
问题描述：当我给el-select添加filterable属性时，展开下拉列表后，再点击收起小箭头图标，想收起下拉列表时，会不起作用，只有点击其他地方才能收起下拉列表，如下图：

![146730539-eae18c98-8a88-4814-8788-bc4681968997](https://user-images.githubusercontent.com/49587633/146739617-d1beb35a-70e9-48f6-9998-21a484a26121.png)

解决方案：给小箭头单独添加一个点击事件，在不影响其他地方的同时，也能保证下拉列表的收起与展开。
