### PR TITLE
docs(theme-chalk): update the modification guide introduced by webpack on demand

### DIFF
--- a/docs/en-US/guide/theming.md
+++ b/docs/en-US/guide/theming.md
@@ -161,6 +161,30 @@ export default defineConfig({
 })
 ```
 
+If you are using webpack, and you want to custom theme when importing on demand.
+
+```
+// webpack.config.ts
+// use unplugin-element-plus
+
+import ElementPlus from 'unplugin-element-plus/webpack'
+
+export default defineConfig({
+  css: {
+    loaderOptions: {
+      scss: {
+        additionalData: `@use "~/styles/element/index.scss" as *;`,
+      },
+    },
+  },
+  plugins: [
+    ElementPlus({
+      useSource: true,
+    }),
+  ],
+})
+```
+
 ### By CSS Variable
 
 CSS Variables is a very useful feature, already supported by almost all browsers. (IE: Wait?)

--- a/docs/en-US/guide/theming.md
+++ b/docs/en-US/guide/theming.md
@@ -163,7 +163,7 @@ export default defineConfig({
 
 If you are using webpack, and you want to custom theme when importing on demand.
 
-```
+```ts
 // webpack.config.ts
 // use unplugin-element-plus
 


### PR DESCRIPTION
when I use Vue-Cli and want to custom theme when importing on demand.I found that the documentation only has the description part of Vite, not Webpack, although the two are used in a similar way, it is better to separate the description.

在使用 unplugin-element-plus 按需引入的情况下，没有Webpack覆盖主题的说明，虽然与vite的方式类似，但是文档只写了Vite，容易让人直接忽略这部分。

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
