### PR TITLE
docs: [form] add FormRules type assertion

### DIFF
--- a/docs/examples/form/validation.vue
+++ b/docs/examples/form/validation.vue
@@ -71,7 +71,7 @@
 
 <script lang="ts" setup>
 import { reactive, ref } from 'vue'
-import type { FormInstance } from 'element-plus'
+import type { FormInstance, FormRules } from 'element-plus'
 
 const formSize = ref('default')
 const ruleFormRef = ref<FormInstance>()
@@ -86,7 +86,7 @@ const ruleForm = reactive({
   desc: '',
 })
 
-const rules = reactive({
+const rules = reactive<FormRules>({
   name: [
     { required: true, message: 'Please input Activity name', trigger: 'blur' },
     { min: 3, max: 5, message: 'Length should be 3 to 5', trigger: 'blur' },


### PR DESCRIPTION
The following example was not compiling in typescript and was throwing a type mismatch error. Adding the following assertion fixes it.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
