### PR TITLE
fix(utils) : [getScrollBarWidth] fix scrollbar calculation error

### DIFF
--- a/packages/utils/dom/scroll.ts
+++ b/packages/utils/dom/scroll.ts
@@ -43,7 +43,6 @@ export const getScrollBarWidth = (): number => {
   // Cannot access 'propKey' before initialization
   // need to be dynamic namespace
   outer.className = 'el-scrollbar__wrap'
-  outer.style.visibility = 'hidden'
   outer.style.width = '100px'
   outer.style.position = 'absolute'
   outer.style.top = '-9999px'


### PR DESCRIPTION
The scrollbar width is calculated incorrectly in the global custom scrollbar style and in the case of browsing with a mobile browser.
在全局自定义滚动条样式以及使用手机浏览器浏览的情况下，滚动条宽度计算错误

For more information, visit [codepen.io](https://codepen.io/hipi-the-selector/pen/MWQzWbQ) on your mobile browser

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
