### PR TITLE
fix(component): [pagination] pageSize reactivity bug

### DIFF
--- a/packages/components/pagination/__tests__/pagination.spec.ts
+++ b/packages/components/pagination/__tests__/pagination.spec.ts
@@ -410,5 +410,33 @@ describe('Pagination', () => {
        * expect(style.outline).toBeTruthy()
        */
     })
+
+    test('test the pageSize selected reactivity', async () => {
+      const wrapper = mount({
+        setup() {
+          return () => {
+            return h(Pagination, {
+              total: 1000,
+              pageSize: 100,
+              pageSizes: [100, 200, 300, 400],
+              layout: 'prev, pager, next, sizes',
+            })
+          }
+        },
+      })
+      await wrapper.find('.el-select').trigger('click')
+      await wrapper
+        .getComponent(selectDropdownVue)
+        .find('li:nth-child(2)')
+        .trigger('click')
+      await nextTick()
+      assertPages(wrapper, '5')
+      await wrapper
+        .getComponent(selectDropdownVue)
+        .find('li:nth-child(3)')
+        .trigger('click')
+      await nextTick()
+      assertPages(wrapper, '4')
+    })
   })
 })

--- a/packages/components/pagination/src/pagination.ts
+++ b/packages/components/pagination/src/pagination.ts
@@ -139,9 +139,9 @@ export default defineComponent({
           // Thus page size listener is required
           // users are account for page size change
           if (!isAbsent(props.pageSize)) {
-            if (!hasPageSizeListener) {
-              return false
-            }
+            // if (!hasPageSizeListener) {
+            //   return false
+            // }
           } else {
             // (else block just for explaination)
             // else page size is controlled by el-pagination internally

--- a/packages/components/pagination/src/pagination.ts
+++ b/packages/components/pagination/src/pagination.ts
@@ -152,20 +152,37 @@ export default defineComponent({
     })
 
     const innerPageSize = ref(
-      isAbsent(props.defaultPageSize) ? 10 : props.defaultPageSize
+      (() => {
+        let pageSize = 10
+        if (!isAbsent(props.defaultPageSize)) {
+          pageSize = props.defaultPageSize
+        }
+        if (!isAbsent(props.pageSize)) {
+          pageSize = props.pageSize
+        }
+        return pageSize
+      })()
     )
+
+    watch(
+      () => props.pageSize,
+      () => {
+        if (!isAbsent(props.pageSize)) {
+          innerPageSize.value = props.pageSize
+        }
+      }
+    )
+
     const innerCurrentPage = ref(
       isAbsent(props.defaultCurrentPage) ? 1 : props.defaultCurrentPage
     )
 
     const pageSizeBridge = computed({
       get() {
-        return isAbsent(props.pageSize) ? innerPageSize.value : props.pageSize
+        return innerPageSize.value
       },
       set(v: number) {
-        if (isAbsent(props.pageSize)) {
-          innerPageSize.value = v
-        }
+        innerPageSize.value = v
         if (hasPageSizeListener) {
           emit('update:page-size', v)
           emit('size-change', v)


### PR DESCRIPTION
fix #5700

I have edit the part of pageSize logic, to ensure the reactivity. Besides, this change can deal with the "WARNING" part in the [document](https://element-plus.gitee.io/en-US/component/pagination.html#attributes), too. Lets user can use this component less extra effort.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
