### PR TITLE
feat(docs): [@element-plus/icons-vue] 修复图标组件示例代码中的错误

### DIFF
--- a/docs/en-US/component/icon.md
+++ b/docs/en-US/component/icon.md
@@ -39,7 +39,7 @@ You need import all icons from `@element-plus/icons-vue` and register them globa
 import * as ElementPlusIconsVue from '@element-plus/icons-vue'
 
 const app = createApp(App)
-for ([key, component] of Object.entries(ElementPlusIconsVue)) {
+for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
   app.component(key, component)
 }
 ```


### PR DESCRIPTION
feat(docs): [@element-plus/icons-vue] 修复图标组件示例代码中的错误

在Register All Icons时使用了for of的示例代码，但缺少了变量的声明
我在注册的示例代码中修改了一行，为其添加上了const声明
for (const [key, component] of Object.entries(ElementPlusIconsVue))
原示例代码为：
for ([key, component] of Object.entries(ElementPlusIconsVue))