### PR TITLE
fix(theme-chalk): dark mode details

### DIFF
--- a/docs/.vitepress/vitepress/components/home/home-cards.vue
+++ b/docs/.vitepress/vitepress/components/home/home-cards.vue
@@ -85,6 +85,11 @@ const homeLang = computed(() => homeLocale[lang.value])
     transition: all 0.3s ease-in-out;
     bottom: 0;
 
+    &:hover {
+      box-shadow: 0px 12px 32px 4px rgba(237, 239, 245, 0.24),
+        0px 8px 20px rgba(237, 239, 245, 0.48);
+    }
+
     img {
       margin: 48px auto;
     }
@@ -144,6 +149,17 @@ const homeLang = computed(() => homeLocale[lang.value])
     }
     .banner img {
       right: 0;
+    }
+  }
+}
+
+.dark {
+  .home-page {
+    .card {
+      &:hover {
+        box-shadow: 0px 12px 32px 4px rgba(9, 11, 16, 0.24),
+          0px 8px 20px rgba(9, 11, 16, 0.48);
+      }
     }
   }
 }

--- a/docs/examples/carousel/arrows.vue
+++ b/docs/examples/carousel/arrows.vue
@@ -1,7 +1,7 @@
 <template>
   <el-carousel :interval="5000" arrow="always">
     <el-carousel-item v-for="item in 4" :key="item">
-      <h3>{{ item }}</h3>
+      <h3 text="2xl" justify="center">{{ item }}</h3>
     </el-carousel-item>
   </el-carousel>
 </template>
