### PR TITLE
fix(components): [dialog] remove not used style props

### DIFF
--- a/packages/components/dialog/src/dialog.vue
+++ b/packages/components/dialog/src/dialog.vue
@@ -41,7 +41,6 @@
               :draggable="draggable"
               :fullscreen="fullscreen"
               :show-close="showClose"
-              :style="style"
               :title="title"
               @close="handleClose"
             >


### PR DESCRIPTION
## Description

### `dialog-content.vue`

```vue
<el-dialog-content
  v-if="rendered"
  ref="dialogContentRef"
  :custom-class="customClass"
  :center="center"
  :close-icon="closeIcon"
  :draggable="draggable"
  :fullscreen="fullscreen"
  :show-close="showClose"
  :style="style" // not used props
  :title="title"
  @close="handleClose"
 />
```

### `dialog-content.ts`

It's not even in the props validation syntax.

```ts
export const dialogContentProps = buildProps({
  center: {
    type: Boolean,
    default: false,
  },
  closeIcon: {
    type: iconPropType,
    default: '',
  },
  customClass: {
    type: String,
    default: '',
  },
  draggable: {
    type: Boolean,
    default: false,
  },
  fullscreen: {
    type: Boolean,
    default: false,
  },
  showClose: {
    type: Boolean,
    default: true,
  },
  title: {
    type: String,
    default: '',
  },
} as const)
```

### `dialog-content.vue`

```vue
const { dialogRef, headerRef, bodyId, ns, style } = inject(dialogInjectionKey)! // here!
```

Because the style provided by provide is used, props style is not required.

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
