### PR TITLE
fix(theme-chalk): datepicker range default height by map.get

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -200,7 +200,12 @@
     // use map.get as default value for date picker range
     @include set-css-var-value(
       'input-inner-height',
-      calc(var(#{getCssVarName('input-height')}) - $border-width * 2)
+      calc(
+        var(
+            #{getCssVarName('input-height')},
+            #{map.get($input-height, 'default')}
+          ) - $border-width * 2
+      )
     );
 
     width: 100%;
@@ -348,7 +353,12 @@
       @include e(inner) {
         @include set-css-var-value(
           'input-inner-height',
-          calc(var(#{getCssVarName('input-height')}) - $border-width * 2)
+          calc(
+            var(
+                #{getCssVarName('input-height')},
+                #{map.get($input-height, $size)}
+              ) - $border-width * 2
+          )
         );
       }
     }


### PR DESCRIPTION
- use `map.get` as datepicker range default height (inner can not inherit css var, not have parent container `el-input`)

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
