### PR TITLE
fix(theme-chalk): components details when dark

### DIFF
--- a/docs/en-US/component/layout.md
+++ b/docs/en-US/component/layout.md
@@ -136,3 +136,7 @@ The classes are:
 | Name | Description               |
 | ---- | ------------------------- |
 | —    | customize default content |
+
+<style lang="scss">
+@use '../../examples/layout/index.scss';
+</style>

--- a/docs/examples/layout/alignment.vue
+++ b/docs/examples/layout/alignment.vue
@@ -41,21 +41,9 @@
 .el-col {
   border-radius: 4px;
 }
-.bg-purple-dark {
-  background: #99a9bf;
-}
-.bg-purple {
-  background: #d3dce6;
-}
-.bg-purple-light {
-  background: #e5e9f2;
-}
+
 .grid-content {
   border-radius: 4px;
   min-height: 36px;
-}
-.row-bg {
-  padding: 10px 0;
-  background-color: #f9fafc;
 }
 </style>

--- a/docs/examples/layout/basic-layout.vue
+++ b/docs/examples/layout/basic-layout.vue
@@ -27,7 +27,7 @@
   </el-row>
 </template>
 
-<style>
+<style lang="scss">
 .el-row {
   margin-bottom: 20px;
 }
@@ -37,21 +37,9 @@
 .el-col {
   border-radius: 4px;
 }
-.bg-purple-dark {
-  background: #99a9bf;
-}
-.bg-purple {
-  background: #d3dce6;
-}
-.bg-purple-light {
-  background: #e5e9f2;
-}
+
 .grid-content {
   border-radius: 4px;
   min-height: 36px;
-}
-.row-bg {
-  padding: 10px 0;
-  background-color: #f9fafc;
 }
 </style>

--- a/docs/examples/layout/column-offset.vue
+++ b/docs/examples/layout/column-offset.vue
@@ -30,21 +30,9 @@
 .el-col {
   border-radius: 4px;
 }
-.bg-purple-dark {
-  background: #99a9bf;
-}
-.bg-purple {
-  background: #d3dce6;
-}
-.bg-purple-light {
-  background: #e5e9f2;
-}
+
 .grid-content {
   border-radius: 4px;
   min-height: 36px;
-}
-.row-bg {
-  padding: 10px 0;
-  background-color: #f9fafc;
 }
 </style>

--- a/docs/examples/layout/column-spacing.vue
+++ b/docs/examples/layout/column-spacing.vue
@@ -17,21 +17,9 @@
 .el-col {
   border-radius: 4px;
 }
-.bg-purple-dark {
-  background: #99a9bf;
-}
-.bg-purple {
-  background: #d3dce6;
-}
-.bg-purple-light {
-  background: #e5e9f2;
-}
+
 .grid-content {
   border-radius: 4px;
   min-height: 36px;
-}
-.row-bg {
-  padding: 10px 0;
-  background-color: #f9fafc;
 }
 </style>

--- a/docs/examples/layout/hybrid-layout.vue
+++ b/docs/examples/layout/hybrid-layout.vue
@@ -26,21 +26,9 @@
 .el-col {
   border-radius: 4px;
 }
-.bg-purple-dark {
-  background: #99a9bf;
-}
-.bg-purple {
-  background: #d3dce6;
-}
-.bg-purple-light {
-  background: #e5e9f2;
-}
+
 .grid-content {
   border-radius: 4px;
   min-height: 36px;
-}
-.row-bg {
-  padding: 10px 0;
-  background-color: #f9fafc;
 }
 </style>

--- a/docs/examples/layout/index.scss
+++ b/docs/examples/layout/index.scss
@@ -1,0 +1,33 @@
+.row-bg {
+  padding: 10px 0;
+  background-color: #f9fafc;
+}
+
+.bg-purple-dark {
+  background: #99a9bf;
+}
+.bg-purple {
+  background: #d3dce6;
+}
+.bg-purple-light {
+  background: #e5e9f2;
+}
+
+.dark {
+  .row-bg {
+    padding: 10px 0;
+    background-color: #18191a;
+  }
+
+  .bg-purple-light {
+    background: #242526;
+  }
+
+  .bg-purple {
+    background: #46494d;
+  }
+
+  .bg-purple-dark {
+    background: #667180;
+  }
+}

--- a/docs/examples/layout/responsive-layout.vue
+++ b/docs/examples/layout/responsive-layout.vue
@@ -19,15 +19,7 @@
 .el-col {
   border-radius: 4px;
 }
