### PR TITLE
docs: only cache the user preferred language pages in the PWA

### DIFF
--- a/docs/.vitepress/crowdin/en-US/component/pwa.json
+++ b/docs/.vitepress/crowdin/en-US/component/pwa.json
@@ -1,5 +1,6 @@
 {
   "message": "New content available, click on refresh button to update.",
   "refresh": "Refresh",
+  "always-refresh": "Always Refresh",
   "close": "Close"
 }

--- a/docs/.vitepress/lang.js
+++ b/docs/.vitepress/lang.js
@@ -25,4 +25,10 @@
         ? toPath
         : toPath.concat('/')
   }
+  if (navigator && navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.postMessage({
+      type: 'LANG',
+      lang: userPreferredLang,
+    })
+  }
 })()

--- a/docs/.vitepress/sw.ts
+++ b/docs/.vitepress/sw.ts
@@ -89,14 +89,13 @@ function matchManifest(item: ManifestEntry, lang: string) {
   const cacheList = [
     lang,
     `assets/(${lang}|app|index|style|chunks)`,
-    'index',
     'images',
     'android-chrome',
     'apple-touch-icon',
     'manifest.webmanifest',
   ]
   const regExp = new RegExp(`^(${cacheList.join('|')})`)
-  return regExp.test(item.url)
+  return regExp.test(item.url) || /^\/$/.test(item.url)
 }
 
 function getManifest(lang: string) {

--- a/docs/.vitepress/sw.ts
+++ b/docs/.vitepress/sw.ts
@@ -56,9 +56,9 @@ class LangDB {
     if (!this.db) await this.initDB()
 
     return new Promise<string>((resolve) => {
-      const transaction = this.db!.transaction(this.storeNames)
-      const objectStore = transaction.objectStore(this.storeNames)
-      const request = objectStore.get(1)
+      const request = this.db!.transaction(this.storeNames)
+        .objectStore(this.storeNames)
+        .get(1)
 
       request.onsuccess = () => {
         if (request.result) {

--- a/docs/.vitepress/vitepress/components/vp-reload-prompt.vue
+++ b/docs/.vitepress/vitepress/components/vp-reload-prompt.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
+import { useStorage } from '@vueuse/core'
 import { useRegisterSW } from 'virtual:pwa-register/vue'
 import { useLang } from '../composables/lang'
 import pwaLocale from '../../i18n/component/pwa.json'
@@ -7,14 +8,22 @@ import pwaLocale from '../../i18n/component/pwa.json'
 const lang = useLang()
 const locale = computed(() => pwaLocale[lang.value])
 const { needRefresh, updateServiceWorker } = useRegisterSW()
+const alwaysRefresh = useStorage('PWA_Always_Refresh', false)
+
+watch(needRefresh, (value) => {
+  value && alwaysRefresh.value && updateServiceWorker()
+})
 </script>
 
 <template>
   <transition name="pwa-popup">
-    <el-card v-if="needRefresh" class="pwa-card" role="alert">
+    <el-card v-if="!alwaysRefresh && needRefresh" class="pwa-card" role="alert">
       <p class="pwa-card-text">{{ locale.message }}</p>
       <el-button type="primary" plain @click="updateServiceWorker()">
         {{ locale.refresh }}
+      </el-button>
+      <el-button plain @click="alwaysRefresh = true">
+        {{ locale['always-refresh'] }}
       </el-button>
       <el-button plain @click="needRefresh = false">
         {{ locale.close }}

--- a/docs/.vitepress/vitepress/composables/translation.ts
+++ b/docs/.vitepress/vitepress/composables/translation.ts
@@ -1,6 +1,6 @@
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vitepress'
-import { useStorage } from '@vueuse/core'
+import { isClient, useStorage } from '@vueuse/core'
 import { PREFERRED_LANG_KEY } from '../constant'
 
 import langs from '../../i18n/lang.json'
@@ -50,6 +50,13 @@ export const useTranslation = () => {
     const goTo = `/${targetLang}/${route.path.slice(firstSlash + 1)}`
 
     router.go(goTo)
+
+    if (isClient) {
+      navigator?.serviceWorker.controller?.postMessage({
+        type: 'LANG',
+        lang: targetLang,
+      })
+    }
   }
 
   return {

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -10,6 +10,7 @@
     "strict": true,
     "noImplicitAny": false,
     "skipLibCheck": true,
+    "lib": ["WebWorker"],
     "paths": {
       "element-plus": ["../packages/element-plus"],
       "~/*": ["./.vitepress/vitepress/*"]

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -104,6 +104,20 @@ export default defineConfig(async ({ mode }) => {
         filename: 'sw.ts',
         outDir: '.vitepress/dist',
         includeAssets: ['images/**'],
+        injectManifest: {
+          manifestTransforms: [
+            (manifest) => {
+              for (const item of manifest) {
+                if (item.url.endsWith('index.html')) {
+                  const url = item.url.replace('index.html', '')
+                  item.url = url ? url : '/'
+                }
+              }
+
+              return { manifest }
+            },
+          ],
+        },
         manifest: {
           id: '/',
           name: 'Element Plus',

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -99,6 +99,9 @@ export default defineConfig(async ({ mode }) => {
       Inspect(),
       mkcert(),
       VitePWA({
+        strategies: 'injectManifest',
+        srcDir: '.vitepress',
+        filename: 'sw.ts',
         outDir: '.vitepress/dist',
         includeAssets: ['images/**'],
         manifest: {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

- For the first time install, the browser default language will be the highest priority
- The rest will be consistent with the user's preferred language

same as `docs/.vitepress/lang.js`

- add always refresh from PWA

![Hesx2.png](https://s1.328888.xyz/2022/05/10/Hesx2.png)

- Used `always refresh` will automatically refresh the page after receiving an update
