### PR TITLE
fix(components): [el-form] fix not set validateState to success after validation is passed

### DIFF
--- a/packages/components/form/__tests__/form.spec.tsx
+++ b/packages/components/form/__tests__/form.spec.tsx
@@ -490,4 +490,34 @@ describe('Form', () => {
     expect(res.valid).toBe(true)
     expect(res.fields).toBe(undefined)
   })
+
+  test('validate status', async () => {
+    const form = reactive({
+      age: '20',
+    })
+
+    const wrapper = mount({
+      setup() {
+        const rules = ref({
+          age: [
+            { required: true, message: 'Please input age', trigger: 'change' },
+          ],
+        })
+        return () => (
+          <Form ref="formRef" model={form} rules={rules}>
+            <FormItem ref="age" prop="age" label="age">
+              <Input v-model={form.age} />
+            </FormItem>
+          </Form>
+        )
+      },
+    })
+
+    await (wrapper.vm.$refs.formRef as FormInstance)
+      .validate()
+      .catch(() => undefined)
+    const ageField = wrapper.findComponent({ ref: 'age' })
+    expect((ageField.vm as FormItemInstance).validateState).toBe('success')
+    expect(ageField.classes()).toContain('is-success')
+  })
 })

--- a/packages/components/form/src/form-item.vue
+++ b/packages/components/form/src/form-item.vue
@@ -248,7 +248,9 @@ const validate: FormItemContext['validate'] = async (trigger, callback) => {
 
   return validator
     .validate(model, { firstFields: true })
-    .then(() => undefined)
+    .then(() => {
+      validateState.value = 'success'
+    })
     .catch((err: ValidateFailure) => {
       const { errors, fields } = err
       if (!errors || !fields) console.error(err)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Fix #6589 - a bug brought by the refactor in #5401.

The validation status icon will be still `validating` for not setting `validateState` to `success` after the validation is passed.
