### PR TITLE
fix(theme-chalk): el-breadcrumb__item style

### DIFF
--- a/docs/en-US/component/breadcrumb.md
+++ b/docs/en-US/component/breadcrumb.md
@@ -17,7 +17,7 @@ breadcrumb/basic
 
 ## Icon separator
 
-:::demo Set `separator-class` to use `iconfont` as the separator，it will cover `separator`
+:::demo Set `separator-icon` to use `iconfont` as the separator，it will cover `separator`
 
 breadcrumb/icon
 
@@ -25,10 +25,10 @@ breadcrumb/icon
 
 ## Breadcrumb Attributes
 
-| Attribute       | Description                      | Type               | Accepted Values | Default |
-| --------------- | -------------------------------- | ------------------ | --------------- | ------- |
-| separator       | separator character              | string             | —               | /       |
-| separator-class | icon component of icon separator | string / Component | —               | -       |
+| Attribute      | Description                      | Type               | Accepted Values | Default |
+| -------------- | -------------------------------- | ------------------ | --------------- | ------- |
+| separator      | separator character              | string             | —               | /       |
+| separator-icon | icon component of icon separator | string / Component | —               | -       |
 
 ## Breadcrumb Slots
 

--- a/docs/en-US/component/breadcrumb.md
+++ b/docs/en-US/component/breadcrumb.md
@@ -17,7 +17,7 @@ breadcrumb/basic
 
 ## Icon separator
 
-:::demo Set `separator-icon` to use `iconfont` as the separator，it will cover `separator`
+:::demo Set `separator-icon` to use `svg icon` as the separator，it will cover `separator`
 
 breadcrumb/icon
 

--- a/packages/theme-chalk/src/breadcrumb.scss
+++ b/packages/theme-chalk/src/breadcrumb.scss
@@ -23,6 +23,8 @@
 
   @include e(item) {
     float: left;
+    display: flex;
+    align-items: center;
 
     @include e(inner) {
       color: var(--el-text-color-regular);


### PR DESCRIPTION
Change the style of el-breadcrumb__item,It wasn't aligned before

fix #5594

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
