### PR TITLE
feat(components): [tooltip] adjust controlled mode

### DIFF
--- a/docs/en-US/component/popover.md
+++ b/docs/en-US/component/popover.md
@@ -9,7 +9,7 @@ lang: en-US
 
 Similar to Tooltip, Popover is also built with `ElPopper`. So for some duplicated attributes, please refer to the documentation of Tooltip.
 
-:::demo The `trigger` attribute is used to define how popover is triggered: `hover`, `click`, `focus` or `contextmenu` . If you want to manually controll it, you can set `v-model:visible`.
+:::demo The `trigger` attribute is used to define how popover is triggered: `hover`, `click`, `focus` or `contextmenu` . If you want to manually controll it, you can set `:visible`.
 
 popover/basic-usage
 

--- a/docs/en-US/component/tooltip.md
+++ b/docs/en-US/component/tooltip.md
@@ -122,7 +122,7 @@ tooltip/singleton
 
 ## Controlled
 
-Tooltip can be controlled by the parent component, by using `v-model:visible` you can implement two way binding.
+Tooltip can be controlled by the parent component, by using `:visible` you can implement two way binding.
 
 :::demo
 

--- a/docs/examples/popover/basic-usage.vue
+++ b/docs/examples/popover/basic-usage.vue
@@ -49,7 +49,7 @@
   </el-popover>
 
   <el-popover
-    v-model:visible="visible"
+    :visible="visible"
     placement="bottom"
     title="Title"
     :width="200"

--- a/docs/examples/tooltip/controlled.vue
+++ b/docs/examples/tooltip/controlled.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-tooltip v-model:visible="visible">
+  <el-tooltip :visible="visible">
     <template #content>
       <span>Content</span>
     </template>

--- a/packages/components/popover/__tests__/popover.test.ts
+++ b/packages/components/popover/__tests__/popover.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { h, nextTick } from 'vue'
+import { mount as _mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, test, vi } from 'vitest'
 import { POPPER_CONTAINER_SELECTOR, useZIndex } from '@element-plus/hooks'
 import makeMount from '@element-plus/test-utils/make-mount'
