### PR TITLE
feat(components): [el-message-box] add role="dialog" attribute

### DIFF
--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -10,6 +10,7 @@
       <div
         ref="root"
         v-trap-focus
+        role="dialog"
         :aria-label="title || 'dialog'"
         aria-modal="true"
         :class="[


### PR DESCRIPTION
Adds a `role="dialog"` attribute to the MessageBox dialogs. This already exists in the ElDialog component and in the legacy ElementUI's version of ElMessageBox.

Improves accessibility and provides a good test selector if using [Vue Testing Library](https://testing-library.com/docs/vue-testing-library/intro/): 

```
getByRole('dialog', { name: 'My dialog title' })
```


Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
