### PR TITLE
refactor(directives): [resize] use useResizeObserver

### DIFF
--- a/packages/directives/resize/index.ts
+++ b/packages/directives/resize/index.ts
@@ -1,10 +1,10 @@
-// @ts-nocheck
-import { addResizeListener, removeResizeListener } from '@element-plus/utils'
+import { useResizeObserver } from '@vueuse/core'
 
 import type { DirectiveBinding, ObjectDirective } from 'vue'
 
 declare interface ResizeEl extends HTMLElement {
   _handleResize?: () => void
+  _stop?: () => void
 }
 
 const Resize: ObjectDirective = {
@@ -12,10 +12,10 @@ const Resize: ObjectDirective = {
     el._handleResize = () => {
       el && binding.value?.(el)
     }
-    addResizeListener(el, el._handleResize)
+    el._stop = useResizeObserver(el, el._handleResize).stop
   },
   beforeUnmount(el: ResizeEl) {
-    removeResizeListener(el, el._handleResize)
+    el && el._stop!()
   },
 }
 


### PR DESCRIPTION
`addResizeListener` and `removeResizeListener` are deprecated. Use `useResizeObserver` in vueuse as suggested

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
