### PR TITLE
fix(components): [table] fix scrollbar maxHeight doesn't consider footer height

### DIFF
--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -46,6 +46,7 @@ function useStyle<T>(
   const tableScrollHeight = ref(0)
   const bodyScrollHeight = ref(0)
   const headerScrollHeight = ref(0)
+  const footerScrollHeight = ref(0)
 
   watchEffect(() => {
     layout.setHeight(props.height)
@@ -221,19 +222,23 @@ function useStyle<T>(
     }
 
     const tableHeader: HTMLElement = table.refs.headerWrapper
-    if (props.showHeader && tableHeader.offsetHeight !== oldHeaderHeight) {
+    if (props.showHeader && tableHeader?.offsetHeight !== oldHeaderHeight) {
       shouldUpdateLayout = true
     }
 
-    tableScrollHeight.value = table.refs.tableWrapper.scrollHeight
-    headerScrollHeight.value = table.refs.headerWrapper?.scrollHeight || 0
-    bodyScrollHeight.value = tableScrollHeight.value - headerScrollHeight.value
+    tableScrollHeight.value = table.refs.tableWrapper?.scrollHeight || 0
+    headerScrollHeight.value = tableHeader?.scrollHeight || 0
+    footerScrollHeight.value = table.refs.footerWrapper?.scrollHeight || 0
+    bodyScrollHeight.value =
+      tableScrollHeight.value -
+      headerScrollHeight.value -
+      footerScrollHeight.value
 
     if (shouldUpdateLayout) {
       resizeState.value = {
         width,
         height,
-        headerHeight: props.showHeader ? tableHeader.offsetHeight : null,
+        headerHeight: (props.showHeader && tableHeader?.offsetHeight) || 0,
       }
       doLayout()
     }
@@ -291,16 +296,21 @@ function useStyle<T>(
     if (props.maxHeight) {
       if (!Number.isNaN(Number(props.maxHeight))) {
         const headerHeight = table.refs.headerWrapper?.scrollHeight || 0
+        const footerHeight = table.refs.footerWrapper?.scrollHeight || 0
         const maxHeight = props.maxHeight
         const reachMaxHeight = tableScrollHeight.value >= Number(maxHeight)
         if (reachMaxHeight) {
           return {
-            maxHeight: `${tableScrollHeight.value - headerHeight}px`,
+            maxHeight: `${
+              tableScrollHeight.value - headerHeight - footerHeight
+            }px`,
           }
         }
       } else {
         return {
-          maxHeight: `calc(${props.maxHeight} - ${headerScrollHeight.value}px)`,
+          maxHeight: `calc(${props.maxHeight} - ${
+            headerScrollHeight.value + footerScrollHeight.value
+          }px)`,
         }
       }
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Resolves #9010 - In the refactor of #8690, the `maxHeight` of the scrollbar didn't take the footer height into account. It should also subtract the footer height.