### PR TITLE
fix(components): [el-dialog]fix document focusout break other eventHa…

### DIFF
--- a/packages/components/focus-trap/src/focus-trap.vue
+++ b/packages/components/focus-trap/src/focus-trap.vue
@@ -104,6 +104,7 @@ export default defineComponent({
       }
     }
 
+    let hasFocusOutHandler: NodeJS.Timeout
     const onFocusOut = (e: Event) => {
       const trapContainer = unref(forwardRef)
       if (focusLayer.paused || !trapContainer) return
@@ -113,7 +114,10 @@ export default defineComponent({
           (e as FocusEvent).relatedTarget as HTMLElement | null
         )
       ) {
-        tryFocus(lastFocusAfterMounted, true)
+        hasFocusOutHandler && clearTimeout(hasFocusOutHandler)
+        hasFocusOutHandler = setTimeout(() => {
+          tryFocus(lastFocusAfterMounted, true)
+        }, 500)
       }
     }
 


### PR DESCRIPTION
### bug description
+ document Listening to an onFocusOut event in focus-trap-component ，This handler function uses the **focus** and **select**  in tryFocus，Causes other default events not to be triggered，e.g.: onselectstart....
+ this event trigger too frequently should use anti-shake optimize

## fix isuse
+ [https://github.com/element-plus/element-plus/issues/6324](https://github.com/element-plus/element-plus/issues/6324)