### PR TITLE
fix: tag in select style

### DIFF
--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -490,6 +490,16 @@ $input-number-width: map.merge(
   $input-number-width
 );
 
+$input-padding-horizontal: () !default;
+$input-padding-horizontal: map.merge(
+  (
+    'large': 16px,
+    'default': 12px,
+    'small': 8px,
+  ),
+  $input-padding-horizontal
+);
+
 // Cascader
 // css3 var in packages/theme-chalk/src/cascader.scss
 $cascader: () !default;

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -8,16 +8,6 @@
   @include set-component-css-var('input', $input);
 }
 
-$input-padding-horizontal: () !default;
-$input-padding-horizontal: map.merge(
-  (
-    'large': 16px,
-    'default': 12px,
-    'small': 8px,
-  ),
-  $input-padding-horizontal
-);
-
 @include b(textarea) {
   position: relative;
   display: inline-block;

--- a/packages/theme-chalk/src/select-v2.scss
+++ b/packages/theme-chalk/src/select-v2.scss
@@ -7,6 +7,7 @@
 @use './select-dropdown-v2.scss';
 @use './option-item.scss';
 @use './option-group.scss';
+@use './select/common.scss' as *;
 
 $input-inline-start: map.get($input-padding-horizontal, 'default') !default;
 
@@ -22,12 +23,11 @@ $input-inline-start: map.get($input-padding-horizontal, 'default') !default;
   @include e(wrapper) {
     display: flex;
     align-items: center;
-
-    height: map.get($input-height, 'default');
+    flex-wrap: wrap;
 
     box-sizing: border-box;
     cursor: pointer;
-    padding-right: 30px;
+    padding: 2px 30px 2px 0;
     border: 1px solid var(--el-border-color-base);
     border-radius: var(--el-border-radius-base);
     transition: border-color var(--el-transition-duration-fast)
@@ -104,13 +104,7 @@ $input-inline-start: map.get($input-padding-horizontal, 'default') !default;
     }
   }
 
-  .#{$namespace}-select-v2__tags-text {
-    text-overflow: ellipsis;
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    overflow: hidden;
-  }
+  @include select-common(select-v2);
 
   @include e(empty) {
     padding: 10px 0;

--- a/packages/theme-chalk/src/select-v2.scss
+++ b/packages/theme-chalk/src/select-v2.scss
@@ -8,7 +8,7 @@
 @use './option-item.scss';
 @use './option-group.scss';
 
-$input-inline-start: 15px !default;
+$input-inline-start: map.get($input-padding-horizontal, 'default') !default;
 
 @include b(select-v2) {
   @include set-component-css-var('select', $select);
@@ -20,11 +20,14 @@ $input-inline-start: 15px !default;
   font-size: map.get($input-font-size, 'default');
   $selector: &;
   @include e(wrapper) {
+    display: flex;
+    align-items: center;
+
     height: map.get($input-height, 'default');
 
     box-sizing: border-box;
     cursor: pointer;
-    padding: 5px 30px 5px 0px;
+    padding-right: 30px;
     border: 1px solid var(--el-border-color-base);
     border-radius: var(--el-border-radius-base);
     transition: border-color var(--el-transition-duration-fast)
@@ -103,9 +106,10 @@ $input-inline-start: 15px !default;
 
   .#{$namespace}-select-v2__tags-text {
     text-overflow: ellipsis;
-    display: inline-block;
-    overflow-x: hidden;
-    vertical-align: bottom;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
   }
 
   @include e(empty) {

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -5,6 +5,7 @@
 @use 'mixins/var' as *;
 @use 'common/var' as *;
 @use './select-dropdown.scss';
+@use './select/common.scss' as *;
 
 @include b(select) {
   @include set-component-css-var('select', $select);
@@ -39,12 +40,7 @@
     }
   }
 
-  .#{$namespace}-select__tags-text {
-    text-overflow: ellipsis;
-    display: inline-block;
-    overflow-x: hidden;
-    vertical-align: bottom;
-  }
+  @include select-common(select);
 
   .#{$namespace}-input__inner {
     cursor: pointer;

--- a/packages/theme-chalk/src/select/common.scss
+++ b/packages/theme-chalk/src/select/common.scss
@@ -1,0 +1,12 @@
+@use '../mixins/mixins' as *;
+
+// same style in select & selevt-v2
+@mixin select-common($name) {
+  .#{$namespace}-#{$name}__tags-text {
+    text-overflow: ellipsis;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+  }
+}

--- a/packages/theme-chalk/src/tag.scss
+++ b/packages/theme-chalk/src/tag.scss
@@ -108,8 +108,6 @@ $tag-border-width: 1px;
     height: 16px;
     width: 16px;
     line-height: 16px;
-    vertical-align: middle;
-    top: -1px;
 
     svg {
       margin: 2px;


### PR DESCRIPTION
- fix tag style in select (caused by overflow style)

Before: 
![image](https://user-images.githubusercontent.com/25154432/146884280-694cdfec-1d88-4048-a8a7-4e857d34580f.png)

After:
![image](https://user-images.githubusercontent.com/25154432/146884305-1004a996-1b89-48e2-ae4b-a247fec6fed8.png)

Related to https://github.com/element-plus/element-plus/pull/4892

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
