### PR TITLE
feat(components): [image] support native lazy loading

### DIFF
--- a/breakings/2.2.3/image.yml
+++ b/breakings/2.2.3/image.yml
@@ -1,0 +1,12 @@
+- scope: 'component'
+  name: 'el-image'
+  type: 'props'
+  version: '2.2.3'
+  commit_hash: '7a48556'
+  description: |
+    Per [HTMLImageElement.loading Request](https://github.com/element-plus/element-plus/issues/7841),
+    Add [native loading](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading) support for Image components.
+  props:
+    - api: 'loading'
+      before: ''
+      after: '"eager" | "lazy"'

--- a/docs/en-US/component/image.md
+++ b/docs/en-US/component/image.md
@@ -33,6 +33,14 @@ image/load-failed
 
 ## Lazy Load
 
+:::tip
+
+Native `loading` has been supported since <VersionTag version="2.2.3" />, you can use `loading = "lazy"` to replace `lazy = true`.
+
+If the current browser supports native lazy loading, the native lazy loading will be used first, otherwise will be implemented through scroll.
+
+:::
+
 :::demo Use lazy load by `lazy = true`. Image will load until scroll into view when set. You can indicate scroll container that adds scroll listener to by `scroll-container`. If undefined, will be the nearest parent container whose overflow property is auto or scroll.
 
 image/lazy-load
@@ -51,20 +59,21 @@ image/image-preview
 
 ### Image Attributes
 
-| Name                    | Description                                                                                                                                       | Type                                                        | Default                                                                 |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `src`                   | image source, same as native.                                                                                                                     | `string`                                                    | —                                                                       |
-| `fit`                   | indicate how the image should be resized to fit its container, same as [object-fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit). | `'fill' \| 'contain' \| 'cover' \| 'none' \| 'scale'-down'` | —                                                                       |
-| `hide-on-click-modal`   | when enabling preview, use this flag to control whether clicking on backdrop can exit preview mode.                                               | `boolean`                                                   | `false`                                                                 |
-| `lazy`                  | whether to use lazy load.                                                                                                                         | `boolean`                                                   | `false`                                                                 |
-| `scroll-container`      | the container to add scroll listener when using lazy load.                                                                                        | `string \| HTMLElement`                                     | the nearest parent container whose overflow property is auto or scroll. |
-| `alt`                   | native attribute `alt`.                                                                                                                           | `string`                                                    | —                                                                       |
-| `referrer-policy`       | native attribute `referrerPolicy`.                                                                                                                | `string`                                                    | —                                                                       |
-| `preview-src-list`      | allow big image preview.                                                                                                                          | `string[]`                                                  | —                                                                       |
-| `z-index`               | set image preview z-index.                                                                                                                        | `number`                                                    | —                                                                       |
-| `initial-index`         | initial preview image index, less than the length of `url-list`.                                                                                  | `number`                                                    | `0`                                                                     |
-| `close-on-press-escape` | whether the image-viewer can be closed by pressing ESC                                                                                            | `boolean`                                                   | `true`                                                                  |
-| `preview-teleported`    | whether to append image-viewer to body. A nested parent element attribute transform should have this attribute set to `true`.                     | `boolean`                                                   | `false`                                                                 |
+| Attribute                                | Description                                                                                                                                       | Type                                                        | Default                                                                 |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `src`                                    | image source, same as native.                                                                                                                     | `string`                                                    | —                                                                       |
+| `fit`                                    | indicate how the image should be resized to fit its container, same as [object-fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit). | `'fill' \| 'contain' \| 'cover' \| 'none' \| 'scale'-down'` | —                                                                       |
+| `hide-on-click-modal`                    | when enabling preview, use this flag to control whether clicking on backdrop can exit preview mode.                                               | `boolean`                                                   | `false`                                                                 |
+| `loading` <VersionTag version="2.2.3" /> | Indicates how the browser should load the image, same as [native](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading)     | `'eager' \| 'lazy'`                                         | —                                                                       |
+| `lazy`                                   | whether to use lazy load.                                                                                                                         | `boolean`                                                   | `false`                                                                 |
+| `scroll-container`                       | the container to add scroll listener when using lazy load.                                                                                        | `string \| HTMLElement`                                     | the nearest parent container whose overflow property is auto or scroll. |
+| `alt`                                    | native attribute `alt`.                                                                                                                           | `string`                                                    | —                                                                       |
+| `referrer-policy`                        | native attribute `referrerPolicy`.                                                                                                                | `string`                                                    | —                                                                       |
+| `preview-src-list`                       | allow big image preview.                                                                                                                          | `string[]`                                                  | —                                                                       |
+| `z-index`                                | set image preview z-index.                                                                                                                        | `number`                                                    | —                                                                       |
+| `initial-index`                          | initial preview image index, less than the length of `url-list`.                                                                                  | `number`                                                    | `0`                                                                     |
+| `close-on-press-escape`                  | whether the image-viewer can be closed by pressing ESC                                                                                            | `boolean`                                                   | `true`                                                                  |
+| `preview-teleported`                     | whether to append image-viewer to body. A nested parent element attribute transform should have this attribute set to `true`.                     | `boolean`                                                   | `false`                                                                 |
 
 ### Image Events
 

--- a/packages/components/image/__tests__/image.test.tsx
+++ b/packages/components/image/__tests__/image.test.tsx
@@ -56,8 +56,8 @@ describe('Image.vue', () => {
     })
     await doubleWait()
     expect(wrapper.emitted('error')).toBeDefined()
-    expect(wrapper.find('.el-image__inner').exists()).toBe(false)
-    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.find('.el-image__inner').exists()).toBe(true)
+    expect(wrapper.find('img').exists()).toBe(true)
     expect(wrapper.find('.el-image__error').exists()).toBe(true)
   })
 

