### PR TITLE
refactor(components): [radio] remove accessibility logic

### DIFF
--- a/packages/components/radio/src/radio-group.vue
+++ b/packages/components/radio/src/radio-group.vue
@@ -12,16 +12,7 @@
 </template>
 
 <script lang="ts" setup>
-import {
-  computed,
-  nextTick,
-  onMounted,
-  provide,
-  reactive,
-  ref,
-  toRefs,
-  watch,
-} from 'vue'
+import { computed, nextTick, provide, reactive, ref, toRefs, watch } from 'vue'
 import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { radioGroupKey } from '@element-plus/tokens'
 import {
@@ -53,15 +44,6 @@ const changeEvent = (value: RadioGroupProps['modelValue']) => {
   emit(UPDATE_MODEL_EVENT, value)
   nextTick(() => emit('change', value))
 }
-
-onMounted(() => {
-  const radios =
-    radioGroupRef.value!.querySelectorAll<HTMLInputElement>('[type=radio]')
-  const firstLabel = radios[0]
-  if (!Array.from(radios).some((radio) => radio.checked) && firstLabel) {
-    firstLabel.tabIndex = 0
-  }
-})
 
 const name = computed(() => {
   return props.name || radioId.value

--- a/packages/components/radio/src/use-radio.ts
+++ b/packages/components/radio/src/use-radio.ts
@@ -29,11 +29,6 @@ export const useRadio = (
   const size = useSize(computed(() => radioGroup?.size))
   const disabled = useDisabled(computed(() => radioGroup?.disabled))
   const focus = ref(false)
-  const tabIndex = computed(() => {
-    return disabled.value || (isGroup.value && modelValue.value !== props.label)
-      ? -1
-      : 0
-  })
 
   return {
     radioRef,
@@ -42,7 +37,6 @@ export const useRadio = (
     focus,
     size,
     disabled,
-    tabIndex,
     modelValue,
   }
 }


### PR DESCRIPTION
## Description

1. That code is not used anywhere.

    ```js
    const tabIndex = computed(() => {
      return disabled.value || (isGroup.value && modelValue.value !== props.label) ? -1 : 0
    })
    ```

2.  Even without this code, you can achieve what you want.

    ```js
    onMounted(() => {
      const radios =
        radioGroupRef.value!.querySelectorAll<HTMLInputElement>('[type=radio]')
      const firstLabel = radios[0]
      if (!Array.from(radios).some((radio) => radio.checked) && firstLabel) {
        firstLabel.tabIndex = 0
      }
    })
    ```

    The purpose of this code is to set the tabindex to 0 if the first label exists and the radio element is not checked. However, even if these conditions are not met, you can still access it with the tab key. So, I think you can delete that code.
    
    [Example]
    
    ![image](https://user-images.githubusercontent.com/27342882/173571192-6f0ce656-c8ce-494f-808a-e2412cd89750.png)

    ![image](https://user-images.githubusercontent.com/27342882/173571322-2fb4f188-7919-4f85-8d41-e298ab4011a0.png)

## What is Expected?

[Element Plus Playground](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZGl2IGNsYXNzPVwibWItMiBmbGV4IGl0ZW1zLWNlbnRlciB0ZXh0LXNtXCI+XG4gICAgPGVsLXJhZGlvLWdyb3VwIHYtbW9kZWw9XCJyYWRpbzFcIiBjbGFzcz1cIm1sLTRcIj5cbiAgICAgIDxlbC1yYWRpbyBsYWJlbD1cIjFcIiBzaXplPVwibGFyZ2VcIj5PcHRpb24gMTwvZWwtcmFkaW8+XG4gICAgICA8ZWwtcmFkaW8gbGFiZWw9XCIyXCIgc2l6ZT1cImxhcmdlXCI+T3B0aW9uIDI8L2VsLXJhZGlvPlxuICAgIDwvZWwtcmFkaW8tZ3JvdXA+XG4gIDwvZGl2PlxuICA8ZGl2IGNsYXNzPVwibXktMiBmbGV4IGl0ZW1zLWNlbnRlciB0ZXh0LXNtXCI+XG4gICAgPGVsLXJhZGlvLWdyb3VwIHYtbW9kZWw9XCJyYWRpbzJcIiBjbGFzcz1cIm1sLTRcIj5cbiAgICAgIDxlbC1yYWRpbyBsYWJlbD1cIjFcIj5PcHRpb24gMTwvZWwtcmFkaW8+XG4gICAgICA8ZWwtcmFkaW8gbGFiZWw9XCIyXCI+T3B0aW9uIDI8L2VsLXJhZGlvPlxuICAgIDwvZWwtcmFkaW8tZ3JvdXA+XG4gIDwvZGl2PlxuICA8ZGl2IGNsYXNzPVwibXktNCBmbGV4IGl0ZW1zLWNlbnRlciB0ZXh0LXNtXCI+XG4gICAgPGVsLXJhZGlvLWdyb3VwIHYtbW9kZWw9XCJyYWRpbzNcIiBjbGFzcz1cIm1sLTRcIj5cbiAgICAgIDxlbC1yYWRpbyBsYWJlbD1cIjFcIiBzaXplPVwic21hbGxcIj5PcHRpb24gMTwvZWwtcmFkaW8+XG4gICAgICA8ZWwtcmFkaW8gbGFiZWw9XCIyXCIgc2l6ZT1cInNtYWxsXCI+T3B0aW9uIDI8L2VsLXJhZGlvPlxuICAgIDwvZWwtcmFkaW8tZ3JvdXA+XG4gIDwvZGl2PlxuICA8ZGl2IGNsYXNzPVwibWItMiBmbGV4IGl0ZW1zLWNlbnRlciB0ZXh0LXNtXCI+XG4gICAgPGVsLXJhZGlvLWdyb3VwIHYtbW9kZWw9XCJyYWRpbzNcIiBkaXNhYmxlZCBjbGFzcz1cIm1sLTRcIj5cbiAgICAgIDxlbC1yYWRpbyBsYWJlbD1cIjFcIiBzaXplPVwic21hbGxcIj5PcHRpb24gMTwvZWwtcmFkaW8+XG4gICAgICA8ZWwtcmFkaW8gbGFiZWw9XCIyXCIgc2l6ZT1cInNtYWxsXCI+T3B0aW9uIDI8L2VsLXJhZGlvPlxuICAgIDwvZWwtcmFkaW8tZ3JvdXA+XG4gIDwvZGl2PlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3QgcmFkaW8xID0gcmVmKCctMScpXG5jb25zdCByYWRpbzIgPSByZWYoJzEnKVxuY29uc3QgcmFkaW8zID0gcmVmKCcxJylcbjwvc2NyaXB0PlxuIiwiUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0X21hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9wcmV2aWV3LTgyNjEtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5mdWxsLm1pbi5tanNcIixcbiAgICBcImVsZW1lbnQtcGx1cy9cIjogXCJ1bnN1cHBvcnRlZFwiXG4gIH1cbn0iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Zhc3RseS5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AbGF0ZXN0L2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvc2hhcmVkXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vcHJldmlldy04MjYxLWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9AZWxlbWVudC1wbHVzL2ljb25zLXZ1ZUAyL2Rpc3QvaW5kZXgubWluLmpzXCJcbiAgfSxcbiAgXCJzY29wZXNcIjoge31cbn0iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5pbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICBsaW5rLmhyZWYgPSAnaHR0cHM6Ly9wcmV2aWV3LTgyNjEtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5jc3MnXG4gICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gIH0pXG59IiwiX28iOnsic2hvd0hpZGRlbiI6dHJ1ZSwic3R5bGVTb3VyY2UiOiJodHRwczovL3ByZXZpZXctODI2MS1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcyJ9fQ==)

## conclusion

In conclusion, you can access the radio element with the tab key without having to set the tabindex.

thank you!

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
