### PR TITLE
feat(components): [radio-button] use without group

### DIFF
--- a/docs/en-US/component/radio.md
+++ b/docs/en-US/component/radio.md
@@ -57,14 +57,14 @@ radio/with-borders
 
 ## Radio Attributes
 
-| Name                  | Description                          | Type                      | Accepted Values        | Default |
-| --------------------- | ------------------------------------ | ------------------------- | ---------------------- | ------- |
-| model-value / v-model | binding value                        | string / number / boolean | —                      | —       |
-| label                 | the value of Radio                   | string / number / boolean | —                      | —       |
-| disabled              | whether Radio is disabled            | boolean                   | —                      | false   |
-| border                | whether to add a border around Radio | boolean                   | —                      | false   |
-| size                  | size of the Radio                    | string                    | large / default /small | —       |
-| name                  | native 'name' attribute              | string                    | —                      | —       |
+| Name                  | Description                          | Type                      | Accepted Values         | Default |
+| --------------------- | ------------------------------------ | ------------------------- | ----------------------- | ------- |
+| model-value / v-model | binding value                        | string / number / boolean | —                       | —       |
+| label                 | the value of Radio                   | string / number / boolean | —                       | —       |
+| disabled              | whether Radio is disabled            | boolean                   | —                       | false   |
+| border                | whether to add a border around Radio | boolean                   | —                       | false   |
+| size                  | size of the Radio                    | string                    | large / default / small | —       |
+| name                  | native 'name' attribute              | string                    | —                       | —       |
 
 ## Radio Events
 
@@ -80,14 +80,14 @@ radio/with-borders
 
 ## Radio-group Attributes
 
-| Name                  | Description                                       | Type                      | Accepted Values         | Default |
-| --------------------- | ------------------------------------------------- | ------------------------- | ----------------------- | ------- |
-| model-value / v-model | binding value                                     | string / number / boolean | —                       | —       |
-| size                  | the size of radio                                 | string                    | large / default / small | default |
-| disabled              | whether the nesting radios are disabled           | boolean                   | —                       | false   |
-| text-color            | font color when button is active                  | string                    | —                       | #ffffff |
-| fill                  | border and background color when button is active | string                    | —                       | #409EFF |
-| validate-event        | whether to trigger form validation                | boolean                   | -                       | true    |
+| Name                  | Description                                                                                                                 | Type                      | Accepted Values         | Default |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------- | ----------------------- | ------- |
+| model-value / v-model | binding value                                                                                                               | string / number / boolean | —                       | —       |
+| size                  | the size of radio                                                                                                           | string                    | large / default / small | default |
+| disabled              | whether the nesting radios are disabled                                                                                     | boolean                   | —                       | false   |
+| text-color            | font color when button is active ( deprecated, use `--el-radio-button-checked-text-color` instead )                         | string                    | —                       | —       |
+| fill                  | border and background color when button is active ( deprecated, use `--el-radio-button-checked-(bg,border)-color` instead ) | string                    | —                       | —       |
+| validate-event        | whether to trigger form validation                                                                                          | boolean                   | -                       | true    |
 
 ## Radio-group Events
 
@@ -103,11 +103,13 @@ radio/with-borders
 
 ## Radio-button Attributes
 
-| Name     | Description               | Type            | Accepted Values | Default |
-| -------- | ------------------------- | --------------- | --------------- | ------- |
-| label    | the value of radio        | string / number | —               | —       |
-| disabled | whether radio is disabled | boolean         | —               | false   |
-| name     | native 'name' attribute   | string          | —               | —       |
+| Name                      | Description               | Type                      | Accepted Values                   | Default |
+| ------------------------- | ------------------------- | ------------------------- | --------------------------------- | ------- |
+| `model-value` / `v-model` | binding value             | string / number / boolean | —                                 | —       |
+| label                     | the value of radio        | string / number           | —                                 | —       |
+| disabled                  | whether radio is disabled | boolean                   | —                                 | false   |
+| size                      | the size of radio         | string                    | `'large' \| 'default' \| 'small'` | —       |
+| name                      | native 'name' attribute   | string                    | —                                 | —       |
 
 ## Radio-button Slots
 

--- a/docs/examples/radio/button-style.vue
+++ b/docs/examples/radio/button-style.vue
@@ -23,6 +23,45 @@
       <el-radio-button label="Chicago" />
     </el-radio-group>
   </div>
