### PR TITLE
refactor(components): [input] change to flex layout

### DIFF
--- a/packages/components/input/__tests__/input.spec.tsx
+++ b/packages/components/input/__tests__/input.spec.tsx
@@ -461,26 +461,6 @@ describe('Input.vue', () => {
     expect(input.element.style.color === 'red').toBeTruthy()
     expect(textarea.element.style.color === 'red').toBeTruthy()
   })
-  test('input-padding', async () => {
-    const wrapper = mount(() => (
-      <>
-        <Input
-          placeholder="请输入内容"
-          v-slots={{
-            suffix: () => <div>suffix</div>,
-            prefix: () => <div>prefix</div>,
-          }}
-          input-style={{ color: 'red' }}
-        />
-      </>
-    ))
-
-    const input = wrapper.find('input')
-    await nextTick()
-    expect(input.element.style.color === 'red').toBeTruthy()
-    expect(input.element.style.paddingLeft).toBeTruthy()
-    expect(input.element.style.paddingRight).toBeTruthy()
-  })
 
   describe('Textarea Events', () => {
     test('event:keydown', async () => {

--- a/packages/components/input/__tests__/input.spec.tsx
+++ b/packages/components/input/__tests__/input.spec.tsx
@@ -485,7 +485,7 @@ describe('Input.vue', () => {
       <Input type="password" modelValue={password.value} show-password />
     ))
 
-    const icon = wrapper.find('.el-input__icon.el-input__clear')
+    const icon = wrapper.find('.el-input__icon.el-input__password')
     const d = icon.find('path').element.getAttribute('d')
     await icon.trigger('click')
     const d0 = icon.find('path').element.getAttribute('d')

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -39,7 +39,7 @@
         :tabindex="tabindex"
         :aria-label="label"
         :placeholder="placeholder"
-        :style="inputStyleInner"
+        :style="inputStyle"
         @compositionstart="handleCompositionStart"
         @compositionupdate="handleCompositionUpdate"
         @compositionend="handleCompositionEnd"
@@ -52,7 +52,7 @@
 
       <!-- prefix slot -->
       <span v-if="$slots.prefix || prefixIcon" :class="nsInput.e('prefix')">
-        <span ref="innerPrefixRef" :class="nsInput.e('prefix-inner')">
+        <span :class="nsInput.e('prefix-inner')">
           <slot name="prefix" />
           <el-icon v-if="prefixIcon" :class="nsInput.e('icon')">
             <component :is="prefixIcon" />
@@ -62,7 +62,7 @@
 
       <!-- suffix slot -->
       <span v-if="suffixVisible" :class="nsInput.e('suffix')">
-        <span ref="innerSuffixRef" :class="nsInput.e('suffix-inner')">
+        <span :class="nsInput.e('suffix-inner')">
           <template v-if="!showClear || !showPwdVisible || !isWordLimitVisible">
             <slot name="suffix" />
             <el-icon v-if="suffixIcon" :class="nsInput.e('icon')">
@@ -175,7 +175,7 @@ import {
 import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { calcTextareaHeight } from './utils'
 import { inputEmits, inputProps } from './input'
-import type { CSSProperties, Ref, StyleValue } from 'vue'
+import type { StyleValue } from 'vue'
 
 type TargetElement = HTMLInputElement | HTMLTextAreaElement
 const PENDANT_MAP = {
@@ -443,37 +443,7 @@ watch(
   }
 )
 
-// Get the widths of 'suffix' and 'prefix' to set the padding property of the input
-// https://github.com/element-plus/element-plus/issues/6464
-const innerSuffixRef = ref<HTMLElement>()
-const innerPrefixRef = ref<HTMLElement>()
-const inputStyleInner = ref<CSSProperties>({})
-const getSuffixOrPrefixWidth = (
-  slotElm: Ref<HTMLElement>,
-  defaultVal: number
-): number => {
-  if (slotElm.value) {
-    const slotElmWidth = (slotElm.value as HTMLElement).offsetWidth
-    return slotElmWidth > 0 ? slotElmWidth + 16 : defaultVal
-  }
-  return defaultVal
-}
-const setInputPadding = (): void => {
-  // If the user sets 'padding', use the 'padding' set by the user
-  inputStyleInner.value = {
-    paddingRight: `${getSuffixOrPrefixWidth(innerSuffixRef, 0)}px`,
-    paddingLeft: `${getSuffixOrPrefixWidth(innerPrefixRef, 11)}px`,
-    ...props.inputStyle,
-  }
-}
-watch(showClear, () => {
-  nextTick(() => {
-    setInputPadding()
-  })
-})
-
 onMounted(async () => {
-  setInputPadding()
   setNativeInputValue()
   updateIconOffset()
   await nextTick()

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -13,7 +13,7 @@
         [nsInput.m('prefix')]: $slots.prefix || prefixIcon,
         [nsInput.m('suffix')]:
           $slots.suffix || suffixIcon || clearable || showPassword,
-        [nsInput.m('suffix--password-clear')]: showClear && showPwdVisible,
+        [nsInput.bm('suffix', 'password-clear')]: showClear && showPwdVisible,
       },
       $attrs.class,
     ]"
@@ -28,79 +28,83 @@
         <slot name="prepend" />
       </div>
 
-      <input
-        ref="input"
-        :class="nsInput.e('inner')"
-        v-bind="attrs"
-        :type="showPassword ? (passwordVisible ? 'text' : 'password') : type"
-        :disabled="inputDisabled"
-        :readonly="readonly"
-        :autocomplete="autocomplete"
-        :tabindex="tabindex"
-        :aria-label="label"
-        :placeholder="placeholder"
-        :style="inputStyle"
-        @compositionstart="handleCompositionStart"
-        @compositionupdate="handleCompositionUpdate"
-        @compositionend="handleCompositionEnd"
-        @input="handleInput"
-        @focus="handleFocus"
-        @blur="handleBlur"
-        @change="handleChange"
-        @keydown="handleKeydown"
-      />
-
-      <!-- prefix slot -->
-      <span v-if="$slots.prefix || prefixIcon" :class="nsInput.e('prefix')">
-        <span :class="nsInput.e('prefix-inner')">
-          <slot name="prefix" />
-          <el-icon v-if="prefixIcon" :class="nsInput.e('icon')">
-            <component :is="prefixIcon" />
-          </el-icon>
-        </span>
-      </span>
-
-      <!-- suffix slot -->
-      <span v-if="suffixVisible" :class="nsInput.e('suffix')">
-        <span :class="nsInput.e('suffix-inner')">
-          <template v-if="!showClear || !showPwdVisible || !isWordLimitVisible">
-            <slot name="suffix" />
-            <el-icon v-if="suffixIcon" :class="nsInput.e('icon')">
-              <component :is="suffixIcon" />
+      <div :class="[nsInput.e('wrapper'), nsInput.is('focus', focused)]">
+        <!-- prefix slot -->
+        <span v-if="$slots.prefix || prefixIcon" :class="nsInput.e('prefix')">
+          <span :class="nsInput.e('prefix-inner')">
+            <slot name="prefix" />
+            <el-icon v-if="prefixIcon" :class="nsInput.e('icon')">
+              <component :is="prefixIcon" />
             </el-icon>
-          </template>
-          <el-icon
-            v-if="showClear"
-            :class="[nsInput.e('icon'), nsInput.e('clear')]"
-            @mousedown.prevent
-            @click="clear"
-          >
-            <circle-close />
-          </el-icon>
-          <el-icon
-            v-if="showPwdVisible"
-            :class="[nsInput.e('icon'), nsInput.e('clear')]"
-            @click="handlePasswordVisible"
-          >
-            <component :is="passwordIcon" />
-          </el-icon>
-          <span v-if="isWordLimitVisible" :class="nsInput.e('count')">
-            <span :class="nsInput.e('count-inner')">
-              {{ textLength }} / {{ attrs.maxlength }}
-            </span>
           </span>
         </span>
-        <el-icon
-          v-if="validateState && validateIcon && needStatusIcon"
-          :class="[
-            nsInput.e('icon'),
-            nsInput.e('validateIcon'),
-            nsInput.is('loading', validateState === 'validating'),
-          ]"
-        >
-          <component :is="validateIcon" />
-        </el-icon>
-      </span>
+
+        <input
+          ref="input"
+          :class="nsInput.e('inner')"
+          v-bind="attrs"
+          :type="showPassword ? (passwordVisible ? 'text' : 'password') : type"
+          :disabled="inputDisabled"
+          :readonly="readonly"
+          :autocomplete="autocomplete"
+          :tabindex="tabindex"
+          :aria-label="label"
+          :placeholder="placeholder"
+          :style="inputStyle"
+          @compositionstart="handleCompositionStart"
+          @compositionupdate="handleCompositionUpdate"
+          @compositionend="handleCompositionEnd"
+          @input="handleInput"
+          @focus="handleFocus"
+          @blur="handleBlur"
+          @change="handleChange"
+          @keydown="handleKeydown"
+        />
+
+        <!-- suffix slot -->
+        <span v-if="suffixVisible" :class="nsInput.e('suffix')">
+          <span :class="nsInput.e('suffix-inner')">
+            <template
+              v-if="!showClear || !showPwdVisible || !isWordLimitVisible"
+            >
+              <slot name="suffix" />
+              <el-icon v-if="suffixIcon" :class="nsInput.e('icon')">
+                <component :is="suffixIcon" />
+              </el-icon>
+            </template>
+            <el-icon
+              v-if="showClear"
+              :class="[nsInput.e('icon'), nsInput.e('clear')]"
+              @mousedown.prevent
+              @click="clear"
+            >
+              <circle-close />
+            </el-icon>
+            <el-icon
+              v-if="showPwdVisible"
+              :class="[nsInput.e('icon'), nsInput.e('password')]"
+              @click="handlePasswordVisible"
+            >
+              <component :is="passwordIcon" />
+            </el-icon>
+            <span v-if="isWordLimitVisible" :class="nsInput.e('count')">
+              <span :class="nsInput.e('count-inner')">
+                {{ textLength }} / {{ attrs.maxlength }}
+              </span>
+            </span>
+          </span>
+          <el-icon
+            v-if="validateState && validateIcon && needStatusIcon"
+            :class="[
+              nsInput.e('icon'),
+              nsInput.e('validateIcon'),
+              nsInput.is('loading', validateState === 'validating'),
+            ]"
+          >
+            <component :is="validateIcon" />
+          </el-icon>
+        </span>
+      </div>
 
       <!-- append slot -->
       <div v-if="$slots.append" :class="nsInput.be('group', 'append')">

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -208,8 +208,7 @@
             </template>
             <template #suffix>
               <el-icon
-                v-if="iconComponent"
-                v-show="!showClose"
+                v-if="iconComponent && !showClose"
                 :class="[nsSelect.e('caret'), nsSelect.e('icon'), iconReverse]"
               >
                 <component :is="iconComponent" />

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -329,9 +329,8 @@ export const useSelect = (props, states: States, ctx) => {
     if (props.collapseTags && !props.filterable) return
     nextTick(() => {
       if (!reference.value) return
-      const inputChildNodes = reference.value.$el.childNodes
-      const input = Array.from(inputChildNodes).find(
-        (item) => (item as HTMLElement).tagName === 'INPUT'
+      const input = reference.value.$el.querySelector(
+        'input'
       ) as HTMLInputElement
       const _tags = tags.value
 

--- a/packages/theme-chalk/src/cascader.scss
+++ b/packages/theme-chalk/src/cascader.scss
@@ -14,7 +14,7 @@
   outline: none;
 
   &:not(.is-disabled):hover {
-    .#{$namespace}-input__inner {
+    .#{$namespace}-input__wrapper {
       cursor: pointer;
       box-shadow: 0 0 0 1px var(--el-input-hover-border-color) inset;
     }
@@ -25,15 +25,7 @@
 
     .#{$namespace}-input__inner {
       text-overflow: ellipsis;
-
-      &:focus {
-        box-shadow: 0 0 0 1px
-          var(
-            --el-input-focus-border-color,
-            map.get($input, 'focus-border-color')
-          )
-          inset;
-      }
+      cursor: pointer;
     }
 
     .#{$namespace}-input__suffix-inner {
@@ -63,7 +55,7 @@
     }
 
     @include when(focus) {
-      .#{$namespace}-input__inner {
+      .#{$namespace}-input__wrapper {
         box-shadow: 0 0 0 1px
           var(
             --el-input-focus-border-color,

--- a/packages/theme-chalk/src/date-picker/picker.scss
+++ b/packages/theme-chalk/src/date-picker/picker.scss
@@ -23,6 +23,18 @@
   display: inline-block;
   text-align: left;
 
+  &.#{$namespace}-input__inner {
+    border-radius: var(--el-input-border-radius, var(--el-border-radius-base));
+
+    @include inset-input-border(
+      var(--el-input-border-color, map.get($input, 'border-color'))
+    );
+
+    &:hover {
+      @include inset-input-border(var(--el-input-hover-border-color));
+    }
+  }
+
   &.#{$namespace}-input,
   &.#{$namespace}-input__inner {
     width: var(--el-date-editor-width);

--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -200,16 +200,18 @@ $form-item-label-top-margin-bottom: map.merge(
 
   @include when(error) {
     .#{$namespace}-select-v2__wrapper,
-    .#{$namespace}-input__inner,
     .#{$namespace}-textarea__inner {
       &,
       &:focus {
         box-shadow: 0 0 0 1px var(--el-color-danger) inset;
       }
     }
+    .#{$namespace}-input__wrapper {
+      box-shadow: 0 0 0 1px var(--el-color-danger) inset;
+    }
     .#{$namespace}-input-group__append,
     .#{$namespace}-input-group__prepend {
-      .#{$namespace}-input__inner {
+      .#{$namespace}-input__wrapper {
         box-shadow: 0 0 0 1px transparent inset;
       }
     }

--- a/packages/theme-chalk/src/input-number.scss
+++ b/packages/theme-chalk/src/input-number.scss
@@ -11,7 +11,11 @@
   line-height: #{map.get($input-height, 'default') - 2};
 
   .#{$namespace}-input {
-    display: block;
+    &__wrapper {
+      display: block;
+      padding-left: #{map.get($input-height, 'default') + 10};
+      padding-right: #{map.get($input-height, 'default') + 10};
+    }
 
     &__inner {
       -webkit-appearance: none;
@@ -21,8 +25,6 @@
         margin: 0;
         -webkit-appearance: none;
       }
-      padding-left: #{map.get($input-height, 'default') + 10};
-      padding-right: #{map.get($input-height, 'default') + 10};
       text-align: center;
     }
   }
@@ -48,7 +50,7 @@
     &:hover {
       color: var(--el-color-primary);
 
-      & ~ .#{$namespace}-input:not(.is-disabled) .#{$namespace}-input__inner {
+      & ~ .#{$namespace}-input:not(.is-disabled) .#{$namespace}-input_wrapper {
         box-shadow: 0 0 0 1px
           var(
             --el-input-focus-border-color,
@@ -98,7 +100,7 @@
         font-size: map.get($input-font-size, $size);
       }
 
-      .#{$namespace}-input__inner {
+      .#{$namespace}-input__wrapper {
         padding-left: #{map.get($input-height, $size) + 7};
         padding-right: #{map.get($input-height, $size) + 7};
       }
@@ -114,14 +116,14 @@
   }
 
   @include when(without-controls) {
-    .#{$namespace}-input__inner {
+    .#{$namespace}-input__wrapper {
       padding-left: 15px;
       padding-right: 15px;
     }
   }
 
   @include when(controls-right) {
-    .#{$namespace}-input__inner {
+    .#{$namespace}-input__wrapper {
       padding-left: 15px;
       padding-right: #{map.get($input-height, 'default') + 10};
     }

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -122,13 +122,15 @@
   display: inline-flex;
   width: 100%;
   line-height: map.get($input-height, 'default');
