### PR TITLE
fix(components): [input] fix prepend/append not fill height

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -323,7 +323,7 @@
 @include b(input-group) {
   display: inline-flex;
   width: 100%;
-  align-items: center;
+  align-items: stretch;
 
   @include e((append, prepend)) {
     background-color: getCssVar('fill-color', 'light');
@@ -332,7 +332,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    height: 100%;
+    min-height: 100%;
     border-radius: var(--el-input-border-radius);
     padding: 0 20px;
     white-space: nowrap;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Fix prepend/append doesn't fill the height of the input container. Resolves #7243.

| Before | After |
| :----: | :----: |
| ![image](https://user-images.githubusercontent.com/26999792/164193208-7a4e06af-eb8c-4143-a378-4ef23ed3c32d.png) | ![image](https://user-images.githubusercontent.com/26999792/164193110-632e6da8-39c1-4ff2-b6b3-d1d0c2dde595.png) |