+  <div style="margin-top: 20px; display: flex">
+    <el-radio-button v-model="radio4" label="New York" />
+    <el-radio-button
+      v-model="radio4"
+      style="margin-left: 10px"
+      label="Washington"
+    />
+    <el-radio-button
+      v-model="radio4"
+      style="margin-left: 10px"
+      label="Los Angeles"
+    />
+    <el-radio-button
+      v-model="radio4"
+      style="margin-left: 10px"
+      label="Chicago"
+    />
+  </div>
+  <div style="margin-top: 20px; display: flex">
+    <el-radio-button v-model="radio5" size="small" label="New York" />
+    <el-radio-button
+      v-model="radio5"
+      size="small"
+      style="margin-left: 10px"
+      label="Washington"
+    />
+    <el-radio-button
+      v-model="radio5"
+      size="small"
+      style="margin-left: 10px"
+      label="Los Angeles"
+    />
+    <el-radio-button
+      v-model="radio5"
+      size="small"
+      style="margin-left: 10px"
+      label="Chicago"
+    />
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -31,4 +70,6 @@ import { ref } from 'vue'
 const radio1 = ref('New York')
 const radio2 = ref('New York')
 const radio3 = ref('New York')
+const radio4 = ref('New York')
+const radio5 = ref('New York')
 </script>

--- a/packages/components/radio/__tests__/radio.test.tsx
+++ b/packages/components/radio/__tests__/radio.test.tsx
@@ -301,6 +301,29 @@ describe('Radio Button', () => {
     expect(wrapper.findAll('.el-radio-button--large').length).toBe(3)
   })
 
