### PR TITLE
fix: formatter func parameter type miss

### DIFF
--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -212,7 +212,7 @@ const valueEquals = function (a: Array<Date> | any, b: Array<Date> | any) {
 }
 
 const parser = function (
-  date: Date | string,
+  date: string | number | Date,
   format: string,
   lang: string
 ): Dayjs {
@@ -223,7 +223,11 @@ const parser = function (
   return day.isValid() ? day : undefined
 }
 
-const formatter = function (date: string | number | Date, format: string, lang: string) {
+const formatter = function (
+  date: string | number | Date,
+  format: string,
+  lang: string
+) {
   if (isEmpty(format)) return date
   if (format === 'x') return +date
   return dayjs(date).locale(lang).format(format)

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -223,7 +223,7 @@ const parser = function (
   return day.isValid() ? day : undefined
 }
 
-const formatter = function (date: number | Date, format: string, lang: string) {
+const formatter = function (date: string | number | Date, format: string, lang: string) {
   if (isEmpty(format)) return date
   if (format === 'x') return +date
   return dayjs(date).locale(lang).format(format)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

I think `formatter` function first parameter `date` need `string` type.
