### PR TITLE
fix(docs): fix "Invalid date" display error in docs site

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -46,6 +46,7 @@ languages.forEach((lang) => {
 export const config: UserConfig = {
   title: 'Element Plus',
   description: 'a Vue 3 based component library for designers and developers',
+  lastUpdated: true,
   head,
   themeConfig: {
     repo: 'element-plus/element-plus',


### PR DESCRIPTION
originally the "Last Updated" field displayed "Invalid date", the bug was in vitepress's file
'config.ts', missing 'lastUpdated' field in UserConfig object.

---
Before:
![The bug was here](https://user-images.githubusercontent.com/40999116/159047182-c3158690-4f8f-4de1-978c-cecbe27b1403.png)

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