+  it('should work without radio-group', async () => {
+    const radio = ref(3)
+    const wrapper = mount(() => (
+      <>
+        <RadioButton v-model={radio.value} label={3} class="radio1">
+          3
+        </RadioButton>
+        <RadioButton v-model={radio.value} label={6} class="radio2">
+          6
+        </RadioButton>
+        <RadioButton v-model={radio.value} label={9} class="radio3">
+          9
+        </RadioButton>
+      </>
+    ))
+    expect(wrapper.findAll('.is-no-group').length).toBe(3)
+    expect(wrapper.find('.radio1').classes()).contains('is-active')
+    wrapper.find('.radio2').trigger('click')
+    await nextTick()
+    expect(wrapper.find('.radio2').classes()).contains('is-active')
+    expect(radio.value).toBe(6)
+  })
+
   describe('form item accessibility integration', () => {
     test('single radio group in form item', async () => {
       const wrapper = mount(() => (

--- a/packages/components/radio/src/radio-button.ts
+++ b/packages/components/radio/src/radio-button.ts
@@ -1,15 +1,14 @@
 import { buildProps } from '@element-plus/utils'
-import { radioPropsBase } from './radio'
+import { radioEmits, radioPropsBase } from './radio'
 import type { ExtractPropTypes } from 'vue'
 import type RadioButton from './radio-button.vue'
 
 export const radioButtonProps = buildProps({
   ...radioPropsBase,
-  name: {
-    type: String,
-    default: '',
-  },
 } as const)
 
+export const radioButtonEmits = radioEmits
+
 export type RadioButtonProps = ExtractPropTypes<typeof radioButtonProps>
+export type RadioButtonEmits = typeof radioButtonEmits
 export type RadioButtonInstance = InstanceType<typeof RadioButton>

--- a/packages/components/radio/src/radio-button.vue
+++ b/packages/components/radio/src/radio-button.vue
@@ -5,6 +5,7 @@
       ns.is('active', modelValue === label),
       ns.is('disabled', disabled),
       ns.is('focus', focus),
+      ns.is('no-group', !radioGroup),
       ns.bm('button', size),
     ]"
   >
@@ -18,6 +19,7 @@
       :disabled="disabled"
       @focus="focus = true"
       @blur="focus = false"
+      @change="handleChange"
     />
     <span
       :class="ns.be('button', 'inner')"
@@ -32,10 +34,10 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, nextTick } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { useRadio } from './use-radio'
-import { radioButtonProps } from './radio-button'
+import { radioButtonEmits, radioButtonProps } from './radio-button'
 import type { CSSProperties } from 'vue'
 
 defineOptions({
@@ -43,17 +45,30 @@ defineOptions({
 })
 
 const props = defineProps(radioButtonProps)
+const emit = defineEmits(radioButtonEmits)
 
 const ns = useNamespace('radio')
-const { radioRef, focus, size, disabled, modelValue, radioGroup } =
-  useRadio(props)
+const { radioRef, focus, size, disabled, modelValue, radioGroup } = useRadio(
+  props,
+  emit
+)
 
 const activeStyle = computed<CSSProperties>(() => {
+  if (!radioGroup) return {}
+
   return {
-    backgroundColor: radioGroup?.fill || '',
-    borderColor: radioGroup?.fill || '',
-    boxShadow: radioGroup?.fill ? `-1px 0 0 0 ${radioGroup.fill}` : '',
-    color: radioGroup?.textColor || '',
-  }
+    ...(radioGroup.fill
+      ? {
+          backgroundColor: radioGroup.fill,
+          borderColor: radioGroup.fill,
+          boxShadow: `-1px 0 0 0 ${radioGroup.fill}`,
+        }
+      : null),
+    ...(radioGroup.textColor ? { color: radioGroup.textColor } : null),
+  } as CSSProperties
 })
+
+function handleChange() {
+  nextTick(() => emit('change', modelValue.value))
+}
 </script>

--- a/packages/components/radio/src/radio.ts
+++ b/packages/components/radio/src/radio.ts
@@ -11,10 +11,6 @@ export const radioPropsBase = buildProps({
     type: [String, Number, Boolean],
     default: '',
   },
-})
-
-export const radioProps = buildProps({
-  ...radioPropsBase,
   modelValue: {
     type: [String, Number, Boolean],
     default: '',
@@ -23,6 +19,10 @@ export const radioProps = buildProps({
     type: String,
     default: '',
   },
+})
+
+export const radioProps = buildProps({
+  ...radioPropsBase,
   border: Boolean,
 } as const)
 

--- a/packages/components/radio/src/use-radio.ts
+++ b/packages/components/radio/src/use-radio.ts
@@ -7,18 +7,18 @@ import type { RadioEmits, RadioProps } from './radio'
 
 export const useRadio = (
   props: { label: RadioProps['label']; modelValue?: RadioProps['modelValue'] },
-  emit?: SetupContext<RadioEmits>['emit']
+  emit: SetupContext<RadioEmits>['emit']
 ) => {
   const radioRef = ref<HTMLInputElement>()
   const radioGroup = inject(radioGroupKey, undefined)
-  const isGroup = computed(() => !!radioGroup)
+  const isGroup = !!radioGroup // radioGroup isn't reactive so using it inside `computed` is meaningless
   const modelValue = computed<RadioProps['modelValue']>({
     get() {
-      return isGroup.value ? radioGroup!.modelValue : props.modelValue!
+      return isGroup ? radioGroup.modelValue : props.modelValue!
     },
     set(val) {
-      if (isGroup.value) {
-        radioGroup!.changeEvent(val)
+      if (isGroup) {
+        radioGroup.changeEvent(val)
       } else {
         emit && emit(UPDATE_MODEL_EVENT, val)
       }
@@ -30,7 +30,7 @@ export const useRadio = (
   const disabled = useDisabled(computed(() => radioGroup?.disabled))
   const focus = ref(false)
   const tabIndex = computed(() => {
-    return disabled.value || (isGroup.value && modelValue.value !== props.label)
+    return disabled.value || (isGroup && modelValue.value !== props.label)
       ? -1
       : 0
   })

--- a/packages/theme-chalk/src/radio-button.scss
+++ b/packages/theme-chalk/src/radio-button.scss
@@ -64,7 +64,8 @@
     }
   }
 
-  &:first-child {
+  &:first-child,
+  &.is-no-group {
     .#{$namespace}-radio-button__inner {
       border-left: getCssVar('border');
       border-radius: getCssVar('border-radius-base') 0 0
@@ -86,16 +87,16 @@
           map.get($radio-button, 'checked-text-color')
         );
         background-color: getCssVarWithDefault(
-          'radio-button-checked-bg-color',
+          ('radio-button', 'checked-bg-color'),
           map.get($radio-button, 'checked-bg-color')
         );
         border-color: getCssVarWithDefault(
-          'radio-button-checked-border-color',
+          ('radio-button', 'checked-border-color'),
           map.get($radio-button, 'checked-border-color')
         );
         box-shadow: -1px 0 0 0
           getCssVarWithDefault(
-            'radio-button-checked-border-color',
+            ('radio-button', 'checked-border-color'),
             map.get($radio-button, 'checked-border-color')
           );
       }
@@ -144,7 +145,8 @@
     }
   }
 
-  &:first-child:last-child {
+  &:first-child:last-child,
+  &.is-no-group {
     .#{$namespace}-radio-button__inner {
       border-radius: getCssVar('border-radius-base');
     }


### PR DESCRIPTION
1. make `el-radio-button` and `el-radio` almost identical ( same props and usable without group )
2. deprecate props `text-color` and `fill` on `el-radio-group` as they only affect `el-radio-button` but their name don't reflect their usage

Considerable improvements: Move CSS variables of `el-radio*` to `:root` so users can change their values on `el-radio-group` level

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
