### PR TITLE
test: fix console output errors and warnings

### DIFF
--- a/packages/components/button/__tests__/button.test.tsx
+++ b/packages/components/button/__tests__/button.test.tsx
@@ -124,7 +124,7 @@ describe('Button.vue', () => {
       setup: () => () =>
         (
           <Button
-            v-slots={{ loading: <span class="custom-loading">111</span> }}
+            v-slots={{ loading: () => <span class="custom-loading">111</span> }}
             loading={true}
           >
             Loading

--- a/packages/components/image-viewer/__tests__/image-viewer.test.ts
+++ b/packages/components/image-viewer/__tests__/image-viewer.test.ts
@@ -7,7 +7,6 @@ import ImageViewer from '../src/image-viewer.vue'
 
 const mount = makeMount(ImageViewer, {
   props: {
-    src: IMAGE_SUCCESS,
     urlList: [IMAGE_SUCCESS],
   },
 })
@@ -25,6 +24,7 @@ describe('<image-viewer />', () => {
     expect(viewer.exists()).toBe(true)
     await wrapper.find('.el-image-viewer__close').trigger('click')
     expect(wrapper.emitted('close')).toEqual([[]])
+    wrapper.unmount()
   })
 
   test('image preview hide-click-on-modal', async () => {
@@ -42,5 +42,6 @@ describe('<image-viewer />', () => {
 
     await wrapper.find('.el-image-viewer__mask').trigger('click')
     expect(wrapper.emitted('close')).toBeDefined()
+    wrapper.unmount()
   })
 })

--- a/packages/components/notification/__tests__/notification.test.ts
+++ b/packages/components/notification/__tests__/notification.test.ts
@@ -8,6 +8,7 @@ import Notification from '../src/notification.vue'
 
 import type { Component, ComponentPublicInstance } from 'vue'
 import type { VueWrapper } from '@vue/test-utils'
+import type { SpyInstance } from 'vitest'
 
 const AXIOM = 'Rem is the best girl'
 
@@ -122,6 +123,8 @@ describe('Notification.vue', () => {
     })
 
     test('should not be able to render invalid type icon', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => vi.fn)
+
       const type = 'some-type'
       const wrapper = _mount({
         props: {
@@ -130,6 +133,8 @@ describe('Notification.vue', () => {
       })
 
       expect(wrapper.find('.el-notification__icon').exists()).toBe(false)
+      expect(console.warn).toHaveBeenCalled()
+      ;(console.warn as any as SpyInstance).mockRestore()
     })
   })
 

--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -807,7 +807,6 @@ describe('Select', () => {
       const wrapper = createSelect({
         data: () => {
           return {
-            popperAppendToBody: false,
             allowCreate: true,
             filterable: true,
             clearable: true,
@@ -982,7 +981,6 @@ describe('Select', () => {
       data() {
         return {
           options: [],
-          popperAppendToBody: false,
         }
       },
       slots: {
@@ -1094,11 +1092,6 @@ describe('Select', () => {
 
   it('customized option renderer', async () => {
     const wrapper = createSelect({
-      data() {
-        return {
-          popperAppendToBody: false,
-        }
-      },
       slots: {
         default: `
           <div class="custom-renderer">

--- a/packages/components/switch/__tests__/switch.test.ts
+++ b/packages/components/switch/__tests__/switch.test.ts
@@ -1,10 +1,19 @@
 import { markRaw, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
-import { describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { debugWarn } from '@element-plus/utils'
 import { Checked, CircleClose } from '@element-plus/icons-vue'
 import Switch from '../src/switch.vue'
 
+vi.mock('@element-plus/utils/error', () => ({
+  debugWarn: vi.fn(),
+}))
+
 describe('Switch.vue', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   test('create', () => {
     const wrapper = mount(Switch, {
       props: {
@@ -303,6 +312,7 @@ describe('Switch.vue', () => {
     vi.runAllTimers()
     await nextTick()
     expect(vm.value).toEqual(true)
+    expect(debugWarn).toHaveBeenCalledTimes(0)
 
     vm.asyncResult = 'success'
 
@@ -310,11 +320,13 @@ describe('Switch.vue', () => {
     vi.runAllTimers()
     await nextTick()
     expect(vm.value).toEqual(false)
+    expect(debugWarn).toHaveBeenCalledTimes(1)
 
     await coreWrapper.trigger('click')
     vi.runAllTimers()
     await nextTick()
     expect(vm.value).toEqual(true)
+    expect(debugWarn).toHaveBeenCalledTimes(1)
   })
 
   test('beforeChange function return boolean', async () => {

--- a/packages/components/virtual-list/__tests__/fixed-size-list.test.ts
+++ b/packages/components/virtual-list/__tests__/fixed-size-list.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../src/defaults'
 import { FixedSizeList } from '..'
 
+import type { SpyInstance } from 'vitest'
 import type { ListExposes } from '../src/types'
 type ListRef = ListExposes
 
@@ -369,6 +370,8 @@ describe('<fixed-size-list />', () => {
 
   describe('to throw', () => {
     it('should throw when layout is invalid', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => vi.fn)
+
       try {
         const wrapper = mount({
           props: {
@@ -380,6 +383,9 @@ describe('<fixed-size-list />', () => {
       } catch (e) {
         expect(e).toBeInstanceOf(Error)
       }
+
+      expect(console.warn).toHaveBeenCalled()
+      ;(console.warn as any as SpyInstance).mockRestore()
     })
   })
 })


### PR DESCRIPTION
Fixes all errors and warnings when running unit tests.

There's aslo this [Vitest bug](https://github.com/vitest-dev/vitest/issues/1072) that flushes the console output which will hopefully be resolved soon with [this fix](https://github.com/sindresorhus/log-update/pull/57).

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
