### PR TITLE
fix(ci): token limitation for commit lint

### DIFF
--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions-awesome/pr-helper@1.1.0
         with:
           actions: 'maintain-comment, add-labels, remove-labels'
-          token: ${{ github.token }}
+          token: ${{ secrets.BOT_TOKEN }}
           labels-to-add: 'CommitMessage::Qualified'
           labels-to-remove: 'CommitMessage::Unqualified'
           body-filter: '<!-- ELEMENT_PLUS_COMMIT_LINT -->'
@@ -87,7 +87,7 @@ jobs:
           actions: 'remove-labels, add-labels, maintain-comment'
           labels-to-remove: 'CommitMessage::Qualified'
           labels-to-add: 'CommitMessage::Unqualified'
-          token: ${{ github.token }}
+          token: ${{ secrets.BOT_TOKEN }}
           comment-body: |
             Hello, @${{ github.event.pull_request.user.login }}, seems like your commit message contains some issues.
 


### PR DESCRIPTION
- Update gitlab.token to BOT_TOKEN for managing triage thing.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
