### PR TITLE
fix(components): date picker range input__inner inherit height

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -165,11 +165,6 @@
   }
 
   @include e(wrapper) {
-    @include set-css-var-value(
-      'input-inner-height',
-      calc(getCssVar('input-height') - $border-width * 2)
-    );
-
     display: inline-flex;
     flex-grow: 1;
     align-items: center;
@@ -202,6 +197,17 @@
   }
 
   @include e(inner) {
+    // use map.get as default value for date picker range
+    @include set-css-var-value(
+      'input-inner-height',
+      calc(
+        var(
+            #{getCssVarName('input-height')},
+            #{map.get($input-height, 'default')}
+          ) - $border-width * 2
+      )
+    );
+
     width: 100%;
     flex-grow: 1;
     -webkit-appearance: none;
@@ -341,12 +347,19 @@
       font-size: map.get($input-font-size, $size);
 
       @include e(wrapper) {
+        padding: $border-width map.get($input-padding-horizontal, $size)-$border-width;
+      }
+
+      @include e(inner) {
         @include set-css-var-value(
           'input-inner-height',
-          calc(getCssVar('input-height', $size) - $border-width * 2)
+          calc(
+            var(
+                #{getCssVarName('input-height', $size)},
+                #{map.get($input-height, $size)}
+              ) - $border-width * 2
+          )
         );
-
-        padding: $border-width map.get($input-padding-horizontal, $size)-$border-width;
       }
     }
   }


### PR DESCRIPTION
- date picker range only use `input__inner`, can not inherit css var from input, so i add a alternative value for it

<img width="514" alt="image" src="https://user-images.githubusercontent.com/25154432/167381919-a9a4e433-b2ec-4fc1-82f8-6066430f27fa.png">

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
