### PR TITLE
fix(components): [table-column] does not render defualt slot when children are comment nodes

### DIFF
--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -1,4 +1,12 @@
-import { computed, getCurrentInstance, h, ref, unref, watchEffect } from 'vue'
+import {
+  Comment,
+  computed,
+  getCurrentInstance,
+  h,
+  ref,
+  unref,
+  watchEffect,
+} from 'vue'
 import { debugWarn } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import {
@@ -127,7 +135,10 @@ function useRender<T>(
       column.renderCell = (data) => {
         let children = null
         if (slots.default) {
-          children = slots.default(data)
+          const vnodes = slots.default(data)
+          children = vnodes.some((v) => v.type !== Comment)
+            ? vnodes
+            : originRenderCell(data)
         } else {
           children = originRenderCell(data)
         }


### PR DESCRIPTION
fix: #6741
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

#### The default behavior of slots should be consistent with vue
before:
![image](https://user-images.githubusercontent.com/39730999/160069296-a9a2286e-1a5d-40f4-b9a2-56549055791a.png)

after:
![image](https://user-images.githubusercontent.com/39730999/160069398-f9c5e6a3-33de-458a-8bba-b436ed91aa36.png)