--- a/packages/components/image/__tests__/image.test.tsx
+++ b/packages/components/image/__tests__/image.test.tsx
@@ -115,6 +115,22 @@ describe('Image.vue', () => {
     ).not.toContain('display: none')
   })
 
+  test('native loading attributes', async () => {
+    const wrapper = mount(Image, {
+      props: {
+        src: IMAGE_FAIL,
+        loading: 'eager',
+      } as ElImageProps,
+    })
+
+    await doubleWait()
+    expect(wrapper.find('img').exists()).toBe(true)
+    expect(wrapper.find('img').attributes('loading')).toBe('eager')
+
+    await wrapper.setProps({ loading: undefined })
+    expect(wrapper.find('img').attributes('loading')).toBe(undefined)
+  })
+
   test('$attrs', async () => {
     const alt = 'this ia alt'
     const props: ElImageProps = {

--- a/packages/components/image/__tests__/image.test.tsx
+++ b/packages/components/image/__tests__/image.test.tsx
@@ -56,8 +56,8 @@ describe('Image.vue', () => {
     })
     await doubleWait()
     expect(wrapper.emitted('error')).toBeDefined()
-    expect(wrapper.find('.el-image__inner').exists()).toBe(true)
-    expect(wrapper.find('img').exists()).toBe(true)
+    expect(wrapper.find('.el-image__inner').exists()).toBe(false)
+    expect(wrapper.find('img').exists()).toBe(false)
     expect(wrapper.find('.el-image__error').exists()).toBe(true)
   })
 
@@ -118,7 +118,7 @@ describe('Image.vue', () => {
   test('native loading attributes', async () => {
     const wrapper = mount(Image, {
       props: {
-        src: IMAGE_FAIL,
+        src: IMAGE_SUCCESS,
         loading: 'eager',
       } as ElImageProps,
     })

--- a/packages/components/image/src/image.ts
+++ b/packages/components/image/src/image.ts
@@ -21,6 +21,10 @@ export const imageProps = buildProps({
     values: ['', 'contain', 'cover', 'fill', 'none', 'scale-down'],
     default: '',
   },
+  loading: {
+    type: String,
+    values: ['eager', 'lazy'],
+  },
   lazy: {
     type: Boolean,
     default: false,

--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="container" :class="[ns.b(), $attrs.class]" :style="containerStyle">
     <img
-      v-if="imageSrc"
+      v-if="imageSrc !== undefined && !hasLoadError"
       v-bind="attrs"
       :src="imageSrc"
       :loading="loading"
@@ -75,7 +75,7 @@ const ns = useNamespace('image')
 const rawAttrs = useRawAttrs()
 const attrs = useAttrs()
 
-const imageSrc = ref('')
+const imageSrc = ref<string | undefined>()
 const hasLoadError = ref(false)
 const isLoading = ref(true)
 const showViewer = ref(false)

--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -44,7 +44,6 @@ import {
   nextTick,
   onMounted,
   ref,
-  toRefs,
   useAttrs as useRawAttrs,
   watch,
 } from 'vue'
@@ -71,7 +70,6 @@ const emit = defineEmits(imageEmits)
 
 let prevOverflow = ''
 
-const { loading } = toRefs(props)
 const { t } = useLocale()
 const ns = useNamespace('image')
 const rawAttrs = useRawAttrs()
@@ -113,8 +111,8 @@ const imageIndex = computed(() => {
 })
 
 const isManual = computed(() => {
-  if (loading?.value === 'eager') return false
-  return (!supportLoading && loading?.value === 'lazy') || props.lazy
+  if (props.loading === 'eager') return false
+  return (!supportLoading && props.loading === 'lazy') || props.lazy
 })
 
 const loadImage = () => {

--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -82,9 +82,9 @@ const hasLoadError = ref(false)
 const isLoading = ref(true)
 const showViewer = ref(false)
 const container = ref<HTMLElement>()
-const supportLoading = ref(true)
-
 const _scrollContainer = ref<HTMLElement | Window>()
+
+const supportLoading = isClient && 'loading' in HTMLImageElement.prototype
 let stopScrollListener: (() => void) | undefined
 let stopWheelListener: (() => void) | undefined
 
@@ -114,7 +114,7 @@ const imageIndex = computed(() => {
 
 const isManual = computed(() => {
   if (loading?.value === 'eager') return false
-  return (!supportLoading.value && loading?.value === 'lazy') || props.lazy
+  return (!supportLoading && loading?.value === 'lazy') || props.lazy
 })
 
 const loadImage = () => {
@@ -231,8 +231,6 @@ watch(
 )
 
 onMounted(() => {
-  supportLoading.value = 'loading' in HTMLImageElement.prototype
-
   if (isManual.value) {
     addLazyLoadListener()
   } else {

--- a/packages/theme-chalk/src/image.scss
+++ b/packages/theme-chalk/src/image.scss
@@ -6,6 +6,12 @@
   height: 100%;
 }
 
+%position {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
 @include b(image) {
   position: relative;
   display: inline-block;
@@ -17,11 +23,13 @@
   }
 
   @include e(placeholder) {
+    @extend %position !optional;
     @extend %size !optional;
     background: getCssVar('fill-color', 'light');
   }
 
   @include e(error) {
+    @extend %position !optional;
     @extend %size !optional;
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Add [native lazy loading](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading) support for Image components. 

close #7841 

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

- `loading` has higher priority than `lazy`.
- If the current browser supports native lazy loading, the native lazy loading will be used first, otherwise will be implemented through scroll.