### PR TITLE
fix(components): [upload] one-way cannot add attachments

### DIFF
--- a/packages/components/upload/src/use-handlers.ts
+++ b/packages/components/upload/src/use-handlers.ts
@@ -100,7 +100,7 @@ export const useHandlers = (
         props.onError(err as Error, uploadFile, uploadFiles.value)
       }
     }
-    uploadFiles.value.push(uploadFile)
+    uploadFiles.value = [...uploadFiles.value, uploadFile]
     props.onChange(uploadFile, uploadFiles.value)
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

close #8815 

Because it is an object, using push directly when adding an attachment will change it to props.fileList. In subsequent changes, due to the transformation of the object, the fileList cannot be updated, causing problems. Therefore, when adding files, a new array object should be used for processing to ensure the normality of one-way.