### PR TITLE
docs(components): [form] add scroll-to-error attribute

### DIFF
--- a/docs/en-US/component/form.md
+++ b/docs/en-US/component/form.md
@@ -140,6 +140,7 @@ form/accessibility
 | `validate-on-rule-change` | Whether to trigger validation when the `rules` prop is changed.                                                                | `boolean`                         | `true`    |
 | `size`                    | Control the size of components in this form.                                                                                   | `'large' \| 'default' \| 'small'` | —         |
 | `disabled`                | Whether to disable all components in this form. If set to `true`, it will override the `disabled` prop of the inner component. | `boolean`                         | `false`   |
+| `scroll-to-error`         | When validation fails, scroll to the first error form entry.                                                                   | `boolean`                         | `false`   |
 
 ### Form Methods
 


### PR DESCRIPTION
## Description

Added `scroll-to-error` attribute that is not in the form component document

## Work History

- add `docs`

## Example

In that example, pressing a button tells you about its function.

[Element Plus Playground](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZGl2IHN0eWxlPVwiaGVpZ2h0OiA1MDAwcHhcIj5cbiAgICA8ZWwtZm9ybVxuICAgICAgcmVmPVwicnVsZUZvcm1SZWZcIlxuICAgICAgOm1vZGVsPVwicnVsZUZvcm1cIlxuICAgICAgOnJ1bGVzPVwicnVsZXNcIlxuICAgICAgbGFiZWwtd2lkdGg9XCIxMjBweFwiXG4gICAgICBjbGFzcz1cImRlbW8tcnVsZUZvcm1cIlxuICAgICAgOnNpemU9XCJmb3JtU2l6ZVwiXG4gICAgICBzdGF0dXMtaWNvblxuICAgICAgc2Nyb2xsLXRvLWVycm9yXG4gICAgPlxuICAgICAgPGVsLWZvcm0taXRlbSBsYWJlbD1cIkFjdGl2aXR5IG5hbWVcIiBwcm9wPVwibmFtZVwiPlxuICAgICAgICA8ZWwtaW5wdXQgdi1tb2RlbD1cInJ1bGVGb3JtLm5hbWVcIiAvPlxuICAgICAgPC9lbC1mb3JtLWl0ZW0+XG4gICAgICA8ZWwtZm9ybS1pdGVtIGxhYmVsPVwiQWN0aXZpdHkgem9uZVwiIHByb3A9XCJyZWdpb25cIj5cbiAgICAgICAgPGVsLXNlbGVjdCB2LW1vZGVsPVwicnVsZUZvcm0ucmVnaW9uXCIgcGxhY2Vob2xkZXI9XCJBY3Rpdml0eSB6b25lXCI+XG4gICAgICAgICAgPGVsLW9wdGlvbiBsYWJlbD1cIlpvbmUgb25lXCIgdmFsdWU9XCJzaGFuZ2hhaVwiIC8+XG4gICAgICAgICAgPGVsLW9wdGlvbiBsYWJlbD1cIlpvbmUgdHdvXCIgdmFsdWU9XCJiZWlqaW5nXCIgLz5cbiAgICAgICAgPC9lbC1zZWxlY3Q+XG4gICAgICA8L2VsLWZvcm0taXRlbT5cbiAgICAgIDxlbC1mb3JtLWl0ZW0gbGFiZWw9XCJBY3Rpdml0eSBjb3VudFwiIHByb3A9XCJjb3VudFwiPlxuICAgICAgICA8ZWwtc2VsZWN0LXYyXG4gICAgICAgICAgdi1tb2RlbD1cInJ1bGVGb3JtLmNvdW50XCJcbiAgICAgICAgICBwbGFjZWhvbGRlcj1cIkFjdGl2aXR5IGNvdW50XCJcbiAgICAgICAgICA6b3B0aW9ucz1cIm9wdGlvbnNcIlxuICAgICAgICAvPlxuICAgICAgPC9lbC1mb3JtLWl0ZW0+XG4gICAgICA8ZWwtZm9ybS1pdGVtIGxhYmVsPVwiQWN0aXZpdHkgdGltZVwiIHJlcXVpcmVkPlxuICAgICAgICA8ZWwtY29sIDpzcGFuPVwiMTFcIj5cbiAgICAgICAgICA8ZWwtZm9ybS1pdGVtIHByb3A9XCJkYXRlMVwiPlxuICAgICAgICAgICAgPGVsLWRhdGUtcGlja2VyXG4gICAgICAgICAgICAgIHYtbW9kZWw9XCJydWxlRm9ybS5kYXRlMVwiXG4gICAgICAgICAgICAgIHR5cGU9XCJkYXRlXCJcbiAgICAgICAgICAgICAgbGFiZWw9XCJQaWNrIGEgZGF0ZVwiXG4gICAgICAgICAgICAgIHBsYWNlaG9sZGVyPVwiUGljayBhIGRhdGVcIlxuICAgICAgICAgICAgICBzdHlsZT1cIndpZHRoOiAxMDAlXCJcbiAgICAgICAgICAgIC8+XG4gICAgICAgICAgPC9lbC1mb3JtLWl0ZW0+XG4gICAgICAgIDwvZWwtY29sPlxuICAgICAgICA8ZWwtY29sIGNsYXNzPVwidGV4dC1jZW50ZXJcIiA6c3Bhbj1cIjJcIj5cbiAgICAgICAgICA8c3BhbiBjbGFzcz1cInRleHQtZ3JheS01MDBcIj4tPC9zcGFuPlxuICAgICAgICA8L2VsLWNvbD5cbiAgICAgICAgPGVsLWNvbCA6c3Bhbj1cIjExXCI+XG4gICAgICAgICAgPGVsLWZvcm0taXRlbSBwcm9wPVwiZGF0ZTJcIj5cbiAgICAgICAgICAgIDxlbC10aW1lLXBpY2tlclxuICAgICAgICAgICAgICB2LW1vZGVsPVwicnVsZUZvcm0uZGF0ZTJcIlxuICAgICAgICAgICAgICBsYWJlbD1cIlBpY2sgYSB0aW1lXCJcbiAgICAgICAgICAgICAgcGxhY2Vob2xkZXI9XCJQaWNrIGEgdGltZVwiXG4gICAgICAgICAgICAgIHN0eWxlPVwid2lkdGg6IDEwMCVcIlxuICAgICAgICAgICAgLz5cbiAgICAgICAgICA8L2VsLWZvcm0taXRlbT5cbiAgICAgICAgPC9lbC1jb2w+XG4gICAgICA8L2VsLWZvcm0taXRlbT5cbiAgICAgIDxlbC1mb3JtLWl0ZW0gbGFiZWw9XCJJbnN0YW50IGRlbGl2ZXJ5XCIgcHJvcD1cImRlbGl2ZXJ5XCI+XG4gICAgICAgIDxlbC1zd2l0Y2ggdi1tb2RlbD1cInJ1bGVGb3JtLmRlbGl2ZXJ5XCIgLz5cbiAgICAgIDwvZWwtZm9ybS1pdGVtPlxuICAgICAgPGVsLWZvcm0taXRlbSBsYWJlbD1cIkFjdGl2aXR5IHR5cGVcIiBwcm9wPVwidHlwZVwiPlxuICAgICAgICA8ZWwtY2hlY2tib3gtZ3JvdXAgdi1tb2RlbD1cInJ1bGVGb3JtLnR5cGVcIj5cbiAgICAgICAgICA8ZWwtY2hlY2tib3ggbGFiZWw9XCJPbmxpbmUgYWN0aXZpdGllc1wiIG5hbWU9XCJ0eXBlXCIgLz5cbiAgICAgICAgICA8ZWwtY2hlY2tib3ggbGFiZWw9XCJQcm9tb3Rpb24gYWN0aXZpdGllc1wiIG5hbWU9XCJ0eXBlXCIgLz5cbiAgICAgICAgICA8ZWwtY2hlY2tib3ggbGFiZWw9XCJPZmZsaW5lIGFjdGl2aXRpZXNcIiBuYW1lPVwidHlwZVwiIC8+XG4gICAgICAgICAgPGVsLWNoZWNrYm94IGxhYmVsPVwiU2ltcGxlIGJyYW5kIGV4cG9zdXJlXCIgbmFtZT1cInR5cGVcIiAvPlxuICAgICAgICA8L2VsLWNoZWNrYm94LWdyb3VwPlxuICAgICAgPC9lbC1mb3JtLWl0ZW0+XG4gICAgICA8ZWwtZm9ybS1pdGVtIGxhYmVsPVwiUmVzb3VyY2VzXCIgcHJvcD1cInJlc291cmNlXCI+XG4gICAgICAgIDxlbC1yYWRpby1ncm91cCB2LW1vZGVsPVwicnVsZUZvcm0ucmVzb3VyY2VcIj5cbiAgICAgICAgICA8ZWwtcmFkaW8gbGFiZWw9XCJTcG9uc29yc2hpcFwiIC8+XG4gICAgICAgICAgPGVsLXJhZGlvIGxhYmVsPVwiVmVudWVcIiAvPlxuICAgICAgICA8L2VsLXJhZGlvLWdyb3VwPlxuICAgICAgPC9lbC1mb3JtLWl0ZW0+XG4gICAgICA8ZWwtZm9ybS1pdGVtIGxhYmVsPVwiQWN0aXZpdHkgZm9ybVwiIHByb3A9XCJkZXNjXCI+XG4gICAgICAgIDxlbC1pbnB1dCB2LW1vZGVsPVwicnVsZUZvcm0uZGVzY1wiIHR5cGU9XCJ0ZXh0YXJlYVwiIC8+XG4gICAgICA8L2VsLWZvcm0taXRlbT5cbiAgICAgIDxlbC1mb3JtLWl0ZW0+XG4gICAgICAgIDxlbC1idXR0b24gdHlwZT1cInByaW1hcnlcIiBAY2xpY2s9XCJzdWJtaXRGb3JtKHJ1bGVGb3JtUmVmKVwiXG4gICAgICAgICAgPkNyZWF0ZTwvZWwtYnV0dG9uXG4gICAgICAgID5cbiAgICAgICAgPGVsLWJ1dHRvbiBAY2xpY2s9XCJyZXNldEZvcm0ocnVsZUZvcm1SZWYpXCI+UmVzZXQ8L2VsLWJ1dHRvbj5cbiAgICAgIDwvZWwtZm9ybS1pdGVtPlxuICAgIDwvZWwtZm9ybT5cbiAgPC9kaXY+XG48L3RlbXBsYXRlPlxuXG48c2NyaXB0IGxhbmc9XCJ0c1wiIHNldHVwPlxuaW1wb3J0IHsgcmVhY3RpdmUsIHJlZiB9IGZyb20gJ3Z1ZSdcbmltcG9ydCB0eXBlIHsgRm9ybUluc3RhbmNlLCBGb3JtUnVsZXMgfSBmcm9tICdlbGVtZW50LXBsdXMnXG5cbmNvbnN0IGZvcm1TaXplID0gcmVmKCdkZWZhdWx0JylcbmNvbnN0IHJ1bGVGb3JtUmVmID0gcmVmPEZvcm1JbnN0YW5jZT4oKVxuY29uc3QgcnVsZUZvcm0gPSByZWFjdGl2ZSh7XG4gIG5hbWU6ICdIZWxsbycsXG4gIHJlZ2lvbjogJ1pvbmUgT25lJyxcbiAgY291bnQ6ICcxJyxcbiAgZGF0ZTE6ICcyMDIyLTA3LTEzJyxcbiAgZGF0ZTI6ICcnLFxuICBkZWxpdmVyeTogZmFsc2UsXG4gIHR5cGU6IFtdLFxuICByZXNvdXJjZTogJycsXG4gIGRlc2M6ICcnLFxufSlcblxuY29uc3QgcnVsZXMgPSByZWFjdGl2ZTxGb3JtUnVsZXM+KHtcbiAgbmFtZTogW1xuICAgIHsgcmVxdWlyZWQ6IHRydWUsIG1lc3NhZ2U6ICdQbGVhc2UgaW5wdXQgQWN0aXZpdHkgbmFtZScsIHRyaWdnZXI6ICdibHVyJyB9LFxuICAgIHsgbWluOiAzLCBtYXg6IDUsIG1lc3NhZ2U6ICdMZW5ndGggc2hvdWxkIGJlIDMgdG8gNScsIHRyaWdnZXI6ICdibHVyJyB9LFxuICBdLFxuICByZWdpb246IFtcbiAgICB7XG4gICAgICByZXF1aXJlZDogdHJ1ZSxcbiAgICAgIG1lc3NhZ2U6ICdQbGVhc2Ugc2VsZWN0IEFjdGl2aXR5IHpvbmUnLFxuICAgICAgdHJpZ2dlcjogJ2NoYW5nZScsXG4gICAgfSxcbiAgXSxcbiAgY291bnQ6IFtcbiAgICB7XG4gICAgICByZXF1aXJlZDogdHJ1ZSxcbiAgICAgIG1lc3NhZ2U6ICdQbGVhc2Ugc2VsZWN0IEFjdGl2aXR5IGNvdW50JyxcbiAgICAgIHRyaWdnZXI6ICdjaGFuZ2UnLFxuICAgIH0sXG4gIF0sXG4gIGRhdGUxOiBbXG4gICAge1xuICAgICAgdHlwZTogJ2RhdGUnLFxuICAgICAgcmVxdWlyZWQ6IHRydWUsXG4gICAgICBtZXNzYWdlOiAnUGxlYXNlIHBpY2sgYSBkYXRlJyxcbiAgICAgIHRyaWdnZXI6ICdjaGFuZ2UnLFxuICAgIH0sXG4gIF0sXG4gIGRhdGUyOiBbXG4gICAge1xuICAgICAgdHlwZTogJ2RhdGUnLFxuICAgICAgcmVxdWlyZWQ6IHRydWUsXG4gICAgICBtZXNzYWdlOiAnUGxlYXNlIHBpY2sgYSB0aW1lJyxcbiAgICAgIHRyaWdnZXI6ICdjaGFuZ2UnLFxuICAgIH0sXG4gIF0sXG4gIHR5cGU6IFtcbiAgICB7XG4gICAgICB0eXBlOiAnYXJyYXknLFxuICAgICAgcmVxdWlyZWQ6IHRydWUsXG4gICAgICBtZXNzYWdlOiAnUGxlYXNlIHNlbGVjdCBhdCBsZWFzdCBvbmUgYWN0aXZpdHkgdHlwZScsXG4gICAgICB0cmlnZ2VyOiAnY2hhbmdlJyxcbiAgICB9LFxuICBdLFxuICByZXNvdXJjZTogW1xuICAgIHtcbiAgICAgIHJlcXVpcmVkOiB0cnVlLFxuICAgICAgbWVzc2FnZTogJ1BsZWFzZSBzZWxlY3QgYWN0aXZpdHkgcmVzb3VyY2UnLFxuICAgICAgdHJpZ2dlcjogJ2NoYW5nZScsXG4gICAgfSxcbiAgXSxcbiAgZGVzYzogW1xuICAgIHsgcmVxdWlyZWQ6IHRydWUsIG1lc3NhZ2U6ICdQbGVhc2UgaW5wdXQgYWN0aXZpdHkgZm9ybScsIHRyaWdnZXI6ICdibHVyJyB9LFxuICBdLFxufSlcblxuY29uc3Qgc3VibWl0Rm9ybSA9IGFzeW5jIChmb3JtRWw6IEZvcm1JbnN0YW5jZSB8IHVuZGVmaW5lZCkgPT4ge1xuICBpZiAoIWZvcm1FbCkgcmV0dXJuXG4gIGF3YWl0IGZvcm1FbC52YWxpZGF0ZSgodmFsaWQsIGZpZWxkcykgPT4ge1xuICAgIGlmICh2YWxpZCkge1xuICAgICAgY29uc29sZS5sb2coJ3N1Ym1pdCEnKVxuICAgIH0gZWxzZSB7XG4gICAgICBjb25zb2xlLmxvZygnZXJyb3Igc3VibWl0IScsIGZpZWxkcylcbiAgICB9XG4gIH0pXG59XG5cbmNvbnN0IHJlc2V0Rm9ybSA9IChmb3JtRWw6IEZvcm1JbnN0YW5jZSB8IHVuZGVmaW5lZCkgPT4ge1xuICBpZiAoIWZvcm1FbCkgcmV0dXJuXG4gIGZvcm1FbC5yZXNldEZpZWxkcygpXG59XG5cbmNvbnN0IG9wdGlvbnMgPSBBcnJheS5mcm9tKHsgbGVuZ3RoOiAxMDAwMCB9KS5tYXAoKF8sIGlkeCkgPT4gKHtcbiAgdmFsdWU6IGAke2lkeCArIDF9YCxcbiAgbGFiZWw6IGAke2lkeCArIDF9YCxcbn0pKVxuPC9zY3JpcHQ+XG4iLCJpbXBvcnRfbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7fVxufSIsIl9vIjp7fX0=)

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
