### PR TITLE
fix(components): [upload] fix onChange double trigger

### DIFF
--- a/packages/components/upload/src/upload-content.vue
+++ b/packages/components/upload/src/upload-content.vue
@@ -42,6 +42,7 @@ import type {
 
 defineOptions({
   name: 'ElUploadContent',
+  inheritAttrs: false,
 })
 
 const props = defineProps(uploadContentProps)


### PR DESCRIPTION
second trigger is input.onchange event, because props has onChange bug not define in upload-content.vue props

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
