### PR TITLE
fix(components): [result] rename slot's name from 'subTitle' to 'sub-title'

### DIFF
--- a/docs/en-US/component/result.md
+++ b/docs/en-US/component/result.md
@@ -33,9 +33,9 @@ result/customized-content
 
 ## Result Slots
 
-| Name     | Description       |
-| -------- | ----------------- |
-| icon     | custom icon       |
-| title    | custom title      |
-| subTitle | custom sub title  |
-| extra    | custom extra area |
+| Name      | Description       |
+| --------- | ----------------- |
+| icon      | custom icon       |
+| title     | custom title      |
+| sub-title | custom sub title  |
+| extra     | custom extra area |

--- a/packages/components/result/__tests__/result.spec.ts
+++ b/packages/components/result/__tests__/result.spec.ts
@@ -85,7 +85,7 @@ describe('Result.vue', () => {
   test('should render sub-title slots', () => {
     const wrapper = mount({
       slots: {
-        subTitle: AXIOM,
+        'sub-title': AXIOM,
       },
     })
     expect(wrapper.find('.el-result__subtitle').exists()).toBe(true)

--- a/packages/components/result/src/result.vue
+++ b/packages/components/result/src/result.vue
@@ -14,8 +14,8 @@
         <p>{{ title }}</p>
       </slot>
     </div>
-    <div v-if="subTitle || $slots.subTitle" :class="ns.e('subtitle')">
-      <slot name="subTitle">
+    <div v-if="subTitle || $slots['sub-title']" :class="ns.e('subtitle')">
+      <slot name="sub-title">
         <p>{{ subTitle }}</p>
       </slot>
     </div>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #6528 the slot name ends up in the attribute name, so it is normalized to all-lowercase by the browser. Rename it to lowercase to avoid mismatch.
