### PR TITLE
fix(components): [el-select]  el-select will not show label of origin selection tags when search via remote-methods and the new options do not includes the origin selection 

### DIFF
--- a/packages/components/select/__tests__/select.spec.ts
+++ b/packages/components/select/__tests__/select.spec.ts
@@ -1685,4 +1685,30 @@ describe('Select', () => {
       ).toBe('')
     })
   })
+
+  it('multiple select has an initial value', async () => {
+    const options = [{ value: `value:Alaska`, label: `label:Alaska` }]
+    const modelValue = [{ value: `value:Alaska`, label: `label:Alaska` }]
+    const wrapper = _mount(
+      `
+    <el-select v-model="modelValue"
+      multiple
+      value-key="value"
+      filterable>
+      <el-option
+        v-for="option in options"
+        :key="option.value"
+        :value="option.value"
+        :label="option.label"
+      >
+      </el-option>
+    </el-select>`,
+      () => ({
+        modelValue,
+        options,
+      })
+    )
+    const select = wrapper.findComponent({ name: 'ElSelect' }).vm
+    expect(select.selected[0].currentLabel).toBe(options[0].label)
+  })
 })

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -476,7 +476,11 @@ export const useSelect = (props, states: States, ctx) => {
       }
     }
     if (option) return option
-    const label = !isObjectValue && !isNull && !isUndefined ? value : ''
+    const label = isObjectValue
+      ? value.label
+      : !isNull && !isUndefined
+      ? value
+      : ''
     const newOption = {
       value,
       currentLabel: label,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
fix: https://github.com/element-plus/element-plus/issues/5760
Because the value isObjectValue, during setSelected, label is assigned to "" in the getOption function, resulting in el-Tag not displaying currentLabel correctly

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
