### PR TITLE
fix(components): [time-picker]fix type cannot be emptied

### DIFF
--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -66,6 +66,8 @@
             v-if="showClose && clearIcon"
             :class="`${nsInput.e('icon')} clear-icon`"
             @click.stop="onClearIconClick"
+            @mouseenter="onClearEnter"
+            @mouseleave="onClearLeave"
           >
             <component :is="clearIcon" />
           </el-icon>
@@ -140,7 +142,9 @@
               [nsRange.e('close-icon--hidden')]: !showClose,
             },
           ]"
-          @click="onClearIconClick"
+          @click.stop="onClearIconClick"
+          @mouseenter="onClearEnter"
+          @mouseleave="onClearLeave"
         >
           <component :is="clearIcon" />
         </el-icon>
@@ -410,8 +414,7 @@ const parsedValue = computed(() => {
       dayOrDays = parseDate(props.modelValue, props.valueFormat, lang.value)!
     }
   }
-
-  if (pickerOptions.value.getRangeAvailableTime) {
+  if (pickerOptions.value.getRangeAvailableTime && !valueIsEmpty.value) {
     const availableResult = pickerOptions.value.getRangeAvailableTime(
       dayOrDays!
     )
@@ -462,11 +465,18 @@ const triggerIcon = computed(
 )
 
 const showClose = ref(false)
+const isInClose = ref(false)
 
-const onClearIconClick = (event: MouseEvent) => {
+const onClearEnter = () => {
+  isInClose.value = true
+}
+const onClearLeave = () => {
+  isInClose.value = false
+}
+
+const onClearIconClick = () => {
   if (props.readonly || pickerDisabled.value) return
   if (showClose.value) {
-    event.stopPropagation()
     focusOnInputBox()
     emitInput(null)
     emitChange(null, true)
@@ -489,6 +499,7 @@ const onMouseDownInput = async (event: MouseEvent) => {
     (event.target as HTMLElement)?.tagName !== 'INPUT' ||
     refInput.value.includes(document.activeElement as HTMLInputElement)
   ) {
+    if (isInClose.value) return
     pickerVisible.value = true
   }
 }


### PR DESCRIPTION
Fix when there is a forbidden range, the clear operation is assigned the present value.
When mode is is-range, clicking on the clear icon will trigger the onMouseDownInput event of the
input box, causing pickerVisible to change and reassign.

closed #8569

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
