### PR TITLE
fix(core): fix unit testing warning

### DIFF
--- a/packages/components/cascader/src/index.vue
+++ b/packages/components/cascader/src/index.vue
@@ -324,7 +324,7 @@ export default defineComponent({
     )
     const realSize = useSize()
     const tagSize = computed(() =>
-      ['small'].includes(realSize.value) ? 'small' : ''
+      ['small'].includes(realSize.value) ? 'small' : 'default'
     )
     const multiple = computed(() => !!props.props.multiple)
     const readonly = computed(() => !props.filterable || multiple.value)

--- a/packages/components/descriptions/__tests__/descriptions.spec.ts
+++ b/packages/components/descriptions/__tests__/descriptions.spec.ts
@@ -1,5 +1,6 @@
 import { nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
+import ElTag from '@element-plus/components/tag'
 import Descriptions from '../src/index.vue'
 import DescriptionsItem from '../src/description-item'
 
@@ -8,6 +9,7 @@ const _mount = (template: string, data?: () => void, methods?: any) =>
     components: {
       'el-descriptions': Descriptions,
       'el-descriptions-item': DescriptionsItem,
+      'el-tag': ElTag,
     },
     template,
     data,
@@ -196,6 +198,6 @@ describe('Descriptions.vue', () => {
     )
     wrapper.find('button').trigger('click')
     await nextTick()
-    expect(wrapper.find('el-tag').text()).toBe(CHANGE_VALUE)
+    expect(wrapper.findComponent(ElTag).text()).toBe(CHANGE_VALUE)
   })
 })

--- a/packages/hooks/__tests__/use-form-item.spec.ts
+++ b/packages/hooks/__tests__/use-form-item.spec.ts
@@ -44,7 +44,7 @@ const getButtonVm = (wrapper: ReturnType<typeof mountComponent>) => {
 describe('use-form-item', () => {
   it('should return local value', () => {
     const wrapper = mountComponent()
-    expect(getButtonVm(wrapper).buttonSize).toBe('')
+    expect(getButtonVm(wrapper).buttonSize).toBe('default')
   })
 
   it('should return props.size instead of injected.size', () => {

--- a/packages/hooks/use-common-props/index.ts
+++ b/packages/hooks/use-common-props/index.ts
@@ -37,7 +37,7 @@ export const useSize = (
       form?.size ||
       globalConfig.value ||
       globalConfigLegacy.size ||
-      ''
+      'default'
   )
 }
 


### PR DESCRIPTION
This includes:
1. fallback to `default` in `useStyle` hook when `size` is unavailable.
2. use real `ElTag` component to render slot to avoid unrecognized element warning.

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