-.bg-purple-dark {
-  background: #99a9bf;
-}
-.bg-purple {
-  background: #d3dce6;
-}
-.bg-purple-light {
-  background: #e5e9f2;
-}
+
 .grid-content {
   border-radius: 4px;
   min-height: 36px;

--- a/docs/examples/loading/customization.vue
+++ b/docs/examples/loading/customization.vue
@@ -4,7 +4,7 @@
     element-loading-text="Loading..."
     :element-loading-spinner="svg"
     element-loading-svg-view-box="-10, -10, 50, 50"
-    element-loading-background="rgba(0, 0, 0, 0.8)"
+    element-loading-background="rgba(122, 122, 122, 0.8)"
     :data="tableData"
     style="width: 100%"
   >

--- a/docs/examples/space/alignment.vue
+++ b/docs/examples/space/alignment.vue
@@ -1,12 +1,5 @@
 <template>
-  <div
-    style="
-      width: 240px;
-      margin-bottom: 20px;
-      padding: 8px;
-      border: 1px solid #ccc;
-    "
-  >
+  <div class="alignment-container">
     <el-space>
       string
       <el-button> button </el-button>
@@ -16,14 +9,7 @@
       </el-card>
     </el-space>
   </div>
-  <div
-    style="
-      width: 240px;
-      margin-bottom: 20px;
-      padding: 8px;
-      border: 1px solid #ccc;
-    "
-  >
+  <div class="alignment-container">
     <el-space alignment="flex-start">
       string
       <el-button> button </el-button>
@@ -33,14 +19,7 @@
       </el-card>
     </el-space>
   </div>
-  <div
-    style="
-      width: 240px;
-      margin-bottom: 20px;
-      padding: 8px;
-      border: 1px solid #ccc;
-    "
-  >
+  <div class="alignment-container">
     <el-space alignment="flex-end">
       string
       <el-button> button </el-button>
@@ -51,3 +30,12 @@
     </el-space>
   </div>
 </template>
+
+<style>
+.alignment-container {
+  width: 240px;
+  margin-bottom: 20px;
+  padding: 8px;
+  border: 1px solid var(--el-border-color);
+}
+</style>

--- a/docs/examples/tree/custom-node-class.vue
+++ b/docs/examples/tree/custom-node-class.vue
@@ -85,7 +85,7 @@ const data: Tree[] = [
 
 <style>
 .is-penultimate > .el-tree-node__content {
-  color: red;
+  color: #626aef;
 }
 
 .el-tree-node.is-expanded.is-penultimate > .el-tree-node__children {

--- a/packages/theme-chalk/src/date-picker/time-picker.scss
+++ b/packages/theme-chalk/src/date-picker/time-picker.scss
@@ -28,8 +28,6 @@
       box-sizing: border-box;
       padding-top: 6px;
       text-align: left;
-      border-top: 1px solid var(--el-border-color-light);
-      border-bottom: 1px solid var(--el-border-color-light);
     }
 
     &::after {
@@ -42,6 +40,8 @@
       padding-left: 50%;
       margin-right: 12%;
       margin-left: 12%;
+      border-top: 1px solid var(--el-border-color-light);
+      border-bottom: 1px solid var(--el-border-color-light);
     }
 
     &.has-seconds {

--- a/packages/theme-chalk/src/step.scss
+++ b/packages/theme-chalk/src/step.scss
@@ -62,7 +62,7 @@
     height: 24px;
     font-size: 14px;
     box-sizing: border-box;
-    background: getCssVar('bg-color', 'overlay');
+    background: getCssVar('fill-color', 'blank');
     transition: 0.15s ease-out;
 
     @include when(text) {

--- a/packages/theme-chalk/src/tabs.scss
+++ b/packages/theme-chalk/src/tabs.scss
@@ -209,7 +209,7 @@
         }
       }
       &.is-active {
-        border-bottom-color: $color-white;
+        border-bottom-color: getCssVar('bg-color');
 
         &.is-closable {
           padding-left: 20px;


### PR DESCRIPTION
- timepicker time border when dark

<img width="184" alt="image" src="https://user-images.githubusercontent.com/25154432/163852556-b7807e4a-4d19-4384-be38-4a18d14fca2f.png">

- tree custom color to `#626aef`
- tabs border
- loading custom mask
- layout color when dark
- space demo border color for alignment

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