+  box-sizing: border-box;
   @include scroll-bar;
 
-  & .#{$namespace}-input__clear {
+  & .#{$namespace}-input__clear,
+  & .#{$namespace}-input__password {
     color: var(--el-input-icon-color);
     font-size: map.get($input-font-size, 'default');
     cursor: pointer;
-    transition: var(--el-transition-color);
+    transition: var(--el-transition-color) !important;
     margin-left: 8px;
 
     &:hover {
@@ -151,29 +153,49 @@
     }
   }
 
-  @include e(inner) {
-    position: relative;
-    -webkit-appearance: none;
+  @include e(wrapper) {
+    display: inline-flex;
+    flex-grow: 1;
+    align-items: center;
+    justify-content: center;
+    padding: 0 map.get($input-padding-horizontal, 'default')-$border-width;
     background-color: var(--el-input-bg-color, map.get($input, 'bg-color'));
     background-image: none;
     border-radius: var(
       --el-input-border-radius,
       map.get($input, 'border-radius')
     );
-    box-sizing: border-box;
-    color: var(--el-input-text-color, map.get($input, 'text-color'));
-    display: inline-block;
-    font-size: inherit;
-    height: map.get($input-height, 'default');
-    line-height: map.get($input-height, 'default');
-    outline: none;
-    padding: 0 map.get($input-padding-horizontal, 'default')-$border-width;
     transition: var(--el-transition-box-shadow);
-    width: 100%;
     @include inset-input-border(
       var(--el-input-border-color, map.get($input, 'border-color'))
     );
+
+    &:hover {
+      @include inset-input-border(var(--el-input-hover-border-color));
+    }
+
+    @include when(focus) {
+      @include inset-input-border(var(--el-input-focus-border-color));
+    }
+  }
+
+  @include e(inner) {
+    width: 100%;
+    flex-grow: 1;
+    -webkit-appearance: none;
+    color: var(--el-input-text-color, map.get($input, 'text-color'));
+    font-size: inherit;
+    height: map.get($input-height, 'default');
+    line-height: map.get($input-height, 'default');
+    padding: 0;
+    outline: none;
     border: none;
+    background: none;
+
+    &:focus {
+      outline: none;
+    }
+
     &::placeholder {
       color: var(
         --el-input-placeholder-color,
@@ -181,53 +203,41 @@
       );
     }
 
-    &:hover {
-      @include inset-input-border(var(--el-input-hover-border-color));
-    }
-
-    &:focus {
-      outline: none;
-      @include inset-input-border(var(--el-input-focus-border-color));
-    }
     // override edge default style
     &[type='password']::-ms-reveal {
       display: none;
     }
   }
 
-  @include e(suffix) {
-    display: inline-flex;
+  @each $slot in (prefix, suffix) {
+    @include e($slot) {
+      display: inline-flex;
+      white-space: nowrap;
+      flex-shrink: 0;
+      flex-wrap: nowrap;
+      height: 100%;
+      text-align: center;
+      color: var(--el-input-icon-color, map.get($input, 'icon-color'));
+      transition: all var(--el-transition-duration);
+      pointer-events: none;
+    }
 
-    position: absolute;
-    height: 100%;
-    right: map.get($input-padding-horizontal, 'default');
-    top: 0;
-    text-align: center;
-    color: var(--el-input-icon-color, map.get($input, 'icon-color'));
-    transition: all var(--el-transition-duration);
-    pointer-events: none;
-  }
+    @include e(#{$slot}-inner) {
+      pointer-events: all;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
 
-  @include e(suffix-inner) {
-    pointer-events: all;
-    display: inline-flex;
-  }
-
-  @include e(prefix) {
-    display: inline-flex;
-
-    position: absolute;
-    height: 100%;
-    left: map.get($input-padding-horizontal, 'default');
-    top: 0;
-    text-align: center;
-    color: var(--el-input-icon-color, map.get($input, 'icon-color'));
-    transition: all var(--el-transition-duration);
-  }
-
-  @include e(prefix-inner) {
-    pointer-events: all;
-    display: inline-flex;
+      @if $slot == prefix {
+        > :last-child {
+          margin-right: 8px;
+        }
+      } @else {
+        > :first-child {
+          margin-left: 8px;
+        }
+      }
+    }
   }
 
   & .#{$namespace}-input__icon {
@@ -243,19 +253,23 @@
   }
 
   @include when(active) {
-    .#{$namespace}-input__inner {
-      outline: none;
-      box-shadow: 0 0 0 1px
-        var(--el-input-focus-border, map.get($input, 'focus-color')) inset;
+    .#{$namespace}-input__wrapper {
+      @include mixed-input-border(
+        var(--el-input-focus-border, map.get($input, 'focus-color'))
+      );
     }
   }
 
   @include when(disabled) {
-    .#{$namespace}-input__inner {
+    cursor: not-allowed;
+
+    .#{$namespace}-input__wrapper {
       background-color: map.get($input-disabled, 'fill');
-      box-shadow: 0 0 0 1px map.get($input-disabled, 'border') inset;
+      @include mixed-input-border(map.get($input-disabled, 'border'));
+    }
+
+    .#{$namespace}-input__inner {
       color: map.get($input-disabled, 'text-color');
