### PR TITLE
fix(components): fix globalConfig can be set by config-provider

### DIFF
--- a/packages/hooks/use-global-config/index.ts
+++ b/packages/hooks/use-global-config/index.ts
@@ -55,7 +55,7 @@ export const provideGlobalConfig = (
     return mergeConfig(oldConfig.value, cfg)
   })
   provideFn(configProviderContextKey, context)
-  if (global || !globalConfig.value) {
+  if (global) {
     globalConfig.value = context.value
   }
   return context


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #7473 

当前版本首次使用 `config-provider`  组件会把传入的 props 设置到全局的 globalConfig 中，个人认为 `config-provider` 是限定范围（在它内的组件）才能接收到他的设置参数，不应该存在首次设置到全局参数这种不受控的情况，全局参数可以通过 app.use 的形式来传入。
