### PR TITLE
refactor(hooks): [use-lockscreen] change from padding to width

### DIFF
--- a/packages/hooks/use-lockscreen/index.ts
+++ b/packages/hooks/use-lockscreen/index.ts
@@ -38,7 +38,6 @@ export const useLockscreen = (trigger: Ref<boolean>) => {
   let scrollBarWidth = 0
   let withoutHiddenClass = false
   let bodyWidth = '0'
-  let computedBodyWidth = Number.parseInt(getStyle(document.body, 'width'), 10)
 
   const cleanup = () => {
     removeClass(document.body, hiddenCls.value)
@@ -55,7 +54,6 @@ export const useLockscreen = (trigger: Ref<boolean>) => {
     withoutHiddenClass = !hasClass(document.body, hiddenCls.value)
     if (withoutHiddenClass) {
       bodyWidth = document.body.style.width
-      computedBodyWidth = Number.parseInt(getStyle(document.body, 'width'), 10)
     }
     scrollBarWidth = getScrollBarWidth(ns.namespace.value)
     const bodyHasOverflow =
@@ -66,7 +64,7 @@ export const useLockscreen = (trigger: Ref<boolean>) => {
       (bodyHasOverflow || bodyOverflowY === 'scroll') &&
       withoutHiddenClass
     ) {
-      document.body.style.width = `${computedBodyWidth}px`
+      document.body.style.width = `calc(100% - ${scrollBarWidth}px)`
     }
     addClass(document.body, hiddenCls.value)
   })

--- a/packages/hooks/use-lockscreen/index.ts
+++ b/packages/hooks/use-lockscreen/index.ts
@@ -37,13 +37,13 @@ export const useLockscreen = (trigger: Ref<boolean>) => {
 
   let scrollBarWidth = 0
   let withoutHiddenClass = false
-  let bodyPaddingRight = '0'
-  let computedBodyPaddingRight = 0
+  let bodyWidth = '0'
+  let computedBodyWidth = Number.parseInt(getStyle(document.body, 'width'), 10)
 
   const cleanup = () => {
     removeClass(document.body, hiddenCls.value)
     if (withoutHiddenClass) {
-      document.body.style.paddingRight = bodyPaddingRight
+      document.body.style.width = bodyWidth
     }
   }
   watch(trigger, (val) => {
@@ -54,11 +54,8 @@ export const useLockscreen = (trigger: Ref<boolean>) => {
 
     withoutHiddenClass = !hasClass(document.body, hiddenCls.value)
     if (withoutHiddenClass) {
-      bodyPaddingRight = document.body.style.paddingRight
-      computedBodyPaddingRight = Number.parseInt(
-        getStyle(document.body, 'paddingRight'),
-        10
-      )
+      bodyWidth = document.body.style.width
+      computedBodyWidth = Number.parseInt(getStyle(document.body, 'width'), 10)
     }
     scrollBarWidth = getScrollBarWidth(ns.namespace.value)
     const bodyHasOverflow =
@@ -69,9 +66,7 @@ export const useLockscreen = (trigger: Ref<boolean>) => {
       (bodyHasOverflow || bodyOverflowY === 'scroll') &&
       withoutHiddenClass
     ) {
-      document.body.style.paddingRight = `${
-        computedBodyPaddingRight + scrollBarWidth
-      }px`
+      document.body.style.width = `${computedBodyWidth}px`
     }
     addClass(document.body, hiddenCls.value)
   })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

Using the paddingright method, it has been found in the document that page jittering will occur, so it is changed to width. The original method is calc(100% - scrollbarWidth), but the user can change the body to a non-100% width, so the calculation of the width of the body is used.