### PR TITLE
fix(components): [el-table] use table width as empty block width

### DIFF
--- a/packages/components/table/src/table-layout.ts
+++ b/packages/components/table/src/table-layout.ts
@@ -261,7 +261,6 @@ class TableLayout<T> {
       }
 
       this.bodyWidth.value = Math.max(bodyMinWidth, bodyWidth)
-      this.table.state.resizeState.value.width = this.bodyWidth.value
     } else {
       flattenColumns.forEach((column) => {
         if (!column.width && !column.minWidth) {

--- a/packages/components/table/src/table-layout.ts
+++ b/packages/components/table/src/table-layout.ts
@@ -261,6 +261,7 @@ class TableLayout<T> {
       }
 
       this.bodyWidth.value = Math.max(bodyMinWidth, bodyWidth)
+      this.table.state.resizeState.value.width = this.bodyWidth.value
     } else {
       flattenColumns.forEach((column) => {
         if (!column.width && !column.minWidth) {

--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -46,6 +46,7 @@ function useStyle<T>(
     display: 'inline-block',
     verticalAlign: 'middle',
   }
+  const tableWidth = ref()
 
   watchEffect(() => {
     layout.setHeight(props.height)
@@ -120,7 +121,7 @@ function useStyle<T>(
     requestAnimationFrame(doLayout)
 
     resizeState.value = {
-      width: table.vnode.el.offsetWidth,
+      width: (tableWidth.value = table.vnode.el.offsetWidth),
       height: table.vnode.el.offsetHeight,
     }
 
@@ -212,7 +213,7 @@ function useStyle<T>(
     const el = table.vnode.el
     const { width: oldWidth, height: oldHeight } = resizeState.value
 
-    const width = el.offsetWidth
+    const width = (tableWidth.value = el.offsetWidth)
     if (oldWidth !== width) {
       shouldUpdateLayout = true
     }
@@ -298,7 +299,7 @@ function useStyle<T>(
       height = `calc(100% - ${layout.appendHeight.value}px)`
     }
     return {
-      width: `${resizeState.value.width}px`,
+      width: tableWidth.value ? `${tableWidth.value}px` : '',
       height,
     }
   })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

In #6615, we fixed the issue that the empty block scrolls together with the table body. But it's still buggy when there are columns with **min-width** as the calculated table width is overridden by the [line 264](https://github.com/plainheart/element-plus/blob/dev/packages/components/table/src/table-layout.ts#L264).

```ts
this.table.state.resizeState.value.width = this.bodyWidth.value
```

Expect the `width` in the computed `emptyBlockStyle` is the table width instead of the table body width. I removed this line after checking the usage of `resizeState`. Please @msidolphin take a double check.

[**Playgroud**](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICAgIDxlbC10YWJsZSBib3JkZXIgc3R5bGU9XCJ3aWR0aDogNTAwcHhcIj5cbiAgICAgIDxlbC10YWJsZS1jb2x1bW4gcHJvcD1cImRhdGVcIiBsYWJlbD1cIkRhdGVcIiB3aWR0aD1cIjE4MFwiIC8+XG4gICAgICA8ZWwtdGFibGUtY29sdW1uIHByb3A9XCJuYW1lXCIgbGFiZWw9XCJOYW1lXCIgd2lkdGg9XCIyMDBcIiAvPlxuICAgICAgPGVsLXRhYmxlLWNvbHVtbiBwcm9wPVwiYWRkcmVzc1wiIGxhYmVsPVwiQWRkcmVzc1wiIHdpZHRoPVwiNDAwXCIgLz5cbiAgICA8L2VsLXRhYmxlPlxuICAgIDxlbC10YWJsZSBib3JkZXIgc3R5bGU9XCJ3aWR0aDogNTAwcHg7IG1hcmdpbi10b3A6IDUwcHhcIj5cbiAgICAgIDxlbC10YWJsZS1jb2x1bW4gcHJvcD1cImRhdGVcIiBsYWJlbD1cIkRhdGVcIiB3aWR0aD1cIjE4MFwiIC8+XG4gICAgICA8ZWwtdGFibGUtY29sdW1uIHByb3A9XCJuYW1lXCIgbGFiZWw9XCJOYW1lXCIgd2lkdGg9XCIyMDBcIiAvPlxuICAgICAgPGVsLXRhYmxlLWNvbHVtbiBwcm9wPVwiYWRkcmVzc1wiIGxhYmVsPVwiQWRkcmVzc1wiIG1pbi13aWR0aD1cIjQwMFwiIC8+XG4gICAgPC9lbC10YWJsZT5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgbGFuZz1cInRzXCIgc2V0dXA+XG5cbjwvc2NyaXB0PlxuXG48c3R5bGU+XG5odG1sLCBib2R5IHtcbiAgd2lkdGg6IDEwMHZ3O1xuICBoZWlnaHQ6IDEwMHZoO1xuICBtYXJnaW46IDA7XG59XG4jYXBwIHtcbiAgaGVpZ2h0OiAxMDAlO1xuICBkaXNwbGF5OiBmbGV4O1xuICBhbGlnbi1pdGVtczogY2VudGVyO1xuICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjtcbiAgZmxleC1kaXJlY3Rpb246IGNvbHVtbjtcbn1cbjwvc3R5bGU+XG5cblxuXG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XCJpbXBvcnRzXCI6e319In0=)
