### PR TITLE
fix(theme-chalk): [mixins] use set-css-var-value to transpile text

### DIFF
--- a/packages/theme-chalk/src/mixins/_var.scss
+++ b/packages/theme-chalk/src/mixins/_var.scss
@@ -4,6 +4,14 @@
 @use 'function' as *;
 @use '../common/var' as *;
 
+// set css var value, because we need translate value to string
+// for example:
+// @include set-css-var-value(('color', 'primary'), red);
+// --el-color-primary: red;
+@mixin set-css-var-value($name, $value) {
+  #{joinVarName($name)}: #{$value};
+}
+
 @mixin set-css-color-type-light($type, $i) {
   #{getCssVarName('color', $type, 'light', $i)}: #{map.get(
       $colors,
@@ -37,8 +45,12 @@
 
 @mixin set-css-color-rgb($type) {
   $color: map.get($colors, $type, 'base');
-  #{getCssVarName('color', $type, 'rgb')}: #{red($color)}, #{green($color)},
-    #{blue($color)};
+  @include set-css-var-value(
+    ('color', $type, 'rgb'),
+    #{red($color),
+    green($color),
+    blue($color)}
+  );
 }
 
 // generate css var from existing css var

--- a/packages/theme-chalk/src/mixins/mixins.scss
+++ b/packages/theme-chalk/src/mixins/mixins.scss
@@ -1,7 +1,9 @@
 @use 'function' as *;
 @use '../common/var' as *;
+// forward mixins
 @forward 'config';
 @forward 'function';
+@forward '_var';
 @use 'config' as *;
 
 // Break-points

--- a/packages/theme-chalk/src/upload.scss
+++ b/packages/theme-chalk/src/upload.scss
@@ -288,12 +288,11 @@
 
   // upload-list
   @include m(picture-card) {
+    @include set-css-var-value(('upload-list', 'picture-card', 'size'), 148px);
+
     display: inline-flex;
     flex-wrap: wrap;
-
     margin: 0;
-
-    @include set-css-var-value(('upload-list', 'picture-card', 'size'), 148px);
 
     .#{bem('upload-list', 'item')} {
       overflow: hidden;

--- a/packages/theme-chalk/src/upload.scss
+++ b/packages/theme-chalk/src/upload.scss
@@ -28,7 +28,7 @@
 
   /* Picture Card for Wall */
   @include m(picture-card) {
-    #{getCssVarName('upload', 'picture-card', 'size')}: 148px;
+    @include set-css-var-value(('upload', 'picture-card', 'size'), 148px);
 
     background-color: #fbfdff;
     border: 1px dashed #c0ccda;
@@ -292,7 +292,8 @@
     flex-wrap: wrap;
 
     margin: 0;
-    #{getCssVarName('upload-list', 'picture-card', 'size')}: 148px;
+
+    @include set-css-var-value(('upload-list', 'picture-card', 'size'), 148px);
 
     .#{bem('upload-list', 'item')} {
       overflow: hidden;


### PR DESCRIPTION
close #6594 

- use mixin `set-css-var-value` to translate text

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
