### PR TITLE
fix(components): [popper-content] don't provide formItemContext when unnecessary

### DIFF
--- a/packages/components/popper/src/content.vue
+++ b/packages/components/popper/src/content.vue
@@ -16,6 +16,7 @@
 
 <script lang="ts" setup>
 import { computed, inject, onMounted, provide, ref, unref, watch } from 'vue'
+import { NOOP } from '@vue/shared'
 import { createPopper } from '@popperjs/core'
 import { useNamespace, useZIndex } from '@element-plus/hooks'
 import {
@@ -50,12 +51,18 @@ provide(POPPER_CONTENT_INJECTION_KEY, {
   arrowRef,
   arrowOffset,
 })
-// disallow auto-id from inside popper content
-provide(formItemContextKey, {
-  ...formItemContext,
-  addInputId: () => undefined,
-  removeInputId: () => undefined,
-})
+
+if (
+  formItemContext &&
+  (formItemContext.addInputId || formItemContext.removeInputId)
+) {
+  // disallow auto-id from inside popper content
+  provide(formItemContextKey, {
+    ...formItemContext,
+    addInputId: NOOP,
+    removeInputId: NOOP,
+  })
+}
 
 const contentZIndex = ref(props.zIndex || nextZIndex())
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

`el-popper-content` will constantly provide `formItemContext` with two noop functions, even not inside a `el-form-item`, which is problematic on other places which only test  `formItemContext` is null or undefined.

For example:

https://github.com/element-plus/element-plus/blob/dev/packages/components/radio/src/radio-group.vue#L65

Fixes https://github.com/element-plus/element-plus/pull/7450

<img width="701" alt="image" src="https://user-images.githubusercontent.com/6134068/169268122-711efb58-6a0c-45aa-b5ea-6b0a649cf09c.png">

@opengraphica @JeremyWuuuuu 