### PR TITLE
fix(components): [input-number] Fix value decimals miss prop precision

### DIFF
--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -94,6 +94,20 @@ describe('InputNumber.vue', () => {
     expect(wrapper.find('input').element.value).toEqual('4')
   })
 
+  test('value decimals miss prop precision', async () => {
+    const num = ref(0.2)
+    const wrapper = mount(() => <InputNumber step={0.1} v-model={num.value} />)
+    const elInputNumber = wrapper.findComponent({ name: 'ElInputNumber' }).vm
+    elInputNumber.increase()
+    await nextTick()
+    expect(wrapper.find('input').element.value).toEqual('0.3')
+    num.value = 0.4
+    await nextTick()
+    elInputNumber.decrease()
+    await nextTick()
+    expect(wrapper.find('input').element.value).toEqual('0.3')
+  })
+
   describe('precision accuracy 2', () => {
     const num = ref(0)
     const wrapper = mount(() => (

--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -96,7 +96,9 @@ describe('InputNumber.vue', () => {
 
   test('value decimals miss prop precision', async () => {
     const num = ref(0.2)
-    const wrapper = mount(() => <InputNumber step={0.1} v-model={num.value} />)
+    const wrapper = mount(() => (
+      <InputNumber step-strictly={true} step={0.1} v-model={num.value} />
+    ))
     const elInputNumber = wrapper.findComponent(InputNumber).vm
     elInputNumber.increase()
     await nextTick()

--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -97,7 +97,7 @@ describe('InputNumber.vue', () => {
   test('value decimals miss prop precision', async () => {
     const num = ref(0.2)
     const wrapper = mount(() => <InputNumber step={0.1} v-model={num.value} />)
-    const elInputNumber = wrapper.findComponent({ name: 'ElInputNumber' }).vm
+    const elInputNumber = wrapper.findComponent(InputNumber).vm
     elInputNumber.increase()
     await nextTick()
     expect(wrapper.find('input').element.value).toEqual('0.3')

--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -99,7 +99,7 @@ describe('InputNumber.vue', () => {
     const wrapper = mount(() => (
       <InputNumber step-strictly={true} step={0.1} v-model={num.value} />
     ))
-    const elInputNumber = wrapper.findComponent(InputNumber).vm
+    const elInputNumber = wrapper.findComponent({ name: 'ElInputNumber' }).vm
     elInputNumber.increase()
     await nextTick()
     expect(wrapper.find('input').element.value).toEqual('0.3')

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -201,7 +201,10 @@ const verifyValue = (
     newVal = isString(valueOnClear) ? { min, max }[valueOnClear] : valueOnClear
   }
   if (stepStrictly) {
-    newVal = Math.round(newVal / step) * step
+    newVal = toPrecision(
+      Math.round(newVal / step) * step,
+      precision || numPrecision.value
+    )
   }
   if (!isUndefined(precision)) {
     newVal = toPrecision(newVal, precision)

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -201,10 +201,7 @@ const verifyValue = (
     newVal = isString(valueOnClear) ? { min, max }[valueOnClear] : valueOnClear
   }
   if (stepStrictly) {
-    newVal = toPrecision(
-      Math.round(newVal / step) * step,
-      precision || numPrecision.value
-    )
+    newVal = toPrecision(Math.round(newVal / step) * step, precision)
   }
   if (!isUndefined(precision)) {
     newVal = toPrecision(newVal, precision)


### PR DESCRIPTION
input-number components modelValue is decimals and  stepStrictly miss prop precision if 0.2 to 0.3 result 0.300004
fix:stepStrictly verifyValue function miss use toPrecision 
close #8570 

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
