### PR TITLE
fix(components): [el-date-picker] show border when readonl

### DIFF
--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -1,7 +1,7 @@
 <template>
   <el-tooltip
     ref="refPopper"
-    v-model:visible="pickerVisible"
+    :visible="pickerVisible && !readonly && !pickerDisabled"
     effect="light"
     pure
     trigger="click"
@@ -370,7 +370,7 @@ export default defineComponent({
     }
 
     const handleFocus = (e) => {
-      if (props.readonly || pickerDisabled.value || pickerVisible.value) return
+      if (pickerVisible.value) return
       pickerVisible.value = true
       ctx.emit('focus', e)
     }


### PR DESCRIPTION
fix #6795 

My idea is：
In view of the native input and the element of the previous generation, when I click readonly, the border is displayed
so. I think el-data-picker in read-only state should have border after being clicked.

What I do is:
When clicking el-data-picker, assign pickervisable to true, then control the display of el-tooltip in the view.

***

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
