### PR TITLE
fix(components): [dialog] make trapFocus available

### DIFF
--- a/packages/components/dialog/src/dialog.ts
+++ b/packages/components/dialog/src/dialog.ts
@@ -60,7 +60,7 @@ export const dialogProps = buildProps({
   },
   trapFocus: {
     type: Boolean,
-    default: false,
+    default: true,
   },
 } as const)
 

--- a/packages/components/dialog/src/dialog.vue
+++ b/packages/components/dialog/src/dialog.vue
@@ -26,7 +26,7 @@
         >
           <el-focus-trap
             loop
-            :trapped="visible"
+            :trapped="visible && trapFocus"
             focus-start-el="container"
             @focus-after-trapped="onOpenAutoFocus"
             @focus-after-released="onCloseAutoFocus"


### PR DESCRIPTION
the props trapFocus of dialog is not available now,  only use visible to control trapped. 
make it true with default, user can control it when open other modal on dialog, such as tinymce. 

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
