### PR TITLE
fix(components): [image] fix src changing not rerender

### DIFF
--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -2,6 +2,7 @@
   <div ref="container" :class="[ns.b(), $attrs.class]" :style="containerStyle">
     <img
       v-if="imageSrc !== undefined && !hasLoadError"
+      :key="imageSrc"
       v-bind="attrs"
       :src="imageSrc"
       :loading="loading"

--- a/packages/theme-chalk/src/image.scss
+++ b/packages/theme-chalk/src/image.scss
@@ -14,10 +14,6 @@
   @include e(inner) {
     @extend %size !optional;
     vertical-align: top;
-    opacity: 1;
-    @include when(loading) {
-      opacity: 0;
-    }
   }
 
   @include e(wrapper) {


### PR DESCRIPTION
When the src changed, the image will steel shown as before util the next image is loaded. So it should be rerendered when the src changed.