### PR TITLE
test: vitest disable ssr for tsx files

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,5 +12,8 @@ export default defineConfig({
     include: ['**/*.vitest.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     exclude: ['**/*.test.*', '**/*.spec.*', '**/node_modules'],
     environment: 'jsdom',
+    transformMode: {
+      web: [/\.[jt]sx$/],
+    },
   },
 })


### PR DESCRIPTION
I started converting couple component tests from `jest` to `vitest` but by default `jsx/tsx` files go through the ssr transform which breaks the tests. Following the vitest docs, we will force those files to go through the web transform:
https://vitest.dev/config/#transformmode-web

As soon as this is merged, i'll create couple more PRs for individual components (jest -> vitest).

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
