### PR TITLE
fix(components): [table] the scrollbar not change when table width change

### DIFF
--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -46,7 +46,7 @@ function useStyle<T>(
   })
   const isGroup = ref(false)
   const scrollbarViewStyle = {
-    display: 'inline-block',
+    display: 'block',
     verticalAlign: 'middle',
   }
   const tableWidth = ref()


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

When used `inline-block`, the `el-scrollbar__view` width same with `el-table__body`. So the `ResizeObserver` inside the Scrollbar component cannot be triggered when table width change.

close #7898