### PR TITLE
fix: select inner input reduce 2px when selected length equal 0

### DIFF
--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -341,7 +341,7 @@ export const useSelect = (props, states: States, ctx) => {
       // it's an inner input so reduce it by 2px.
       input.style.height = `${
         states.selected.length === 0
-          ? sizeInMap
+          ? sizeInMap - 2
           : Math.max(
               _tags
                 ? _tags.clientHeight + (_tags.clientHeight > sizeInMap ? 6 : 0)


### PR DESCRIPTION
fix: select inner input reduce 2px when selected length equal 0

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
