### PR TITLE
fix(components): [form] resetFields object error

### DIFF
--- a/packages/components/form/src/form-item.vue
+++ b/packages/components/form/src/form-item.vue
@@ -319,7 +319,7 @@ const resetField: FormItemContext['resetField'] = async () => {
     isResettingField = true
   }
 
-  computedValue.value = initialValue
+  computedValue.value = clone(initialValue)
 
   await nextTick()
   clearValidate()


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fix #8051
![image](https://user-images.githubusercontent.com/23251408/171693193-7df6700e-0463-459d-a503-5cc6a1b5d9ab.png)

The second reset fails because `prop` is an `Object`

https://github.com/element-plus/element-plus/blob/63cbc59e2a382339d0399aad91c221312ea61e6b/packages/components/form/src/form-item.vue#L322

Since they are `Objects`, they become the same `Object` after the first reset.