### PR TITLE
feat(components): [select] add value-display attr

### DIFF
--- a/docs/en-US/component/select.md
+++ b/docs/en-US/component/select.md
@@ -146,6 +146,7 @@ If the binding value of Select is an object, make sure to assign `value-key` as 
 | fit-input-width                   | whether the width of the dropdown is the same as the input                                                                  | boolean                            | —                           | false            |
 | suffix-icon                       | Custom suffix icon component                                                                                                | string / Component                 | —                           | ArrowUp          |
 | tag-type                          | tag type                                                                                                                    | string                             | success/info/warning/danger | info             |
+| value-display                     | Customize the presentation mode of selected items                                                                           | function                           | -                           | -                |
 
 ## Select Events
 

--- a/docs/en-US/component/select.md
+++ b/docs/en-US/component/select.md
@@ -146,7 +146,7 @@ If the binding value of Select is an object, make sure to assign `value-key` as 
 | fit-input-width                   | whether the width of the dropdown is the same as the input                                                                  | boolean                            | —                           | false            |
 | suffix-icon                       | Custom suffix icon component                                                                                                | string / Component                 | —                           | ArrowUp          |
 | tag-type                          | tag type                                                                                                                    | string                             | success/info/warning/danger | info             |
-| value-display                     | Customize the presentation mode of selected items                                                                           | function                           | -                           | -                |
+| format-selection-label                     | Customize the presentation mode of selected items                                                                           | function                           | -                           | -                |
 
 ## Select Events
 

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -2042,10 +2042,10 @@ describe('Select', () => {
       expect(formItem.attributes().role).toBe('group')
     })
   })