-      cursor: not-allowed;
 
       &::placeholder {
         color: map.get($input-disabled, 'placeholder-color');
@@ -268,8 +282,8 @@
   }
 
   @include when(exceed) {
-    .#{$namespace}-input__inner {
-      box-shadow: 0 0 0 1px var(--el-color-danger) inset;
+    .#{$namespace}-input__wrapper {
+      @include mixed-input-border(var(--el-color-danger));
     }
 
     .#{$namespace}-input__suffix {
@@ -279,97 +293,42 @@
     }
   }
 
-  $input-padding-size-with-extra-icon: calc(
-    5px + #{map.get($input-font-size, 'default')} + #{map.get(
-        $input-padding-horizontal,
-        'default'
-      )}
-  );
-
-  @include m(suffix) {
-    .#{$namespace}-input__inner {
-      padding-right: $input-padding-size-with-extra-icon;
-    }
-
-    @include m(password-clear) {
-      .#{$namespace}-input__inner {
-        padding-right: 55px;
-      }
-    }
-  }
-
-  @include m(prefix) {
-    .#{$namespace}-input__inner {
-      padding-left: $input-padding-size-with-extra-icon;
-    }
-  }
-
   @each $size in (large, small) {
     @include m($size) {
       font-size: map.get($input-font-size, $size);
       line-height: map.get($input-height, $size) - 2;
 
+      @include e(wrapper) {
+        padding: 0 map.get($input-padding-horizontal, $size)-$border-width;
+      }
+
       @include e(inner) {
         height: map.get($input-height, $size);
         line-height: map.get($input-height, $size);
-        padding: 0 map.get($input-padding-horizontal, $size)-$border-width;
       }
 
       .#{$namespace}-input__icon {
         line-height: map.get($input-height, $size);
-      }
-
-      $input-padding-size-with-extra-icon: calc(
-        5px + #{map.get($input-font-size, $size)} + #{map.get(
-            $input-padding-horizontal,
-            $size
-          )}
-      );
-
-      &.#{$namespace}-input--prefix {
-        .#{$namespace}-input__inner {
-          padding-left: $input-padding-size-with-extra-icon;
-        }
-      }
-
-      &.#{$namespace}-input--suffix {
-        .#{$namespace}-input__inner {
-          padding-right: $input-padding-size-with-extra-icon;
-        }
-      }
-
-      @include e(prefix) {
-        left: map.get($input-padding-horizontal, $size);
-      }
-
-      @include e(suffix) {
-        right: map.get($input-padding-horizontal, $size);
       }
     }
   }
 }
 
 @include b(input-group) {
-  line-height: normal;
-  display: inline-table;
+  display: inline-flex;
   width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-
-  > .#{$namespace}-input__inner {
-    vertical-align: middle;
-    display: table-cell;
-  }
+  align-items: center;
 
   @include e((append, prepend)) {
     background-color: getCssVar('fill-color', 'light');
     color: var(--el-color-info);
-    vertical-align: middle;
-    display: table-cell;
     position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
     border-radius: var(--el-input-border-radius);
     padding: 0 20px;
-    width: 1px;
     white-space: nowrap;
 
     &:focus {
@@ -384,8 +343,8 @@
 
     button.#{$namespace}-button,
     button.#{$namespace}-button:hover,
-    div.#{$namespace}-select .#{$namespace}-input__inner,
-    div.#{$namespace}-select:hover .#{$namespace}-input__inner {
+    div.#{$namespace}-select .#{$namespace}-input__wrapper,
+    div.#{$namespace}-select:hover .#{$namespace}-input__wrapper {
       border-color: transparent;
       background-color: transparent;
       color: inherit;
@@ -412,42 +371,27 @@
   }
 
   @include m(prepend) {
-    .#{$namespace}-input__inner {
-      box-shadow: 1px 0 0 0 var(--el-input-border-color) inset,
-        0 1px 0 0 var(--el-input-border-color) inset,
-        0 -1px 0 0 var(--el-input-border-color) inset;
-    }
-
-    > .#{$namespace}-input__inner {
+    > .#{$namespace}-input__wrapper {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
-      @include mixed-input-border(var(--el-input-border-color));
-      &:hover {
-        @include mixed-input-border(var(--el-input-hover-border-color));
-      }
-
-      &:focus {
-        outline: none;
-        @include mixed-input-border(var(--el-input-focus-border-color));
-      }
     }
 
     @include e(prepend) {
       .#{$namespace}-select {
         .#{$namespace}-input {
           .#{$namespace}-input__inner {
+            box-shadow: none !important;
+          }
+          .#{$namespace}-input__wrapper {
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;
-            &:focus {
-              outline: none;
-              z-index: 2;
-              @include inset-prepend-input-border(
-                var(--el-input-focus-border-color)
-              );
-            }
+            @include inset-prepend-border(var(--el-input-border-color));
           }
           &.is-focus {
             .#{$namespace}-input__inner {
+              box-shadow: none !important;
+            }
+            .#{$namespace}-input__wrapper {
               @include inset-prepend-input-border(
                 var(--el-input-focus-border-color)
               );
