### PR TITLE
fixed:tree 组件 is-leaf类下color层级过低无法覆盖.icon颜色导致leaf始终存在展开icon的bug

### DIFF
--- a/packages/theme-chalk/src/tree.scss
+++ b/packages/theme-chalk/src/tree.scss
@@ -98,8 +98,10 @@
     }
 
     &.is-leaf {
-      color: transparent;
       cursor: default;
+      .icon{
+        color: transparent;
+      }
     }
     &.is-hidden {
       visibility: hidden;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
