### PR TITLE
feat(components): make `value-format="x"` emit number value

### DIFF
--- a/packages/components/date-picker/__tests__/date-picker.spec.ts
+++ b/packages/components/date-picker/__tests__/date-picker.spec.ts
@@ -356,8 +356,8 @@ describe('DatePicker', () => {
       )
       const vm = wrapper.vm as any
       const input = wrapper.find('input')
-      input.trigger('blur')
-      input.trigger('focus')
+      await input.trigger('blur')
+      await input.trigger('focus')
       await nextTick()
       {
         ;(document.querySelector('td.available') as HTMLElement).click()
@@ -369,9 +369,50 @@ describe('DatePicker', () => {
           valueFormat
         ).format(valueFormat)
       )
-      wrapper.find('button').trigger('click')
+      await wrapper.find('button').trigger('click')
       await nextTick()
       expect(wrapper.findComponent(Input).vm.modelValue).toBe('2021-05-31')
+    })
+
+    it('with "x"', async () => {
+      const format = 'YYYY/MM/DD'
+      const dateStr = '2021/05/31'
+      const valueFormat = 'x'
+      const value = Date.now()
+      const wrapper = _mount(
+        `
+        <el-date-picker
+          ref="compo"
+          v-model="value"
+          type="date"
+          format="${format}"
+          value-format="${valueFormat}" />
+        <button @click="changeValue">click</button>
+      `,
+        () => {
+          return {
+            value,
+          }
+        },
+        {
+          methods: {
+            changeValue() {
+              this.value = +new Date(dateStr)
+            },
+          },
+        }
+      )
+      const vm = wrapper.vm as any
+      const input = wrapper.find('input')
+      await input.trigger('blur')
+      await input.trigger('focus')
+      await nextTick()
+      ;(document.querySelector('td.available') as HTMLElement).click()
+      await nextTick()
+      expect(vm.value).toBe(+dayjs().startOf('M'))
+      await wrapper.find('button').trigger('click')
+      await nextTick()
+      expect(wrapper.findComponent(Input).vm.modelValue).toBe(dateStr)
     })
   })
 })

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -212,14 +212,17 @@ const parser = function (
   format: string,
   lang: string
 ): Dayjs {
-  const day = isEmpty(format)
-    ? dayjs(date).locale(lang)
-    : dayjs(date, format).locale(lang)
+  const day =
+    isEmpty(format) || format === 'x'
+      ? dayjs(date).locale(lang)
+      : dayjs(date, format).locale(lang)
   return day.isValid() ? day : undefined
 }
 
 const formatter = function (date: number | Date, format: string, lang: string) {
-  return isEmpty(format) ? date : dayjs(date).locale(lang).format(format)
+  if (isEmpty(format)) return date
+  if (format === 'x') return +date
+  return dayjs(date).locale(lang).format(format)
 }
 
 export default defineComponent({


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

element-ui 2.0 的 `date-picker` 组件支持 `value-format="timestamp"`，这个参数对于前后端使用时间戳通信时非常有用。

https://element.eleme.io/#/zh-CN/component/date-picker#ri-qi-ge-shi

而 element-plus 却没有对应的属性。最接近的 `value-format="x"` 虽然会把 value 格式化为时间戳，但是得到的确是字符串类型的时间戳，而非数字类型