### PR TITLE
fix(components): [tree-select] use `proxy` instead of `ctx`

### DIFF
--- a/packages/components/tree-select/src/tree.ts
+++ b/packages/components/tree-select/src/tree.ts
@@ -121,7 +121,7 @@ export const useTree = (
           select.value?.handleOptionSelect(option, true)
         }
       } else {
-        e.ctx.handleExpandIconClick()
+        e.proxy.handleExpandIconClick()
       }
     },
     onCheck: (data, params) => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Resolves #7159

The `ctx` property will be an empty object in the production environment and shouldn't be used. Use `proxy` instead.
