### PR TITLE
fix(theme-chalk): [el-table] fix custom header background of fixed column

### DIFF
--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -420,6 +420,9 @@
         }
       }
     }
+    .#{$namespace}-table-fixed-column--left {
+      background-color: var(--el-table-header-bg-color);
+    }
   }
 
   @include when(scrolling-right) {
@@ -430,6 +433,9 @@
     }
     .#{$namespace}-table-fixed-column--left.is-last-column.#{$namespace}-table__cell {
       border-right: none;
+    }
+    .#{$namespace}-table-fixed-column--right {
+      background-color: var(--el-table-header-bg-color);
     }
   }
 
@@ -452,6 +458,7 @@
   @include when(scrolling-none) {
     .#{$namespace}-table-fixed-column--left,
     .#{$namespace}-table-fixed-column--right {
+      background-color: var(--el-table-header-bg-color);
       &.is-first-column,
       &.is-last-column {
         &::before {

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -469,13 +469,17 @@
   @include when(scrolling-none) {
     .#{$namespace}-table-fixed-column--left,
     .#{$namespace}-table-fixed-column--right {
-      background-color: var(--el-table-header-bg-color);
       &.is-first-column,
       &.is-last-column {
         &::before {
           box-shadow: none;
         }
       }
+    }
+
+    th.#{$namespace}-table-fixed-column--left,
+    th.#{$namespace}-table-fixed-column--right {
+      background-color: var(--el-table-header-bg-color);
     }
   }
 

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -383,6 +383,17 @@
     }
   }
 
+  @include e(header-wrapper) {
+    tr {
+      th {
+        &.#{$namespace}-table-fixed-column--left,
+        &.#{$namespace}-table-fixed-column--right {
+          background-color: var(--el-table-header-bg-color);
+        }
+      }
+    }
+  }
+
   @include e((header, body, footer)) {
     table-layout: fixed;
     border-collapse: separate;
@@ -420,7 +431,7 @@
         }
       }
     }
-    .#{$namespace}-table-fixed-column--left {
+    th.#{$namespace}-table-fixed-column--left {
       background-color: var(--el-table-header-bg-color);
     }
   }
@@ -434,7 +445,7 @@
     .#{$namespace}-table-fixed-column--left.is-last-column.#{$namespace}-table__cell {
       border-right: none;
     }
-    .#{$namespace}-table-fixed-column--right {
+    th.#{$namespace}-table-fixed-column--right {
       background-color: var(--el-table-header-bg-color);
     }
   }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Fix the customized background color of the fixed column header isn't correct.

