### PR TITLE
fix(components): input textarea padding & label line-height

### DIFF
--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -140,21 +140,19 @@ $form-item-label-top-margin-bottom: map.merge(
 
   @include e(label-wrap) {
     display: flex;
-
-    .#{$namespace}-form-item__label {
-      display: inline-block;
-    }
   }
 
   @include e(label) {
     display: inline-flex;
     justify-content: flex-end;
-    align-items: center;
+    align-items: flex-start;
 
     flex: 0 0 auto;
     font-size: getCssVar('form-label-font-size');
     color: getCssVar('text-color', 'regular');
-    line-height: #{map.get($form-item-label-top-line-height, 'default')};
+
+    height: #{map.get($form-item-line-height, 'default')};
+    line-height: #{map.get($form-item-line-height, 'default')};
 
     padding: 0 12px 0 0;
     box-sizing: border-box;

--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -147,11 +147,15 @@ $form-item-label-top-margin-bottom: map.merge(
   }
 
   @include e(label) {
+    display: inline-flex;
+    justify-content: flex-end;
+    align-items: center;
+
     flex: 0 0 auto;
-    text-align: right;
     font-size: getCssVar('form-label-font-size');
     color: getCssVar('text-color', 'regular');
-    line-height: #{map.get($form-item-line-height, 'default')};
+    line-height: #{map.get($form-item-label-top-line-height, 'default')};
+
     padding: 0 12px 0 0;
     box-sizing: border-box;
   }

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -43,7 +43,7 @@
     position: relative;
     display: block;
     resize: vertical;
-    padding: 5px 15px;
+    padding: 5px map.get($input-padding-horizontal, 'default')-$border-width;
     line-height: 1.5;
     box-sizing: border-box;
     width: 100%;


### PR DESCRIPTION
close #7519 

- change textarea padding left/right from `15px` to `11px` (same with input)
- ~~change label line-height from 32px to 22px~~ i didn't find a way to use 22px and align to top (unless we add a new container dom)

---

By the way, I found that the size of select seems to be fixed by initialInputHeight and cannot be changed dynamically by size. The current official documentation is normal.

https://github.com/element-plus/element-plus/blob/a196b3a1e348c5f7e82de72d283c14f81fa76d44/packages/components/select/src/select.vue#L529

But I didn't figure it out, so I didn't modify it directly. #7592 

<img width="494" alt="image" src="https://user-images.githubusercontent.com/25154432/167308899-611d1920-92a2-4af5-bd80-e6e6fb4fe275.png">

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
