### PR TITLE
docs: change bg color for layout container when dark

### DIFF
--- a/docs/examples/container/common-layout.scss
+++ b/docs/examples/container/common-layout.scss
@@ -10,19 +10,19 @@
 
   .el-header,
   .el-footer {
-    background-color: #b3c0d1;
+    background-color: var(--el-color-primary-light-7);
     color: var(--el-text-color-primary);
     text-align: center;
   }
 
   .el-aside {
-    background-color: #d3dce6;
+    background-color: var(--el-color-primary-light-8);
     color: var(--el-text-color-primary);
     text-align: center;
   }
 
   .el-main {
-    background-color: #e9eef3;
+    background-color: var(--el-color-primary-light-9);
     color: var(--el-text-color-primary);
     text-align: center;
 

--- a/docs/examples/container/example.vue
+++ b/docs/examples/container/example.vue
@@ -1,9 +1,6 @@
 <template>
-  <el-container
-    class="layout-container-demo"
-    style="height: 500px; border: 1px solid #eee"
-  >
-    <el-aside width="200px" style="background-color: rgb(238, 241, 246)">
+  <el-container class="layout-container-demo" style="height: 500px">
+    <el-aside width="200px">
       <el-scrollbar>
         <el-menu :default-openeds="['1', '3']">
           <el-sub-menu index="1">
@@ -108,15 +105,12 @@ const tableData = ref(Array.from({ length: 20 }).fill(item))
 <style scoped>
 .layout-container-demo .el-header {
   position: relative;
-  background-color: #b3c0d1;
+  background-color: var(--el-color-primary-light-7);
   color: var(--el-text-color-primary);
 }
 .layout-container-demo .el-aside {
-  width: 240px;
   color: var(--el-text-color-primary);
-  background: #fff !important;
-  border-right: solid 1px #e6e6e6;
-  box-sizing: border-box;
+  background: var(--el-color-primary-light-8);
 }
 .layout-container-demo .el-menu {
   border-right: none;
@@ -125,11 +119,10 @@ const tableData = ref(Array.from({ length: 20 }).fill(item))
   padding: 0;
 }
 .layout-container-demo .toolbar {
-  position: absolute;
   display: inline-flex;
   align-items: center;
-  top: 50%;
+  justify-content: center;
+  height: 100%;
   right: 20px;
-  transform: translateY(-50%);
 }
 </style>


### PR DESCRIPTION
- use css var for layout container (dark mode)

<img width="775" alt="image" src="https://user-images.githubusercontent.com/25154432/162576330-10167cef-4edb-4abe-ab8c-b8507c8c962e.png">

<img width="781" alt="image" src="https://user-images.githubusercontent.com/25154432/162576313-1a5a80ad-9c00-4472-ae17-1753f849094a.png">

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
