### PR TITLE
fix: remove default size warn by set componetSizes

### DIFF
--- a/docs/examples/avatar/basic.vue
+++ b/docs/examples/avatar/basic.vue
@@ -32,7 +32,7 @@ const state = reactive({
     'https://cube.elemecdn.com/3/7c/3ea6beec64369c2642b92c6726f1epng.png',
   squareUrl:
     'https://cube.elemecdn.com/9/c2/f0ee8a3c7c9638a54940382568c9dpng.png',
-  sizeList: ['large', 'default', 'small'],
+  sizeList: ['large', '', 'default', 'small'],
 })
 
 const { circleUrl, squareUrl, sizeList } = toRefs(state)

--- a/docs/examples/avatar/basic.vue
+++ b/docs/examples/avatar/basic.vue
@@ -32,7 +32,7 @@ const state = reactive({
     'https://cube.elemecdn.com/3/7c/3ea6beec64369c2642b92c6726f1epng.png',
   squareUrl:
     'https://cube.elemecdn.com/9/c2/f0ee8a3c7c9638a54940382568c9dpng.png',
-  sizeList: ['large', '', 'default', 'small'],
+  sizeList: ['small', '', 'large'] as const,
 })
 
 const { circleUrl, squareUrl, sizeList } = toRefs(state)

--- a/packages/components/avatar/src/avatar.ts
+++ b/packages/components/avatar/src/avatar.ts
@@ -1,4 +1,5 @@
 import { buildProps, definePropType, iconPropType } from '@element-plus/utils'
+import { componentSizes } from '@element-plus/constants'
 import type { ExtractPropTypes } from 'vue'
 import type { ObjectFitProperty } from 'csstype'
 import type Avatar from './avatar.vue'
@@ -6,8 +7,8 @@ import type Avatar from './avatar.vue'
 export const avatarProps = buildProps({
   size: {
     type: [Number, String],
-    values: ['large', 'default', 'small'],
-    default: 'default',
+    values: componentSizes,
+    default: '',
     validator: (val: unknown): val is number => typeof val === 'number',
   },
   shape: {

--- a/packages/components/config-provider/src/config-provider.ts
+++ b/packages/components/config-provider/src/config-provider.ts
@@ -2,6 +2,7 @@ import { defineComponent, renderSlot, watch } from 'vue'
 import { buildProps, definePropType } from '@element-plus/utils'
 import { provideGlobalConfig } from '@element-plus/hooks'
 
+import { componentSizes } from '@element-plus/constants'
 import type { ExtractPropTypes } from 'vue'
 import type { ExperimentalFeatures } from '@element-plus/tokens'
 import type { Language } from '@element-plus/locale'
@@ -23,7 +24,8 @@ export const configProviderProps = buildProps({
 
   size: {
     type: String,
-    values: ['large', '', 'small'],
+    values: componentSizes,
+    default: '',
   },
 
   button: {

--- a/packages/components/tag/src/tag.ts
+++ b/packages/components/tag/src/tag.ts
@@ -1,4 +1,5 @@
 import { buildProps } from '@element-plus/utils'
+import { componentSizes } from '@element-plus/constants'
 import type Tag from './tag.vue'
 
 import type { ExtractPropTypes } from 'vue'
@@ -18,7 +19,8 @@ export const tagProps = buildProps({
   },
   size: {
     type: String,
-    values: ['large', 'default', 'small'],
+    values: componentSizes,
+    default: '',
   },
   effect: {
     type: String,

--- a/packages/components/time-select/src/time-select.vue
+++ b/packages/components/time-select/src/time-select.vue
@@ -38,8 +38,8 @@ import ElSelect from '@element-plus/components/select'
 import ElIcon from '@element-plus/components/icon'
 import { CircleClose, Clock } from '@element-plus/icons-vue'
 
+import { componentSizes } from '@element-plus/constants'
 import type { Component, PropType } from 'vue'
-import type { ComponentSize } from '@element-plus/constants'
 dayjs.extend(customParseFormat)
 
 const { Option: ElOption } = ElSelect
@@ -128,9 +128,8 @@ export default defineComponent({
     },
     size: {
       type: String as PropType<ComponentSize>,
-      default: 'default',
-      validator: (value: string) =>
-        !value || ['large', 'default', 'small'].includes(value),
+      values: componentSizes,
+      default: '',
     },
     placeholder: {
       type: String,

--- a/packages/theme-chalk/src/avatar.scss
+++ b/packages/theme-chalk/src/avatar.scss
@@ -8,6 +8,11 @@
   @include set-component-css-var('avatar', $avatar);
   @include set-component-css-var('avatar-size', $avatar-size);
 
+  @include set-css-var-value(
+    ('avatar', 'size'),
+    map.get($avatar-size, 'default')
+  );
+
   display: inline-flex;
   justify-content: center;
   align-items: center;
@@ -37,9 +42,12 @@
     font-size: var(--el-avatar-icon-size);
   }
 
-  @each $size in (small, default, large) {
+  @each $size in (small, large) {
     @include m($size) {
-      --el-avatar-size: #{map.get($avatar-size, $size)};
+      @include set-css-var-value(
+        ('avatar', 'size'),
+        map.get($avatar-size, $size)
+      );
     }
   }
 }


### PR DESCRIPTION
close #6897

- set default componentSizes to remove warn when set size default

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
