### PR TITLE
fix(hooks): [use-locale] fix init locale bug

### DIFF
--- a/packages/hooks/use-locale/index.ts
+++ b/packages/hooks/use-locale/index.ts
@@ -2,6 +2,7 @@ import { computed, getCurrentInstance, inject, provide, ref, unref } from 'vue'
 import get from 'lodash/get'
 import English from '@element-plus/locale/lang/en'
 import { buildProps, definePropType } from '@element-plus/utils/props'
+import { useGlobalConfig } from '@element-plus/hooks'
 import type { MaybeRef } from '@vueuse/core'
 import type { InjectionKey, Ref } from 'vue'
 import type { Language } from '@element-plus/locale'
@@ -71,7 +72,7 @@ export const translate = (
     (_, key) => `${option?.[key] ?? `{${key}}`}`
   )
 
-export const localeProviderMaker = (locale = English) => {
+export const localeProviderMaker = (locale: Language = English) => {
   const lang = ref(locale.name)
   const localeRef = ref(locale)
   return {
@@ -82,5 +83,9 @@ export const localeProviderMaker = (locale = English) => {
 }
 
 export const useLocale = () => {
-  return inject(localeContextKey, cache || localeProviderMaker(English))
+  const locale = useGlobalConfig('locale').value
+  return inject(
+    localeContextKey,
+    cache || localeProviderMaker(locale || English)
+  )
 }


### PR DESCRIPTION
修复初始化传入locale后，国际化还是英文
版本：1.3.0-beta.1
比如
import zhCn from 'element-plus/es/locale/lang/zh-cn'
app.use(ElementPlus, { locale: zhCn })

UI组件还是英文，并没有变中文