### PR TITLE
fix(component):[el-cascader] fix when the search value is selected blur clean placeholder disappear

### DIFF
--- a/packages/components/cascader/src/index.vue
+++ b/packages/components/cascader/src/index.vue
@@ -40,7 +40,7 @@
         <el-input
           ref="input"
           v-model="inputValue"
-          :placeholder="inputPlaceholder"
+          :placeholder="searchInputValue ? '' : inputPlaceholder"
           :readonly="readonly"
           :disabled="isDisabled"
           :validate-event="false"

--- a/packages/components/cascader/src/index.vue
+++ b/packages/components/cascader/src/index.vue
@@ -411,7 +411,7 @@ export default defineComponent({
       const nodes = checkedNodes.value
       return nodes.length
         ? multiple.value
-          ? ' '
+          ? ''
           : nodes[0].calcText(showAllLevels, separator)
         : ''
     })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

问题可在element-plus官网中可复现
复现步骤
- Cascader多选进行搜索并且选中值
- 选中值后点击组件外区域 使组件失去焦点
- 失去焦点后再去删除 组件中选中项
结果：输入框中存在空格空项
预期：输入框为空并显示 placeholder

复现问题视频⬇️

https://user-images.githubusercontent.com/62927479/167594157-2c8eeeb6-8bcc-4a03-8c8f-aca54832556c.mov