-  test('value-display format diaplay label', async () => {
+  test('format-selection-label format diaplay label', async () => {
     wrapper = _mount(
       `
-      <el-select v-model="value" :value-display="labelFormat">
+      <el-select v-model="value" :format-selection-label="formatLabel">
         <el-option
           v-for="item in options"
           :label="item.label"
@@ -2056,7 +2056,7 @@ describe('Select', () => {
       </el-select>
     `,
       () => ({
-        labelFormat(option: any) {
+        formatLabel(option: any) {
           return `${option.currentLabel}123`
         },
         options: [
@@ -2077,10 +2077,10 @@ describe('Select', () => {
     expect(findInnerInput().value).toEqual('双皮奶123')
   })
 
-  test('value-display multiple format diaplay label', async () => {
+  test('format-selection-label multiple format diaplay label', async () => {
     wrapper = _mount(
       `
-      <el-select v-model="value" multiple :value-display="labelFormat">
+      <el-select v-model="value" multiple :format-selection-label="formatLabel">
         <el-option
           v-for="item in options"
           :label="item.label"
@@ -2091,7 +2091,7 @@ describe('Select', () => {
       </el-select>
     `,
       () => ({
-        labelFormat(option: any) {
+        formatLabel(option: any) {
           return `${option.currentLabel}123`
         },
         options: [

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -2042,4 +2042,73 @@ describe('Select', () => {
       expect(formItem.attributes().role).toBe('group')
     })
   })
+  test('value-display format diaplay label', async () => {
+    wrapper = _mount(
+      `
+      <el-select v-model="value" :value-display="labelFormat">
+        <el-option
+          v-for="item in options"
+          :label="item.label"
+          :key="item.value"
+          :value="item.value"
+        >
+        </el-option>
+      </el-select>
+    `,
+      () => ({
+        labelFormat(option: any) {
+          return `${option.currentLabel}123`
+        },
+        options: [
+          {
+            value: '选项1',
+            label: '黄金糕'
+          },
+          {
+            value: '选项2',
+            label: '双皮奶'
+          }
+        ],
+        value: '选项2'
+      })
+    )
+    await nextTick()
+
+    expect(findInnerInput().value).toEqual('双皮奶123')
+  })
+
+  test('value-display multiple format diaplay label', async () => {
+    wrapper = _mount(
+      `
+      <el-select v-model="value" multiple :value-display="labelFormat">
+        <el-option
+          v-for="item in options"
+          :label="item.label"
+          :key="item.value"
+          :value="item.value"
+        >
+        </el-option>
+      </el-select>
+    `,
+      () => ({
+        labelFormat(option: any) {
+          return `${option.currentLabel}123`
+        },
+        options: [
+          {
+            value: '选项1',
+            label: '黄金糕'
+          },
+          {
+            value: '选项2',
+            label: '双皮奶'
+          }
+        ],
+        value: ['选项2']
+      })
+    )
+    await nextTick()
+    const tags = wrapper.findAll('.el-select__tags-text')
+    expect(tags[0].element.textContent).toEqual('双皮奶123')
+  })
 })

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -345,6 +345,7 @@ export default defineComponent({
     noDataText: String,
     remoteMethod: Function,
     filterMethod: Function,
+    valueDisplay: Function,
     multiple: Boolean,
     multipleLimit: {
       type: Number,

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -474,8 +474,8 @@ export default defineComponent({
       optionsCount,
       prefixWidth,
       tagInMultiLine,
+      treeSelection,
     } = toRefs(states)
-
     const wrapperKls = computed(() => {
       const classList = [nsSelect.b()]
       const _selectSize = unref(selectSize)
@@ -592,6 +592,7 @@ export default defineComponent({
       isOnComposition,
       isSilentBlur,
       options,
+      treeSelection,
       resetInputHeight,
       managePlaceholder,
       showClose,

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -345,7 +345,7 @@ export default defineComponent({
     noDataText: String,
     remoteMethod: Function,
     filterMethod: Function,
-    valueDisplay: Function,
+    formatSelectionLabel: Function,
     multiple: Boolean,
     multipleLimit: {
       type: Number,

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -57,7 +57,7 @@ export function useSelectStates(props) {
     isSilentBlur: false,
     prefixWidth: 11,
     tagInMultiLine: false,
-    // tree-select value-display
+    // tree-select format-selection-label
     data: null as any,
     node: null as any,
   })
@@ -446,8 +446,8 @@ export const useSelect = (props, states: States, ctx) => {
       } else {
         states.createdSelected = false
       }
-      states.selectedLabel = isFunction(props.valueDisplay)
-        ? props.valueDisplay(option)
+      states.selectedLabel = isFunction(props.formatSelectionLabel)
+        ? props.formatSelectionLabel(option)
         : option.currentLabel
       states.selected = option
       if (props.filterable) states.query = states.selectedLabel
@@ -459,8 +459,8 @@ export const useSelect = (props, states: States, ctx) => {
     if (Array.isArray(props.modelValue)) {
       props.modelValue.forEach((value) => {
         const option = getOption(value)
-        if (isFunction(props.valueDisplay)) {
-          option.currentLabel = props.valueDisplay(option)
+        if (isFunction(props.formatSelectionLabel)) {
+          option.currentLabel = props.formatSelectionLabel(option)
         }
         result.push(option)
       })

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -58,8 +58,9 @@ export function useSelectStates(props) {
     prefixWidth: 11,
     tagInMultiLine: false,
     // tree-select format-selection-label
-    data: null as any,
     node: null as any,
+    // tree-select
+    treeSelection: new Map(),
   })
 }
 
@@ -476,6 +477,7 @@ export const useSelect = (props, states: States, ctx) => {
     const isObjectValue = toRawType(value).toLowerCase() === 'object'
     const isNull = toRawType(value).toLowerCase() === 'null'
     const isUndefined = toRawType(value).toLowerCase() === 'undefined'
+    const isFormatLabel = isFunction(props.formatSelectionLabel)
 
     for (let i = states.cachedOptions.size - 1; i >= 0; i--) {
       const cachedOption = cachedOptionsArray.value[i]
@@ -488,9 +490,8 @@ export const useSelect = (props, states: States, ctx) => {
           currentLabel: cachedOption.currentLabel,
           isDisabled: cachedOption.isDisabled,
         }
-        if (cachedOption.node) {
-          option.data = cachedOption.data
-          option.node = cachedOption.node
+        if (isFormatLabel) {
+          option.node = states.treeSelection.get(value)
         }
         break
       }
@@ -505,9 +506,8 @@ export const useSelect = (props, states: States, ctx) => {
       value,
       currentLabel: label,
     }
-    if (newOption.node) {
-      newOption.data = states.data
-      newOption.node = states.node
+    if (isFormatLabel) {
+      newOption.node = states.treeSelection.get(value)
     }
     if (props.multiple) {
       ;(newOption as any).hitState = false

--- a/packages/components/tree-select/__tests__/tree-select.test.ts
+++ b/packages/components/tree-select/__tests__/tree-select.test.ts
@@ -311,4 +311,69 @@ describe('TreeSelect.vue', () => {
     await nextTick()
     expect(onNodeClick).toBeCalled()
   })
+
+  test('format selection label', async () => {
+    const { select, tree } = createComponent({
+      props: {
+        defaultExpandAll: true,
+        formatSelectionLabel: (option: any) => {
+          return `${option.currentLabel}123`
+        },
+      },
+    })
+    await nextTick()
+    await tree
+      .findAll('.el-select-dropdown__item')
+      .slice(-1)[0]
+      .trigger('click')
+    await nextTick()
+    expect(select.vm.modelValue).toEqual(111)
+    expect(select.find('input').element.value).toEqual(`三级 1-1123`)
+  })
+
+  test('format selection label show-checkbox', async () => {
+    const value = ref([])
+    const { select, tree } = createComponent({
+      props: {
+        modelValue: value,
+        checkStrictly: true,
+        showCheckbox: true,
+        multiple: true,
+        formatSelectionLabel: (option: any) => {
+          return `${option.currentLabel}123`
+        },
+      },
+    })
+    await nextTick()
+    await tree.findAll('.el-checkbox')[1].trigger('click')
+    await nextTick()
+    console.log(select.vm.modelValue)
+    expect(select.vm.modelValue).toEqual([11])
+    expect(select.findAll('.el-select__tags-text')[0].text()).toEqual(
+      `二级 1-1123`
+    )
+  })
+
+  test('format selection label multiple', async () => {
+    const { select, tree } = createComponent({
+      props: {
+        defaultExpandAll: true,
+        multiple: true,
+        formatSelectionLabel: (option: any) => {
+          return `${option.currentLabel}123`
+        },
+      },
+    })
+    await nextTick()
+    await tree
+      .findAll('.el-select-dropdown__item')
+      .slice(-1)[0]
+      .trigger('click')
+    await nextTick()
+    expect(select.vm.modelValue).toEqual([111])
+    expect(select.findAll('.el-select__tags-text')[0].text()).toEqual(
+      `三级 1-1123`
+    )
+  })
+
 })

--- a/packages/components/tree-select/src/tree.ts
+++ b/packages/components/tree-select/src/tree.ts
@@ -1,4 +1,4 @@
-import { computed, nextTick, toRefs, watch } from 'vue'
+import { computed, nextTick, toRaw, toRefs, watch } from 'vue'
 import { isEqual, pick } from 'lodash-unified'
 import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { isFunction } from '@element-plus/utils'
@@ -118,6 +118,10 @@ export const useTree = (
           const option = select.value?.options.get(
             getNodeValByProp('value', data)
           )
+          if (isFunction(select.value?.valueDisplay)) {
+            option.data = toRaw(data)
+            option.node = toRaw(node)
+          }
           select.value?.handleOptionSelect(option, true)
         }
       } else {

--- a/packages/components/tree-select/src/tree.ts
+++ b/packages/components/tree-select/src/tree.ts
@@ -115,12 +115,10 @@ export const useTree = (
 
       if (props.checkStrictly || node.isLeaf) {
         if (!getNodeValByProp('disabled', data)) {
-          const option = select.value?.options.get(
-            getNodeValByProp('value', data)
-          )
+          const value = getNodeValByProp('value', data)
+          const option = select.value?.options.get(value)
           if (isFunction(select.value?.formatSelectionLabel)) {
-            option.data = toRaw(data)
-            option.node = toRaw(node)
+            selectNode(select, value, node)
           }
           select.value?.handleOptionSelect(option, true)
         }
@@ -130,13 +128,17 @@ export const useTree = (
     },
     onCheck: (data, params) => {
       attrs.onCheck?.(data, params)
-
       // remove folder node when `checkStrictly` is false
       const checkedKeys = !props.checkStrictly
         ? tree.value?.getCheckedKeys(true)
         : params.checkedKeys
 
       const value = getNodeValByProp('value', data)
+
+      if (isFunction(select.value?.formatSelectionLabel)) {
+        selectNode(select, value, tree.value?.getNode(value))
+      }
+
       emit(
         UPDATE_MODEL_EVENT,
         props.multiple
@@ -147,6 +149,14 @@ export const useTree = (
       )
     },
   }
+}
+
+function selectNode(
+  select: Ref<InstanceType<typeof ElSelect> | undefined>,
+  value: any,
+  node: any
+) {
+  select.value?.treeSelection.set(value, node ? toRaw(node) : undefined)
 }
 
 function isValidValue(val: any) {

--- a/packages/components/tree-select/src/tree.ts
+++ b/packages/components/tree-select/src/tree.ts
@@ -118,7 +118,7 @@ export const useTree = (
           const option = select.value?.options.get(
             getNodeValByProp('value', data)
           )
-          if (isFunction(select.value?.valueDisplay)) {
+          if (isFunction(select.value?.formatSelectionLabel)) {
             option.data = toRaw(data)
             option.node = toRaw(node)
           }


### PR DESCRIPTION
下面是列举了一些其他组件库的类似功能点。

- `tdesign`[valueDisplay](https://tdesign.tencent.com/vue-next/components/select?tab=api)
-  `Vue-Treeselect`[ value-label](https://vue-treeselect.js.org/)
-  `Ant Design Vue`[tagRender](https://www.antdv.com/components/select#API)