@@ -464,6 +408,9 @@
         }
         &:hover {
           .#{$namespace}-input__inner {
+            box-shadow: none !important;
+          }
+          .#{$namespace}-input__wrapper {
             z-index: 1;
             @include inset-prepend-input-border(
               var(--el-input-hover-border-color)
@@ -475,7 +422,7 @@
   }
 
   @include m(append) {
-    > .#{$namespace}-input__inner {
+    > .#{$namespace}-input__wrapper {
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
     }
@@ -483,36 +430,30 @@
       .#{$namespace}-select {
         .#{$namespace}-input {
           .#{$namespace}-input__inner {
+            box-shadow: none !important;
+          }
+          .#{$namespace}-input__wrapper {
             border-top-left-radius: 0;
             border-bottom-left-radius: 0;
-            @include inset-append-input-border(var(--el-input-border-color));
-            &:focus {
-              outline: none;
-              z-index: 2;
-              @include inset-append-input-border(
-                var(--el-input-focus-border-color)
-              );
-            }
+            @include inset-append-border(var(--el-input-border-color));
           }
           &.is-focus {
             .#{$namespace}-input__inner {
-              outline: none;
+              box-shadow: none !important;
+            }
+            .#{$namespace}-input__wrapper {
               z-index: 2;
               @include inset-append-input-border(
                 var(--el-input-focus-border-color)
               );
