### PR TITLE
fix: message-box confirm button style

### DIFF
--- a/docs/.vitepress/i18n/component/demo-block.json
+++ b/docs/.vitepress/i18n/component/demo-block.json
@@ -1,8 +1,9 @@
 {
   "en-US": {
     "view-source": "View source",
-    "edit-on-github": "Edit on Github",
     "edit-in-editor": "Edit in PlayGround",
+    "edit-on-github": "Edit on Github",
+    "edit-in-codepen": "Edit in Codepen.io",
     "copy-code": "Copy code",
     "switch-button-option-text": "Switch to Options API",
     "switch-button-setup-text": "Switch to Composition API",

--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -99,7 +99,6 @@
             v-show="showConfirmButton"
             ref="confirmRef"
             type="primary"
-            plain
             :loading="confirmButtonLoading"
             :class="[confirmButtonClasses]"
             :round="roundButton"


### PR DESCRIPTION
- fix message-box confirm button style (remove plain)

Caused by #4564

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
