### PR TITLE
fix(components):[radio-button]自适应外部容器宽度

### DIFF
--- a/packages/theme-chalk/src/radio-button.scss
+++ b/packages/theme-chalk/src/radio-button.scss
@@ -33,6 +33,7 @@
     position: relative;
     cursor: pointer;
     transition: var(--el-transition-all);
+    width: 100%;
     user-select: none;
 
     @include button-size(


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
直接给与el-radio-button这个标签的class设置width的话，并没有改变其宽度，不知是否应该修改此处？
