### PR TITLE
docs: dark palette when toggle & fix autocomplete bg

### DIFF
--- a/docs/.vitepress/vitepress/components/globals/main-color.vue
+++ b/docs/.vitepress/vitepress/components/globals/main-color.vue
@@ -22,7 +22,7 @@ const { copyColor } = useCopyColor()
             class="bg-blue-sub-item hover:(cursor-pointer shadow)"
             :style="{
               width: `${100 / 6}%`,
-              background: getColorValue('primary-' + level),
+              background: 'var(--el-color-primary-' + level + ')',
             }"
             @click="copyColor('primary-' + level)"
           />

--- a/docs/.vitepress/vitepress/components/globals/main-color.vue
+++ b/docs/.vitepress/vitepress/components/globals/main-color.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { useCssVar } from '@vueuse/core'
-import { getColorValue, useCopyColor } from '../../utils'
+import { useCopyColor } from '../../utils'
 
 const primary = useCssVar('--el-color-primary')
 const colorLevel = [3, 5, 7, 8, 9].map((i) => `light-${i}`)

--- a/docs/.vitepress/vitepress/components/globals/neutral-color.vue
+++ b/docs/.vitepress/vitepress/components/globals/neutral-color.vue
@@ -5,12 +5,30 @@
         <div
           v-for="(text, i) in textColors"
           :key="i"
-          class="demo-color-box demo-color-box-other"
-          :style="{ background: getCssVarName('text-color', text.type) }"
+          class="demo-color-box demo-color-box-other shadow"
+          :style="{
+            color: 'var(--el-bg-color)',
+            background: text.var.value,
+          }"
         >
-          {{ text.name || formatType(text.type) + ' Text' }}
-          <div class="value">
-            {{ getCssVarValue('text-color', text.type).toUpperCase() }}
+          {{ text.name }}
+          <div class="value" text="xs">
+            {{ text.var.value.toUpperCase() }}
+          </div>
+        </div>
+      </div>
+    </el-col>
+    <el-col :span="6" :xs="{ span: 12 }">
+      <div class="demo-color-box-group">
+        <div
+          v-for="(fill, i) in fillColors"
+          :key="i"
+          class="demo-color-box demo-color-box-other demo-color-box-lite shadow"
+          :style="{ background: fill.var.value }"
+        >
+          {{ fill.name }}
+          <div class="value" text="xs">
+            {{ fill.var.value.toUpperCase() }}
           </div>
         </div>
       </div>
@@ -20,12 +38,12 @@
         <div
           v-for="(border, i) in borderColors"
           :key="i"
-          class="demo-color-box demo-color-box-other demo-color-box-lite"
-          :style="{ background: `var(--el-border-color-${border.type})` }"
+          class="demo-color-box demo-color-box-other demo-color-box-lite shadow"
+          :style="{ background: border.var.value }"
         >
-          {{ formatType(border.type) + ' Border' }}
-          <div class="value">
-            {{ getColorValue(border.type).toUpperCase() }}
+          {{ border.name }}
+          <div class="value" text="xs">
+            {{ border.var.value.toUpperCase() }}
           </div>
         </div>
       </div>
@@ -37,7 +55,7 @@
           :style="{ background: black }"
         >
           Basic Black
-          <div class="value">{{ black }}</div>
+          <div class="value" text="xs">{{ black }}</div>
         </div>
         <div
           class="demo-color-box demo-color-box-other"
@@ -48,90 +66,78 @@
           }"
         >
           Basic White
-          <div class="value">{{ white }}</div>
+          <div class="value" text="xs">{{ white }}</div>
         </div>
-        <div class="demo-color-box demo-color-box-other bg-transparent">
+        <div
+          class="demo-color-box demo-color-box-other demo-color-box-lite bg-transparent shadow"
+        >
           Transparent
