### PR TITLE
fix(components): [el-select] update visible immediately if query changed

### DIFF
--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -762,9 +762,8 @@ describe('Select', () => {
       .spyOn(selectDom, 'getBoundingClientRect')
       .mockReturnValue(selectRect as DOMRect)
     const dropdown = wrapper.findComponent({ name: 'ElSelectDropdown' })
-    dropdown.vm.minWidth = `${
-      selectWrapper.element.getBoundingClientRect().width
-    }px`
+    dropdown.vm.minWidth = `${selectWrapper.element.getBoundingClientRect().width
+      }px`
     await nextTick()
     expect(dropdown.element.style.width).toBe('221px')
     mockSelectWidth.mockRestore()
@@ -2083,5 +2082,36 @@ describe('Select', () => {
       expect(vm.value).toBe(2)
       expect(findInnerInput().value).toBe('z')
     })
+  })
+
+  test('visible of option is updated immediately after query changed', async () => {
+    const wrapper = _mount(
+      `
+        <el-select 
+          v-model="value" 
+          multiple
+          filterable
+          default-first-option
+        >
+          <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value"></el-option>
+        </el-select>`,
+      () => {
+        return {
+          value: [],
+          options: [
+            {
+              value: 'test1',
+              label: 'test1',
+            },
+          ],
+        }
+      }
+    )
+    const options = wrapper.findAllComponents(Option)
+    const selectInput = wrapper.find('.el-select__input')
+    const selectInputEl = selectInput.element as HTMLInputElement
+    selectInputEl.value = 'test2'
+    selectInput.trigger('input')
+    expect(options.map((option) => option.vm.visible)).toEqual([false])
   })
 })

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -762,8 +762,9 @@ describe('Select', () => {
       .spyOn(selectDom, 'getBoundingClientRect')
       .mockReturnValue(selectRect as DOMRect)
     const dropdown = wrapper.findComponent({ name: 'ElSelectDropdown' })
-    dropdown.vm.minWidth = `${selectWrapper.element.getBoundingClientRect().width
-      }px`
+    dropdown.vm.minWidth = `${
+      selectWrapper.element.getBoundingClientRect().width
+    }px`
     await nextTick()
     expect(dropdown.element.style.width).toBe('221px')
     mockSelectWidth.mockRestore()

--- a/packages/components/select/src/useOption.ts
+++ b/packages/components/select/src/useOption.ts
@@ -124,15 +124,19 @@ export function useOption(props, states) {
   )
 
   const { queryChange } = toRaw(select)
-  watch(queryChange, (changes: Ref<QueryChangeCtx>) => {
-    const { query } = unref(changes)
+  watch(
+    queryChange,
+    (changes: Ref<QueryChangeCtx>) => {
+      const { query } = unref(changes)
 
-    const regexp = new RegExp(escapeStringRegexp(query), 'i')
-    states.visible = regexp.test(currentLabel.value) || props.created
-    if (!states.visible) {
-      select.filteredOptionsCount--
-    }
-  })
+      const regexp = new RegExp(escapeStringRegexp(query), 'i')
+      states.visible = regexp.test(currentLabel.value) || props.created
+      if (!states.visible) {
+        select.filteredOptionsCount--
+      }
+    },
+    { immediate: true }
+  )
 
   return {
     select,

--- a/packages/components/select/src/useOption.ts
+++ b/packages/components/select/src/useOption.ts
@@ -135,7 +135,7 @@ export function useOption(props, states) {
         select.filteredOptionsCount--
       }
     },
-    { immediate: true }
+    { flush: 'sync' }
   )
 
   return {


### PR DESCRIPTION
The `visible` property needs to be updated immediately when the `query` changed, otherwise the `visible` of option at func`checkDefaultFirstOption` will be old and incorrect. Also closes #5914 .

```javascript
// !!! should be invoked immediately, so that `n.visible` at the `checkDefaultFirstOption` is newest
watch(
    queryChange,
    (changes: Ref<QueryChangeCtx>) => {
      const { query } = unref(changes)

      const regexp = new RegExp(escapeStringRegexp(query), 'i')
      states.visible = regexp.test(currentLabel.value) || props.created
      if (!states.visible) {
        select.filteredOptionsCount--
      }
    },
    { flush: 'sync' }
  )
```
```javascript

const checkDefaultFirstOption = () => {
    const optionsInDropdown = optionsArray.value.filter(
      (n) => n.visible && !n.disabled && !n.states.groupDisabled
    )
    const userCreatedOption = optionsInDropdown.filter((n) => n.created)[0]
    const firstOriginOption = optionsInDropdown[0]
    states.hoverIndex = getValueIndex(
      optionsArray.value,
      userCreatedOption || firstOriginOption
    )
  }

```


---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
