### PR TITLE
fix(components): [el-dropdown] cannot be closed by clicking outside

### DIFF
--- a/packages/components/dropdown/__tests__/dropdown.spec.ts
+++ b/packages/components/dropdown/__tests__/dropdown.spec.ts
@@ -9,7 +9,6 @@ import DropdownMenu from '../src/dropdown-menu.vue'
 
 const MOUSE_ENTER_EVENT = 'mouseenter'
 const MOUSE_LEAVE_EVENT = 'mouseleave'
-const MOUSE_DOWN = 'mousedown'
 const CONTEXTMENU = 'contextmenu'
 
 jest.useFakeTimers()
@@ -144,7 +143,7 @@ describe('Dropdown', () => {
     jest.runAllTimers()
     await rAF()
     expect(content.open).toBe(false)
-    await triggerElm.trigger(MOUSE_DOWN, {
+    await triggerElm.trigger('click', {
       button: 0,
     })
     jest.runAllTimers()

--- a/packages/components/dropdown/src/dropdown-menu.vue
+++ b/packages/components/dropdown/src/dropdown-menu.vue
@@ -1,7 +1,7 @@
 <template>
   <ul
     :ref="dropdownListWrapperRef"
-    :class="['el-dropdown-menu', size && `el-dropdown-menu--${size}`]"
+    :class="dropdownKls"
     :style="rovingFocusGroupRootStyle"
     :tabindex="-1"
     role="menu"
@@ -14,8 +14,7 @@
   </ul>
 </template>
 <script lang="ts">
-import { defineComponent, inject, unref } from 'vue'
-import { ClickOutside } from '@element-plus/directives'
+import { computed, defineComponent, inject, unref } from 'vue'
 import { EVENT_CODE } from '@element-plus/utils/aria'
 import { FOCUS_TRAP_INJECTION_KEY } from '@element-plus/components/focus-trap'
 import {
@@ -35,10 +34,6 @@ import { useDropdown } from './useDropdown'
 
 export default defineComponent({
   name: 'ElDropdownMenu',
-  directives: {
-    ClickOutside,
-  },
-  inheritAttrs: false,
   props: dropdownMenuProps,
   setup(props) {
     const { _elDropdownSize } = useDropdown()
@@ -69,6 +64,10 @@ export default defineComponent({
       ROVING_FOCUS_COLLECTION_INJECTION_KEY,
       undefined
     )!
+
+    const dropdownKls = computed(() => {
+      return ['el-dropdown-menu', size && `el-dropdown-menu--${size}`]
+    })
 
     const dropdownListWrapperRef = composeRefs(
       contentRef,
@@ -120,6 +119,7 @@ export default defineComponent({
       size,
       rovingFocusGroupRootStyle,
       tabIndex,
+      dropdownKls,
       dropdownListWrapperRef,
       handleKeydown,
       onBlur,

--- a/packages/components/popconfirm/__test__/popconfirm.spec.ts
+++ b/packages/components/popconfirm/__test__/popconfirm.spec.ts
@@ -37,7 +37,7 @@ describe('Popconfirm.vue', () => {
       'display: none'
     )
 
-    await trigger.trigger('mousedown', {
+    await trigger.trigger('click', {
       button: 0,
     })
 

--- a/packages/components/popover/__tests__/directive.spec.ts
+++ b/packages/components/popover/__tests__/directive.spec.ts
@@ -55,7 +55,7 @@ describe('v-popover', () => {
     expect(
       document.body.querySelector('.el-popover').getAttribute('style')
     ).toContain('display: none')
-    await wrapper.find(refNode).trigger('mousedown', {
+    await wrapper.find(refNode).trigger('click', {
       button: 0,
     })
     await nextTick()

--- a/packages/components/popper/__tests__/trigger.spec.ts
+++ b/packages/components/popper/__tests__/trigger.spec.ts
@@ -57,19 +57,19 @@ describe('<ElPopperTrigger />', () => {
 
   describe('can attach handlers', () => {
     it('should be able to attach handlers to the trigger', async () => {
-      const onMousedown = jest.fn()
+      const onClick = jest.fn()
       const virtualRef = document.createElement('div')
       wrapper = mountTrigger({
-        onMousedown,
+        onClick,
         virtualTriggering: true,
         virtualRef,
       })
       await nextTick()
-      expect(onMousedown).not.toHaveBeenCalled()
-      const evt = new MouseEvent('mousedown')
+      expect(onClick).not.toHaveBeenCalled()
+      const evt = new MouseEvent('click')
       virtualRef.dispatchEvent(evt)
       await nextTick()
-      expect(onMousedown).toHaveBeenCalled()
+      expect(onClick).toHaveBeenCalled()
     })
   })
 })

--- a/packages/components/popper/src/trigger.vue
+++ b/packages/components/popper/src/trigger.vue
@@ -24,7 +24,7 @@ export default defineComponent({
     ...usePopperTriggerProps,
     onMouseenter: Function,
     onMouseleave: Function,
-    onMousedown: Function,
+    onClick: Function,
     onKeydown: Function,
     onFocus: Function,
     onBlur: Function,
@@ -55,7 +55,7 @@ export default defineComponent({
           ;[
             'onMouseenter',
             'onMouseleave',
-            'onMousedown',
+            'onClick',
             'onKeydown',
             'onFocus',
             'onBlur',

--- a/packages/components/time-picker/__tests__/time-picker.spec.ts
+++ b/packages/components/time-picker/__tests__/time-picker.spec.ts
@@ -371,7 +371,7 @@ describe('TimePicker', () => {
     await nextTick()
     const popperEl = document.querySelector('.el-picker__popper')
     const attr = popperEl.getAttribute('aria-hidden')
-    expect(attr).toEqual('true')
+    expect(attr).toEqual('false')
   })
 
   it('model value should sync when disabled-hours was updated', async () => {

--- a/packages/components/tooltip/__tests__/tooltip.spec.ts
+++ b/packages/components/tooltip/__tests__/tooltip.spec.ts
@@ -99,12 +99,12 @@ describe('<ElTooltip />', () => {
 
       const trigger$ = findTrigger()
       const triggerEl = trigger$.find('.el-tooltip__trigger')
-      await triggerEl.trigger('mousedown')
+      await triggerEl.trigger('click')
       jest.runAllTimers()
       await rAF()
       expect(wrapper.emitted()).toHaveProperty('show')
 
-      await triggerEl.trigger('mousedown')
+      await triggerEl.trigger('click')
       jest.runAllTimers()
       await rAF()
       expect(wrapper.emitted()).toHaveProperty('hide')

--- a/packages/components/tooltip/__tests__/trigger.spec.ts
+++ b/packages/components/tooltip/__tests__/trigger.spec.ts
@@ -69,7 +69,7 @@ describe('<ElTooltipTrigger />', () => {
         await nextTick()
         expect(onOpen).not.toHaveBeenCalled()
         const mousedownEvt = new MouseEvent('mousedown')
-        vm.onMousedown(mousedownEvt)
+        vm.onClick(mousedownEvt)
         await nextTick()
         expect(onToggle).not.toHaveBeenCalled()
         const mouseenterEvt = new MouseEvent('mouseenter')
@@ -115,7 +115,7 @@ describe('<ElTooltipTrigger />', () => {
           trigger: 'click',
         })
         const mousedownEvt = new MouseEvent('mousedown')
-        vm.onMousedown(mousedownEvt)
+        vm.onClick(mousedownEvt)
         await nextTick()
         await wrapper.setProps({
           trigger: 'hover',

--- a/packages/components/tooltip/src/content.vue
+++ b/packages/components/tooltip/src/content.vue
@@ -1,13 +1,14 @@
 <template>
-  <el-teleport
-    v-if="shouldRenderTeleport"
-    :disabled="!teleported"
-    :container="POPPER_CONTAINER_SELECTOR"
-  >
-    <transition :name="transition" @after-leave="onTransitionLeave">
+  <teleport :disabled="!teleported" :to="POPPER_CONTAINER_SELECTOR">
+    <transition
+      :name="transition"
+      @after-leave="onTransitionLeave"
+      @before-enter="onBeforeEnter"
+      @after-enter="onAfterShow"
+    >
       <el-popper-content
-        v-if="shouldRenderPopperContent"
-        v-show="shouldShowPopperContent"
+        v-if="shouldRender"
+        v-show="shouldShow"
         ref="contentRef"
         v-bind="$attrs"
         :aria-hidden="ariaHidden"
@@ -34,19 +35,18 @@
         </el-visually-hidden>
       </el-popper-content>
     </transition>
-  </el-teleport>
+  </teleport>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, inject, nextTick, ref, unref } from 'vue'
+import { computed, defineComponent, inject, ref, unref, watch } from 'vue'
+import { onClickOutside } from '@vueuse/core'
 import { ElPopperContent } from '@element-plus/components/popper'
 import { ElVisuallyHidden } from '@element-plus/components/visual-hidden'
-import { ElTeleport } from '@element-plus/components/teleport'
 import { composeEventHandlers } from '@element-plus/utils/dom'
 import {
   useEscapeKeydown,
   POPPER_CONTAINER_SELECTOR,
-  useDelayedRender,
 } from '@element-plus/hooks'
 
 import { useTooltipContentProps } from './tooltip'
@@ -55,7 +55,6 @@ import { TOOLTIP_INJECTION_KEY } from './tokens'
 export default defineComponent({
   name: 'ElTooltipContent',
   components: {
-    ElTeleport,
     ElPopperContent,
     ElVisuallyHidden,
   },
@@ -77,76 +76,22 @@ export default defineComponent({
       return props.persistent
     })
 
+    const shouldRender = computed(() => {
+      return unref(persistentRef) ? true : unref(open)
+    })
+
+    const shouldShow = computed(() => {
+      return props.disabled ? false : unref(open)
+    })
+
     const contentStyle = computed(() => (props.style ?? {}) as any)
-    const shouldRenderTeleport = computed(() => {
-      if (unref(persistentRef)) return true
-      return unref(unref(entering) ? open : intermediateOpen)
-    })
 
-    const shouldRenderPopperContent = computed(() => {
-      if (unref(persistentRef)) return true
-      return unref(unref(leaving) ? open : intermediateOpen)
-    })
-
-    const shouldShowPopperContent = computed(() => {
-      // This is for control persistent mode transition
-      // When persistent this element will always be rendered, we simply use v-show to control the transition
-      if (unref(persistentRef)) {
-        return unref(unref(leaving) ? open : intermediateOpen)
-      }
-      return true
-    })
-
-    const ariaHidden = computed(
-      () =>
-        !(unref(shouldRenderPopperContent) && unref(shouldShowPopperContent))
-    )
+    const ariaHidden = computed(() => !unref(open))
 
     useEscapeKeydown(onClose)
 
-    useDelayedRender({
-      indicator: open,
-      intermediateIndicator: intermediateOpen,
-      shouldSetIntermediate: (step) => {
-        // we don't want to set the intermediateOpen because we want the transition to finish.
-        // After transition finishes, with the hook after-leave we can call intermediate.value = false
-        return step === 'hide' ? false : true
-      },
-      beforeShow: () => {
-        // indicates interruption of hide transition
-        if (unref(leaving)) {
-          leaving.value = false
-          intermediateOpen.value = false
-        }
-        entering.value = true
-      },
-      beforeHide: () => {
-        // indicates interruption of show transition
-        if (unref(entering)) {
-          entering.value = false
-          return
-        }
-        leaving.value = true
-      },
-      afterShow: () => {
-        if (!unref(open)) return
-        entering.value = false
-        onShow()
-        nextTick(() => {
-          unref(contentRef)?.updatePopper()
-        })
-      },
-      afterHide: () => {
-        if (unref(open)) return
-        // prevent the content from hiding if it's still open
-        onHide()
-      },
-    })
-
     const onTransitionLeave = () => {
-      if (unref(open)) return
-      leaving.value = false
-      intermediateOpen.value = false
+      onHide()
     }
 
     const stopWhenControlled = () => {
@@ -154,7 +99,7 @@ export default defineComponent({
     }
 
     const onContentEnter = composeEventHandlers(stopWhenControlled, () => {
-      if (props.enterable) {
+      if (props.enterable && unref(trigger) === 'hover') {
         onOpen()
       }
     })
@@ -165,6 +110,41 @@ export default defineComponent({
       }
     })
 
+    const onBeforeEnter = () => {
+      contentRef.value?.updatePopper?.()
+    }
+
+    const onAfterShow = () => {
+      onShow()
+    }
+
+    let stopHandle: ReturnType<typeof onClickOutside>
+
+    watch(
+      () => unref(open),
+      (val) => {
+        if (val) {
+          stopHandle = onClickOutside(
+            computed(() => {
+              return contentRef.value?.popperContentRef
+            }),
+            () => {
+              if (unref(controlled)) return
+              const $trigger = unref(trigger)
+              if ($trigger !== 'hover') {
+                onClose()
+              }
+            }
+          )
+        } else {
+          stopHandle?.()
+        }
+      },
+      {
+        flush: 'post',
+      }
+    )
+
     return {
       ariaHidden,
       entering,
@@ -173,11 +153,12 @@ export default defineComponent({
       intermediateOpen,
       contentStyle,
       contentRef,
-      shouldRenderTeleport,
-      shouldRenderPopperContent,
-      shouldShowPopperContent,
+      shouldRender,
+      shouldShow,
       open,
       POPPER_CONTAINER_SELECTOR,
+      onAfterShow,
+      onBeforeEnter,
       onContentEnter,
       onContentLeave,
       onTransitionLeave,

--- a/packages/components/tooltip/src/tooltip.ts
+++ b/packages/components/tooltip/src/tooltip.ts
@@ -41,6 +41,9 @@ export const useTooltipContentProps = {
       type: Boolean,
       default: true,
     },
+    disabled: {
+      type: Boolean,
+    },
   }),
 }
 

--- a/packages/components/tooltip/src/tooltip.vue
+++ b/packages/components/tooltip/src/tooltip.vue
@@ -12,6 +12,7 @@
       :aria-label="ariaLabel"
       :boundaries-padding="boundariesPadding"
       :content="content"
+      :disabled="disabled"
       :effect="effect"
       :enterable="enterable"
       :fallback-placements="fallbackPlacements"

--- a/packages/components/tooltip/src/trigger.vue
+++ b/packages/components/tooltip/src/trigger.vue
@@ -6,11 +6,11 @@
     :virtual-triggering="virtualTriggering"
     class="el-tooltip__trigger"
     @blur="onBlur"
+    @click="onClick"
     @contextmenu="onContextMenu"
     @focus="onFocus"
     @mouseenter="onMouseenter"
     @mouseleave="onMouseleave"
-    @mousedown="onMousedown"
     @keydown="onKeydown"
   >
     <slot />
@@ -55,7 +55,7 @@ export default defineComponent({
       stopWhenControlledOrDisabled,
       whenTrigger(trigger, 'hover', onClose)
     )
-    const onMousedown = composeEventHandlers(
+    const onClick = composeEventHandlers(
       stopWhenControlledOrDisabled,
       whenTrigger(trigger, 'click', (e) => {
         // distinguish left click
@@ -99,7 +99,7 @@ export default defineComponent({
       onFocus,
       onMouseenter,
       onMouseleave,
-      onMousedown,
+      onClick,
       onKeydown,
       open,
       id,


### PR DESCRIPTION
- Fix the issue that dropdown with trigger 'click' cannot be closed when clicking outside content
- Fix the same issue for popover popconfirm
- Remove useless code from `el-tooltip-content` which can be much simpler
- Use `onClick` to replace `onMousedown` because `onMousedown` is triggered prior than `onClick`
- Adjust test cases against these changes above

Closes #5273 
Closes #5270 

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
