### PR TITLE
improvement(components): [select] remove duplicate items

### DIFF
--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -1074,8 +1074,8 @@ describe('Select', () => {
     const triggerWrappers = wrapper.findAll('.el-tooltip__trigger')
     expect(triggerWrappers[0]).toBeDefined()
     const tags = wrapper.findAll('.el-select__tags-text')
-    expect(tags.length).toBe(5)
-    expect(tags[4].element.textContent).toBe('蚵仔煎')
+    expect(tags.length).toBe(4)
+    expect(tags[3].element.textContent).toBe('蚵仔煎')
   })
 
   test('multiple remove-tag', async () => {

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -73,7 +73,7 @@
                   <template #content>
                     <div :class="nsSelect.e('collapse-tags')">
                       <div
-                        v-for="(item, idx) in selected"
+                        v-for="(item, idx) in restSelected"
                         :key="idx"
                         :class="nsSelect.e('collapse-tag')"
                       >
@@ -489,6 +489,10 @@ export default defineComponent({
       width: '100%',
     }))
 
+    const restSelected = computed(() =>
+      selected.value.filter((_: any, index: number) => index !== 0)
+    )
+
     provide(
       selectKey,
       reactive({
@@ -567,6 +571,7 @@ export default defineComponent({
       scrollToOption,
       inputWidth,
       selected,
+      restSelected,
       inputLength,
       filteredOptionsCount,
       visible,


### PR DESCRIPTION
# Suggest

## Description

If collapse-tags-tooltip is used in the current select component, it will be displayed as shown below.

![image](https://user-images.githubusercontent.com/27342882/174431304-da15044f-85f8-4939-b9b0-e5ff977e3894.png)

You can see that the same element is displayed twice. I think this should be removed.

## Why

There is no reason to show the same element twice, and users would think that the tooltip will contain all but the first element. 

![image](https://user-images.githubusercontent.com/27342882/174431412-e3661e53-2cea-4656-8d29-721434fadeec.png)

And the number indicated by + is different from the number of items displayed in the actual tooltip.

## etc

I think there must have been a good reason why the component was developed like this at the time it was developed. But I thought what I was suggesting would be more intuitive when viewed by users.

Thanks for reading. Any comments would be appreciated!

## video


https://user-images.githubusercontent.com/27342882/174431802-c58da02f-9b82-4635-b8de-93914542bfe5.mp4



---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
