### PR TITLE
fix(theme-chalk): [cascader/checkbox] fix unexpected fill color is appiled

### DIFF
--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -253,7 +253,7 @@ $checkbox: map.merge(
     'checked-text-color': var(--el-color-primary),
     'checked-input-border-color': var(--el-color-primary),
     'checked-bg-color': var(--el-color-primary),
-    'checked-icon-color': getCssVar('fill-color'),
+    'checked-icon-color': getCssVar('fill-color', 'blank'),
     'input-border-color-hover': var(--el-color-primary),
   ),
   $checkbox
@@ -578,7 +578,7 @@ $cascader: map.merge(
   (
     'menu-text-color': var(--el-text-color-regular),
     'menu-selected-text-color': var(--el-color-primary),
-    'menu-fill': getCssVar('fill-color'),
+    'menu-fill': getCssVar('fill-color', 'blank'),
     'menu-font-size': var(--el-font-size-base),
     'menu-radius': var(--el-border-radius-base),
     'menu-border': solid 1px var(--el-border-color-light),


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Fix #6618
Fix #6617 

\- A "bug" brought by the refactor in #6593. Related commit is 06f684450914213ecae523c1dcda63a9e1761f3e. It removed `--el-fill-base: var(--el-color-white)` but applied the unexpected `--el-fill-color`.

See also,

- [Change 1](https://github.com/element-plus/element-plus/commit/06f684450914213ecae523c1dcda63a9e1761f3e#diff-c9498a29f918206777e9fd87a9bc41b37e93ab3a9c0443d79f2652d294210686L47)
- [Change 2](https://github.com/element-plus/element-plus/commit/06f684450914213ecae523c1dcda63a9e1761f3e#diff-eb85fc73444e26f19f950007c73a7d86028b1453c33efc86d2b5478ea027c01aL545)
- [Change 3](https://github.com/element-plus/element-plus/commit/06f684450914213ecae523c1dcda63a9e1761f3e#diff-eb85fc73444e26f19f950007c73a7d86028b1453c33efc86d2b5478ea027c01aL220)