### PR TITLE
feat(components): [el-dialog] remove width validator (#5329)

### DIFF
--- a/packages/components/dialog/src/dialog.ts
+++ b/packages/components/dialog/src/dialog.ts
@@ -1,4 +1,3 @@
-import { isValidWidthUnit } from '@element-plus/utils/validators'
 import { buildProps, definePropType } from '@element-plus/utils/props'
 import { UPDATE_MODEL_EVENT } from '@element-plus/utils/constants'
 
@@ -74,7 +73,6 @@ export const dialogProps = buildProps({
   modalClass: String,
   width: {
     type: [String, Number],
-    validator: isValidWidthUnit,
   },
   zIndex: {
     type: Number,

--- a/packages/utils/validators.ts
+++ b/packages/utils/validators.ts
@@ -1,16 +1,3 @@
-import { isNumber } from './util'
-
-export const isValidWidthUnit = (val: string | number): boolean => {
-  if (isNumber(val)) {
-    return true
-  }
-  return (
-    ['px', 'rem', 'em', 'vw', '%', 'vmin', 'vmax'].some((unit) =>
-      val.endsWith(unit)
-    ) || val.startsWith('calc')
-  )
-}
-
 export const isValidComponentSize = (val: string) =>
   ['', 'large', 'default', 'small'].includes(val)
 


### PR DESCRIPTION
ElDialog is the only place that `isValidWidthUnit` is used and it is somewhat restrictive in terms of valid css width values. Because there are many possible non-"number + unit" ways to set the width i think it's better to just remove the validator instead of checking for things like `min(...), max(...), clamp(...), calc(...), min-content, max-content, fit-content(...), auto, inherit, initial`, etc.

If people think it's better to keep the validator but validate agains all possible css width values just let me know and i'll try to do that instead.

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
