### PR TITLE
fix(components): el-loading service single bug

### DIFF
--- a/packages/components/loading/src/directive.ts
+++ b/packages/components/loading/src/directive.ts
@@ -52,6 +52,7 @@ const createInstance = (
     target: getBindingProp('target') ?? (fullscreen ? undefined : el),
     body: getBindingProp('body') ?? binding.modifiers.body,
     lock: getBindingProp('lock') ?? binding.modifiers.lock,
+    isService: getBindingProp('isService') ?? false,
   }
   el[INSTANCE_KEY] = {
     options,

--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -35,7 +35,7 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
       let loadingNumber: number | string | null =
         target.getAttribute('loading-number')
       loadingNumber = Number.parseInt(loadingNumber as any) - 1
-      if (!loadingNumber) {
+      if (!loadingNumber || data.isService) {
         removeClass(target, 'el-loading-parent--relative')
         target.removeAttribute('loading-number')
       } else {

--- a/packages/components/loading/src/service.ts
+++ b/packages/components/loading/src/service.ts
@@ -18,19 +18,29 @@ export const Loading = function (
 
   const resolved = resolveOptions(options)
 
-  if (resolved.fullscreen && fullscreenInstance) {
-    fullscreenInstance.remvoeElLoadingChild()
-    fullscreenInstance.close()
+  if (resolved.isService && fullscreenInstance) {
+    addElAttris(resolved, fullscreenInstance)
+    return fullscreenInstance
+  } else {
+    const instance = createLoadingComponent({
+      ...resolved,
+      closed: () => {
+        resolved.closed?.()
+        if (resolved.fullscreen) fullscreenInstance = undefined
+      },
+    })
+
+    addElAttris(resolved, instance)
+    if (resolved.isService) {
+      fullscreenInstance = instance
+    }
+    return instance
   }
-
-  const instance = createLoadingComponent({
-    ...resolved,
-    closed: () => {
-      resolved.closed?.()
-      if (resolved.fullscreen) fullscreenInstance = undefined
-    },
-  })
-
+}
+const addElAttris = (
+  resolved: LoadingOptionsResolved,
+  instance: LoadingInstance
+) => {
   addStyle(resolved, resolved.parent, instance)
   addClassList(resolved, resolved.parent, instance)
 
@@ -58,11 +68,6 @@ export const Loading = function (
 
   // after instance render, then modify visible to trigger transition
   nextTick(() => (instance.visible.value = resolved.visible))
-
-  if (resolved.fullscreen) {
-    fullscreenInstance = instance
-  }
-  return instance
 }
 
 const resolveOptions = (options: LoadingOptions): LoadingOptionsResolved => {
@@ -85,6 +90,7 @@ const resolveOptions = (options: LoadingOptions): LoadingOptionsResolved => {
     customClass: options.customClass || '',
     visible: options.visible ?? true,
     target,
+    isService: options.isService ?? true,
   }
 }
 

--- a/packages/components/loading/src/service.ts
+++ b/packages/components/loading/src/service.ts
@@ -90,7 +90,7 @@ const resolveOptions = (options: LoadingOptions): LoadingOptionsResolved => {
     customClass: options.customClass || '',
     visible: options.visible ?? true,
     target,
-    isService: options.isService ?? true,
+    isService: target === document.body && (options.isService ?? true),
   }
 }
 

--- a/packages/components/loading/src/types.ts
+++ b/packages/components/loading/src/types.ts
@@ -14,6 +14,7 @@ export type LoadingOptionsResolved = {
   target: HTMLElement
   beforeClose?: () => boolean
   closed?: () => void
+  isService: boolean
 }
 export type LoadingOptions = Partial<
   Omit<LoadingOptionsResolved, 'parent' | 'target'> & {


### PR DESCRIPTION
[以服务的方式调用的全屏 Loading 是单例的](https://element-plus.gitee.io/zh-CN/component/loading.html#以服务的方式来调用)
需要注意的是，以服务的方式调用的全屏 Loading 是单例的。 若在前一个全屏 Loading 关闭前再次调用全屏 Loading，并不会创建一个新的 Loading 实例，而是返回现有全屏 Loading 的实例：
```
const loadingInstance1 = ElLoading.service({ fullscreen: true })
const loadingInstance2 = ElLoading.service({ fullscreen: true })
console.log(loadingInstance1 === loadingInstance2) // true
```
测试结果：false

demo:
```
<template>
  <div>
    <div class="container">
      <el-button type="primary" @click="openFullScreen1">
        singleton service
      </el-button>
    </div>
    <div @click="openFullScreen">
      <el-button
        v-loading.lock="fullscreenLoading"
        element-loading-text="Loading111"
        type="primary"
        style="width: 30%"
      >
        v-loading not single
      </el-button>
      <el-button
        v-loading.lock="fullscreenLoading"
        element-loading-text="Loading222"
        type="primary"
        style="width: 30%"
      >
        v-loading not single
      </el-button>
    </div>
  </div>
</template>

<script lang="ts">
import { defineComponent, ref } from 'vue'
import { ElLoading } from 'element-plus'
export default defineComponent({
  setup() {
    const fullscreenLoading = ref(false)
    const openFullScreen = () => {
      fullscreenLoading.value = true
      setTimeout(() => {
        fullscreenLoading.value = false
      }, 2000)
    }
    const openFullScreen1 = () => {
      const loading = ElLoading.service({
        lock: true,
        text: 'Loading',
        background: 'rgba(0, 0, 0, 0.3)',
      })
      const loading2 = ElLoading.service({
        lock: true,
        text: 'Loading',
        background: 'rgba(0, 0, 0, 0.3)',
      })
      console.log(`ElLoading.service-is:${loading === loading2}`)
      setTimeout(() => {
        loading.close()
      }, 2000)
    }
    return {
      fullscreenLoading,
      openFullScreen,
      openFullScreen1,
    }
  },
})
</script>
<style scoped>
.container {
  display: flex;
  justify-content: center;
  align-items: center;
}
div {
  margin-top: 30px;
}
</style>

```
期望结果：true

