### PR TITLE
refactor(components): [tabs] add deprecated to activeName

### DIFF
--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -1,4 +1,5 @@
 import {
+  computed,
   defineComponent,
   nextTick,
   provide,
@@ -18,7 +19,7 @@ import { EVENT_CODE, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import ElIcon from '@element-plus/components/icon'
 import { Plus } from '@element-plus/icons-vue'
 import { tabsRootContextKey } from '@element-plus/tokens'
-import { useNamespace } from '@element-plus/hooks'
+import { useDeprecated, useNamespace } from '@element-plus/hooks'
 import TabNav from './tab-nav'
 import type { TabNavInstance } from './tab-nav'
 import type { TabsPaneContext } from '@element-plus/tokens'
@@ -134,6 +135,18 @@ export default defineComponent({
       emit('edit', undefined, 'add')
       emit('tab-add')
     }
+
+    useDeprecated(
+      {
+        from: '"activeName"',
+        replacement: '"model-value" or "v-model"',
+        scope: 'ElTabs',
+        version: '2.3.0',
+        ref: 'https://element-plus.org/en-US/component/tabs.html#attributes',
+        type: 'Attribute',
+      },
+      computed(() => !!props.activeName)
+    )
 
     watch(
       () => props.activeName,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

The `activeName` attribute seems to be redundant now, and it repeats with the `model-value / v-model`. I did not find it in the docs, I think we can consider remove the `activeName` attribute.

