### PR TITLE
fix(components): [select] exclude item when using collapseTagsTooltip

### DIFF
--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -1074,7 +1074,7 @@ describe('Select', () => {
     const triggerWrappers = wrapper.findAll('.el-tooltip__trigger')
     expect(triggerWrappers[0]).toBeDefined()
     const tags = wrapper.findAll('.el-select__tags-text')
-    expect(tags.length).toBe(5)
+    expect(tags.length).toBe(4)
     expect(tags[4].element.textContent).toBe('蚵仔煎')
   })
 

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -73,7 +73,7 @@
                   <template #content>
                     <div :class="nsSelect.e('collapse-tags')">
                       <div
-                        v-for="(item, idx) in selected"
+                        v-for="(item, idx) in restSelected"
                         :key="idx"
                         :class="nsSelect.e('collapse-tag')"
                       >
@@ -489,6 +489,10 @@ export default defineComponent({
       width: '100%',
     }))
 
+    const restSelected = computed(() =>
+      selected.value.filter((_: any, index: number) => index !== 0)
+    )
+
     provide(
       selectKey,
       reactive({
@@ -567,6 +571,7 @@ export default defineComponent({
       scrollToOption,
       inputWidth,
       selected,
+      restSelected,
       inputLength,
       filteredOptionsCount,
       visible,


### PR DESCRIPTION
## Description

If you use the collapseTagsTooltip props, I think the first element should be excluded.

![image](https://user-images.githubusercontent.com/27342882/174427868-3ddd3b0d-c739-4727-aa48-d505cf8641e2.png)

As you can see from the photos, it's a duplicate.

![image](https://user-images.githubusercontent.com/27342882/174428401-1191572e-8e36-4d64-b9c4-4768b9c29179.png)

The number displayed is different from the actual number of items.

## What is Expected?

[Element Plus Playground]()

## What is actually happening?

[Element Plus Playground](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZGl2IHN0eWxlPVwiZGlzcGxheTogaW5saW5lLWJsb2NrXCI+XG4gICAgPHAgc3R5bGU9XCJtYXJnaW4tbGVmdDogMTBweFwiPmRlZmF1bHQ8L3A+XG4gICAgPGVsLXNlbGVjdFxuICAgICAgdi1tb2RlbD1cInZhbHVlMVwiXG4gICAgICBtdWx0aXBsZVxuICAgICAgcGxhY2Vob2xkZXI9XCJTZWxlY3RcIlxuICAgICAgc3R5bGU9XCJ3aWR0aDogMjQwcHhcIlxuICAgID5cbiAgICAgIDxlbC1vcHRpb25cbiAgICAgICAgdi1mb3I9XCJpdGVtIGluIG9wdGlvbnNcIlxuICAgICAgICA6a2V5PVwiaXRlbS52YWx1ZVwiXG4gICAgICAgIDpsYWJlbD1cIml0ZW0ubGFiZWxcIlxuICAgICAgICA6dmFsdWU9XCJpdGVtLnZhbHVlXCJcbiAgICAgIC8+XG4gICAgPC9lbC1zZWxlY3Q+XG4gIDwvZGl2PlxuICA8ZGl2IHN0eWxlPVwiZGlzcGxheTogaW5saW5lLWJsb2NrOyBtYXJnaW4tbGVmdDogMjBweFwiPlxuICAgIDxwIHN0eWxlPVwibWFyZ2luLWxlZnQ6IDEwcHhcIj51c2UgY29sbGFwc2UtdGFnczwvcD5cbiAgICA8ZWwtc2VsZWN0XG4gICAgICB2LW1vZGVsPVwidmFsdWUyXCJcbiAgICAgIG11bHRpcGxlXG4gICAgICBjb2xsYXBzZS10YWdzXG4gICAgICBwbGFjZWhvbGRlcj1cIlNlbGVjdFwiXG4gICAgICBzdHlsZT1cIndpZHRoOiAyNDBweFwiXG4gICAgPlxuICAgICAgPGVsLW9wdGlvblxuICAgICAgICB2LWZvcj1cIml0ZW0gaW4gb3B0aW9uc1wiXG4gICAgICAgIDprZXk9XCJpdGVtLnZhbHVlXCJcbiAgICAgICAgOmxhYmVsPVwiaXRlbS5sYWJlbFwiXG4gICAgICAgIDp2YWx1ZT1cIml0ZW0udmFsdWVcIlxuICAgICAgLz5cbiAgICA8L2VsLXNlbGVjdD5cbiAgPC9kaXY+XG4gIDxkaXYgc3R5bGU9XCJkaXNwbGF5OiBpbmxpbmUtYmxvY2s7IG1hcmdpbi1sZWZ0OiAyMHB4XCI+XG4gICAgPHAgc3R5bGU9XCJtYXJnaW4tbGVmdDogMTBweFwiPnVzZSBjb2xsYXBzZS10YWdzLXRvb2x0aXA8L3A+XG4gICAgPGVsLXNlbGVjdFxuICAgICAgdi1tb2RlbD1cInZhbHVlM1wiXG4gICAgICBtdWx0aXBsZVxuICAgICAgY29sbGFwc2UtdGFnc1xuICAgICAgY29sbGFwc2UtdGFncy10b29sdGlwXG4gICAgICBwbGFjZWhvbGRlcj1cIlNlbGVjdFwiXG4gICAgICBzdHlsZT1cIndpZHRoOiAyNDBweFwiXG4gICAgPlxuICAgICAgPGVsLW9wdGlvblxuICAgICAgICB2LWZvcj1cIml0ZW0gaW4gb3B0aW9uc1wiXG4gICAgICAgIDprZXk9XCJpdGVtLnZhbHVlXCJcbiAgICAgICAgOmxhYmVsPVwiaXRlbS5sYWJlbFwiXG4gICAgICAgIDp2YWx1ZT1cIml0ZW0udmFsdWVcIlxuICAgICAgLz5cbiAgICA8L2VsLXNlbGVjdD5cbiAgPC9kaXY+XG48L3RlbXBsYXRlPlxuXG48c2NyaXB0IGxhbmc9XCJ0c1wiIHNldHVwPlxuaW1wb3J0IHsgcmVmIH0gZnJvbSAndnVlJ1xuXG5jb25zdCB2YWx1ZTEgPSByZWYoW10pXG5jb25zdCB2YWx1ZTIgPSByZWYoW10pXG5jb25zdCB2YWx1ZTMgPSByZWYoW10pXG5jb25zdCBvcHRpb25zID0gW1xuICB7XG4gICAgdmFsdWU6ICdPcHRpb24xJyxcbiAgICBsYWJlbDogJ09wdGlvbjEnLFxuICB9LFxuICB7XG4gICAgdmFsdWU6ICdPcHRpb24yJyxcbiAgICBsYWJlbDogJ09wdGlvbjInLFxuICB9LFxuICB7XG4gICAgdmFsdWU6ICdPcHRpb24zJyxcbiAgICBsYWJlbDogJ09wdGlvbjMnLFxuICB9LFxuICB7XG4gICAgdmFsdWU6ICdPcHRpb240JyxcbiAgICBsYWJlbDogJ09wdGlvbjQnLFxuICB9LFxuICB7XG4gICAgdmFsdWU6ICdPcHRpb241JyxcbiAgICBsYWJlbDogJ09wdGlvbjUnLFxuICB9LFxuXVxuPC9zY3JpcHQ+XG4iLCJpbXBvcnRfbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7fVxufSIsIl9vIjp7fX0=)

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
