### PR TITLE
docs(docs): [el-message] 第8行组件引入错误

### DIFF
--- a/docs/examples/message/basic.vue
+++ b/docs/examples/message/basic.vue
@@ -5,7 +5,7 @@
 
 <script lang="ts" setup>
 import { h } from 'vue'
-import { ElMessage } from 'element-plus'
+import { ElMessage } from 'element-plus/lib/components'
 
 const open = () => {
   ElMessage('this is a message.')


### PR DESCRIPTION
第8行组件引入应该为：
```
import { ElMessage } from 'element-plus/lib/components'
```
否则在编译阶段会报错找不到依赖。
同时在文档中多处地方依然采用过去版本的引入方式：
```
import { ElMessage } from 'element-plus'
```