### PR TITLE
fix(components): [date-picker] should work when selected different month of date directly

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/basic-date-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-date-table.vue
@@ -45,6 +45,7 @@
 <script lang="ts" setup>
 import { computed, nextTick, ref, unref, watch } from 'vue'
 import dayjs from 'dayjs'
+import { debounce } from 'lodash-unified'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { castArray } from '@element-plus/utils'
 import { basicDateTableProps } from '../props/basic-date-table'
@@ -371,7 +372,7 @@ const handleFocus = (event: Event) => {
   }
 }
 
-const handlePickDate = (event: Event, isKeyboardMovement = false) => {
+const handlePickDate = debounce((event: Event, isKeyboardMovement = false) => {
   const target = (event.target as HTMLElement).closest('td')
 
   if (!target || target.tagName !== 'TD') return
@@ -415,7 +416,7 @@ const handlePickDate = (event: Event, isKeyboardMovement = false) => {
       : castArray(props.parsedValue).concat([newDate])
     emit('pick', newValue)
   }
-}
+}, 200)
 
 const isWeekActive = (cell: DateCell) => {
   if (props.selectionMode !== 'week') return false


### PR DESCRIPTION
Close #8112 

Caused because the `handlePickDate` function triggered twice (from focus and click event), we may just use `debounce` to make the function trigger once that ensure it work normal.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
