### PR TITLE
fix(components): [el-avatar] fix avatar default size

### DIFF
--- a/packages/components/avatar/src/avatar.ts
+++ b/packages/components/avatar/src/avatar.ts
@@ -6,7 +6,7 @@ export const avatarProps = buildProps({
   size: {
     type: [Number, String],
     values: ['large', 'default', 'small'],
-    default: 'large',
+    default: 'default',
     validator: (val: unknown): val is number => typeof val === 'number',
   },
   shape: {


### PR DESCRIPTION
avatar default size is "large“ in the version 1.3.0-beta.1
avatar default size should be "default"