### PR TITLE
fix(components): [select] not set input padding anymore

### DIFF
--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -543,27 +543,16 @@ export default defineComponent({
         resetInputHeight()
       }
       nextTick(() => {
-        if (!reference.value) return
-        if (reference.value.$el) {
-          inputWidth.value = reference.value.$el.getBoundingClientRect().width
-        }
+        const refEl = reference.value && reference.value.$el
+        if (!refEl) return
+        inputWidth.value = refEl.getBoundingClientRect().width
+
         if (ctx.slots.prefix) {
-          const inputChildNodes = reference.value.$el.childNodes
-          const input = (Array.from(inputChildNodes) as HTMLElement[]).find(
-            (item) => item.tagName === 'INPUT'
+          const prefix = refEl.querySelector(`.${nsInput.e('prefix')}`)
+          prefixWidth.value = Math.max(
+            prefix.getBoundingClientRect().width + 5,
+            30
           )
-          if (input) {
-            const prefix = reference.value.$el.querySelector(
-              `.${nsInput.e('prefix')}`
-            )
-            prefixWidth.value = Math.max(
-              prefix.getBoundingClientRect().width + 5,
-              30
-            )
-            if (states.prefixWidth) {
-              input.style.paddingLeft = `${Math.max(states.prefixWidth, 30)}px`
-            }
-          }
         }
       })
       setSelected()


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

The padding is no longer needed after the `el-input` component enabled flex layout.

Fix #7244 
Fix #7271