### PR TITLE
fix(components): form select size change with inline style

### DIFF
--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -263,6 +263,7 @@
 import {
   computed,
   defineComponent,
+  inject,
   nextTick,
   onBeforeUnmount,
   onMounted,
@@ -283,10 +284,12 @@ import ElIcon from '@element-plus/components/icon'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import {
   addResizeListener,
+  getComponentSize,
   isValidComponentSize,
   removeResizeListener,
 } from '@element-plus/utils'
 import { ArrowUp, CircleClose } from '@element-plus/icons-vue'
+import { formContextKey } from '@element-plus/tokens'
 import ElOption from './option.vue'
 import ElSelectMenu from './select-dropdown.vue'
 import { useSelect, useSelectStates } from './useSelect'
@@ -295,6 +298,7 @@ import { selectKey } from './token'
 import type { Component, PropType } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
 import type { SelectContext } from './token'
+import type { FormContext } from '@element-plus/tokens'
 
 const COMPONENT_NAME = 'ElSelect'
 export default defineComponent({
@@ -513,6 +517,8 @@ export default defineComponent({
       }) as unknown as SelectContext
     )
 
+    const elForm = inject(formContextKey, {} as FormContext)
+
     onMounted(() => {
       states.cachedPlaceHolder = currentPlaceholder.value =
         props.placeholder || t('el.select.placeholder')
@@ -526,7 +532,13 @@ export default defineComponent({
       addResizeListener(selectWrapper.value as any, handleResize)
       if (reference.value && reference.value.$el) {
         const input = reference.value.input as HTMLInputElement
-        states.initialInputHeight = input.getBoundingClientRect().height
+        // +2 for border
+        if (
+          input.getBoundingClientRect().height + 2 !==
+          getComponentSize(selectSize.value || elForm.size)
+        ) {
+          states.initialInputHeight = input.getBoundingClientRect().height
+        }
       }
       if (props.remote && props.multiple) {
         resetInputHeight()

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -351,7 +351,9 @@ export const useSelect = (props, states: States, ctx) => {
               sizeInMap
             )}px`
 
-      states.tagInMultiLine = Number.parseFloat(input.style.height) >= sizeInMap
+      // +2 for border
+      states.tagInMultiLine =
+        Number.parseFloat(input.style.height) + 2 >= sizeInMap
 
       if (states.visible && emptyText.value !== false) {
         tooltipRef.value?.updatePopper?.()


### PR DESCRIPTION
- not add `initialInputHeight` when size same as componentSize to avoid inline style override

https://github.com/chenxch/element-plus/blob/d26f995291964175295141d376462cb708d81d60/packages/components/select/src/useSelect.ts#L179

> https://github.com/element-plus/element-plus/pull/7471

When we watch these, select will always resetInputWidth.
This causes when we switch the form size, the size of the select is overwritten by the inline style.

The solution I thought of, when the size is the same as the default size, don't add the initialInputHeight.

@chenxch Can you have a look?

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
