### PR TITLE
fix(components): always emit scroll with scrollTop number

### DIFF
--- a/packages/components/affix/src/affix.vue
+++ b/packages/components/affix/src/affix.vue
@@ -75,7 +75,7 @@ export default defineComponent({
       state.scrollTop =
         scrollContainer.value instanceof Window
           ? document.documentElement.scrollTop
-          : scrollContainer.value.scrollTop
+          : scrollContainer.value.scrollTop || 0
       state.clientHeight = document.documentElement.clientHeight
 
       if (props.position === 'top') {


### PR DESCRIPTION
when tested in jsdom, scrollTarget's scrollTop can be undefined.
This patch uses 0 as default value.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
