### PR TITLE
fix(hooks): [use-escape-keydown] fix memory leak (#8005)

### DIFF
--- a/packages/hooks/use-escape-keydown/index.ts
+++ b/packages/hooks/use-escape-keydown/index.ts
@@ -4,16 +4,16 @@ import { EVENT_CODE } from '@element-plus/constants'
 
 let registeredEscapeHandlers: ((e: KeyboardEvent) => void)[] = []
 
-export const useEscapeKeydown = (handler: (e: KeyboardEvent) => void) => {
-  const cachedHandler = (e: Event) => {
-    const event = e as KeyboardEvent
-    if (event.key === EVENT_CODE.esc) {
-      registeredEscapeHandlers.forEach((registeredHandler) =>
-        registeredHandler(event)
-      )
-    }
+const cachedHandler = (e: Event) => {
+  const event = e as KeyboardEvent
+  if (event.key === EVENT_CODE.esc) {
+    registeredEscapeHandlers.forEach((registeredHandler) =>
+      registeredHandler(event)
+    )
   }
+}
 
+export const useEscapeKeydown = (handler: (e: KeyboardEvent) => void) => {
   onMounted(() => {
     if (registeredEscapeHandlers.length === 0) {
       document.addEventListener('keydown', cachedHandler)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

原代码中监听事件和取消监听时使用的`cachedHandler`有可能不是同一个。
导致在`document`处的监听有可能没被正确取消，导致内存泄漏。
现把`cachedHandler`函数提到外面，变为单例，以修复该问题。

fix #8005 
