### PR TITLE
fix(theme-chalk): auto menu item height & add css var, close #4864

### DIFF
--- a/docs/examples/menu/vertical.vue
+++ b/docs/examples/menu/vertical.vue
@@ -1,7 +1,7 @@
 <template>
   <el-row class="tac">
     <el-col :span="12">
-      <h5>Default colors</h5>
+      <h5 class="mb-2">Default colors</h5>
       <el-menu
         default-active="2"
         class="el-menu-vertical-demo"
@@ -40,7 +40,7 @@
       </el-menu>
     </el-col>
     <el-col :span="12">
-      <h5>Custom colors</h5>
+      <h5 class="mb-2">Custom colors</h5>
       <el-menu
         active-text-color="#ffd04b"
         background-color="#545c64"

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -915,6 +915,7 @@ $menu: map.merge(
     'hover-text-color': var(--el-text-color-primary),
     'bg-color': var(--el-color-white),
     'hover-bg-color': var(--el-color-primary-light-9),
+    'item-height': 56px,
     'item-font-size': var(--el-font-size-base),
     'item-hover-fill': var(--el-color-primary-light-9),
     'border-color': #e6e6e6,

--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -7,8 +7,8 @@
 @mixin menu-item {
   display: flex;
   align-items: center;
-  height: 56px;
-  line-height: 56px;
+  height: var(--el-menu-item-height);
+  line-height: var(--el-menu-item-height);
   font-size: var(--el-menu-item-font-size);
   color: var(--el-menu-text-color);
   padding: 0 20px;
@@ -67,7 +67,7 @@
       justify-content: center;
       align-items: center;
 
-      height: 60px;
+      height: 100%;
       margin: 0;
       border-bottom: 2px solid transparent;
       color: var(--el-menu-text-color);
@@ -102,8 +102,7 @@
       }
 
       & .#{$namespace}-sub-menu__title {
-        height: 60px;
-        line-height: 60px;
+        height: 100%;
         border-bottom: 2px solid transparent;
         color: var(--el-menu-text-color);
 


### PR DESCRIPTION
- make sub menu item height be 100%
- add `--el-menu-item-height` to custom height by css var

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