Please refer to this [playground](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICAgIDxlbC10YWJsZSBib3JkZXIgOmRhdGE9XCJkYXRhXCIgc3R5bGU9XCJ3aWR0aDogNTAwcHg7IC0tZWwtdGFibGUtaGVhZGVyLWJnLWNvbG9yOiAjZmFmYWZhXCI+XG4gICAgICA8ZWwtdGFibGUtY29sdW1uIGxhYmVsPVwiTmFtZVwiIHByb3A9XCJuYW1lXCIgZml4ZWQ9XCJsZWZ0XCIgd2lkdGg9XCIxMDBcIiAvPlxuICAgICAgPGVsLXRhYmxlLWNvbHVtbiBsYWJlbD1cIlBob25lXCIgcHJvcD1cInBob25lXCIgd2lkdGg9XCIxMDBcIiAvPlxuICAgICAgPGVsLXRhYmxlLWNvbHVtbiBsYWJlbD1cIkFkZHJlc3NcIiBwcm9wPVwiYWRkcmVzc1wiIHdpZHRoPVwiMjAwXCIgLz5cbiAgICAgIDxlbC10YWJsZS1jb2x1bW4gbGFiZWw9XCJPcGVyYXRpb25cIiBhbGlnbj1cImNlbnRlclwiIGZpeGVkPVwicmlnaHRcIiB3aWR0aD1cIjEwMFwiPlxuICAgICAgICA8ZWwtYnV0dG9uIHNpemU9XCJzbWFsbFwiPkVkaXQ8L2VsLWJ1dHRvbj5cbiAgICAgIDwvZWwtdGFibGUtY29sdW1uPlxuICAgIDwvZWwtdGFibGU+XG4gIFxuICBcdDxlbC10YWJsZSBib3JkZXIgOmRhdGE9XCJkYXRhXCIgc3R5bGU9XCJ3aWR0aDogNDAwcHg7IC0tZWwtdGFibGUtaGVhZGVyLWJnLWNvbG9yOiAjZmFmYWZhOyBtYXJnaW4tdG9wOiA1MHB4XCI+XG4gICAgICA8ZWwtdGFibGUtY29sdW1uIGxhYmVsPVwiTmFtZVwiIHByb3A9XCJuYW1lXCIgZml4ZWQ9XCJsZWZ0XCIgd2lkdGg9XCIxMDBcIiAvPlxuICAgICAgPGVsLXRhYmxlLWNvbHVtbiBsYWJlbD1cIlBob25lXCIgcHJvcD1cInBob25lXCIgd2lkdGg9XCIxMDBcIiAvPlxuICAgICAgPGVsLXRhYmxlLWNvbHVtbiBsYWJlbD1cIkFkZHJlc3NcIiBwcm9wPVwiYWRkcmVzc1wiIHdpZHRoPVwiMjAwXCIgLz5cbiAgICAgIDxlbC10YWJsZS1jb2x1bW4gbGFiZWw9XCJPcGVyYXRpb25cIiBwcm9wPVwiY2VudGVyXCIgYWxpZ249XCJjZW50ZXJcIiBmaXhlZD1cInJpZ2h0XCIgd2lkdGg9XCIxMDBcIj5cbiAgICAgICAgPGVsLWJ1dHRvbiBzaXplPVwic21hbGxcIj5FZGl0PC9lbC1idXR0b24+XG4gICAgICA8L2VsLXRhYmxlLWNvbHVtbj5cbiAgICA8L2VsLXRhYmxlPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmNvbnN0IGRhdGEgPSBbXG4gIHtcbiAgICBuYW1lOiAnSmFja3knLFxuICAgIHBob25lOiAnMTIzNDU2Nzg5JyxcbiAgICBhZGRyZXNzOiAnRWFydGhFYXJ0aEVhcnRoRWFydGhFYXJ0aCdcbiAgfVxuXVxuPC9zY3JpcHQ+XG5cbjxzdHlsZT5cbmh0bWwsIGJvZHkge1xuICB3aWR0aDogMTAwdnc7XG4gIGhlaWdodDogMTAwdmg7XG4gIG1hcmdpbjogMDtcbn1cbiNhcHAge1xuICBoZWlnaHQ6IDEwMCU7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gIGp1c3RpZnktY29udGVudDogY2VudGVyO1xuICBmbGV4LWRpcmVjdGlvbjogY29sdW1uO1xufVxuPC9zdHlsZT5cblxuXG5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcImltcG9ydHNcIjp7fX0ifQ==),

- When the table is not scrollable, **(the top table)**
  - **_is-scrolling-none_**: should be customized color.

| Before | After |
| :----: | :----: |
| ![Before](https://user-images.githubusercontent.com/26999792/161070955-33cf066d-2e49-40db-b1e3-a29569ffa928.png) | ![After](https://user-images.githubusercontent.com/26999792/161070884-91f44adc-005e-4173-8863-49ad4169f676.png) |

- When the table is scrollable: **(the bottom table)**
  - **_is-scrolling-left_**: the columns fixed at the left should be the customized color when the scrollbar is at the left
  - **_is-scrolling-middle_**: the fixed columns should be **#fff** when the scrollbar is at the middle
  - **_is-scrolling-right_**: the columns fixed at the right should be the customized color when the scrollbar is at the right

| - | Left | Middle | Right |
| :----: | :----: | :----: | :----: |
| Before | ![Left](https://user-images.githubusercontent.com/26999792/161072234-4d60b596-cd62-422f-9c41-125f735a5d65.png) | ![Middle](https://user-images.githubusercontent.com/26999792/161072331-16e10973-ff98-4f99-8a36-5261b49acf42.png) | ![Right](https://user-images.githubusercontent.com/26999792/161072431-4b328cdc-8d6e-4581-970f-e853e6a87dc0.png) |
| After | ![Left](https://user-images.githubusercontent.com/26999792/161071467-d631b7fe-2538-4dbe-b4f5-87c656dd31ef.png) | ![Middle](https://user-images.githubusercontent.com/26999792/161072084-9346ed63-a410-49b5-8a29-f38c04d8b2d6.png) | ![Right](https://user-images.githubusercontent.com/26999792/161071890-53191d48-32d3-4157-a1a2-dedd89434904.png) |

And I didn't add the test case as it seems we currently can't get and check the final computed background color in jest.