### PR TITLE
fix(components): [el-input] unicode charactors does not work as expected

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "lodash-es": "^4.17.21",
     "lodash-unified": "^1.0.2",
     "memoize-one": "^6.0.0",
-    "normalize-wheel-es": "^1.1.1"
+    "normalize-wheel-es": "^1.1.1",
+    "runes": "^0.4.3"
   },
   "devDependencies": {
     "@babel/core": "^7.17.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,7 @@ importers:
       rollup-plugin-css-only: ^3.1.0
       rollup-plugin-esbuild: ^4.8.2
       rollup-plugin-filesize: ^9.1.2
+      runes: ^0.4.3
       sass: ^1.49.9
       sucrase: ^3.20.3
       ts-jest: ^26.5.6
@@ -113,6 +114,7 @@ importers:
       lodash-unified: 1.0.2_da03a4540fbd16bbaafbb96724306afd
       memoize-one: 6.0.0
       normalize-wheel-es: 1.1.1
+      runes: 0.4.3
     devDependencies:
       '@babel/core': 7.17.5
       '@babel/preset-env': 7.16.11_@babel+core@7.17.5
@@ -3673,12 +3675,12 @@ packages:
     dev: true
 
   /ansi-regex/2.1.1:
-    resolution: {integrity: sha1-w7M6te42DYbg5ijwRorn7yfWVN8=}
+    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
   /ansi-regex/3.0.0:
-    resolution: {integrity: sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=}
+    resolution: {integrity: sha512-wFUFA5bg5dviipbQQ32yOQhl6gcJaJXiHE7dvR8VYPG97+J/GNC5FKGepKdEDUFeXRzDxPF1X/Btc8L+v7oqIQ==}
     engines: {node: '>=4'}
     dev: true
 
@@ -7959,7 +7961,7 @@ packages:
     dev: true
 
   /isexe/2.0.0:
-    resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
   /isobject/2.1.0:
@@ -10871,6 +10873,11 @@ packages:
     dependencies:
       queue-microtask: 1.2.3
 
+  /runes/0.4.3:
+    resolution: {integrity: sha512-K6p9y4ZyL9wPzA+PMDloNQPfoDGTiFYDvdlXznyGKgD10BJpcAosvATKrExRKOrNLgD8E7Um7WGW0lxsnOuNLg==}
+    engines: {node: '>=4.0.0'}
+    dev: false
+
   /rxjs/6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
     engines: {npm: '>=2.0.0'}
@@ -11377,14 +11384,14 @@ packages:
     dev: true
 
   /strip-ansi/3.0.1:
-    resolution: {integrity: sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=}
+    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-regex: 2.1.1
     dev: true
 
   /strip-ansi/4.0.0:
-    resolution: {integrity: sha1-qEeQIusaw2iocTibY1JixQXuNo8=}
+    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
     engines: {node: '>=4'}
     dependencies:
       ansi-regex: 3.0.0


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### 问题描述：
当输入表情符号等unicode特殊字符时，使用原生JS计算字符串长度以及使用DOM Props`maxlength`属性存在如下问题：
* JS计算字符串长度与DOM Props计算长度方式不一致，并且与用户期望有所差异。
* 存在兼容问题，不同浏览器行为表现不一致。

### 解决方案：
抛弃原生DOM Props `maxlength`属性，使用JS逻辑控制最大长度
使用了第三方npm包[`runes`](https://www.npmjs.com/package/runes)做字符串长度的计算以及截取

###  截图：
Chrome：
用户认为输入了8个长度字符串，JS计算长度为9，DOM Props计算长度为10（因为此时无法继续输入了）
<img width="684" alt="image" src="https://user-images.githubusercontent.com/18349295/158051513-b6855853-18e4-4040-af33-5a6d3863bb2d.png">

Safari：
计算方式也存在问题，甚至可以输入超过最大长度的字符串
<img width="754" alt="image" src="https://user-images.githubusercontent.com/18349295/158051583-a72df63c-9b89-4bf1-9b31-1ddf73f2bb55.png">

