### PR TITLE
fix(theme-chalk): [DatetimePicker] change inner to wrapper & use css var

### DIFF
--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -968,7 +968,7 @@ describe('DateRangePicker', () => {
     inputs[0].trigger('focus')
     await nextTick()
 
-    const outterInput = wrapper.find('.el-range-editor.el-input__inner')
+    const outterInput = wrapper.find('.el-range-editor.el-input__wrapper')
     expect(outterInput.classes()).toContain(customClassName)
     expect(outterInput.attributes().style).toBeDefined()
     const panels = document.querySelectorAll('.el-date-range-picker__content')

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -73,7 +73,7 @@
         :class="[
           nsDate.b('editor'),
           nsDate.bm('editor', type),
-          nsInput.e('inner'),
+          nsInput.e('wrapper'),
           nsDate.is('disabled', pickerDisabled),
           nsDate.is('active', pickerVisible),
           nsRange.b('editor'),

--- a/packages/theme-chalk/src/date-picker/picker.scss
+++ b/packages/theme-chalk/src/date-picker/picker.scss
@@ -23,12 +23,7 @@
   display: inline-block;
   text-align: left;
 
-  &.#{$namespace}-input__inner {
-    border-radius: var(
-      #{getCssVarName('input-border-radius')},
-      #{getCssVar('border-radius-base')}
-    );
-
+  &.#{$namespace}-input__wrapper {
     @include inset-input-border(
       var(
         #{getCssVarName('input-border-color')},
@@ -42,33 +37,34 @@
   }
 
   &.#{$namespace}-input,
-  &.#{$namespace}-input__inner {
+  &.#{$namespace}-input__wrapper {
     width: getCssVar('date-editor-width');
+    height: getCssVar('component-size', '');
   }
 
   @include m((monthrange)) {
-    &.#{$namespace}-input,
-    &.#{$namespace}-input__inner {
-      width: getCssVar('date-editor-monthrange-width');
-    }
+    @include css-var-from-global(
+      'date-editor-width',
+      'date-editor-monthrange-width'
+    );
   }
 
   @include m((daterange, timerange)) {
-    &.#{$namespace}-input,
-    &.#{$namespace}-input__inner {
-      width: getCssVar('date-editor-daterange-width');
-    }
+    @include css-var-from-global(
+      'date-editor-width',
+      'date-editor-daterange-width'
+    );
   }
 
   @include m(datetimerange) {
-    &.#{$namespace}-input,
-    &.#{$namespace}-input__inner {
-      width: getCssVar('date-editor-datetimerange-width');
-    }
+    @include css-var-from-global(
+      'date-editor-width',
+      'date-editor-datetimerange-width'
+    );
   }
 
   @include m(dates) {
-    .#{$namespace}-input__inner {
+    .#{$namespace}-input__wrapper {
       text-overflow: ellipsis;
       white-space: nowrap;
     }
@@ -152,7 +148,7 @@
 }
 
 @include b(range-editor) {
-  &.#{$namespace}-input__inner {
+  &.#{$namespace}-input__wrapper {
     display: inline-flex;
     align-items: center;
     padding: 3px 10px;
@@ -171,10 +167,10 @@
 
   @each $size in (large, small) {
     @include m($size) {
-      line-height: map.get($input-height, $size);
+      line-height: getCssVar('component-size', $size);
 
-      &.#{$namespace}-input__inner {
-        height: map.get($input-height, $size);
+      &.#{$namespace}-input__wrapper {
+        height: getCssVar('component-size', $size);
       }
 
       .#{$namespace}-range-separator {


### PR DESCRIPTION
- change datetime picker range`inner` to `wrapper` related to:
  - https://github.com/element-plus/element-plus/pull/7179
  - https://github.com/element-plus/element-plus/pull/7608
- use css var for `datetimerange` `monthrange` `timerange` `daterange`
- fix 30px height to 32px

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
