### PR TITLE
fix(components): [el-collapse] collapse item key pressing jumping

### DIFF
--- a/packages/components/collapse/src/collapse-item.vue
+++ b/packages/components/collapse/src/collapse-item.vue
@@ -22,7 +22,7 @@
         role="button"
         :tabindex="disabled ? -1 : 0"
         @click="handleHeaderClick"
-        @keyup.space.enter.stop="handleEnterClick"
+        @keypress.space.enter.stop.prevent="handleEnterClick"
         @focus="handleFocus"
         @blur="focusing = false"
       >


### PR DESCRIPTION
- Fix the issue when pressing `space` key on collapse item the page will jump

## Screencasts

### Before

https://user-images.githubusercontent.com/15975785/156984252-95124452-c26e-477b-a37b-6a423d7e63aa.mov


### After 

https://user-images.githubusercontent.com/15975785/156984454-a6168943-59da-4171-bb3d-99bd3c60fd49.mov


Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
