### PR TITLE
fix(directives): use standard wheel event with passive option

### DIFF
--- a/packages/directives/mousewheel/index.ts
+++ b/packages/directives/mousewheel/index.ts
@@ -1,5 +1,4 @@
 import normalizeWheel from 'normalize-wheel-es'
-import { isFirefox } from '@element-plus/utils'
 import type { DirectiveBinding, ObjectDirective } from 'vue'
 
 const mousewheel = function (element, callback) {
@@ -8,11 +7,7 @@ const mousewheel = function (element, callback) {
       const normalized = normalizeWheel(event)
       callback && Reflect.apply(callback, this, [event, normalized])
     }
-    if (isFirefox()) {
-      element.addEventListener('DOMMouseScroll', fn)
-    } else {
-      element.onmousewheel = fn
-    }
+    element.addEventListener('wheel', fn, { passive: true })
   }
 }
 


### PR DESCRIPTION
Both DOMMouseScroll and mousewheel event are non-standard now. And "[Violation]" warning will be
printed in console without setting `passive: true`.

fix #7016 #2016

- [Element: DOMMouseScroll event
](https://developer.mozilla.org/en-US/docs/Web/API/Element/DOMMouseScroll_event)
- [Element: mousewheel event](https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event)

![image](https://user-images.githubusercontent.com/37934144/163983831-9fa0f073-d25e-4d65-a049-ecc8f0f718e6.png)

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
