### PR TITLE
fix(components):[date-picker] timer header  select date input display…

### DIFF
--- a/packages/components/time-picker/src/utils.ts
+++ b/packages/components/time-picker/src/utils.ts
@@ -17,7 +17,7 @@ export const rangeArr = (n: number) =>
 
 export const extractDateFormat = (format: string) => {
   return format
-    .replace(/\W?m{1,2}|\W?ZZ/g, '')
+    .replace(/\W?m{1,2}|\W?ZZ|\W?\d{1,2}/g, '')
     .replace(/\W?h{1,2}|\W?s{1,3}|\W?a/gi, '')
     .trim()
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20198499/181430287-e0cca0dd-7b90-45ec-83b4-bde48d2660bb.png)

if i set format to "YYYY-MM-DD HH:00" , then get the display error . because of the method : extractDateFormat dont filter number out 