### PR TITLE
fix(components): [table] not scroll empty block when scrolling table

### DIFF
--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -43,7 +43,10 @@ function useStyle<T>(
   })
   const isGroup = ref(false)
   const scrollbarViewStyle = {
-    display: 'inline-block',
+    //display: 'inline-block',
+    //verticalAlign: 'middle',
+    display: 'inline-flex',
+    flexDirection: 'column',
   }
 
   watchEffect(() => {

--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -43,10 +43,8 @@ function useStyle<T>(
   })
   const isGroup = ref(false)
   const scrollbarViewStyle = {
-    //display: 'inline-block',
-    //verticalAlign: 'middle',
-    display: 'inline-flex',
-    flexDirection: 'column',
+    display: 'inline-block',
+    verticalAlign: 'middle',
   }
 
   watchEffect(() => {

--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -43,8 +43,7 @@ function useStyle<T>(
   })
   const isGroup = ref(false)
   const scrollbarViewStyle = {
-    display: 'inline-flex',
-    flexDirection: 'column',
+    display: 'inline-block',
   }
 
   watchEffect(() => {
@@ -298,7 +297,7 @@ function useStyle<T>(
       height = `calc(100% - ${layout.appendHeight.value}px)`
     }
     return {
-      width: bodyWidth.value,
+      width: `${resizeState.value.width}px`,
       height,
     }
   })

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -42,6 +42,8 @@
 
   // when data is empty
   @include e(empty-block) {
+    position: sticky;
+    left: 0;
     min-height: 60px;
     text-align: center;
     width: 100%;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

I'm not sure if this behavior is by design but I always feel that the empty shouldn't be placed in the scroll view as it also unexpectedly scrolls together with the content when the table is scrollable. See the comparison below,

| Current | After |
| :----: | :----: |
| <img src="https://user-images.githubusercontent.com/26999792/158139085-837c833d-b6c6-4307-8ec1-e8ebf185e883.gif" alt="current behavior"> | <img src="https://user-images.githubusercontent.com/26999792/158139214-6632565e-531d-41ff-9c1e-aac4eb82a106.gif" alt="expected behavior"> |

Playground is available [here](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICAgIDxlbC10YWJsZSBib3JkZXIgc3R5bGU9XCJ3aWR0aDogNTAwcHhcIj5cbiAgICAgIDxlbC10YWJsZS1jb2x1bW4gcHJvcD1cImRhdGVcIiBsYWJlbD1cIkRhdGVcIiB3aWR0aD1cIjE4MFwiIC8+XG4gICAgICA8ZWwtdGFibGUtY29sdW1uIHByb3A9XCJuYW1lXCIgbGFiZWw9XCJOYW1lXCIgd2lkdGg9XCIyMDBcIiAvPlxuICAgICAgPGVsLXRhYmxlLWNvbHVtbiBwcm9wPVwiYWRkcmVzc1wiIGxhYmVsPVwiQWRkcmVzc1wiIHdpZHRoPVwiNDAwXCIgLz5cbiAgICA8L2VsLXRhYmxlPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cblxuPC9zY3JpcHQ+XG5cbjxzdHlsZT5cbmh0bWwsIGJvZHkge1xuICB3aWR0aDogMTAwdnc7XG4gIGhlaWdodDogMTAwdmg7XG4gIG1hcmdpbjogMDtcbn1cbiNhcHAge1xuICBoZWlnaHQ6IDEwMCU7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gIGp1c3RpZnktY29udGVudDogY2VudGVyO1xuICBmbGV4LWRpcmVjdGlvbjogY29sdW1uO1xufVxuPC9zdHlsZT5cblxuXG5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcImltcG9ydHNcIjp7fX0ifQ==).