### PR TITLE
fix: cannot get the latest offsetHeight in resize event callback

### DIFF
--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -116,7 +116,6 @@ export default defineComponent({
 
     const update = () => {
       if (!wrap$.value) return
-
       const offsetHeight = wrap$.value.offsetHeight - GAP
       const offsetWidth = wrap$.value.offsetWidth - GAP
 
@@ -124,7 +123,6 @@ export default defineComponent({
       const originalWidth = offsetWidth ** 2 / wrap$.value.scrollWidth
       const height = Math.max(originalHeight, props.minSize)
       const width = Math.max(originalWidth, props.minSize)
-
       ratioY.value =
         originalHeight /
         (offsetHeight - originalHeight) /
@@ -146,7 +144,9 @@ export default defineComponent({
           stopResizeListener?.()
         } else {
           ;({ stop: stopResizeObserver } = useResizeObserver(resize$, update))
-          stopResizeListener = useEventListener('resize', update)
+          stopResizeListener = useEventListener('resize', () =>
+            setTimeout(() => update(), 0)
+          )
         }
       },
       { immediate: true }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.



BUG screenshot：
![1](https://user-images.githubusercontent.com/22633943/153115817-5a51107d-056d-4dc1-809f-6520d64b999a.gif)


[代码链接](https://github.com/element-plus/element-plus/compare/dev...L1yp:fix/scrollbar-resize-offsetHeight#diff-e27619e12f65c1d00d6cb6b43bc52333fb26fd103f60caa963485c7844cf8496L149)

```JavaScript
stopResizeListener = useEventListener('resize', update)
```

获取的offsetHeight是上一次的值，使用setTimeout可以获取到最新，测试过nextTick获取到的依然是旧的值，怀疑是VUE的问题，但是我没有证据，水平有限，希望有兴趣的朋友试试看是不是VUE的问题。
