### PR TITLE
fix(theme-chalk): [message] long text support newline

### DIFF
--- a/packages/theme-chalk/src/message.scss
+++ b/packages/theme-chalk/src/message.scss
@@ -55,6 +55,7 @@
 
       .#{$namespace}-message__content {
         color: getCssVar('message', 'text-color');
+        word-break: break-all;
       }
     }
 


### PR DESCRIPTION
closed #9072

This [PR](https://github.com/element-plus/element-plus/pull/8957) support small screen for message,newline only.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