-              &:focus {
-                outline: none;
-                z-index: 2;
-                @include inset-append-input-border(
-                  var(--el-input-focus-border-color)
-                );
-              }
             }
           }
         }
         &:hover {
           .#{$namespace}-input__inner {
+            box-shadow: none !important;
+          }
+          .#{$namespace}-input__wrapper {
             z-index: 1;
             @include inset-append-input-border(
               var(--el-input-hover-border-color)

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -54,23 +54,26 @@
   }
 
   &:hover:not(.#{$namespace}-select--disabled) {
-    .#{$namespace}-input__inner {
+    .#{$namespace}-input__wrapper {
       box-shadow: 0 0 0 1px var(--el-select-border-color-hover) inset;
     }
   }
 
   @include select-common(select);
 
-  .#{$namespace}-input__inner {
+  .#{$namespace}-input__wrapper {
     cursor: pointer;
-    display: inline-flex;
 
-    &:focus {
+    @include when(focus) {
       @include inset-input-border(
         var(--el-select-input-focus-border-color),
         true
       );
     }
+  }
+
+  .#{$namespace}-input__inner {
+    cursor: pointer;
   }
 
   .#{$namespace}-input {
@@ -108,19 +111,22 @@
     }
 
     &.is-disabled {
-      & .#{$namespace}-input__inner {
+      & .#{$namespace}-input__wrapper {
         cursor: not-allowed;
 
         &:hover {
           @include inset-input-border(var(--el-select-disabled-border));
         }
       }
+      & .#{$namespace}-input__inner {
+        cursor: not-allowed;
+      }
       & .#{$namespace}-select__caret {
         cursor: not-allowed;
       }
     }
 
-    &.is-focus .#{$namespace}-input__inner {
+    &.is-focus .#{$namespace}-input__wrapper {
       @include inset-input-border(
         var(--el-select-input-focus-border-color),
         true


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Many developers have reported the issue that input icons(slots) may overlap with the text. In #7001, we tried to use javascript to calculate the padding dynamically, but it's not enough to cover all cases and has brought some new unexpected bugs.

To fix this issue, I think it's better to use the flex layout to place the elements.

Note that the PR has the following changes,

- Revert changes in #7001 
- Change to `flex` layout
- Add a new wrapper element `el-input__wrapper`

!! **Please check if releated components can work well as before.**

Related PR: #7104