### PR TITLE
fix [el-loading] use service ,single bug

### DIFF
--- a/packages/components/loading/src/directive.ts
+++ b/packages/components/loading/src/directive.ts
@@ -52,6 +52,7 @@ const createInstance = (
     target: getBindingProp('target') ?? (fullscreen ? undefined : el),
     body: getBindingProp('body') ?? binding.modifiers.body,
     lock: getBindingProp('lock') ?? binding.modifiers.lock,
+    isService: false,
   }
   el[INSTANCE_KEY] = {
     options,

--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -43,15 +43,18 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
       }
       removeClass(target, 'el-loading-parent--hidden')
     }
+    removeElParent()
+  }
+  function removeElParent() {
     vm.$el?.parentNode?.removeChild(vm.$el)
   }
-
   function close() {
     if (options.beforeClose && !options.beforeClose()) return
 
     const target = data.parent
     target.vLoadingAddClassList = undefined
     afterLeaveFlag.value = true
+    removeElParent()
     clearTimeout(afterLeaveTimer)
 
     afterLeaveTimer = window.setTimeout(() => {

--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -45,7 +45,7 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
     }
     removeElParent()
   }
-  function removeElParent() {
+  function removeElParent(): void {
     vm.$el?.parentNode?.removeChild(vm.$el)
   }
   function close() {

--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -43,9 +43,9 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
       }
       removeClass(target, 'el-loading-parent--hidden')
     }
-    removeElParent()
+    remvoeElLoadingChild()
   }
