### PR TITLE
fix: the type extends error

### DIFF
--- a/packages/element-plus/make-installer.ts
+++ b/packages/element-plus/make-installer.ts
@@ -1,11 +1,11 @@
 import { provideGlobalConfig } from '@element-plus/hooks'
 import { version } from './version'
-import type { App, Plugin } from 'vue'
+import type { App, Plugin } from '@vue/runtime-core'
 import type { ConfigProviderContext } from '@element-plus/tokens'
 
 const INSTALLED_KEY = Symbol('INSTALLED_KEY')
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   interface App {
     [INSTALLED_KEY]?: boolean
   }


### PR DESCRIPTION
vue -> @vue/runtime-core

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

If we extends the App type directly from Vue, it will break the App type.

```ts
// other projects used element-plus
import type { App } from 'vue'

const app: App
// lost type from vue
```

