### PR TITLE
fix(theme-chalk): [message] border width & style css var

### DIFF
--- a/packages/theme-chalk/src/message.scss
+++ b/packages/theme-chalk/src/message.scss
@@ -12,8 +12,8 @@
   min-width: getCssVar('message', 'min-width');
   box-sizing: border-box;
   border-radius: getCssVar('border-radius-base');
-  border-width: getCssVar('border-width-base');
-  border-style: getCssVar('border-style-base');
+  border-width: getCssVar('border-width');
+  border-style: getCssVar('border-style');
   border-color: getCssVar('message', 'border-color');
   position: fixed;
   left: 50%;


### PR DESCRIPTION
- fix message border width & style

Before:

<img width="415" alt="image" src="https://user-images.githubusercontent.com/25154432/171854662-8dd6849b-676e-4305-98c6-abc481b8e7a8.png">

After:

<img width="440" alt="image" src="https://user-images.githubusercontent.com/25154432/171854614-e151bd49-46b7-4202-8949-01ec4b215a12.png">

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
