### PR TITLE
feat(components): [slider] aria keyboard controls and attrs

### DIFF
--- a/docs/en-US/component/slider.md
+++ b/docs/en-US/component/slider.md
@@ -91,6 +91,9 @@ slider/show-marks
 | vertical              | vertical mode                                                                                             | boolean         | —                       | false   |
 | height                | Slider height, required in vertical mode                                                                  | string          | —                       | —       |
 | label                 | label for screen reader                                                                                   | string          | —                       | —       |
+| range-start-label     | when `range` is true, screen reader label for the start of the range                                      | string          | —                       | —       |
+| range-end-label       | when `range` is true, screen reader label for the end of the range                                        | string          | —                       | —       |
+| format-value-text     | format to display the `aria-valuenow` attribute for screen readers                                        | function(value) | —                       | —       |
 | debounce              | debounce delay when typing, in milliseconds, works when `show-input` is true                              | number          | —                       | 300     |
 | tooltip-class         | custom class name for the tooltip                                                                         | string          | —                       | —       |
 | marks                 | marks， type of key must be `number` and must in closed interval `[min, max]`, each mark can custom style | object          | —                       | —       |

--- a/packages/components/slider/__tests__/slider.test.ts
+++ b/packages/components/slider/__tests__/slider.test.ts
@@ -118,7 +118,7 @@ describe('Slider', () => {
         }
       },
       methods: {
-        formatTooltip(val) {
+        formatTooltip(val: number) {
           return `$${val}`
         },
       },
@@ -151,9 +151,11 @@ describe('Slider', () => {
       )
       const slider = wrapper.findComponent({ name: 'ElSliderButton' })
 
-      const mockClientWidth = vi
-        .spyOn(wrapper.find('.el-slider__runway').element, 'clientWidth', 'get')
-        .mockImplementation(() => 200)
+      vi.spyOn(
+        wrapper.find('.el-slider__runway').element,
+        'clientWidth',
+        'get'
+      ).mockImplementation(() => 200)
       slider.trigger('mousedown', { clientX: 0 })
 
       const mousemove = document.createEvent('MouseEvent')
@@ -198,7 +200,6 @@ describe('Slider', () => {
 
       await nextTick()
       expect(wrapper.vm.value === 50).toBeTruthy()
-      mockClientWidth.mockRestore()
     })
 
     it('vertical', async () => {
@@ -221,14 +222,11 @@ describe('Slider', () => {
         }
       )
       const slider = wrapper.findComponent({ name: 'ElSliderButton' })
-
-      const mockClientHeight = vi
-        .spyOn(
-          wrapper.find('.el-slider__runway').element,
-          'clientHeight',
-          'get'
-        )
-        .mockImplementation(() => 200)
+      vi.spyOn(
+        wrapper.find('.el-slider__runway').element,
+        'clientHeight',
+        'get'
+      ).mockImplementation(() => 200)
       slider.trigger('mousedown', { clientY: 0 })
       const mousemove = document.createEvent('MouseEvent')
       mousemove.initMouseEvent(
@@ -270,34 +268,113 @@ describe('Slider', () => {
       window.dispatchEvent(mouseup)
       await nextTick()
       expect(wrapper.vm.value).toBe(50)
-      mockClientHeight.mockRestore()
     })
   })
 
-  it('accessibility', (done) => {
-    const wrapper = mount({
-      template: `
-        <div>
-          <slider v-model="value"></slider>
-        </div>
-      `,
-      components: { Slider },
-      data() {
-        return {
-          value: 0.1,
-        }
-      },
-    })
-    const slider: any = wrapper.findComponent({ name: 'ElSliderButton' })
-    slider.vm.onRightKeyDown()
-    setTimeout(() => {
-      expect(wrapper.vm.value).toBe(1)
-      slider.vm.onLeftKeyDown()
+  describe('accessibility', () => {
+    it('left/right arrows', (done) => {
+      const wrapper = mount({
+        template: `
+          <div>
+            <slider v-model="value"></slider>
+          </div>
+        `,
+        components: { Slider },
+        data() {
+          return {
+            value: 0.1,
+          }
+        },
+      })
+      const slider: any = wrapper.findComponent({ name: 'ElSliderButton' })
+      slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
       setTimeout(() => {
-        expect(wrapper.vm.value).toBe(0)
-        done()
+        expect(wrapper.vm.value).toBe(1)
+        slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+        setTimeout(() => {
+          expect(wrapper.vm.value).toBe(0)
+          done()
+        }, 10)
       }, 10)
-    }, 10)
+    })
+
+    it('up/down arrows', (done) => {
+      const wrapper = mount({
+        template: `
+          <div>
+            <slider v-model="value"></slider>
+          </div>
+        `,
+        components: { Slider },
+        data() {
+          return {
+            value: 0.1,
+          }
+        },
+      })
+      const slider: any = wrapper.findComponent({ name: 'ElSliderButton' })
+      slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
+      setTimeout(() => {
+        expect(wrapper.vm.value).toBe(1)
+        slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
+        setTimeout(() => {
+          expect(wrapper.vm.value).toBe(0)
+          done()
+        }, 10)
+      }, 10)
+    })
+
+    it('page up/down keys', (done) => {
+      const wrapper = mount({
+        template: `
+          <div>
+            <slider v-model="value" :min="-5" :max="10"></slider>
+          </div>
+        `,
+        components: { Slider },
+        data() {
+          return {
+            value: -1,
+          }
+        },
+      })
+      const slider: any = wrapper.findComponent({ name: 'ElSliderButton' })
+      slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'PageUp' }))
+      setTimeout(() => {
+        expect(wrapper.vm.value).toBe(3)
+        slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'PageDown' }))
+        setTimeout(() => {
+          expect(wrapper.vm.value).toBe(-1)
+          done()
+        }, 10)
+      }, 10)
+    })
+
+    it('home/end keys', (done) => {
+      const wrapper = mount({
+        template: `
+          <div>
+            <slider v-model="value" :min="-5" :max="10"></slider>
+          </div>
+        `,
+        components: { Slider },
+        data() {
+          return {
+            value: -5,
+          }
+        },
+      })
+      const slider: any = wrapper.findComponent({ name: 'ElSliderButton' })
+      slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'Home' }))
+      setTimeout(() => {
+        expect(wrapper.vm.value).toBe(-5)
+        slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'End' }))
+        setTimeout(() => {
+          expect(wrapper.vm.value).toBe(10)
+          done()
+        }, 10)
+      }, 10)
+    })
   })
 
   it('step', (done) => {
@@ -387,7 +464,7 @@ describe('Slider', () => {
     })
     const slider: any = wrapper.findComponent({ name: 'ElSlider' })
     setTimeout(() => {
-      slider.vm.onSliderClick({ clientX: 100 })
+      slider.vm.onSliderClick(new MouseEvent('mousedown', { clientX: 100 }))
       setTimeout(() => {
         expect(wrapper.vm.value > 0).toBeTruthy()
         done()
@@ -411,7 +488,7 @@ describe('Slider', () => {
         }
       },
       methods: {
-        onChange(val) {
+        onChange(val: number) {
           this.data = val
         },
       },
@@ -432,7 +509,7 @@ describe('Slider', () => {
       .mockImplementation(() => 200)
     setTimeout(() => {
       expect(wrapper.vm.data).toBe(0)
-      slider.vm.onSliderClick({ clientX: 100 })
+      slider.vm.onSliderClick(new MouseEvent('mousedown', { clientX: 100 }))
       setTimeout(() => {
         expect(wrapper.vm.data === 50).toBeTruthy()
         mockRectLeft.mockRestore()
@@ -458,7 +535,7 @@ describe('Slider', () => {
         }
       },
       methods: {
-        onInput(val) {
+        onInput(val: number) {
           this.data = val
         },
       },
@@ -479,7 +556,7 @@ describe('Slider', () => {
       .mockImplementation(() => 200)
     await nextTick()
     expect(wrapper.vm.data).toBe(0)
-    slider.vm.onSliderClick({ clientX: 100 })
+    slider.vm.onSliderClick(new MouseEvent('mousedown', { clientX: 100 }))
     await nextTick()
     expect(wrapper.vm.data === 50).toBeTruthy()
     mockRectLeft.mockRestore()
@@ -618,7 +695,7 @@ describe('Slider', () => {
       .mockImplementation(() => 200)
     const slider: any = wrapper.getComponent({ name: 'ElSlider' })
     setTimeout(() => {
-      slider.vm.onSliderClick({ clientY: 100 })
+      slider.vm.onSliderClick(new MouseEvent('mousedown', { clientX: 100 }))
       setTimeout(() => {
         expect(wrapper.vm.value > 0).toBeTruthy()
         mockRectBottom.mockRestore()
@@ -727,7 +804,7 @@ describe('Slider', () => {
         .mockImplementation(() => 200)
       const slider: any = wrapper.getComponent({ name: 'ElSlider' })
       setTimeout(() => {
-        slider.vm.onSliderClick({ clientX: 100 })
+        slider.vm.onSliderClick(new MouseEvent('mousedown', { clientX: 100 }))
         setTimeout(() => {
           // Because mock the clientWidth, so the targetValue is 50.
           // The behavior of the setPosition method in the useSlider.ts file should be that the value of the second button is 50

--- a/packages/components/slider/__tests__/slider.test.ts
+++ b/packages/components/slider/__tests__/slider.test.ts
@@ -2,7 +2,6 @@ import { h, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { EVENT_CODE } from '@element-plus/constants'
-import sleep from '@element-plus/test-utils/sleep'
 import Slider from '../src/index.vue'
 
 vi.mock('lodash-unified', async () => {

--- a/packages/components/slider/__tests__/slider.test.ts
+++ b/packages/components/slider/__tests__/slider.test.ts
@@ -360,7 +360,7 @@ describe('Slider', () => {
         components: { Slider },
         data() {
           return {
-            value: -5,
+            value: 0,
           }
         },
       })

--- a/packages/components/slider/__tests__/slider.test.ts
+++ b/packages/components/slider/__tests__/slider.test.ts
@@ -462,12 +462,16 @@ describe('Slider', () => {
         }
       },
     })
+    const mockClientWidth = vi
+      .spyOn(wrapper.find('.el-slider__runway').element, 'clientWidth', 'get')
+      .mockImplementation(() => 200)
     const slider: any = wrapper.findComponent({ name: 'ElSlider' })
     setTimeout(() => {
       slider.vm.onSliderClick(new MouseEvent('mousedown', { clientX: 100 }))
       setTimeout(() => {
         expect(wrapper.vm.value > 0).toBeTruthy()
         done()
+        mockClientWidth.mockRestore()
       }, 10)
     }, 10)
   })

--- a/packages/components/slider/__tests__/slider.test.ts
+++ b/packages/components/slider/__tests__/slider.test.ts
@@ -1,6 +1,7 @@
 import { h, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EVENT_CODE } from '@element-plus/constants'
 import sleep from '@element-plus/test-utils/sleep'
 import Slider from '../src/index.vue'
 
@@ -16,6 +17,14 @@ vi.mock('lodash-unified', async () => {
 })
 
 describe('Slider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('create', () => {
     const wrapper = mount(Slider)
     expect(wrapper.props().modelValue).toBe(0)
@@ -34,7 +43,7 @@ describe('Slider', () => {
       },
     })
 
-    await sleep(10)
+    await nextTick()
     wrapper.vm.value = 40
     await nextTick()
     expect(wrapper.vm.value).toBe(50)
@@ -131,6 +140,7 @@ describe('Slider', () => {
 
   describe('drag', () => {
     it('horizontal', async () => {
+      vi.useRealTimers()
       const wrapper = mount(
         {
           template: `
@@ -203,6 +213,7 @@ describe('Slider', () => {
     })
 
     it('vertical', async () => {
+      vi.useRealTimers()
       const wrapper = mount(
         {
           template: `
@@ -272,7 +283,7 @@ describe('Slider', () => {
   })
 
   describe('accessibility', () => {
-    it('left/right arrows', (done) => {
+    it('left/right arrows', async () => {
       const wrapper = mount({
         template: `
           <div>
@@ -287,18 +298,21 @@ describe('Slider', () => {
         },
       })
       const slider: any = wrapper.findComponent({ name: 'ElSliderButton' })
-      slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
-      setTimeout(() => {
-        expect(wrapper.vm.value).toBe(1)
-        slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
-        setTimeout(() => {
-          expect(wrapper.vm.value).toBe(0)
-          done()
-        }, 10)
-      }, 10)
+
+      slider.vm.onKeyDown(
+        new KeyboardEvent('keydown', { key: EVENT_CODE.right })
+      )
+      await nextTick()
+      expect(wrapper.vm.value).toBe(1)
+
+      slider.vm.onKeyDown(
+        new KeyboardEvent('keydown', { key: EVENT_CODE.left })
+      )
+      await nextTick()
+      expect(wrapper.vm.value).toBe(0)
     })
 
-    it('up/down arrows', (done) => {
+    it('up/down arrows', async () => {
       const wrapper = mount({
         template: `
           <div>
@@ -313,18 +327,19 @@ describe('Slider', () => {
         },
       })
       const slider: any = wrapper.findComponent({ name: 'ElSliderButton' })
-      slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
-      setTimeout(() => {
-        expect(wrapper.vm.value).toBe(1)
-        slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
-        setTimeout(() => {
-          expect(wrapper.vm.value).toBe(0)
-          done()
-        }, 10)
-      }, 10)
+
+      slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: EVENT_CODE.up }))
+      await nextTick()
+      expect(wrapper.vm.value).toBe(1)
+
+      slider.vm.onKeyDown(
+        new KeyboardEvent('keydown', { key: EVENT_CODE.down })
+      )
+      await nextTick()
+      expect(wrapper.vm.value).toBe(0)
     })
 
-    it('page up/down keys', (done) => {
+    it('page up/down keys', async () => {
       const wrapper = mount({
         template: `
           <div>
@@ -339,18 +354,20 @@ describe('Slider', () => {
         },
       })
       const slider: any = wrapper.findComponent({ name: 'ElSliderButton' })
-      slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'PageUp' }))
-      setTimeout(() => {
-        expect(wrapper.vm.value).toBe(3)
-        slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'PageDown' }))
-        setTimeout(() => {
-          expect(wrapper.vm.value).toBe(-1)
-          done()
-        }, 10)
-      }, 10)
+      slider.vm.onKeyDown(
+        new KeyboardEvent('keydown', { key: EVENT_CODE.pageUp })
+      )
+      await nextTick()
+      expect(wrapper.vm.value).toBe(3)
+
+      slider.vm.onKeyDown(
+        new KeyboardEvent('keydown', { key: EVENT_CODE.pageDown })
+      )
+      await nextTick()
+      expect(wrapper.vm.value).toBe(-1)
     })
 
-    it('home/end keys', (done) => {
+    it('home/end keys', async () => {
       const wrapper = mount({
         template: `
           <div>
@@ -365,19 +382,20 @@ describe('Slider', () => {
         },
       })
       const slider: any = wrapper.findComponent({ name: 'ElSliderButton' })
-      slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'Home' }))
-      setTimeout(() => {
-        expect(wrapper.vm.value).toBe(-5)
-        slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: 'End' }))
-        setTimeout(() => {
-          expect(wrapper.vm.value).toBe(10)
-          done()
-        }, 10)
-      }, 10)
+      slider.vm.onKeyDown(
+        new KeyboardEvent('keydown', { key: EVENT_CODE.home })
+      )
+      await nextTick()
+      expect(wrapper.vm.value).toBe(-5)
+
+      slider.vm.onKeyDown(new KeyboardEvent('keydown', { key: EVENT_CODE.end }))
+      await nextTick()
+      expect(wrapper.vm.value).toBe(10)
     })
   })
 
   it('step', (done) => {
+    vi.useRealTimers()
     const wrapper = mount(
       {
         template: `
@@ -449,6 +467,7 @@ describe('Slider', () => {
   })
 
   it('click', (done) => {
+    vi.useRealTimers()
     const wrapper = mount({
       template: `
         <div>
@@ -477,6 +496,7 @@ describe('Slider', () => {
   })
 
   it('change event', (done) => {
+    vi.useRealTimers()
     const wrapper = mount({
       template: `
         <div style="width: 200px">
@@ -524,6 +544,7 @@ describe('Slider', () => {
   })
 
   it('input event', async (done) => {
+    vi.useRealTimers()
     const wrapper = mount({
       template: `
         <div style="width: 200px">
@@ -569,6 +590,7 @@ describe('Slider', () => {
   })
 
   it('disabled', (done) => {
+    vi.useRealTimers()
     const wrapper = mount({
       template: `
         <div>
@@ -633,6 +655,7 @@ describe('Slider', () => {
   })
 
   it('show input', (done) => {
+    vi.useRealTimers()
     const wrapper = mount({
       template: `
         <div>
@@ -666,6 +689,7 @@ describe('Slider', () => {
   })
 
   it('vertical mode', (done) => {
+    vi.useRealTimers()
     const wrapper = mount(
       {
         template: `
@@ -746,7 +770,7 @@ describe('Slider', () => {
       expect(sliders.length).toBe(2)
     })
 
-    it('should not exceed min and max', (done) => {
+    it('should not exceed min and max', async () => {
       const wrapper = mount({
         template: `
           <div>
@@ -761,20 +785,19 @@ describe('Slider', () => {
           }
         },
       })
-      setTimeout(() => {
-        wrapper.vm.value = [40, 60]
-        setTimeout(() => {
-          expect(wrapper.vm.value).toStrictEqual([50, 60])
-          wrapper.vm.value = [50, 120]
-          setTimeout(() => {
-            expect(wrapper.vm.value).toStrictEqual([50, 100])
-            done()
-          }, 10)
-        }, 10)
-      }, 10)
+      await nextTick()
+
+      wrapper.vm.value = [40, 60]
+      await nextTick()
+      expect(wrapper.vm.value).toStrictEqual([50, 60])
+
+      wrapper.vm.value = [50, 120]
+      await nextTick()
+      expect(wrapper.vm.value).toStrictEqual([50, 100])
     })
 
     it('click', (done) => {
+      vi.useRealTimers()
       const wrapper = mount(
         {
           template: `
@@ -821,7 +844,7 @@ describe('Slider', () => {
       }, 10)
     })
 
-    it('responsive to dynamic min and max', (done) => {
+    it('responsive to dynamic min and max', async () => {
       const wrapper = mount({
         template: `
           <div>
@@ -838,21 +861,19 @@ describe('Slider', () => {
           }
         },
       })
-      setTimeout(() => {
-        wrapper.vm.min = 60
-        setTimeout(() => {
-          expect(wrapper.vm.value).toStrictEqual([60, 80])
-          wrapper.vm.min = 30
-          wrapper.vm.max = 40
-          setTimeout(() => {
-            expect(wrapper.vm.value).toStrictEqual([40, 40])
-            done()
-          }, 10)
-        }, 10)
-      }, 10)
+      await nextTick()
+
+      wrapper.vm.min = 60
+      await nextTick()
+      expect(wrapper.vm.value).toStrictEqual([60, 80])
+
+      wrapper.vm.min = 30
+      wrapper.vm.max = 40
+      await nextTick()
+      expect(wrapper.vm.value).toStrictEqual([40, 40])
     })
 
-    it('show stops', (done) => {
+    it('show stops', async () => {
       const wrapper = mount({
         template: `
           <div>
@@ -871,11 +892,9 @@ describe('Slider', () => {
           }
         },
       })
-      setTimeout(() => {
-        const stops = wrapper.findAll('.el-slider__stop')
-        expect(stops.length).toBe(5)
-        done()
-      }, 10)
+      await nextTick()
+      const stops = wrapper.findAll('.el-slider__stop')
+      expect(stops.length).toBe(5)
     })
 
     it('marks', async () => {
@@ -911,14 +930,11 @@ describe('Slider', () => {
         },
       })
 
-      nextTick().then(() => {
-        const stops = wrapper.findAll('.el-slider__marks-stop.el-slider__stop')
-        const marks = wrapper.findAll(
-          '.el-slider__marks .el-slider__marks-text'
-        )
-        expect(marks.length).toBe(2)
-        expect(stops.length).toBe(2)
-      })
+      await nextTick()
+      const stops = wrapper.findAll('.el-slider__marks-stop.el-slider__stop')
+      const marks = wrapper.findAll('.el-slider__marks .el-slider__marks-text')
+      expect(marks.length).toBe(2)
+      expect(stops.length).toBe(2)
     })
   })
 })

--- a/packages/components/slider/src/button.vue
+++ b/packages/components/slider/src/button.vue
@@ -10,10 +10,7 @@
     @touchstart="onButtonDown"
     @focus="handleMouseEnter"
     @blur="handleMouseLeave"
-    @keydown.left="onLeftKeyDown"
-    @keydown.right="onRightKeyDown"
-    @keydown.down.prevent="onLeftKeyDown"
-    @keydown.up.prevent="onRightKeyDown"
+    @keydown="onKeyDown"
   >
     <el-tooltip
       ref="tooltip"
@@ -79,6 +76,7 @@ export default defineComponent({
     })
 
     const {
+      button,
       tooltip,
       showTooltip,
       tooltipVisible,
@@ -87,8 +85,7 @@ export default defineComponent({
       handleMouseEnter,
       handleMouseLeave,
       onButtonDown,
-      onLeftKeyDown,
-      onRightKeyDown,
+      onKeyDown,
       setPosition,
     } = useSliderButton(props, initData, emit)
 
@@ -96,6 +93,7 @@ export default defineComponent({
 
     return {
       ns,
+      button,
       tooltip,
       tooltipVisible,
       showTooltip,
@@ -104,8 +102,7 @@ export default defineComponent({
       handleMouseEnter,
       handleMouseLeave,
       onButtonDown,
-      onLeftKeyDown,
-      onRightKeyDown,
+      onKeyDown,
       setPosition,
 
       hovering,

--- a/packages/components/slider/src/index.vue
+++ b/packages/components/slider/src/index.vue
@@ -126,7 +126,7 @@ import { useMarks } from './useMarks'
 import { useSlide } from './useSlide'
 import { useStops } from './useStops'
 
-import type { PropType, Ref } from 'vue'
+import type { PropType } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
 
 export default defineComponent({

--- a/packages/components/slider/src/index.vue
+++ b/packages/components/slider/src/index.vue
@@ -2,11 +2,8 @@
   <div
     ref="sliderWrapper"
     :class="sliderKls"
-    role="slider"
-    :aria-valuemin="min"
-    :aria-valuemax="max"
-    :aria-orientation="vertical ? 'vertical' : 'horizontal'"
-    :aria-disabled="sliderDisabled"
+    :role="range ? 'group' : undefined"
+    :aria-label="range ? groupLabel : undefined"
   >
     <div
       ref="slider"
@@ -16,7 +13,8 @@
         ns.is('disabled', sliderDisabled),
       ]"
       :style="runwayStyle"
-      @click="onSliderClick"
+      @mousedown="onSliderDown"
+      @touchstart="onSliderDown"
     >
       <div :class="ns.e('bar')" :style="barStyle" />
       <slider-button
@@ -24,6 +22,14 @@
         :model-value="firstValue"
         :vertical="vertical"
         :tooltip-class="tooltipClass"
+        role="slider"
+        :aria-label="firstButtonLabel"
+        :aria-valuemin="min"
+        :aria-valuemax="range ? secondValue : max"
+        :aria-valuenow="firstValue"
+        :aria-valuetext="firstValueText"
+        :aria-orientation="vertical ? 'vertical' : 'horizontal'"
+        :aria-disabled="sliderDisabled"
         @update:model-value="setFirstValue"
       />
       <slider-button
@@ -32,6 +38,14 @@
         :model-value="secondValue"
         :vertical="vertical"
         :tooltip-class="tooltipClass"
+        role="slider"
+        :aria-label="secondButtonLabel"
+        :aria-valuemin="firstValue"
+        :aria-valuemax="max"
+        :aria-valuenow="secondValue"
+        :aria-valuetext="secondValueText"
+        :aria-orientation="vertical ? 'vertical' : 'horizontal'"
+        :aria-disabled="sliderDisabled"
         @update:model-value="setSecondValue"
       />
       <div v-if="showStops">
@@ -101,11 +115,9 @@ import {
 import {
   debugWarn,
   isValidComponentSize,
-  off,
-  on,
   throwError,
 } from '@element-plus/utils'
-import { useNamespace, useSize } from '@element-plus/hooks'
+import { useLocale, useNamespace, useSize } from '@element-plus/hooks'
 import SliderButton from './button.vue'
 import SliderMarker from './marker.vue'
 import { useMarks } from './useMarks'
@@ -114,7 +126,6 @@ import { useStops } from './useStops'
 
 import type { PropType, Ref } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
-import type { Nullable } from '@element-plus/utils'
 
 export default defineComponent({
   name: 'ElSlider',
@@ -194,6 +205,18 @@ export default defineComponent({
       type: String,
       default: undefined,
     },
+    rangeStartLabel: {
+      type: String,
+      default: undefined,
+    },
+    rangeEndLabel: {
+      type: String,
+      default: undefined,
+    },
+    formatValueText: {
+      type: Function as PropType<(val: number) => string>,
+      default: undefined,
+    },
     tooltipClass: {
       type: String,
       default: undefined,
@@ -205,6 +228,7 @@ export default defineComponent({
 
   setup(props, { emit }) {
     const ns = useNamespace('slider')
+    const { t } = useLocale()
     const initData = reactive({
       firstValue: 0,
       secondValue: 0,
@@ -226,6 +250,7 @@ export default defineComponent({
       resetSize,
       emitChange,
       onSliderClick,
+      onSliderDown,
       setFirstValue,
       setSecondValue,
     } = useSlide(props, initData, emit)
@@ -241,6 +266,40 @@ export default defineComponent({
     const sliderInputSize = computed(
       () => props.inputSize || sliderWrapperSize.value
     )
+
+    const groupLabel = computed<string>(() => {
+      return (
+        props.label ||
+        t('el.slider.defaultLabel', {
+          min: props.min,
+          max: props.max,
+        })
+      )
+    })
+
+    const firstButtonLabel = computed<string>(() => {
+      if (props.range) {
+        return props.rangeStartLabel || t('el.slider.defaultRangeStartLabel')
+      } else {
+        return groupLabel.value
+      }
+    })
+
+    const firstValueText = computed<string>(() => {
+      return props.formatValueText
+        ? props.formatValueText(firstValue.value)
+        : `${firstValue.value}`
+    })
+
+    const secondButtonLabel = computed<string>(() => {
+      return props.rangeEndLabel || t('el.slider.defaultRangeEndLabel')
+    })
+
+    const secondValueText = computed<string>(() => {
+      return props.formatValueText
+        ? props.formatValueText(secondValue.value)
+        : `${secondValue.value}`
+    })
 
     const sliderKls = computed(() => [
       ns.b(),
@@ -282,6 +341,7 @@ export default defineComponent({
 
     return {
       ns,
+      t,
       firstValue,
       secondValue,
       oldValue,
@@ -289,13 +349,19 @@ export default defineComponent({
       sliderSize,
 
       slider,
+      groupLabel,
       firstButton,
+      firstButtonLabel,
+      firstValueText,
       secondButton,
+      secondButtonLabel,
+      secondValueText,
       sliderDisabled,
       runwayStyle,
       barStyle,
       emitChange,
       onSliderClick,
+      onSliderDown,
       getStopStyle,
       setFirstValue,
       setSecondValue,
@@ -405,10 +471,9 @@ const useWatch = (props, initData, minValue, maxValue, emit, elFormItem) => {
 }
 
 const useLifecycle = (props, initData, resetSize) => {
-  const sliderWrapper: Ref<Nullable<HTMLElement>> = ref(null)
+  const sliderWrapper: Ref<HTMLElement> = ref()
 
   onMounted(async () => {
-    let valuetext
     if (props.range) {
       if (Array.isArray(props.modelValue)) {
         initData.firstValue = Math.max(props.min, props.modelValue[0])
@@ -418,7 +483,6 @@ const useLifecycle = (props, initData, resetSize) => {
         initData.secondValue = props.max
       }
       initData.oldValue = [initData.firstValue, initData.secondValue]
-      valuetext = `${initData.firstValue}-${initData.secondValue}`
     } else {
       if (
         typeof props.modelValue !== 'number' ||
@@ -432,25 +496,16 @@ const useLifecycle = (props, initData, resetSize) => {
         )
       }
       initData.oldValue = initData.firstValue
-      valuetext = initData.firstValue
     }
 
-    sliderWrapper.value.setAttribute('aria-valuetext', valuetext)
-
-    // label screen reader
-    sliderWrapper.value.setAttribute(
-      'aria-label',
-      props.label ? props.label : `slider between ${props.min} and ${props.max}`
-    )
-
-    on(window, 'resize', resetSize)
+    window.addEventListener('resize', resetSize)
 
     await nextTick()
     resetSize()
   })
 
   onBeforeUnmount(() => {
-    off(window, 'resize', resetSize)
+    window.removeEventListener('resize', resetSize)
   })
 
   return {

--- a/packages/components/slider/src/index.vue
+++ b/packages/components/slider/src/index.vue
@@ -4,6 +4,8 @@
     :class="sliderKls"
     :role="range ? 'group' : undefined"
     :aria-label="range ? groupLabel : undefined"
+    @touchstart="onSliderWrapperPrevent"
+    @touchmove="onSliderWrapperPrevent"
   >
     <div
       ref="slider"
@@ -249,6 +251,7 @@ export default defineComponent({
       barStyle,
       resetSize,
       emitChange,
+      onSliderWrapperPrevent,
       onSliderClick,
       onSliderDown,
       setFirstValue,
@@ -361,6 +364,7 @@ export default defineComponent({
       barStyle,
       emitChange,
       onSliderClick,
+      onSliderWrapperPrevent,
       onSliderDown,
       getStopStyle,
       setFirstValue,

--- a/packages/components/slider/src/index.vue
+++ b/packages/components/slider/src/index.vue
@@ -344,7 +344,6 @@ export default defineComponent({
 
     return {
       ns,
-      t,
       firstValue,
       secondValue,
       oldValue,
@@ -475,7 +474,7 @@ const useWatch = (props, initData, minValue, maxValue, emit, elFormItem) => {
 }
 
 const useLifecycle = (props, initData, resetSize) => {
-  const sliderWrapper: Ref<HTMLElement> = ref()
+  const sliderWrapper = ref<HTMLElement>()
 
   onMounted(async () => {
     if (props.range) {

--- a/packages/components/slider/src/slider.type.ts
+++ b/packages/components/slider/src/slider.type.ts
@@ -4,7 +4,6 @@ import type {
   ComputedRef,
   Ref,
 } from 'vue'
-import type { Nullable } from '@element-plus/utils'
 
 export interface ISliderProps {
   modelValue: number | number[]

--- a/packages/components/slider/src/slider.type.ts
+++ b/packages/components/slider/src/slider.type.ts
@@ -1,4 +1,9 @@
-import type { CSSProperties, ComputedRef, Ref } from 'vue'
+import type {
+  CSSProperties,
+  ComponentPublicInstance,
+  ComputedRef,
+  Ref,
+} from 'vue'
 import type { Nullable } from '@element-plus/utils'
 
 export interface ISliderProps {
@@ -18,14 +23,17 @@ export interface ISliderProps {
   height: string
   debounce: number
   label: string
+  rangeStartLabel: string
+  rangeEndLabel: string
+  formatValueText: (val: number) => string
   tooltipClass: string
   marks?: Record<number, any>
 }
 
 export interface ISliderInitData {
-  firstValue: Nullable<number>
-  secondValue: Nullable<number>
-  oldValue: Nullable<number>
+  firstValue: number
+  secondValue: number
+  oldValue?: number
   dragging: boolean
   sliderSize: number
 }
@@ -73,7 +81,7 @@ export type Slide = {
 }
 
 export type ButtonRefs = {
-  [s in 'firstButton' | 'secondButton']: Ref<Nullable<ISliderButton>>
+  [s in 'firstButton' | 'secondButton']: Ref<ISliderButton | undefined>
 }
 
 export interface ISliderButtonProps {
@@ -95,8 +103,8 @@ export interface ISliderButtonInitData {
   oldValue: number
 }
 
-export interface ISliderButton {
-  tooltip: Ref<Nullable<HTMLElement>>
+export interface ISliderButton extends ComponentPublicInstance {
+  tooltip: Ref<HTMLElement | undefined>
   showTooltip: Ref<boolean>
   wrapperStyle: ComputedRef<CSSProperties>
   formatValue: ComputedRef<number | string>

--- a/packages/components/slider/src/slider.type.ts
+++ b/packages/components/slider/src/slider.type.ts
@@ -107,10 +107,10 @@ export interface ISliderButton extends ComponentPublicInstance {
   showTooltip: Ref<boolean>
   wrapperStyle: ComputedRef<CSSProperties>
   formatValue: ComputedRef<number | string>
+  dragging: boolean
   handleMouseEnter: () => void
   handleMouseLeave: () => void
   onButtonDown: (event: MouseEvent | TouchEvent) => void
-  onLeftKeyDown: () => void
-  onRightKeyDown: () => void
+  onKeyDown: (event: KeyboardEvent) => void
   setPosition: (newPosition: number) => void
 }

--- a/packages/components/slider/src/useSlide.ts
+++ b/packages/components/slider/src/useSlide.ts
@@ -5,24 +5,28 @@ import {
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
 import { formContextKey, formItemContextKey } from '@element-plus/tokens'
-import type { CSSProperties } from 'vue'
-import type { ButtonRefs, ISliderInitData, ISliderProps } from './slider.type'
+import type { CSSProperties, ComponentInternalInstance, Ref } from 'vue'
+import type {
+  ButtonRefs,
+  ISliderButton,
+  ISliderInitData,
+  ISliderProps,
+} from './slider.type'
 import type { FormContext, FormItemContext } from '@element-plus/tokens'
-import type { Nullable } from '@element-plus/utils'
 
 export const useSlide = (
   props: ISliderProps,
   initData: ISliderInitData,
-  emit
+  emit: ComponentInternalInstance['emit']
 ) => {
   const elForm = inject(formContextKey, {} as FormContext)
   const elFormItem = inject(formItemContextKey, {} as FormItemContext)
 
-  const slider = shallowRef<Nullable<HTMLElement>>(null)
+  const slider = shallowRef<HTMLElement>()
 
-  const firstButton = ref(null)
+  const firstButton = ref<ISliderButton>()
 
-  const secondButton = ref(null)
+  const secondButton = ref<ISliderButton>()
 
   const buttonRefs: ButtonRefs = {
     firstButton,
@@ -80,13 +84,14 @@ export const useSlide = (
     }
   }
 
-  const setPosition = (percent: number) => {
+  const getButtonRefByPercent = (
+    percent: number
+  ): Ref<ISliderButton | undefined> => {
     const targetValue = props.min + (percent * (props.max - props.min)) / 100
     if (!props.range) {
-      firstButton.value.setPosition(percent)
-      return
+      return firstButton
     }
-    let buttonRefName: string
+    let buttonRefName: 'firstButton' | 'secondButton'
     if (
       Math.abs(minValue.value - targetValue) <
       Math.abs(maxValue.value - targetValue)
@@ -101,7 +106,13 @@ export const useSlide = (
           ? 'firstButton'
           : 'secondButton'
     }
-    buttonRefs[buttonRefName].value.setPosition(percent)
+    return buttonRefs[buttonRefName]
+  }
+
+  const setPosition = (percent: number): Ref<ISliderButton | undefined> => {
+    const buttonRef = getButtonRefByPercent(percent)
+    buttonRef.value!.setPosition(percent)
+    return buttonRef
   }
 
   const setFirstValue = (firstValue: number) => {
@@ -130,21 +141,41 @@ export const useSlide = (
     )
   }
 
-  const onSliderClick = (event: MouseEvent) => {
+  const handleSliderPointerEvent = (
+    event: MouseEvent | TouchEvent
+  ): Ref<ISliderButton | undefined> | undefined => {
     if (sliderDisabled.value || initData.dragging) return
     resetSize()
+    let newPercent = 0
     if (props.vertical) {
-      const sliderOffsetBottom = slider.value.getBoundingClientRect().bottom
-      setPosition(
-        ((sliderOffsetBottom - event.clientY) / initData.sliderSize) * 100
-      )
+      const clientY =
+        (event as TouchEvent).touches?.item(0)?.clientY ??
+        (event as MouseEvent).clientY
+      const sliderOffsetBottom = slider.value!.getBoundingClientRect().bottom
+      newPercent = ((sliderOffsetBottom - clientY) / initData.sliderSize) * 100
     } else {
-      const sliderOffsetLeft = slider.value.getBoundingClientRect().left
-      setPosition(
-        ((event.clientX - sliderOffsetLeft) / initData.sliderSize) * 100
-      )
+      const clientX =
+        (event as TouchEvent).touches?.item(0)?.clientX ??
+        (event as MouseEvent).clientX
+      const sliderOffsetLeft = slider.value!.getBoundingClientRect().left
+      newPercent = ((clientX - sliderOffsetLeft) / initData.sliderSize) * 100
     }
-    emitChange()
+    return setPosition(newPercent)
+  }
+
+  const onSliderDown = async (event: MouseEvent | TouchEvent) => {
+    const buttonRef = handleSliderPointerEvent(event)
+    if (buttonRef) {
+      await nextTick()
+      buttonRef.value!.onButtonDown(event)
+    }
+  }
+
+  const onSliderClick = (event: MouseEvent | TouchEvent) => {
+    const buttonRef = handleSliderPointerEvent(event)
+    if (buttonRef) {
+      emitChange()
+    }
   }
 
   return {
@@ -161,6 +192,7 @@ export const useSlide = (
     setPosition,
     emitChange,
     onSliderClick,
+    onSliderDown,
     setFirstValue,
     setSecondValue,
   }

--- a/packages/components/slider/src/useSlide.ts
+++ b/packages/components/slider/src/useSlide.ts
@@ -164,7 +164,7 @@ export const useSlide = (
     return setPosition(newPercent)
   }
 
-  const onSliderWrapperPrevent = async (event: TouchEvent) => {
+  const onSliderWrapperPrevent = (event: TouchEvent) => {
     if (
       buttonRefs['firstButton'].value?.dragging ||
       buttonRefs['secondButton'].value?.dragging

--- a/packages/components/slider/src/useSlide.ts
+++ b/packages/components/slider/src/useSlide.ts
@@ -160,7 +160,17 @@ export const useSlide = (
       const sliderOffsetLeft = slider.value!.getBoundingClientRect().left
       newPercent = ((clientX - sliderOffsetLeft) / initData.sliderSize) * 100
     }
+    if (newPercent < 0 || newPercent > 100) return
     return setPosition(newPercent)
+  }
+
+  const onSliderWrapperPrevent = async (event: TouchEvent) => {
+    if (
+      buttonRefs['firstButton'].value?.dragging ||
+      buttonRefs['secondButton'].value?.dragging
+    ) {
+      event.preventDefault()
+    }
   }
 
   const onSliderDown = async (event: MouseEvent | TouchEvent) => {
@@ -191,6 +201,7 @@ export const useSlide = (
     resetSize,
     setPosition,
     emitChange,
+    onSliderWrapperPrevent,
     onSliderClick,
     onSliderDown,
     setFirstValue,

--- a/packages/components/slider/src/useSliderButton.ts
+++ b/packages/components/slider/src/useSliderButton.ts
@@ -1,9 +1,8 @@
 import { computed, inject, nextTick, ref, watch } from 'vue'
 import { debounce } from 'lodash-unified'
 import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
-import { off, on } from '@element-plus/utils'
 
-import type { CSSProperties, ComputedRef } from 'vue'
+import type { CSSProperties, ComponentInternalInstance, ComputedRef } from 'vue'
 import type {
   ISliderButtonInitData,
   ISliderButtonProps,
@@ -15,7 +14,7 @@ const useTooltip = (
   formatTooltip: ComputedRef<(value: number) => number | string>,
   showTooltip: ComputedRef<boolean>
 ) => {
-  const tooltip = ref(null)
+  const tooltip = ref<any>()
 
   const tooltipVisible = ref(false)
 
@@ -50,7 +49,7 @@ const useTooltip = (
 export const useSliderButton = (
   props: ISliderButtonProps,
   initData: ISliderButtonInitData,
-  emit
+  emit: ComponentInternalInstance['emit']
 ) => {
   const {
     disabled,
@@ -64,10 +63,12 @@ export const useSliderButton = (
     emitChange,
     resetSize,
     updateDragging,
-  } = inject<ISliderProvider>('SliderProvider')
+  } = inject<ISliderProvider>('SliderProvider')!
 
   const { tooltip, tooltipVisible, formatValue, displayTooltip, hideTooltip } =
     useTooltip(props, formatTooltip, showTooltip)
+
+  const button = ref<any>()
 
   const currentPosition = computed(() => {
     return `${
@@ -99,29 +100,69 @@ export const useSliderButton = (
     if (disabled.value) return
     event.preventDefault()
     onDragStart(event)
-    on(window, 'mousemove', onDragging)
-    on(window, 'touchmove', onDragging)
-    on(window, 'mouseup', onDragEnd)
-    on(window, 'touchend', onDragEnd)
-    on(window, 'contextmenu', onDragEnd)
+    window.addEventListener('mousemove', onDragging)
+    window.addEventListener('touchmove', onDragging)
+    window.addEventListener('mouseup', onDragEnd)
+    window.addEventListener('touchend', onDragEnd)
+    window.addEventListener('contextmenu', onDragEnd)
+    button.value.focus()
   }
 
-  const onLeftKeyDown = () => {
-    if (disabled.value) return
-    initData.newPosition =
-      Number.parseFloat(currentPosition.value) -
-      (step.value / (max.value - min.value)) * 100
-    setPosition(initData.newPosition)
-    emitChange()
-  }
-
-  const onRightKeyDown = () => {
+  const incrementPosition = (amount: number) => {
     if (disabled.value) return
     initData.newPosition =
       Number.parseFloat(currentPosition.value) +
-      (step.value / (max.value - min.value)) * 100
+      (amount / (max.value - min.value)) * 100
     setPosition(initData.newPosition)
     emitChange()
+  }
+
+  const onLeftKeyDown = () => {
+    incrementPosition(-step.value)
+  }
+
+  const onRightKeyDown = () => {
+    incrementPosition(step.value)
+  }
+
+  const onPageDownKeyDown = () => {
+    incrementPosition(-step.value * 4)
+  }
+
+  const onPageUpKeyDown = () => {
+    incrementPosition(step.value * 4)
+  }
+
+  const onHomeKeyDown = () => {
+    if (disabled.value) return
+    setPosition(0)
+    emitChange()
+  }
+
+  const onEndKeyDown = () => {
+    if (disabled.value) return
+    setPosition(100)
+    emitChange()
+  }
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    let isPreventDefault = true
+    if (['ArrowLeft', 'ArrowDown'].includes(event.key)) {
+      onLeftKeyDown()
+    } else if (['ArrowRight', 'ArrowUp'].includes(event.key)) {
+      onRightKeyDown()
+    } else if (event.key === 'Home') {
+      onHomeKeyDown()
+    } else if (event.key === 'End') {
+      onEndKeyDown()
+    } else if (event.key === 'PageDown') {
+      onPageDownKeyDown()
+    } else if (event.key === 'PageUp') {
+      onPageUpKeyDown()
+    } else {
+      isPreventDefault = false
+    }
+    isPreventDefault && event.preventDefault()
   }
 
   const getClientXY = (event: MouseEvent | TouchEvent) => {
@@ -188,11 +229,11 @@ export const useSliderButton = (
           emitChange()
         }
       }, 0)
-      off(window, 'mousemove', onDragging)
-      off(window, 'touchmove', onDragging)
-      off(window, 'mouseup', onDragEnd)
-      off(window, 'touchend', onDragEnd)
-      off(window, 'contextmenu', onDragEnd)
+      window.removeEventListener('mousemove', onDragging)
+      window.removeEventListener('touchmove', onDragging)
+      window.removeEventListener('mouseup', onDragEnd)
+      window.removeEventListener('touchend', onDragEnd)
+      window.removeEventListener('contextmenu', onDragEnd)
     }
   }
 
@@ -227,6 +268,7 @@ export const useSliderButton = (
   )
 
   return {
+    button,
     tooltip,
     tooltipVisible,
     showTooltip,
@@ -235,8 +277,7 @@ export const useSliderButton = (
     handleMouseEnter,
     handleMouseLeave,
     onButtonDown,
-    onLeftKeyDown,
-    onRightKeyDown,
+    onKeyDown,
     setPosition,
   }
 }

--- a/packages/components/slider/src/useSliderButton.ts
+++ b/packages/components/slider/src/useSliderButton.ts
@@ -1,6 +1,6 @@
 import { computed, inject, nextTick, ref, watch } from 'vue'
 import { debounce } from 'lodash-unified'
-import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
+import { EVENT_CODE, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
 import type { CSSProperties, ComponentInternalInstance, ComputedRef } from 'vue'
 import type {
@@ -8,6 +8,8 @@ import type {
   ISliderButtonProps,
   ISliderProvider,
 } from './slider.type'
+
+const { left, down, right, up, home, end, pageUp, pageDown } = EVENT_CODE
 
 const useTooltip = (
   props: ISliderButtonProps,
@@ -147,17 +149,17 @@ export const useSliderButton = (
 
   const onKeyDown = (event: KeyboardEvent) => {
     let isPreventDefault = true
-    if (['ArrowLeft', 'ArrowDown'].includes(event.key)) {
+    if ([left, down].includes(event.key)) {
       onLeftKeyDown()
-    } else if (['ArrowRight', 'ArrowUp'].includes(event.key)) {
+    } else if ([right, up].includes(event.key)) {
       onRightKeyDown()
-    } else if (event.key === 'Home') {
+    } else if (event.key === home) {
       onHomeKeyDown()
-    } else if (event.key === 'End') {
+    } else if (event.key === end) {
       onEndKeyDown()
-    } else if (event.key === 'PageDown') {
+    } else if (event.key === pageDown) {
       onPageDownKeyDown()
-    } else if (event.key === 'PageUp') {
+    } else if (event.key === pageUp) {
       onPageUpKeyDown()
     } else {
       isPreventDefault = false

--- a/packages/locale/lang/en.ts
+++ b/packages/locale/lang/en.ts
@@ -91,6 +91,11 @@ export default {
       preview: 'Preview',
       continue: 'Continue',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}',
+      defaultRangeStartLabel: 'pick start value',
+      defaulRangeEndLabel: 'pick end value',
+    },
     table: {
       emptyText: 'No Data',
       confirmFilter: 'Confirm',

--- a/packages/locale/lang/en.ts
+++ b/packages/locale/lang/en.ts
@@ -94,7 +94,7 @@ export default {
     slider: {
       defaultLabel: 'slider between {min} and {max}',
       defaultRangeStartLabel: 'pick start value',
-      defaulRangeEndLabel: 'pick end value',
+      defaultRangeEndLabel: 'pick end value',
     },
     table: {
       emptyText: 'No Data',


### PR DESCRIPTION
fix #7350

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### Summary

General
- Fixed various typescript errors
- Changed clicking on slider rail to immediately pull slider thumb to that position

Ref: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role
- Added aria-valuenow attribute (required)
- Added page up, page down, home, and end keyboard controls
- Added rangeStartLabel and rangeEndLabel props for controlling aria-label on range slider
- Added formatValueText attribute for controlling aria-valuenow on the slider

Ref: https://www.w3.org/TR/wai-aria-practices-1.1/examples/slider/multithumb-slider.html
- Moved Aria attributes to slider-button, in order to properly support multithumb slider. 
