### PR TITLE
fix(components): [el-dialog] don't ignore z-index

### DIFF
--- a/packages/components/dialog/src/dialog.vue
+++ b/packages/components/dialog/src/dialog.vue
@@ -89,6 +89,7 @@ const {
   style,
   handleClose,
   rendered,
+  zIndex,
 } = dialog
 
 provide(elDialogInjectionKey, {


### PR DESCRIPTION
This is a regression.
El-dialog is ignoring z-index(which by default is incrementally autogenerated). 

For example when we have el-dialog nested in el-drawer(even if they are appended directly to the body), the drawer ends up on top because it has z-index while el-dialogs has none.

Repro:
https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuXHQ8ZGl2IGNsYXNzPVwicGxheS1jb250YWluZXJcIj5cbiAgICA8ZWwtYnV0dG9uIEBjbGljaz1cImRyYXdlciA9IHRydWVcIj5PcGVuIERyYXdlcjwvZWwtYnV0dG9uPlxuICAgIDxlbC1kcmF3ZXIgdi1tb2RlbD1cImRyYXdlclwiIGFwcGVuZC10by1ib2R5PlxuICAgICAgPGVsLWJ1dHRvbiBAY2xpY2s9XCJkaWFsb2cgPSB0cnVlXCI+T3BlbiBEaWFsb2c8L2VsLWJ1dHRvbj5cbiAgICAgIDxlbC1kaWFsb2cgdi1tb2RlbD1cImRpYWxvZ1wiIGFwcGVuZC10by1ib2R5PkRpYWxvZzwvZWwtZGlhbG9nPlxuICAgIDwvZWwtZHJhd2VyPlxuICA8L2Rpdj5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgbGFuZz1cInRzXCIgc2V0dXA+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5cbmNvbnN0IGRyYXdlciA9IHJlZihmYWxzZSlcbmNvbnN0IGRpYWxvZyA9IHJlZihmYWxzZSlcbjwvc2NyaXB0PlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1wiaW1wb3J0c1wiOnt9fSJ9


- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
