### PR TITLE
test: vitest setup file

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     include: ['**/*.vitest.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     exclude: ['**/*.test.*', '**/*.spec.*', '**/node_modules'],
     environment: 'jsdom',
+    setupFiles: ['./vitest.setup.js'],
     transformMode: {
       web: [/\.[jt]sx$/],
     },

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,7 @@
+import { config } from '@vue/test-utils'
+import { vi } from 'vitest'
+import ResizeObserver from 'resize-observer-polyfill'
+
+vi.stubGlobal('ResizeObserver', ResizeObserver)
+
+config.global.stubs = {}


### PR DESCRIPTION
Adds `vitest.setup.js` similar to `jest.setup.js`:
* Polyfill `ResizeObserver`
* Reset `@vue/test-utils` default config stubs: no `transition`/`transition-group` stubs by default

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
