### PR TITLE
test: enable clearMocks in vitest config

### DIFF
--- a/packages/components/form/__tests__/form-item.test.tsx
+++ b/packages/components/form/__tests__/form-item.test.tsx
@@ -114,8 +114,8 @@ describe('ElFormItem', () => {
       it('should be able to validate with callback without throwing rejection', async () => {
         const emailInput = formItemRef.value!
         const callback = vi.fn()
-        expect(console.warn).toHaveBeenCalled()
         expect(emailInput.validate('', callback)).resolves.toBe(false)
+        expect(console.warn).toHaveBeenCalled()
         await rAF()
         expect(callback).toHaveBeenCalled()
       })
@@ -123,8 +123,8 @@ describe('ElFormItem', () => {
       it('should emit validate event', async () => {
         const emailInput = formItemRef.value!
         const callback = vi.fn()
-        expect(console.warn).toHaveBeenCalled()
         expect(emailInput.validate('', callback)).resolves.toBe(false)
+        expect(console.warn).toHaveBeenCalled()
         await rAF()
         expect(findForm().emitted('validate')).toEqual([
           ['email', false, 'email is required'],

--- a/packages/components/form/__tests__/form.test.tsx
+++ b/packages/components/form/__tests__/form.test.tsx
@@ -569,8 +569,6 @@ describe('Form', () => {
     const findDomainItems = () => wrapper.findAll('.domain-item')
 
     beforeEach(() => {
-      onSuccess.mockClear()
-      onError.mockClear()
       createComponent()
     })
 

--- a/packages/components/roving-focus-group/__tests__/roving-focus-group.test.ts
+++ b/packages/components/roving-focus-group/__tests__/roving-focus-group.test.ts
@@ -83,7 +83,6 @@ describe('<ElRovingFocusGroup />', () => {
     await nextTick()
   })
   afterEach(() => {
-    ;[onFocus, onBlur, onMousedown].forEach((f) => f.mockClear())
     wrapper.unmount()
   })
 

--- a/packages/components/roving-focus-group/__tests__/roving-focus-item.test.ts
+++ b/packages/components/roving-focus-group/__tests__/roving-focus-item.test.ts
@@ -102,7 +102,6 @@ describe('<ElRovingFocusItem />', () => {
     await nextTick()
   })
   afterEach(() => {
-    ;[onItemFocus, onItemShiftTab].forEach((f) => f.mockClear())
     wrapper.unmount()
   })
 

--- a/packages/components/slot/__tests__/only-child.test.tsx
+++ b/packages/components/slot/__tests__/only-child.test.tsx
@@ -5,7 +5,6 @@ import { debugWarn } from '@element-plus/utils'
 import { FORWARD_REF_INJECTION_KEY } from '@element-plus/hooks'
 import { OnlyChild } from '../src/only-child'
 import type { MountingOptions } from '@vue/test-utils'
-import type { SpyInstanceFn } from 'vitest'
 
 type Slot = NonNullable<NonNullable<MountingOptions<any>['slots']>['default']>
 
@@ -34,7 +33,6 @@ describe('ElOnlyChild', () => {
   let wrapper: ReturnType<typeof createComponent>
 
   afterEach(() => {
-    ;(debugWarn as SpyInstanceFn).mockClear()
     wrapper?.unmount()
   })
 

--- a/packages/components/tooltip/__tests__/content.test.ts
+++ b/packages/components/tooltip/__tests__/content.test.ts
@@ -91,15 +91,6 @@ describe('<ElTooltipContent />', () => {
   })
 
   afterEach(() => {
-    ;[
-      onOpen,
-      onClose,
-      onToggle,
-      onShow,
-      onHide,
-      onBeforeShow,
-      onBeforeHide,
-    ].forEach((fn) => fn.mockClear())
     open.value = false
     controlled.value = false
     trigger.value = 'hover'

--- a/packages/components/tooltip/__tests__/tooltip.test.ts
+++ b/packages/components/tooltip/__tests__/tooltip.test.ts
@@ -7,7 +7,6 @@ import { ElPopperTrigger } from '@element-plus/components/popper'
 import Tooltip from '../src/tooltip.vue'
 
 import type { VNode } from 'vue'
-import type { SpyInstanceFn } from 'vitest'
 
 vi.mock('@element-plus/utils/error', () => ({
   debugWarn: vi.fn(),
@@ -32,7 +31,6 @@ describe('<ElTooltip />', () => {
   afterEach(() => {
     wrapper?.unmount()
     document.body.innerHTML = ''
-    ;(debugWarn as SpyInstanceFn).mockClear()
   })
 
   describe('rendering', () => {

--- a/packages/components/tooltip/__tests__/trigger.test.ts
+++ b/packages/components/tooltip/__tests__/trigger.test.ts
@@ -52,7 +52,6 @@ describe('<ElTooltipTrigger />', () => {
   let wrapper: ReturnType<typeof createComponent>
 
   afterEach(() => {
-    ;[onOpen, onClose, onToggle, onShow, onHide].forEach((fn) => fn.mockClear())
     open.value = false
     controlled.value = false
     wrapper?.unmount()

--- a/packages/components/virtual-list/__tests__/dynamic-size-grid.test.ts
+++ b/packages/components/virtual-list/__tests__/dynamic-size-grid.test.ts
@@ -1,13 +1,5 @@
 import { nextTick, unref } from 'vue'
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import makeMount from '@element-plus/test-utils/make-mount'
 import makeScroll from '@element-plus/test-utils/make-scroll'
 import setupMock from '../setup-mock'
@@ -64,10 +56,6 @@ describe('<fixed-size-grid />', () => {
 
   afterAll(() => {
     cleanup()
-  })
-
-  beforeEach(() => {
-    onItemRendered.mockClear()
   })
 
   describe('render testing', () => {

--- a/packages/components/virtual-list/__tests__/dynamic-size-list.test.ts
+++ b/packages/components/virtual-list/__tests__/dynamic-size-list.test.ts
@@ -1,13 +1,5 @@
 import { nextTick } from 'vue'
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import makeMount from '@element-plus/test-utils/make-mount'
 import setupMock from '../setup-mock'
 import {
@@ -65,10 +57,6 @@ describe('<dynamic-size-list />', () => {
 
   afterAll(() => {
     cleanup()
-  })
-
-  beforeEach(() => {
-    onItemRendered.mockClear()
   })
 
   describe('render testing', () => {

--- a/packages/components/virtual-list/__tests__/fixed-size-grid.test.ts
+++ b/packages/components/virtual-list/__tests__/fixed-size-grid.test.ts
@@ -1,13 +1,5 @@
 import { nextTick, unref } from 'vue'
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import makeMount from '@element-plus/test-utils/make-mount'
 import makeScroll from '@element-plus/test-utils/make-scroll'
 import setupMock from '../setup-mock'
@@ -61,10 +53,6 @@ describe('<fixed-size-grid />', () => {
 
   afterAll(() => {
     cleanup()
-  })
-
-  beforeEach(() => {
-    onItemRendered.mockClear()
   })
 
   describe('render testing', () => {

--- a/packages/components/virtual-list/__tests__/fixed-size-list.test.ts
+++ b/packages/components/virtual-list/__tests__/fixed-size-list.test.ts
@@ -1,13 +1,5 @@
 import { nextTick } from 'vue'
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import makeMount from '@element-plus/test-utils/make-mount'
 import makeScroll from '@element-plus/test-utils/make-scroll'
 import setupMock from '../setup-mock'
@@ -63,10 +55,6 @@ describe('<fixed-size-list />', () => {
 
   afterAll(() => {
     cleanup()
-  })
-
-  beforeEach(() => {
-    onItemRendered.mockClear()
   })
 
   it('should render correctly', async () => {

--- a/packages/directives/__tests__/click-outside.test.ts
+++ b/packages/directives/__tests__/click-outside.test.ts
@@ -85,8 +85,6 @@ describe('Directives.vue', () => {
     // clear the previously assigned event object
     mousedownObject = null
     mouseupObject = null
-
-    handler.mockClear()
   })
   test('render test', () => {
     const wrapper = _mount()

--- a/packages/directives/__tests__/repeat-click.test.ts
+++ b/packages/directives/__tests__/repeat-click.test.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import sleep from '@element-plus/test-utils/sleep'
 import RepeatClick from '../repeat-click'
 
@@ -18,10 +18,6 @@ const _mount = () =>
       },
     },
   })
-
-beforeEach(() => {
-  handler.mockClear()
-})
 
 describe('Directives.vue', () => {
   test('Click test', async () => {

--- a/packages/hooks/__tests__/use-model-toggle.test.tsx
+++ b/packages/hooks/__tests__/use-model-toggle.test.tsx
@@ -52,8 +52,6 @@ describe('use-model-toggle', () => {
   beforeEach(() => {
     flag = true
     wrapper = mount(Comp)
-    onShow.mockClear()
-    onHide.mockClear()
   })
 
   afterEach(() => {

--- a/packages/hooks/__tests__/use-prevent-global.test.ts
+++ b/packages/hooks/__tests__/use-prevent-global.test.ts
@@ -1,13 +1,5 @@
 import { ref } from 'vue'
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import triggerEvent from '@element-plus/test-utils/trigger-event'
 import { usePreventGlobal } from '../use-prevent-global'
 
@@ -16,10 +8,6 @@ describe('usePreventGlobal', () => {
   const evtHandler = vi.fn()
   beforeAll(() => {
     document.body.addEventListener(evtName, evtHandler)
-  })
-
-  beforeEach(() => {
-    evtHandler.mockClear()
   })
 
   afterAll(() => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     disabled: true,
   },
   test: {
+    clearMocks: true,
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     transformMode: {


### PR DESCRIPTION
Enables global `clearMocks` in vitest config (https://vitest.dev/config/#clearmocks)

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
