### PR TITLE
fix(components): [el-popconfirm] fix onConfirm and onCancel type bug

### DIFF
--- a/packages/components/popconfirm/src/popconfirm.ts
+++ b/packages/components/popconfirm/src/popconfirm.ts
@@ -43,10 +43,10 @@ export const popconfirmProps = {
       default: 200,
     },
     onConfirm: {
-      type: definePropType<(e: Event) => Promise<boolean> | boolean>(Function),
+      type: definePropType<(e: Event) => Promise<void> | void>(Function),
     },
     onCancel: {
-      type: definePropType<(e: Event) => Promise<boolean> | boolean>(Function),
+      type: definePropType<(e: Event) => Promise<void> | void>(Function),
     },
   } as const),
   teleported: useTooltipContentProps.teleported,


### PR DESCRIPTION
Hello, When I use onConfirm, IDE hint `Type 'Promise<void>' is not assignable to type 'boolean | Promise<boolean>'.ts(2322)`. But I found the return value is not use. So I change the props type.

https://github.com/element-plus/element-plus/blob/d2db02111dd932143a6029a8bacb1a702bc59c77/packages/components/popconfirm/src/popconfirm.vue#L80
https://github.com/element-plus/element-plus/blob/d2db02111dd932143a6029a8bacb1a702bc59c77/packages/components/popconfirm/src/popconfirm.vue#L84


Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
