### PR TITLE
fix(components): [input] fix #8411 clearable icon show and hide unexpectly 

### DIFF
--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -272,8 +272,7 @@ const showClear = computed(
     props.clearable &&
     !inputDisabled.value &&
     !props.readonly &&
-    !!nativeInputValue.value &&
-    (focused.value || hovering.value)
+    !!nativeInputValue.value
 )
 const showPwdVisible = computed(
   () =>


### PR DESCRIPTION
Description: 
Fix the issue: #8411 
The clearable icon show and hide unexpectly  during focus and hover.
Especially when your text is not left-aligned.

Spec:
It removes focus and hover condition when show clearable icon.

Test result:
<img width="663" alt="image" src="https://user-images.githubusercontent.com/9068314/178784246-a0dab6ae-5902-475d-8ad0-fc734490eeb5.png">


Like some other componet library act the same:
https://antdv.com/components/input-cn#components-input-demo-allow-clear
https://vuetifyjs.com/zh-Hans/components/text-fields/#section-53ef6e059664


Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Here is my test sample App.vue
```
<template>
  <div class="play-container">
    <div>
      <el-input v-model="testInput1" clearable maxlength="5" class="center" />
    </div>
    <div>
      <el-input v-model="testInput2" clearable maxlength="5" class="right" />
    </div>
  </div>
</template>

<script setup lang="ts">
import { ref } from 'vue'
const testInput1 = ref('')
const testInput2 = ref('')
</script>

<style lang="scss" scoped>
html,
body {
  width: 100vw;
  height: 100vh;
  margin: 0;
  #play {
    height: 100%;
    width: 100%;
    .play-container {
      height: 100%;
      width: 100%;
      display: flex;
      align-items: center;
      justify-content: center;
    }
  }
}

.center :deep(.el-input__inner) {
  text-align: center;
}

.right :deep(.el-input__inner) {
  text-align: right;
}
</style>
```