### PR TITLE
fix  ElLoading. Service creates multiple objects, not singletons bug

### DIFF
--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -43,15 +43,18 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
       }
       removeClass(target, 'el-loading-parent--hidden')
     }
+    removeElParent()
+  }
+  function removeElParent() {
     vm.$el?.parentNode?.removeChild(vm.$el)
   }
-
   function close() {
     if (options.beforeClose && !options.beforeClose()) return
 
     const target = data.parent
     target.vLoadingAddClassList = undefined
     afterLeaveFlag.value = true
+    removeElParent()
     clearTimeout(afterLeaveTimer)
 
     afterLeaveTimer = window.setTimeout(() => {

--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -45,7 +45,7 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
     }
     removeElParent()
   }
-  function removeElParent() {
+  function removeElParent(): void {
     vm.$el?.parentNode?.removeChild(vm.$el)
   }
   function close() {

--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -43,9 +43,9 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
       }
       removeClass(target, 'el-loading-parent--hidden')
     }
-    removeElParent()
+    remvoeElLoadingChild()
   }
-  function removeElParent(): void {
+  function remvoeElLoadingChild(): void {
     vm.$el?.parentNode?.removeChild(vm.$el)
   }
   function close() {
@@ -54,7 +54,6 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
     const target = data.parent
     target.vLoadingAddClassList = undefined
     afterLeaveFlag.value = true
-    removeElParent()
     clearTimeout(afterLeaveTimer)
 
     afterLeaveTimer = window.setTimeout(() => {
@@ -146,6 +145,7 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
   return {
     ...toRefs(data),
     setText,
+    remvoeElLoadingChild,
     close,
     handleAfterLeave,
     vm,

--- a/packages/components/loading/src/service.ts
+++ b/packages/components/loading/src/service.ts
@@ -3,7 +3,6 @@ import { isString } from '@vue/shared'
 import { isClient } from '@vueuse/core'
 import { addClass, getStyle, removeClass } from '@element-plus/utils/dom'
 import PopupManager from '@element-plus/utils/popup-manager'
-import el from '@element-plus/locale/lang/el'
 import { createLoadingComponent } from './loading'
 import type { LoadingInstance } from './loading'
 import type { LoadingOptionsResolved } from '..'
@@ -18,7 +17,6 @@ export const Loading = function (
   if (!isClient) return undefined as any
 
   const resolved = resolveOptions(options)
-
   if (resolved.fullscreen && fullscreenInstance) {
     return fullscreenInstance
   } else {

--- a/packages/components/loading/src/service.ts
+++ b/packages/components/loading/src/service.ts
@@ -19,6 +19,7 @@ export const Loading = function (
   const resolved = resolveOptions(options)
 
   if (resolved.fullscreen && fullscreenInstance) {
+    fullscreenInstance.remvoeElLoadingChild()
     fullscreenInstance.close()
   }
 


### PR DESCRIPTION
```
<template>
  <div class="container">
    <el-button type="primary" @click="openFullScreen">
      singleton service
    </el-button>
  </div>
</template>

<script lang="ts">
import { defineComponent, ref } from 'vue'
import { ElLoading } from 'element-plus'
export default defineComponent({
  setup() {
    const openFullScreen = () => {
      const loading = ElLoading.service({
        lock: true,
        text: 'Loading1',
        background: 'rgba(0, 0, 0, 0.3)',
      })
      const loading2 = ElLoading.service({
        lock: true,
        text: 'Loading2',
        background: 'rgba(0, 0, 0, 0.3)',
      })
      // loading2.setText('Loading2')
      console.log(loading === loading2) // true
      setTimeout(() => {
        loading.close()
      }, 2000)
    }

    return {
      openFullScreen,
    }
  },
})
</script>
<style scoped>
.container {
  display: flex;
  justify-content: center;
  align-items: center;
}
</style>

```
