### PR TITLE
refactor(components): [main] switch to script-setup syntax

### DIFF
--- a/packages/components/container/index.ts
+++ b/packages/components/container/index.ts
@@ -19,4 +19,4 @@ export const ElFooter = withNoopInstall(Footer)
 export const ElHeader = withNoopInstall(Header)
 export const ElMain = withNoopInstall(Main)
 
-export * from './src/main'
+export type MainInstance = InstanceType<typeof Main>

--- a/packages/components/container/index.ts
+++ b/packages/components/container/index.ts
@@ -18,3 +18,5 @@ export const ElAside = withNoopInstall(Aside)
 export const ElFooter = withNoopInstall(Footer)
 export const ElHeader = withNoopInstall(Header)
 export const ElMain = withNoopInstall(Main)
+
+export * from './src/main'

--- a/packages/components/container/src/main.ts
+++ b/packages/components/container/src/main.ts
@@ -1,0 +1,3 @@
+import type Main from './main.vue'
+
+export type MainInstance = InstanceType<typeof Main>

--- a/packages/components/container/src/main.ts
+++ b/packages/components/container/src/main.ts
@@ -1,3 +1,0 @@
-import type Main from './main.vue'
-
-export type MainInstance = InstanceType<typeof Main>

--- a/packages/components/container/src/main.vue
+++ b/packages/components/container/src/main.vue
@@ -3,18 +3,12 @@
     <slot />
   </main>
 </template>
-<script lang="ts">
-import { defineComponent } from 'vue'
+<script lang="ts" setup>
 import { useNamespace } from '@element-plus/hooks'
 
-export default defineComponent({
+defineOptions({
   name: 'ElMain',
-  setup() {
-    const ns = useNamespace('main')
-
-    return {
-      ns,
-    }
-  },
 })
+
+const ns = useNamespace('main')
 </script>

--- a/packages/theme-chalk/src/main.scss
+++ b/packages/theme-chalk/src/main.scss
@@ -5,7 +5,6 @@
 @include b(main) {
   @include set-component-css-var('main', $main);
 
-  // IE11 supports the <main> element partially https://caniuse.com/#search=main
   display: block;
   flex: 1;
   flex-basis: auto;


### PR DESCRIPTION
## Description

> Refactor/container-main

- [x] Switch to `script-setup` syntax
- [x] Support custom namespace config
- [x] export component instance type

## Question

- Is adding an instance syntax to this little component an exaggeration?
  ```ts
  import type Main from './main.vue'
  
  export type MainInstance = InstanceType<typeof Main>
  ```
  If so, I will delete this file.(`packages/components/container/src/main.ts`)
 
---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
