### PR TITLE
fix(components): [el-input] pass input-style props to input-wrapper

### DIFF
--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -209,7 +209,10 @@ export default defineComponent({
     const validateIcon = computed(
       () => ValidateComponentsMap[validateState.value]
     )
-    const containerStyle = computed(() => rawAttrs.style as StyleValue)
+    const containerStyle = computed<StyleValue>(() => [
+      rawAttrs.style,
+      props.inputStyle,
+    ])
     const computedTextareaStyle = computed<StyleValue>(() => [
       props.inputStyle,
       _textareaCalcStyle.value,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

问题描述：当给input组件设置`input-style`属性时(例如宽度), 同时设置`show-word-limit`或者`clearable`属性，会导致角标定位不准。

复现地址：[codepen](https://codesandbox.io/s/element-plus-demo-forked-50yq40?file=/src/App.vue)
