### PR TITLE
fix(components): popper content fallback placements

### DIFF
--- a/packages/components/popper/src/utils.ts
+++ b/packages/components/popper/src/utils.ts
@@ -39,7 +39,7 @@ export const unwrapMeasurableEl = (
 }
 
 function genModifiers(options: UsePopperCoreConfigProps) {
-  const { offset, gpuAcceleration } = options
+  const { offset, gpuAcceleration, fallbackPlacements } = options
   return [
     {
       name: 'offset',
@@ -62,7 +62,7 @@ function genModifiers(options: UsePopperCoreConfigProps) {
       name: 'flip',
       options: {
         padding: 5,
-        fallbackPlacements: [],
+        fallbackPlacements: fallbackPlacements ?? [],
       },
     },
     {


### PR DESCRIPTION
- Fix popper content don't fallback to correct placement

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
