### PR TITLE
fix(components): [tooltip] related components are controlled

### DIFF
--- a/packages/components/cascader/src/index.vue
+++ b/packages/components/cascader/src/index.vue
@@ -1,7 +1,7 @@
 <template>
   <el-tooltip
     ref="tooltipRef"
-    v-model:visible="popperVisible"
+    :visible="popperVisible"
     :teleported="teleported"
     :popper-class="[nsCascader.e('dropdown'), popperClass]"
     :popper-options="popperOptions"

--- a/packages/components/color-picker/src/index.vue
+++ b/packages/components/color-picker/src/index.vue
@@ -1,7 +1,7 @@
 <template>
   <el-tooltip
     ref="popper"
-    v-model:visible="showPicker"
+    :visible="showPicker"
     :show-arrow="false"
     :fallback-placements="['bottom', 'top', 'right', 'left']"
     :offset="0"

--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -9,7 +9,7 @@
   >
     <el-tooltip
       ref="popper"
-      v-model:visible="dropdownMenuVisible"
+      :visible="dropdownMenuVisible"
       :teleported="teleported"
       :popper-class="[nsSelectV2.e('popper'), popperClass]"
       :gpu-acceleration="false"

--- a/packages/components/slider/src/button.vue
+++ b/packages/components/slider/src/button.vue
@@ -14,7 +14,7 @@
   >
     <el-tooltip
       ref="tooltip"
-      v-model:visible="tooltipVisible"
+      :visible="tooltipVisible"
       :placement="placement"
       :fallback-placements="['top', 'bottom', 'right', 'left']"
       :stop-popper-mouse-event="false"

--- a/packages/components/table/src/filter-panel.vue
+++ b/packages/components/table/src/filter-panel.vue
@@ -1,7 +1,7 @@
 <template>
   <el-tooltip
     ref="tooltip"
-    v-model:visible="tooltipVisible"
+    :visible="tooltipVisible"
     :offset="0"
     :placement="placement"
     :show-arrow="false"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

Due to the adjustment of the `tooltip` `controlled` mode in the previous version, a pop-up window will still appear in the case of `disabled`, and the related components used by the `tooltip` need to be synchronized.

Related Components：

- [x] cascader
- [x] color-picker
- [x] select-v2
- [x] slider/button
- [x] table/filter-panel
- [x] select(#8998)
- [x] time-picker(#8762)