### PR TITLE
fix(components): [popper]  Omit 'Select' focus

### DIFF
--- a/packages/components/popper/src/content.vue
+++ b/packages/components/popper/src/content.vue
@@ -139,7 +139,10 @@ const onFocusAfterReleased = () => {
 
 const onFocusInTrap = (event: FocusEvent) => {
   if (props.visible && !trapped.value) {
-    if (event.relatedTarget) {
+    if (
+      event.relatedTarget &&
+      (event.relatedTarget as HTMLElement).tagName !== 'INPUT'
+    ) {
       ;(event.relatedTarget as HTMLElement)?.focus()
     }
     if (event.target) {


### PR DESCRIPTION
The Select `relatedtarget` is `INPUT` and can be excluded from the focus of the Popper without affecting the original Popper.
https://github.com/element-plus/element-plus/issues/7862

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
