### PR TITLE
fix(components): [el-upload] show border when readonly

### DIFF
--- a/packages/components/upload/src/upload-list.vue
+++ b/packages/components/upload/src/upload-list.vue
@@ -44,7 +44,9 @@
             @click="handleClick(file)"
           >
             <el-icon :class="nsIcon.m('document')"><Document /></el-icon>
-            {{ file.name }}
+            <span :class="nsUpload.be('list', 'item-file-name')">
+              {{ file.name }}
+            </span>
           </a>
           <el-progress
             v-if="file.status === 'uploading'"

--- a/packages/theme-chalk/src/upload.scss
+++ b/packages/theme-chalk/src/upload.scss
@@ -192,7 +192,7 @@
       display: inline-flex;
       justify-content: center;
       flex-direction: column;
-      width: 100%;
+      width: calc(100% - 30px);
       margin-left: 4px;
     }
 
@@ -247,16 +247,19 @@
 
     padding: 0 4px;
 
-    overflow: hidden;
-    text-overflow: ellipsis;
     transition: color var(--el-transition-duration);
-    white-space: nowrap;
     font-size: var(--el-font-size-base);
 
     .#{$namespace}-icon {
       margin-right: 6px;
       color: var(--el-text-color-secondary);
     }
+  }
+
+  @include e(item-file-name) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   @include e(item-status-label) {


### PR DESCRIPTION
fix #6867 

Because the file name is too long, the icon on the right is obscured.
I limited the item-info length calc(100% - 30px),
Make the icon display properly.