### PR TITLE
docs: fix custom thumbnail upload example preview img

### DIFF
--- a/docs/examples/upload/custom-thumbnail.vue
+++ b/docs/examples/upload/custom-thumbnail.vue
@@ -32,7 +32,7 @@
   </el-upload>
 
   <el-dialog v-model="dialogVisible">
-    <img width="100%" :src="dialogImageUrl" alt="" />
+    <img w-full :src="dialogImageUrl" alt="Preview Image" />
   </el-dialog>
 </template>
 <script lang="ts" setup>


### PR DESCRIPTION
## description

In the example, the thumbnail doesn't look right.

https://element-plus.org/en-US/component/upload.html#custom-thumbnail

## What is Expected?

![after](https://user-images.githubusercontent.com/27342882/166915764-c9fd9c10-f012-4bdd-be2c-e55d615ce7ec.PNG)

## What is actually happening?

![before](https://user-images.githubusercontent.com/27342882/166915789-2fbafcc4-e130-4fc2-b0a5-f7f40097289b.PNG)

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