@@ -127,6 +128,109 @@ describe('Popover.vue', () => {
     vi.useRealTimers()
     await rAF()
     expect(wrapper.emitted()).toHaveProperty('after-leave')
+  })
+
+  test('test visible controlled mode trigger invalid', async () => {
+    const wrapper = _mount(
+      {
+        components: {
+          Popover,
+        },
+        template: `
+          <Popover
+            :visible="visible"
+            trigger="click"
+            :content="content"
+          >
+          <template #reference>
+            <button>click me</button>
+          </template>
+          </Popover>
+        `,
+        data() {
+          return {
+            visible: false,
+            content: AXIOM,
+          }
+        },
+      },
+      {
+        attachTo: 'body',
+      }
+    )
+    await nextTick()
+    const trigger$ = wrapper.findComponent(ElPopperTrigger)
+    const triggerEl = trigger$.find('.el-tooltip__trigger')
+    const popoverDom = document.querySelector('.el-popper')
+
+    vi.useFakeTimers()
+    await triggerEl.trigger('click')
+    vi.runAllTimers()
+    vi.useRealTimers()
+    await rAF()
+    expect(popoverDom.style.display).toBe('none')
+
+    vi.useFakeTimers()
+    wrapper.vm.visible = true
+    vi.runAllTimers()
+    vi.useRealTimers()
+    await rAF()
+    expect(popoverDom.style.display).not.toBe('none')
+
+    vi.useFakeTimers()
+    wrapper.vm.visible = false
+    vi.runAllTimers()
+    vi.useRealTimers()
+    await rAF()
+    expect(popoverDom.style.display).toBe('none')
+  })
+
+  test('test v-model:visible', async () => {
+    const wrapper = _mount(
+      {
+        components: {
+          Popover,
+        },
+        template: `
+          <Popover
+            v-model:visible="visible"
+            trigger="click"
+            :content="content"
+          >
+          <template #reference>
+            <button>click me</button>
+          </template>
+          </Popover>
+        `,
+        data() {
+          return {
+            visible: false,
+            content: AXIOM,
+          }
+        },
+      },
+      {
+        attachTo: 'body',
+      }
+    )
+    await nextTick()
+    const trigger$ = wrapper.findComponent(ElPopperTrigger)
+    const triggerEl = trigger$.find('.el-tooltip__trigger')
+    const popoverDom = document.querySelector('.el-popper')
+
+    vi.useFakeTimers()
+    await triggerEl.trigger('click')
+    vi.runAllTimers()
+    vi.useRealTimers()
+    await rAF()
+    expect(popoverDom.style.display).not.toBe('none')
+
+    vi.useFakeTimers()
+    await triggerEl.trigger('click')
+    vi.runAllTimers()
+    vi.useRealTimers()
+    await rAF()
+    expect(popoverDom.style.display).toBe('none')
   })
 
   describe('teleported API', () => {

--- a/packages/components/popover/src/popover.ts
+++ b/packages/components/popover/src/popover.ts
@@ -4,7 +4,7 @@ import {
   useTooltipTriggerProps,
 } from '@element-plus/components/tooltip'
 import { dropdownProps } from '@element-plus/components/dropdown'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, PropType } from 'vue'
 import type Popover from './popover.vue'
 
 export const popoverProps = buildProps({
@@ -56,6 +56,9 @@ export const popoverProps = buildProps({
   persistent: {
     type: Boolean,
     default: true,
+  },
+  'onUpdate:visible': {
+    type: Function as PropType<(visible: boolean) => void>,
   },
 } as const)
 export type PopoverProps = ExtractPropTypes<typeof popoverProps>

--- a/packages/components/popover/src/popover.vue
+++ b/packages/components/popover/src/popover.vue
@@ -23,6 +23,7 @@
     :teleported="teleported"
     :persistent="persistent"
     :gpu-acceleration="gpuAcceleration"
+    @update:visible="onUpdateVisible"
     @before-show="beforeEnter"
     @before-hide="beforeLeave"
     @show="afterEnter"
@@ -56,6 +57,12 @@ defineOptions({
 
 const props = defineProps(popoverProps)
 const emit = defineEmits(popoverEmits)
+
+const updateEventKeyRaw = `onUpdate:visible` as const
+
+const onUpdateVisible = computed(() => {
+  return props[updateEventKeyRaw]
+})
 
 const ns = useNamespace('popover')
 const tooltipRef = ref<TooltipInstance>()

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -1,7 +1,7 @@
 <template>
   <el-tooltip
     ref="refPopper"
-    v-model:visible="pickerVisible"
+    :visible="pickerVisible"
     effect="light"
     pure
     trigger="click"

--- a/packages/components/tooltip/src/tooltip.vue
+++ b/packages/components/tooltip/src/tooltip.vue
@@ -146,7 +146,7 @@ export default defineComponent({
     const open = ref(false)
     const toggleReason = ref<Event | undefined>(undefined)
 
-    const { show, hide } = useModelToggle({
+    const { show, hide, hasUpdateHandler } = useModelToggle({
       indicator: open,
       toggleReason,
     })
@@ -158,7 +158,9 @@ export default defineComponent({
       close: hide,
     })
 
-    const controlled = computed(() => isBoolean(props.visible))
+    const controlled = computed(
+      () => isBoolean(props.visible) && !hasUpdateHandler.value
+    )
 
     provide(TOOLTIP_INJECTION_KEY, {
       controlled,

--- a/packages/hooks/use-model-toggle/index.ts
+++ b/packages/hooks/use-model-toggle/index.ts
@@ -171,6 +171,7 @@ export const createModelToggleComposable = <T extends string>(name: T) => {
       hide,
       show,
       toggle,
+      hasUpdateHandler,
     }
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

`v-model:visible` as a bidirectional parameter does not seem very reasonable to use it as a controlled condition, `:visible` is more suitable.
In the original code, as long as the `:visible` parameter is judged to be used, the controlled mode is turned on. I think `v-model:visible` should not be in the uncontrolled mode. It can coexist with the `trigger` and can be simply used to judge whether the `tooltip` is displayed.

### Related issues
#8696 

### Of course, I think this change is a destructive change. In addition to the change in the controlled mode, the components involved in the tooltip have been adjusted accordingly to keep them under control. The following is the list of components found so far:

- [x] tooltip
- [x] popover
- [x] time-picker
- [x] dropdown