-          <div class="value">Transparent</div>
+          <div class="value" text="xs">Transparent</div>
+        </div>
+
+        <div
+          v-for="(bg, i) in backgroundColors"
+          :key="i"
+          class="demo-color-box demo-color-box-other demo-color-box-lite shadow"
+          :style="{ background: bg.var.value }"
+        >
+          {{ bg.name }}
+          <div class="value" text="xs">
+            {{ bg.var.value.toUpperCase() }}
+          </div>
         </div>
       </div>
     </el-col>
   </el-row>
 </template>
 
-<script lang="ts">
-import { defineComponent, markRaw } from 'vue'
+<script lang="ts" setup>
+import { getCssVarName, getCssVarValue } from '~/utils/colors'
 
-export default defineComponent({
-  setup() {
-    const getColorValue = (type: string) => {
-      return getComputedStyle(document.documentElement).getPropertyValue(
-        `--el-border-color-${type}`
-      )
-    }
-
-    const formatType = (type: string) => {
-      return type
-        .split('-')
-        .map((item) => item.charAt(0).toUpperCase() + item.slice(1))
-        .join(' ')
-    }
-
-    const getCssVarName = (namespace: string, type: string) => {
-      return `var(--el-${namespace}-${type})`
-    }
-
-    const getCssVarValue = (namespace, type) => {
-      return getComputedStyle(document.documentElement).getPropertyValue(
-        `--el-${namespace}-${type}`
-      )
-    }
-
-    return {
-      borderColors: markRaw([
-        {
-          type: 'base',
-          color: '#DCDFE6',
-        },
-        {
-          type: 'light',
-          color: '#E4E7ED',
-        },
-        {
-          type: 'lighter',
-          color: '#EBEEF5',
-        },
-        {
-          type: 'extra-light',
-          color: '#F2F6FC',
-        },
-      ]),
-      textColors: markRaw([
-        {
-          name: 'Primary Text',
-          type: 'primary',
-        },
-        {
-          name: 'Regular Text',
-          type: 'regular',
-        },
-        {
-          name: 'Secondary Text',
-          type: 'secondary',
-        },
-        {
-          name: 'Placeholder Text',
-          type: 'placeholder',
-        },
-      ]),
-      black: '#000000',
-      white: '#FFFFFF',
-
-      formatType,
-      getColorValue,
-      getCssVarName,
-      getCssVarValue,
-    }
-  },
+const backgroundTypes = ['page', '', 'overlay']
+const backgroundColors = backgroundTypes.map((type) => {
+  return {
+    name: type
+      ? `${type[0].toUpperCase() + type.slice(1)} Background`
+      : 'Base Background',
+    var: getCssVarValue(getCssVarName('bg-color', type)),
+  }
 })
+
+const borderTypes = ['darker', 'dark', '', 'light', 'lighter', 'extra-light']
+const borderColors = borderTypes.map((type) => {
+  return {
+    name: type
+      ? `${type[0].toUpperCase() + type.slice(1)} Border`
+      : 'Base Border',
+    var: getCssVarValue(getCssVarName('border-color', type)),
+  }
+})
+
+const fillTypes = [
+  'darker',
+  'dark',
+  '',
+  'light',
+  'lighter',
+  'extra-light',
+  'blank',
+]
+const fillColors = fillTypes.map((type) => {
+  return {
+    name: type ? `${type[0].toUpperCase() + type.slice(1)} Fill` : 'Base Fill',
+    var: getCssVarValue(getCssVarName('fill-color', type)),
+  }
+})
+
+const textTypes = ['primary', 'regular', 'secondary', 'placeholder', 'disabled']
+const textColors = textTypes.map((type) => {
+  return {
+    name: `${type[0].toUpperCase() + type.slice(1)} Text`,
+    var: getCssVarValue(getCssVarName('text-color', type)),
+  }
+})
+
+const black = '#000000'
+const white = '#FFFFFF'
 </script>

--- a/docs/.vitepress/vitepress/components/globals/neutral-color.vue
+++ b/docs/.vitepress/vitepress/components/globals/neutral-color.vue
@@ -5,7 +5,7 @@
         <div
           v-for="(text, i) in textColors"
           :key="i"
-          class="demo-color-box demo-color-box-other shadow"
+          class="demo-color-box demo-color-box-other"
           :style="{
             color: 'var(--el-bg-color)',
             background: text.var.value,
@@ -24,7 +24,7 @@
         <div
           v-for="(border, i) in borderColors"
           :key="i"
-          class="demo-color-box demo-color-box-other demo-color-box-lite shadow"
+          class="demo-color-box demo-color-box-other demo-color-box-lite"
           :style="{ background: border.var.value }"
         >
           {{ border.name }}
@@ -40,7 +40,7 @@
         <div
           v-for="(fill, i) in fillColors"
           :key="i"
-          class="demo-color-box demo-color-box-other demo-color-box-lite shadow"
+          class="demo-color-box demo-color-box-other demo-color-box-lite"
           :style="{
             background: fill.var.value,
             border: `1px solid ${
@@ -79,7 +79,7 @@
           <div class="value" text="xs">{{ white }}</div>
         </div>
         <div
-          class="demo-color-box demo-color-box-other demo-color-box-lite bg-transparent shadow"
+          class="demo-color-box demo-color-box-other demo-color-box-lite bg-transparent"
         >
           Transparent
           <div class="value" text="xs">Transparent</div>
@@ -88,14 +88,10 @@
         <div
           v-for="(bg, i) in backgroundColors"
           :key="i"
-          class="demo-color-box demo-color-box-other demo-color-box-lite shadow"
+          class="demo-color-box demo-color-box-other demo-color-box-lite"
           :style="{
             background: bg.var.value,
-            border: `1px solid ${
-              bg.name === 'Base Background'
-                ? 'var(--el-border-color-light)'
-                : 'transparent'
-            }`,
+            border: '1px solid var(--el-border-color-light)',
           }"
         >
           {{ bg.name }}

--- a/docs/.vitepress/vitepress/components/globals/neutral-color.vue
+++ b/docs/.vitepress/vitepress/components/globals/neutral-color.vue
@@ -18,21 +18,7 @@
         </div>
       </div>
     </el-col>
-    <el-col :span="6" :xs="{ span: 12 }">
-      <div class="demo-color-box-group">
-        <div
-          v-for="(fill, i) in fillColors"
-          :key="i"
-          class="demo-color-box demo-color-box-other demo-color-box-lite shadow"
-          :style="{ background: fill.var.value }"
-        >
-          {{ fill.name }}
-          <div class="value" text="xs">
-            {{ fill.var.value.toUpperCase() }}
-          </div>
-        </div>
-      </div>
-    </el-col>
+
     <el-col :span="6" :xs="{ span: 12 }">
       <div class="demo-color-box-group">
         <div
@@ -48,6 +34,30 @@
         </div>
       </div>
     </el-col>
+
+    <el-col :span="6" :xs="{ span: 12 }">
+      <div class="demo-color-box-group">
+        <div
+          v-for="(fill, i) in fillColors"
+          :key="i"
+          class="demo-color-box demo-color-box-other demo-color-box-lite shadow"
+          :style="{
+            background: fill.var.value,
+            border: `1px solid ${
+              fill.name === 'Blank Fill'
+                ? 'var(--el-border-color-light)'
+                : 'transparent'
+            }`,
+          }"
+        >
+          {{ fill.name }}
+          <div class="value" text="xs">
+            {{ fill.var.value.toUpperCase() }}
+          </div>
+        </div>
+      </div>
+    </el-col>
+
     <el-col :span="6" :xs="{ span: 12 }">
       <div class="demo-color-box-group">
         <div
@@ -79,7 +89,14 @@
           v-for="(bg, i) in backgroundColors"
           :key="i"
           class="demo-color-box demo-color-box-other demo-color-box-lite shadow"
-          :style="{ background: bg.var.value }"
+          :style="{
+            background: bg.var.value,
+            border: `1px solid ${
+              bg.name === 'Base Background'
+                ? 'var(--el-border-color-light)'
+                : 'transparent'
+            }`,
+          }"
         >
           {{ bg.name }}
           <div class="value" text="xs">

--- a/docs/.vitepress/vitepress/components/globals/secondary-colors.vue
+++ b/docs/.vitepress/vitepress/components/globals/secondary-colors.vue
@@ -27,7 +27,7 @@ const { copyColor } = useCopyColor()
             class="bg-secondary-sub-item transition hover:(cursor-pointer shadow)"
             :style="{
               width: `${100 / 6}%`,
-              background: getColorValue(type + '-' + level),
+              background: `var(--el-color-${type}-` + level + ')',
             }"
             @click="copyColor(type + '-' + level)"
           />

--- a/docs/.vitepress/vitepress/utils/colors.ts
+++ b/docs/.vitepress/vitepress/utils/colors.ts
@@ -1,5 +1,31 @@
-import { getCurrentInstance, ref } from 'vue'
+import { getCurrentInstance, ref, watch } from 'vue'
 import { useClipboard } from '@vueuse/core'
+import { isDark } from '~/composables/dark'
+export const getCssVarName = (namespace: string, type: string) => {
+  return type ? `--el-${namespace}-${type}` : `--el-${namespace}`
+}
+
+/**
+ * get css var value by css var name
+ * @param name
+ * @returns
+ */
+export const getCssVarValue = (name: string) => {
+  const val = ref(
+    getComputedStyle(document.documentElement).getPropertyValue(name)
+  )
+  watch(
+    () => isDark.value,
+    () => {
+      setTimeout(() => {
+        val.value = getComputedStyle(document.documentElement).getPropertyValue(
+          name
+        )
+      }, 100)
+    }
+  )
+  return val
+}
 
 export const getColorValue = (type: string) => {
   const color = getComputedStyle(document.documentElement).getPropertyValue(

--- a/docs/en-US/component/color.md
+++ b/docs/en-US/component/color.md
@@ -46,12 +46,6 @@ Element Plus uses a specific set of palettes to specify colors to provide a cons
 
 .demo-color-box-lite {
   color: var(--el-text-color-primary);
-
-  .value {
-    font-size: 12px;
-    opacity: .69;
-    line-height: 24px;
-  }
 }
 </style>
 

--- a/docs/examples/input/autocomplete.vue
+++ b/docs/examples/input/autocomplete.vue
@@ -8,7 +8,7 @@
         v-model="state1"
         :fetch-suggestions="querySearch"
         clearable
-        class="inline-input"
+        class="inline-input w-50"
         placeholder="Please Input"
         @select="handleSelect"
       />
@@ -22,13 +22,14 @@
         :fetch-suggestions="querySearch"
         :trigger-on-focus="false"
         clearable
-        class="inline-input"
+        class="inline-input w-50"
         placeholder="Please Input"
         @select="handleSelect"
       />
     </el-col>
   </el-row>
 </template>
+
 <script lang="ts" setup>
 import { onMounted, ref } from 'vue'
 

--- a/packages/theme-chalk/src/autocomplete.scss
+++ b/packages/theme-chalk/src/autocomplete.scss
@@ -73,7 +73,7 @@
       @include utils-vertical-center;
 
       &:hover {
-        background-color: getCssVar('color', 'white');
+        background-color: getCssVar('bg-color', 'overlay');
       }
     }
 

--- a/packages/theme-chalk/src/autocomplete.scss
+++ b/packages/theme-chalk/src/autocomplete.scss
@@ -10,15 +10,15 @@
 
   @include e(popper) {
     @include picker-popper(
-      $color-white,
-      1px solid var(--el-border-color-light),
-      var(--el-box-shadow-light)
+      getCssVar('bg-color', 'overlay'),
+      1px solid getCssVar('border-color', 'light'),
+      getCssVar('box-shadow', 'light')
     );
   }
 }
 
 @include b(autocomplete-suggestion) {
-  border-radius: var(--el-border-radius-base);
+  border-radius: getCssVar('border-radius', 'base');
   box-sizing: border-box;
 
   @include e(wrap) {
@@ -37,8 +37,8 @@
     margin: 0;
     line-height: 34px;
     cursor: pointer;
-    color: var(--el-text-color-regular);
-    font-size: var(--el-font-size-base);
+    color: getCssVar('text-color', 'regular');
+    font-size: getCssVar('font-size', 'base');
     list-style: none;
     text-align: left;
     white-space: nowrap;
@@ -55,7 +55,7 @@
 
     &.divider {
       margin-top: 6px;
-      border-top: 1px solid var(--el-color-black);
+      border-top: 1px solid getCssVar('color', 'black');
     }
 
     &.divider:last-child {
@@ -69,11 +69,11 @@
       height: 100px;
       line-height: 100px;
       font-size: 20px;
-      color: var(--el-text-color-secondary);
+      color: getCssVar('text-color', 'secondary');
       @include utils-vertical-center;
 
       &:hover {
-        background-color: var(--el-color-white);
+        background-color: getCssVar('color', 'white');
       }
     }
 

--- a/packages/theme-chalk/src/check-tag.scss
+++ b/packages/theme-chalk/src/check-tag.scss
@@ -5,14 +5,14 @@
 
 @include b(check-tag) {
   background-color: getCssVar('color', 'info', 'light-9');
-  border-radius: var(--el-border-radius-base);
-  color: var(--el-color-info);
+  border-radius: getCssVar('border-radius', 'base');
+  color: getCssVar('color', 'info');
   cursor: pointer;
   display: inline-block;
-  font-size: var(--el-font-size-base);
-  line-height: var(--el-font-size-base);
+  font-size: getCssVar('font-size', 'base');
+  line-height: getCssVar('font-size', 'base');
   padding: 7px 15px;
-  transition: var(--el-transition-all);
+  transition: getCssVar('transition', 'all');
   font-weight: bold;
 
   &:hover {

--- a/packages/theme-chalk/src/dark/var.scss
+++ b/packages/theme-chalk/src/dark/var.scss
@@ -174,15 +174,15 @@ $empty: () !default;
 $empty: map.merge(
   (
     'fill-color-0': getCssVar('color-black'),
-    'fill-color-1': #262629,
-    'fill-color-2': #34363b,
+    'fill-color-1': #4b4b52,
+    'fill-color-2': #36383d,
     'fill-color-3': #1e1e20,
-    'fill-color-4': #171719,
+    'fill-color-4': #262629,
     'fill-color-5': #202124,
-    'fill-color-6': #373a3e,
-    'fill-color-7': #191c1f,
-    'fill-color-8': #202225,
-    'fill-color-9': #202225,
+    'fill-color-6': #212224,
+    'fill-color-7': #1b1c1f,
+    'fill-color-8': #1c1d1f,
+    'fill-color-9': #18181a,
   ),
   $empty
 );


### PR DESCRIPTION
- fix: autocomplete bg color
- fix: empty svg shadow when dark
- fix: remote search overlay hover color when loading
- fix: autocomplete width in example
- docs: support dark palette when toggle & add fill-color bg-color

<img width="827" alt="image" src="https://user-images.githubusercontent.com/25154432/164541504-c0dae22e-2a81-4834-a8cd-f64eac874a3f.png">

<img width="837" alt="image" src="https://user-images.githubusercontent.com/25154432/164541476-d1dae35c-4798-43d7-a2d9-b14ba7b65ab3.png">

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
