### PR TITLE
feat(components): [input-number] make it nullable

### DIFF
--- a/docs/en-US/component/input-number.md
+++ b/docs/en-US/component/input-number.md
@@ -81,21 +81,22 @@ input-number/controlled
 
 ## Attributes
 
-| Attribute             | Description                                      | Type               | Accepted Values | Default     |
-| --------------------- | ------------------------------------------------ | ------------------ | --------------- | ----------- |
-| model-value / v-model | binding value                                    | number / undefined | —               | —           |
-| min                   | the minimum allowed value                        | number             | —               | `-Infinity` |
-| max                   | the maximum allowed value                        | number             | —               | `Infinity`  |
-| step                  | incremental step                                 | number             | —               | 1           |
-| step-strictly         | whether input value can only be multiple of step | boolean            | —               | false       |
-| precision             | precision of input value                         | number             | —               | —           |
-| size                  | size of the component                            | string             | large/small     | default     |
-| disabled              | whether the component is disabled                | boolean            | —               | false       |
-| controls              | whether to enable the control buttons            | boolean            | —               | true        |
-| controls-position     | position of the control buttons                  | string             | right           | -           |
-| name                  | same as `name` in native input                   | string             | —               | —           |
-| label                 | label text                                       | string             | —               | —           |
-| placeholder           | placeholder in input                             | string             | -               | -           |
+| Attribute             | Description                                      | Type                   | Accepted Values | Default     |
+| --------------------- | ------------------------------------------------ | ---------------------- | --------------- | ----------- |
+| model-value / v-model | binding value                                    | number / undefined     | —               | —           |
+| min                   | the minimum allowed value                        | number                 | —               | `-Infinity` |
+| max                   | the maximum allowed value                        | number                 | —               | `Infinity`  |
+| step                  | incremental step                                 | number                 | —               | 1           |
+| step-strictly         | whether input value can only be multiple of step | boolean                | —               | false       |
+| precision             | precision of input value                         | number                 | —               | —           |
+| size                  | size of the component                            | string                 | large/small     | default     |
+| disabled              | whether the component is disabled                | boolean                | —               | false       |
+| controls              | whether to enable the control buttons            | boolean                | —               | true        |
+| controls-position     | position of the control buttons                  | string                 | right           | -           |
+| name                  | same as `name` in native input                   | string                 | —               | —           |
+| label                 | label text                                       | string                 | —               | —           |
+| placeholder           | placeholder in input                             | string                 | -               | -           |
+| value-on-clear        | value should be set when input box is cleared    | string / number / null | min/max         | -           |
 
 ## Events
 

