### PR TITLE
fix(theme-chalk): [pagination] fix spacing when `sizes` is at the end

### DIFF
--- a/packages/theme-chalk/src/pagination.scss
+++ b/packages/theme-chalk/src/pagination.scss
@@ -276,6 +276,12 @@
         min-width: 24px;
       }
     }
+
+    @include e(sizes) {
+      @include when(last) {
+        margin-left: 16px;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Fix #7338 - No spacing when the `sizes` component is at the end.