@@ -9,7 +9,6 @@
 <style scoped>
 .el-carousel__item h3 {
   color: #475669;
-  font-size: 18px;
   opacity: 0.75;
   line-height: 300px;
   margin: 0;

--- a/docs/examples/carousel/basic.vue
+++ b/docs/examples/carousel/basic.vue
@@ -1,28 +1,31 @@
 <template>
-  <div class="block">
+  <div class="block text-center">
     <span class="demonstration"
       >Switch when indicator is hovered (default)</span
     >
     <el-carousel height="150px">
       <el-carousel-item v-for="item in 4" :key="item">
-        <h3 class="small">{{ item }}</h3>
+        <h3 class="small justify-center" text="2xl">{{ item }}</h3>
       </el-carousel-item>
     </el-carousel>
   </div>
-  <div class="block">
+  <div class="block text-center" m="t-4">
     <span class="demonstration">Switch when indicator is clicked</span>
     <el-carousel trigger="click" height="150px">
       <el-carousel-item v-for="item in 4" :key="item">
-        <h3 class="small">{{ item }}</h3>
+        <h3 class="small justify-center" text="2xl">{{ item }}</h3>
       </el-carousel-item>
     </el-carousel>
   </div>
 </template>
 
 <style scoped>
+.demonstration {
+  color: var(--el-text-color-secondary);
+}
+
 .el-carousel__item h3 {
   color: #475669;
-  font-size: 14px;
   opacity: 0.75;
   line-height: 150px;
   margin: 0;

--- a/docs/examples/carousel/card.vue
+++ b/docs/examples/carousel/card.vue
@@ -1,7 +1,7 @@
 <template>
   <el-carousel :interval="4000" type="card" height="200px">
     <el-carousel-item v-for="item in 6" :key="item">
-      <h3>{{ item }}</h3>
+      <h3 text="2xl" justify="center">{{ item }}</h3>
     </el-carousel-item>
   </el-carousel>
 </template>
@@ -9,7 +9,6 @@
 <style scoped>
 .el-carousel__item h3 {
   color: #475669;
-  font-size: 14px;
   opacity: 0.75;
   line-height: 200px;
   margin: 0;

--- a/docs/examples/carousel/indicator.vue
+++ b/docs/examples/carousel/indicator.vue
@@ -1,19 +1,18 @@
 <template>
   <el-carousel indicator-position="outside">
     <el-carousel-item v-for="item in 4" :key="item">
-      <h3>{{ item }}</h3>
+      <h3 text="2xl" justify="center">{{ item }}</h3>
     </el-carousel-item>
   </el-carousel>
 </template>
 
 <style scoped>
 .el-carousel__item h3 {
+  display: flex;
   color: #475669;
-  font-size: 18px;
   opacity: 0.75;
   line-height: 300px;
   margin: 0;
-  text-align: center;
 }
 
 .el-carousel__item:nth-child(2n) {

--- a/docs/examples/carousel/vertical.vue
+++ b/docs/examples/carousel/vertical.vue
@@ -1,7 +1,7 @@
 <template>
   <el-carousel height="200px" direction="vertical" :autoplay="false">
     <el-carousel-item v-for="item in 4" :key="item">
-      <h3>{{ item }}</h3>
+      <h3 text="2xl" justify="center">{{ item }}</h3>
     </el-carousel-item>
   </el-carousel>
 </template>
@@ -9,7 +9,6 @@
 <style scoped>
 .el-carousel__item h3 {
   color: #475669;
-  font-size: 14px;
   opacity: 0.75;
   line-height: 200px;
   margin: 0;

--- a/docs/examples/config-provider/button.vue
+++ b/docs/examples/config-provider/button.vue
@@ -1,13 +1,14 @@
 <template>
   <div>
-    <el-config-provider :button="config">
-      <el-button>中文</el-button>
-    </el-config-provider>
-    <div>
+    <div m="b-2">
       <el-checkbox v-model="config.autoInsertSpace"
         >autoInsertSpace</el-checkbox
       >
     </div>
+
+    <el-config-provider :button="config">
+      <el-button>中文</el-button>
+    </el-config-provider>
   </div>
 </template>
 

--- a/docs/examples/config-provider/message.vue
+++ b/docs/examples/config-provider/message.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <el-config-provider :message="config">
-      <el-button @click="open">open</el-button>
+      <el-button @click="open">OPEN</el-button>
     </el-config-provider>
   </div>
 </template>
@@ -13,6 +13,6 @@ const config = reactive({
   max: 3,
 })
 const open = () => {
-  ElMessage('this is a message.')
+  ElMessage('This is a message.')
 }
 </script>

--- a/docs/examples/config-provider/usage.vue
+++ b/docs/examples/config-provider/usage.vue
@@ -1,11 +1,10 @@
 <template>
   <div>
+    <el-button m="b-2" @click="toggle"> Switch Lang </el-button>
+    <br />
     <el-config-provider :locale="locale2">
       <el-color-picker :model-value="''" style="vertical-align: middle" />
     </el-config-provider>
-    <el-button style="margin-left: 8px; vertical-align: middle" @click="toggle">
-      Switch Lang
-    </el-button>
   </div>
 </template>
 

--- a/docs/examples/popconfirm/customize.vue
+++ b/docs/examples/popconfirm/customize.vue
@@ -3,7 +3,7 @@
     confirm-button-text="OK"
     cancel-button-text="No, Thanks"
     :icon="InfoFilled"
-    icon-color="red"
+    icon-color="#626AEF"
     title="Are you sure to delete this?"
   >
     <template #reference>

--- a/docs/examples/popconfirm/trigger-event.vue
+++ b/docs/examples/popconfirm/trigger-event.vue
@@ -3,7 +3,7 @@
     confirm-button-text="Yes"
     cancel-button-text="No"
     :icon="InfoFilled"
-    icon-color="red"
+    icon-color="#626AEF"
     title="Are you sure to delete this?"
     @confirm="confirmEvent"
     @cancel="cancelEvent"

--- a/docs/examples/table/expandable-row.vue
+++ b/docs/examples/table/expandable-row.vue
@@ -2,10 +2,12 @@
   <el-table :data="tableData" style="width: 100%">
     <el-table-column type="expand">
       <template #default="props">
-        <p>State: {{ props.row.state }}</p>
-        <p>City: {{ props.row.city }}</p>
-        <p>Address: {{ props.row.address }}</p>
-        <p>Zip: {{ props.row.zip }}</p>
+        <div m="4">
+          <p m="t-0 b-2">State: {{ props.row.state }}</p>
+          <p m="t-0 b-2">City: {{ props.row.city }}</p>
+          <p m="t-0 b-2">Address: {{ props.row.address }}</p>
+          <p m="t-0 b-2">Zip: {{ props.row.zip }}</p>
+        </div>
       </template>
     </el-table-column>
     <el-table-column label="Date" prop="date" />

--- a/docs/examples/tree-select/slots.vue
+++ b/docs/examples/tree-select/slots.vue
@@ -23,7 +23,7 @@ const renderContent = (h, { data }) => {
     'span',
     {
       style: {
-        color: 'orange',
+        color: '#626AEF',
       },
     },
     data.label

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -924,7 +924,7 @@ $dropdown: map.merge(
   (
     'menu-box-shadow': getCssVar('box-shadow-light'),
     'menuItem-hover-fill': getCssVar('color-primary-light-9'),
-    'menuItem-hover-color': getCssVar('color-primary-light-3'),
+    'menuItem-hover-color': getCssVar('color-primary'),
     'menu-index': 10,
   ),
   $dropdown
@@ -992,7 +992,7 @@ $menu: map.merge(
   (
     'active-color': getCssVar('color-primary'),
     'text-color': getCssVar('text-color-primary'),
-    'hover-text-color': getCssVar('text-color-primary'),
+    'hover-text-color': getCssVar('color-primary'),
     'bg-color': getCssVar('fill-color', 'blank'),
     'hover-bg-color': getCssVar('color-primary-light-9'),
     'item-height': 56px,

--- a/packages/theme-chalk/src/dark/var.scss
+++ b/packages/theme-chalk/src/dark/var.scss
@@ -2,7 +2,7 @@
 @use 'sass:math';
 
 @use '../common/var.scss' as common;
-
+@use '../mixins/mixins.scss' as *;
 @use '../color/index.scss' as *;
 
 $colors: () !default;
@@ -162,6 +162,15 @@ $text-color: map.merge(
   ),
   $text-color
 );
+// mix to hex to avoid overlay issues
+@each $key, $val in $text-color {
+  $text-color: map.merge(
+    $text-color,
+    (
+      $key: mix-overlay-color($val, map.get($bg-color, '')),
+    )
+  ) !global;
+}
 
 // mask
 $mask-color: () !default;

--- a/packages/theme-chalk/src/dark/var.scss
+++ b/packages/theme-chalk/src/dark/var.scss
@@ -139,12 +139,14 @@ $fill-color: map.merge(
 
 // mix to hex to avoid overlay issues
 @each $key, $val in $fill-color {
-  $fill-color: map.merge(
-    $fill-color,
-    (
-      $key: mix-overlay-color($val, map.get($bg-color, '')),
-    )
-  ) !global;
+  @if ($key != 'blank') {
+    $fill-color: map.merge(
+      $fill-color,
+      (
+        $key: mix-overlay-color($val, map.get($bg-color, '')),
+      )
+    ) !global;
+  }
 }
 
 // text

--- a/packages/theme-chalk/src/option-item.scss
+++ b/packages/theme-chalk/src/option-item.scss
@@ -24,7 +24,7 @@
       cursor: not-allowed;
 
       &:hover {
-        background-color: getCssVar('color-white');
+        background-color: getCssVar('bg-color');
       }
     }
 


### PR DESCRIPTION
- add box-shadow for home cards when dark
- change popconfirm/tree custom color to `#626AEF`
- not mix fill-color when key is `blank` to fix table bg
- mix text-color to hex
- fix card bg-color (overlay)
- fix select v2 virtualized selector hover bg color
- fix badge dropdown menu hover text color
- adjust carousel example text styles 
- fix menu hover active text color
- adjust config-provider example spacing
- remove select hover bg color when option disbaled

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