--- a/packages/components/input-number/__tests__/input-number.test.ts
+++ b/packages/components/input-number/__tests__/input-number.test.ts
@@ -74,7 +74,7 @@ describe('InputNumber.vue', () => {
     await nextTick()
     expect(wrapper.find('input').element.value).toEqual('')
     expect(wrapper.find('input').element.getAttribute('aria-valuenow')).toEqual(
-      'NaN'
+      'null'
     )
   })
   test('min', async () => {
@@ -278,9 +278,41 @@ describe('InputNumber.vue', () => {
     expect(wrapper.getComponent(InputNumber).emitted('focus')).toHaveLength(1)
   })
 
-  test('clear', async () => {
+  test('clear with :value-on-clear="null"', async () => {
     const wrapper = _mount({
-      template: '<el-input-number v-model="num" :min="1"/>',
+      template: '<el-input-number v-model="num" :min="1" :max="10"/>',
+      setup() {
+        const num = ref(2)
+        return {
+          num,
+        }
+      },
+    })
+    const elInput = wrapper.findComponent({ name: 'ElInputNumber' }).vm
+    elInput.handleInputChange('')
+    await nextTick()
+    expect(wrapper.vm.num).toBe(null)
+    elInput.increase()
+    await nextTick()
+    expect(wrapper.vm.num).toBe(1)
+    elInput.increase()
+    await nextTick()
+    expect(wrapper.vm.num).toBe(2)
+    elInput.handleInputChange('')
+    await nextTick()
+    expect(wrapper.vm.num).toBe(null)
+    elInput.decrease()
+    await nextTick()
+    expect(wrapper.vm.num).toBe(1)
+    elInput.decrease()
+    await nextTick()
+    expect(wrapper.vm.num).toBe(1)
+  })
+
+  test('clear with value-on-clear="min"', async () => {
+    const wrapper = _mount({
+      template:
+        '<el-input-number v-model="num" value-on-clear="min" :min="1" :max="10"/>',
       setup() {
         const num = ref(2)
         return {
@@ -301,6 +333,58 @@ describe('InputNumber.vue', () => {
     elInput.decrease()
     await nextTick()
     expect(wrapper.vm.num).toBe(1)
+  })
+
+  test('clear with value-on-clear="max"', async () => {
+    const wrapper = _mount({
+      template:
+        '<el-input-number v-model="num" value-on-clear="max" :min="1" :max="10"/>',
+      setup() {
+        const num = ref(2)
+        return {
+          num,
+        }
+      },
+    })
+    const elInput = wrapper.findComponent({ name: 'ElInputNumber' }).vm
+    elInput.handleInputChange('')
+    await nextTick()
+    expect(wrapper.vm.num).toBe(10)
+    elInput.increase()
+    await nextTick()
+    expect(wrapper.vm.num).toBe(10)
+    elInput.handleInputChange('')
+    await nextTick()
+    expect(wrapper.vm.num).toBe(10)
+    elInput.decrease()
+    await nextTick()
+    expect(wrapper.vm.num).toBe(9)
+  })
+
+  test('clear with :value-on-clear="5"', async () => {
+    const wrapper = _mount({
+      template:
+        '<el-input-number v-model="num" :value-on-clear="5" :min="1" :max="10"/>',
+      setup() {
+        const num = ref(2)
+        return {
+          num,
+        }
+      },
+    })
+    const elInput = wrapper.findComponent({ name: 'ElInputNumber' }).vm
+    elInput.handleInputChange('')
+    await nextTick()
+    expect(wrapper.vm.num).toBe(5)
+    elInput.increase()
+    await nextTick()
+    expect(wrapper.vm.num).toBe(6)
+    elInput.handleInputChange('')
+    await nextTick()
+    expect(wrapper.vm.num).toBe(5)
+    elInput.decrease()
+    await nextTick()
+    expect(wrapper.vm.num).toBe(4)
   })
 
   test('check increase and decrease button when modelValue not in [min, max]', async () => {

--- a/packages/components/input-number/src/input-number.ts
+++ b/packages/components/input-number/src/input-number.ts
@@ -1,3 +1,4 @@
+import { isNil } from 'lodash-unified'
 import { buildProps, isNumber } from '@element-plus/utils'
 import { componentSizes } from '@element-plus/constants'
 
@@ -42,6 +43,12 @@ export const inputNumberProps = buildProps({
     default: '',
     values: ['', 'right'],
   },
+  valueOnClear: {
+    type: [String, Number, null],
+    validator: (val: 'min' | 'max' | number | null) =>
+      val === null || isNumber(val) || ['min', 'max'].includes(val),
+    default: null,
+  },
   name: String,
   label: String,
   placeholder: String,
@@ -56,7 +63,6 @@ export const inputNumberEmits = {
   change: (prev: number | undefined, cur: number | undefined) => prev !== cur,
   blur: (e: FocusEvent) => e instanceof FocusEvent,
   focus: (e: FocusEvent) => e instanceof FocusEvent,
-  input: (val: number | undefined) => isNumber(val),
-  'update:modelValue': (val: number | undefined) =>
-    isNumber(val) || val === undefined,
+  input: (val: number | null | undefined) => isNumber(val) || isNil(val),
+  'update:modelValue': (val: number | undefined) => isNumber(val) || isNil(val),
 }

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -68,6 +68,7 @@ import {
   ref,
   watch,
 } from 'vue'
+import { isNil } from 'lodash-unified'
 
 import { ElIcon } from '@element-plus/components/icon'
 import { RepeatClick } from '@element-plus/directives'
@@ -79,14 +80,14 @@ import {
   useSize,
 } from '@element-plus/hooks'
 import ElInput from '@element-plus/components/input'
-import { debugWarn, isNumber, isUndefined } from '@element-plus/utils'
+import { debugWarn, isNumber, isString, isUndefined } from '@element-plus/utils'
 import { ArrowDown, ArrowUp, Minus, Plus } from '@element-plus/icons-vue'
 import { inputNumberEmits, inputNumberProps } from './input-number'
 
 import type { ComponentPublicInstance } from 'vue'
 
 interface IData {
-  currentValue: number | undefined
+  currentValue: number | null | undefined
   userInput: null | number | string
 }
 
@@ -116,10 +117,14 @@ export default defineComponent({
     const ns = useNamespace('input-number')
 
     const minDisabled = computed(
-      () => ensurePrecision(props.modelValue, -1) < props.min
+      () =>
+        isNumber(props.modelValue) &&
+        ensurePrecision(props.modelValue, -1) < props.min
     )
     const maxDisabled = computed(
-      () => ensurePrecision(props.modelValue) > props.max
+      () =>
+        isNumber(props.modelValue) &&
+        ensurePrecision(props.modelValue) > props.max
     )
 
     const numPrecision = computed(() => {
@@ -147,7 +152,8 @@ export default defineComponent({
       if (data.userInput !== null) {
         return data.userInput
       }
-      let currentValue: number | string | undefined = data.currentValue
+      let currentValue: number | string | undefined | null = data.currentValue
+      if (isNil(currentValue)) return ''
       if (isNumber(currentValue)) {
         if (Number.isNaN(currentValue)) return ''
         if (!isUndefined(props.precision)) {
@@ -166,8 +172,8 @@ export default defineComponent({
       }
       return Number.parseFloat(`${Math.round(num * 10 ** pre) / 10 ** pre}`)
     }
-    const getPrecision = (value: number | undefined) => {
-      if (isUndefined(value)) return 0
+    const getPrecision = (value: number | null | undefined) => {
+      if (isNil(value)) return 0
       const valueString = value.toString()
       const dotPosition = valueString.indexOf('.')
       let precision = 0
@@ -179,7 +185,6 @@ export default defineComponent({
     const ensurePrecision = (val: number, coefficient: 1 | -1 = 1) => {
       if (!isNumber(val)) return data.currentValue
       // Solve the accuracy problem of JS decimal calculation by converting the value to integer.
-      val = isNumber(val) ? val : Number.NaN
       return toPrecision(val + props.step * coefficient)
     }
     const increase = () => {
@@ -195,35 +200,38 @@ export default defineComponent({
       setCurrentValue(newVal)
     }
     const verifyValue = (
-      value: number | string | undefined,
+      value: number | string | null | undefined,
       update?: boolean
-    ): number | undefined => {
-      const { max, min, step, precision, stepStrictly } = props
+    ): number | null | undefined => {
+      const { max, min, step, precision, stepStrictly, valueOnClear } = props
       let newVal = Number(value)
-      if (value === null) {
-        newVal = Number.NaN
+      if (isNil(value) || Number.isNaN(newVal)) {
+        return null
       }
-      if (!Number.isNaN(newVal)) {
-        if (stepStrictly) {
-          newVal = Math.round(newVal / step) * step
+      if (value === '') {
+        if (valueOnClear === null) {
+          return null
         }
-        if (!isUndefined(precision)) {
-          newVal = toPrecision(newVal, precision)
-        }
-        if (newVal > max || newVal < min) {
-          newVal = newVal > max ? max : min
-          update && emit('update:modelValue', newVal)
-        }
+        newVal = isString(valueOnClear)
+          ? { min, max }[valueOnClear]
+          : valueOnClear
+      }
+      if (stepStrictly) {
+        newVal = Math.round(newVal / step) * step
+      }
+      if (!isUndefined(precision)) {
+        newVal = toPrecision(newVal, precision)
+      }
+      if (newVal > max || newVal < min) {
+        newVal = newVal > max ? max : min
+        update && emit('update:modelValue', newVal)
       }
       return newVal
     }
-    const setCurrentValue = (value: number | string | undefined) => {
+    const setCurrentValue = (value: number | string | null | undefined) => {
       const oldVal = data.currentValue
-      let newVal = verifyValue(value)
+      const newVal = verifyValue(value)
       if (oldVal === newVal) return
-      if (Number.isNaN(newVal)) {
-        newVal = undefined
-      }
       data.userInput = null
       emit('update:modelValue', newVal)
       emit('input', newVal)
@@ -262,22 +270,22 @@ export default defineComponent({
     watch(
       () => props.modelValue,
       (value) => {
-        const newVal = verifyValue(value, true)
-        data.currentValue = newVal
+        data.currentValue = verifyValue(value, true)
         data.userInput = null
       },
       { immediate: true }
     )
     onMounted(() => {
+      const { min, max, modelValue } = props
       const innerInput = input.value?.input as HTMLInputElement
       innerInput.setAttribute('role', 'spinbutton')
-      if (Number.isFinite(props.max)) {
-        innerInput.setAttribute('aria-valuemax', String(props.max))
+      if (Number.isFinite(max)) {
+        innerInput.setAttribute('aria-valuemax', String(max))
       } else {
         innerInput.removeAttribute('aria-valuemax')
       }
-      if (Number.isFinite(props.min)) {
-        innerInput.setAttribute('aria-valuemin', String(props.min))
+      if (Number.isFinite(min)) {
+        innerInput.setAttribute('aria-valuemin', String(min))
       } else {
         innerInput.removeAttribute('aria-valuemin')
       }
@@ -286,10 +294,10 @@ export default defineComponent({
         'aria-disabled',
         String(inputNumberDisabled.value)
       )
-      if (!isNumber(props.modelValue)) {
-        let val: number | undefined = Number(props.modelValue)
+      if (!isNumber(modelValue) && modelValue != null) {
+        let val: number | null = Number(modelValue)
         if (Number.isNaN(val)) {
-          val = undefined
+          val = null
         }
         emit('update:modelValue', val)
       }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Fixes https://github.com/element-plus/element-plus/issues/7590

这个功能在我做的项目里非常重要，因为在很多情况下我们的业务需求是某个字段为null时表示使用后端配置的默认值。现在的情况是一旦用户在输入框中输入了某个值就无法再改回来了

This feature is very important to my project, because a field equals to null means that it should use the default value set by backend in many situations. Now once users input some number they can't revert it back.

另外就算字段在业务中不能为null也不应该在用户删除文本后自动填充最小值，因为这个删除操作有可能是个意外操作，最小值很可能并非用户想要的数据。非空的判断应该交给表单验证而非由输入组件保证

In addition, even some fields should not be null, it should not fill the minimum value because the clear action can be an accident. In most situation the minimum value is not what users want. The non-null requirement should be ensure by form validation instead.

* What's changed:

When user clears the input box, try updating model-value to null

