### PR TITLE
fix(components): [form] label-position props default value

### DIFF
--- a/packages/components/form/__tests__/form.test.tsx
+++ b/packages/components/form/__tests__/form.test.tsx
@@ -210,6 +210,14 @@ describe('Form', () => {
                 <Input v-model={form.address} />
               </FormItem>
             </Form>
+            <Form model={form} ref="labelRight">
+              <FormItem>
+                <Input v-model={form.name} />
+              </FormItem>
+              <FormItem>
+                <Input v-model={form.address} />
+              </FormItem>
+            </Form>
           </div>
         )
       },
@@ -219,6 +227,9 @@ describe('Form', () => {
     )
     expect(wrapper.findComponent({ ref: 'labelLeft' }).classes()).toContain(
       'el-form--label-left'
+    )
+    expect(wrapper.findComponent({ ref: 'labelRight' }).classes()).toContain(
+      'el-form--label-right'
     )
   })
 

--- a/packages/components/form/src/form.ts
+++ b/packages/components/form/src/form.ts
@@ -16,7 +16,11 @@ export const formProps = buildProps({
   rules: {
     type: definePropType<FormRules>(Object),
   },
-  labelPosition: String,
+  labelPosition: {
+    type: String,
+    values: ['left', 'right', 'top'] as const,
+    default: 'right',
+  },
   labelWidth: {
     type: [String, Number],
     default: '',


### PR DESCRIPTION
## Description

![label-position-props-default](https://user-images.githubusercontent.com/27342882/169675924-a6221073-4b31-4e52-aab7-06b31a0291d0.png)

This may feel useless as it only adds styles with no attributes. But I think the user can do custom based on the class being added.

Default values ​​for props exist in the documentation, but not in code.

## What is Expected?

The default value of props is 'right'.

## What is actually happening?

There is no default.

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