-  function removeElParent(): void {
+  function remvoeElLoadingChild(): void {
     vm.$el?.parentNode?.removeChild(vm.$el)
   }
   function close() {
@@ -54,7 +54,6 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
     const target = data.parent
     target.vLoadingAddClassList = undefined
     afterLeaveFlag.value = true
-    removeElParent()
     clearTimeout(afterLeaveTimer)
 
     afterLeaveTimer = window.setTimeout(() => {
@@ -146,6 +145,7 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
   return {
     ...toRefs(data),
     setText,
+    remvoeElLoadingChild,
     close,
     handleAfterLeave,
     vm,

--- a/packages/components/loading/src/service.ts
+++ b/packages/components/loading/src/service.ts
@@ -3,7 +3,6 @@ import { isString } from '@vue/shared'
 import { isClient } from '@vueuse/core'
 import { addClass, getStyle, removeClass } from '@element-plus/utils/dom'
 import PopupManager from '@element-plus/utils/popup-manager'
-import el from '@element-plus/locale/lang/el'
 import { createLoadingComponent } from './loading'
 import type { LoadingInstance } from './loading'
 import type { LoadingOptionsResolved } from '..'
@@ -18,7 +17,6 @@ export const Loading = function (
   if (!isClient) return undefined as any
 
   const resolved = resolveOptions(options)
-
   if (resolved.fullscreen && fullscreenInstance) {
     return fullscreenInstance
   } else {

--- a/packages/components/loading/src/service.ts
+++ b/packages/components/loading/src/service.ts
@@ -19,6 +19,7 @@ export const Loading = function (
   const resolved = resolveOptions(options)
 
   if (resolved.fullscreen && fullscreenInstance) {
+    fullscreenInstance.remvoeElLoadingChild()
     fullscreenInstance.close()
   }
 

--- a/packages/components/loading/src/service.ts
+++ b/packages/components/loading/src/service.ts
@@ -17,7 +17,9 @@ export const Loading = function (
   if (!isClient) return undefined as any
 
   const resolved = resolveOptions(options)
-  if (resolved.fullscreen && fullscreenInstance) {
+
+  if (resolved.isService && fullscreenInstance) {
+    addElAttris(resolved, fullscreenInstance)
     return fullscreenInstance
   } else {
     const instance = createLoadingComponent({
@@ -28,39 +30,44 @@ export const Loading = function (
       },
     })
 
-    addStyle(resolved, resolved.parent, instance)
-    addClassList(resolved, resolved.parent, instance)
-
-    resolved.parent.vLoadingAddClassList = () =>
-      addClassList(resolved, resolved.parent, instance)
-
-    /**
-     * add loading-number to parent.
-     * because if a fullscreen loading is triggered when somewhere
-     * a v-loading.body was triggered before and it's parent is
-     * document.body which with a margin , the fullscreen loading's
-     * destroySelf function will remove 'el-loading-parent--relative',
-     * and then the position of v-loading.body will be error.
-     */
-    let loadingNumber: string | null =
-      resolved.parent.getAttribute('loading-number')
-    if (!loadingNumber) {
-      loadingNumber = '1'
-    } else {
-      loadingNumber = `${Number.parseInt(loadingNumber) + 1}`
-    }
-    resolved.parent.setAttribute('loading-number', loadingNumber)
-
-    resolved.parent.appendChild(instance.$el)
-
-    // after instance render, then modify visible to trigger transition
-    nextTick(() => (instance.visible.value = resolved.visible))
-
-    if (resolved.fullscreen) {
+    addElAttris(resolved, instance)
+    if (resolved.isService) {
       fullscreenInstance = instance
     }
     return instance
   }
+}
+const addElAttris = (
+  resolved: LoadingOptionsResolved,
+  instance: LoadingInstance
+) => {
+  addStyle(resolved, resolved.parent, instance)
+  addClassList(resolved, resolved.parent, instance)
+
+  resolved.parent.vLoadingAddClassList = () =>
+    addClassList(resolved, resolved.parent, instance)
+
+  /**
+   * add loading-number to parent.
+   * because if a fullscreen loading is triggered when somewhere
+   * a v-loading.body was triggered before and it's parent is
+   * document.body which with a margin , the fullscreen loading's
+   * destroySelf function will remove 'el-loading-parent--relative',
+   * and then the position of v-loading.body will be error.
+   */
+  let loadingNumber: string | null =
+    resolved.parent.getAttribute('loading-number')
+  if (!loadingNumber) {
+    loadingNumber = '1'
+  } else {
+    loadingNumber = `${Number.parseInt(loadingNumber) + 1}`
+  }
+  resolved.parent.setAttribute('loading-number', loadingNumber)
+
+  resolved.parent.appendChild(instance.$el)
+
+  // after instance render, then modify visible to trigger transition
+  nextTick(() => (instance.visible.value = resolved.visible))
 }
 
 const resolveOptions = (options: LoadingOptions): LoadingOptionsResolved => {
@@ -83,6 +90,7 @@ const resolveOptions = (options: LoadingOptions): LoadingOptionsResolved => {
     customClass: options.customClass || '',
     visible: options.visible ?? true,
     target,
+    isService: options.isService ?? true,
   }
 }
 

--- a/packages/components/loading/src/types.ts
+++ b/packages/components/loading/src/types.ts
@@ -14,6 +14,7 @@ export type LoadingOptionsResolved = {
   target: HTMLElement
   beforeClose?: () => boolean
   closed?: () => void
+  isService: boolean
 }
 export type LoadingOptions = Partial<
   Omit<LoadingOptionsResolved, 'parent' | 'target'> & {


### PR DESCRIPTION
[以服务的方式来调用-官网解释](https://element-plus.gitee.io/zh-CN/component/loading.html#以服务的方式来调用)
需要注意的是，以服务的方式调用的全屏 Loading 是单例的。 若在前一个全屏 Loading 关闭前再次调用全屏 Loading，并不会创建一个新的 Loading 实例，而是返回现有全屏 Loading 的实例：

```
const loadingInstance1 = ElLoading.service({ fullscreen: true })
const loadingInstance2 = ElLoading.service({ fullscreen: true })
console.log(loadingInstance1 === loadingInstance2) // true
```
实测结果为：false 并不是单例的

demo 
```
<template>
  <div
    v-loading.lock=""
    element-loading-background="rgba(0, 0, 0, 0.3)"
    class="container"
  >
    <el-button type="primary" @click="openFullScreen1">
      singleton service
    </el-button>
  </div>
  <div @click="openFullScreen">
    <el-button
      v-loading.lock="fullscreenLoading"
      element-loading-text="Loading111"
      type="primary"
      style="width: 30%"
    >
      v-loading not service
    </el-button>
    <el-button
      v-loading.lock="fullscreenLoading"
      element-loading-text="Loading222"
      type="primary"
      style="width: 30%"
    >
      v-loading not service
    </el-button>
  </div>
</template>

<script lang="ts">
import { defineComponent, ref } from 'vue'
import { ElLoading } from 'element-plus'
export default defineComponent({
  setup() {
    const fullscreenLoading = ref(false)
    const openFullScreen = () => {
      fullscreenLoading.value = true
      setTimeout(() => {
        fullscreenLoading.value = false
      }, 2000)
    }
    const openFullScreen1 = () => {
      const loading = ElLoading.service({
        lock: true,
        text: 'Loading',
        background: 'rgba(0, 0, 0, 0.3)',
      })
      const loading2 = ElLoading.service({
        lock: true,
        text: 'Loading',
        background: 'rgba(0, 0, 0, 0.3)',
      })
      console.log(loading === loading2) // true
      setTimeout(() => {
        loading.close()
        loading2.close()
      }, 2000)
    }
    return {
      fullscreenLoading,
      openFullScreen,
      openFullScreen1,
    }
  },
})
</script>
<style scoped>
.container {
  display: flex;
  justify-content: center;
  align-items: center;
}
div {
  margin-top: 30px;
}
</style>

```
