### PR TITLE
fix(components): [el-input] change icon when toggling password visibility

### DIFF
--- a/packages/components/input/__tests__/input.spec.tsx
+++ b/packages/components/input/__tests__/input.spec.tsx
@@ -479,6 +479,19 @@ describe('Input.vue', () => {
     })
   })
 
+  test('show-password icon', async () => {
+    const password = ref('123456')
+    const wrapper = mount(() => (
+      <Input type="password" modelValue={password.value} show-password />
+    ))
+
+    const icon = wrapper.find('.el-input__icon.el-input__clear')
+    const d = icon.find('path').element.getAttribute('d')
+    await icon.trigger('click')
+    const d0 = icon.find('path').element.getAttribute('d')
+    expect(d !== d0).toBeTruthy()
+  })
+
   // TODO: validateEvent & input containes select cases should be added after the rest components finished
   // ...
 })

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -82,7 +82,7 @@
             :class="[nsInput.e('icon'), nsInput.e('clear')]"
             @click="handlePasswordVisible"
           >
-            <icon-view />
+            <component :is="passwordIcon" />
           </el-icon>
           <span v-if="isWordLimitVisible" :class="nsInput.e('count')">
             <span :class="nsInput.e('count-inner')">
@@ -154,7 +154,11 @@ import {
 import { isClient } from '@vueuse/core'
 import { isNil } from 'lodash-unified'
 import { ElIcon } from '@element-plus/components/icon'
-import { CircleClose, View as IconView } from '@element-plus/icons-vue'
+import {
+  CircleClose,
+  Hide as IconHide,
+  View as IconView,
+} from '@element-plus/icons-vue'
 import {
   ValidateComponentsMap,
   debugWarn,
@@ -211,6 +215,9 @@ const _ref = computed(() => input.value || textarea.value)
 const needStatusIcon = computed(() => form?.statusIcon ?? false)
 const validateState = computed(() => formItem?.validateState || '')
 const validateIcon = computed(() => ValidateComponentsMap[validateState.value])
+const passwordIcon = computed(() =>
+  passwordVisible.value ? IconView : IconHide
+)
 const containerStyle = computed<StyleValue>(() => [
   rawAttrs.style as StyleValue,
   props.inputStyle,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

It would be better to change the icon to **View**/**Hide** when toggling the visibility of the password. Currently, it always keeps the same icon **View**.

**Comparison**

| Before | After |
| :----: | :----: |
| ![Before](https://user-images.githubusercontent.com/26999792/160241016-71330cb7-86d1-4261-b7b4-2dfa81e75ba7.gif) | ![After](https://user-images.githubusercontent.com/26999792/160241012-13c096ae-c777-444c-ba23-2a714ce46000.gif) |
