### PR TITLE
refactor(components)!: [switch] remove value prop

### DIFF
--- a/breakings/2.3.0/switch.yml
+++ b/breakings/2.3.0/switch.yml
@@ -1,0 +1,17 @@
+- scope: 'component'
+  name: 'el-switch'
+  type: 'props'
+  version: '2.3.0'
+  commit_hash: 'e0db71cd8'
+  description: |
+    Remove `value` prop and `input` event. Since Vue 3 no longer uses `value` and `input`, but `modelValue` and `update:modelValue`. Also they are not public in the documentation either.
+
+  props:
+    - api: value
+      before: '`string`'
+      after: removed
+
+  emits:
+    - api: input
+      before: '`(val: boolean | string | number) => void`'
+      after: removed

--- a/packages/components/switch/src/switch.ts
+++ b/packages/components/switch/src/switch.ts
@@ -5,23 +5,14 @@ import {
   isBoolean,
   isNumber,
   isString,
-  isValidComponentSize,
 } from '@element-plus/utils'
-import {
-  CHANGE_EVENT,
-  INPUT_EVENT,
-  UPDATE_MODEL_EVENT,
-} from '@element-plus/constants'
-import type { ComponentSize } from '@element-plus/constants'
+import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
+import { useSizeProp } from '@element-plus/hooks'
 import type Switch from './switch.vue'
-import type { ExtractPropTypes, PropType } from 'vue'
+import type { ExtractPropTypes } from 'vue'
 
 export const switchProps = buildProps({
   modelValue: {
-    type: [Boolean, String, Number],
-    default: false,
-  },
-  value: {
     type: [Boolean, String, Number],
     default: false,
   },
@@ -87,10 +78,7 @@ export const switchProps = buildProps({
   beforeChange: {
     type: definePropType<() => Promise<boolean> | boolean>(Function),
   },
-  size: {
-    type: String as PropType<ComponentSize>,
-    validator: isValidComponentSize,
-  },
+  size: useSizeProp,
   tabindex: {
     type: [String, Number],
   },
@@ -102,8 +90,6 @@ export const switchEmits = {
   [UPDATE_MODEL_EVENT]: (val: boolean | string | number) =>
     isBoolean(val) || isString(val) || isNumber(val),
   [CHANGE_EVENT]: (val: boolean | string | number) =>
-    isBoolean(val) || isString(val) || isNumber(val),
-  [INPUT_EVENT]: (val: boolean | string | number) =>
     isBoolean(val) || isString(val) || isNumber(val),
 }
 export type SwitchEmits = typeof switchEmits

--- a/packages/components/switch/src/switch.vue
+++ b/packages/components/switch/src/switch.vue
@@ -145,7 +145,7 @@ const coreStyle = computed<CSSProperties>(() => ({
   width: addUnit(props.width),
 }))
 
-const toggleSwitch = async () => {
+const toggleSwitch = () => {
   checked.value = !checked.value
   rAF(() => {
     input.value!.checked = checked.value


### PR DESCRIPTION
Remove `value` prop and `input` event. Since Vue 3 no longer uses `value` and `input`, but `modelValue` and `update:modelValue`. Also they are not public in the documentation either.