### PR TITLE
fix(components): [dropdown] fix #8311

### DIFF
--- a/packages/components/dropdown/src/dropdown.vue
+++ b/packages/components/dropdown/src/dropdown.vue
@@ -17,7 +17,7 @@
       :trigger-target-el="contentRef"
       :show-after="trigger === 'hover' ? showTimeout : 0"
       :stop-popper-mouse-event="false"
-      :virtual-ref="triggeringElementRef"
+      :virtual-ref="triggeringElementRef?.$el"
       :virtual-triggering="splitButton"
       :disabled="disabled"
       :transition="`${ns.namespace.value}-zoom-in-top`"

--- a/packages/components/popper/src/content.vue
+++ b/packages/components/popper/src/content.vue
@@ -188,14 +188,7 @@ onMounted(() => {
           popperContentEl,
           arrowEl: unref(arrowRef),
         })
-
-        updateHandle = watch(
-          () => referenceEl.getBoundingClientRect(),
-          () => updatePopper(),
-          {
-            immediate: true,
-          }
-        )
+        updatePopper()
       } else {
         popperInstanceRef.value = undefined
       }


### PR DESCRIPTION
* dropdown/src/content.vue: `triggeringElementRef` is a reference of
`el-button` component, not the `button` dom object. We should get its
dom object before passing it to `virtual-ref`.
* popper/src/content.vue: `referenceEl` is `triggeringElementRef`, which
is a dom object. Because both dom object and its instance function
`getBoundingClientRect` are not reactive, watching their changes are of
non-sence.

It's strange that it worked before v2.2.6, don't know what happened

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
