### PR TITLE
fix(components): [el-cascader] placeholder disappeared after clear value

### DIFF
--- a/packages/components/cascader/src/index.vue
+++ b/packages/components/cascader/src/index.vue
@@ -450,9 +450,7 @@ export default defineComponent({
           updatePopperPosition()
           nextTick(panel.value?.scrollToExpandingNode)
         } else if (props.filterable) {
-          const { value } = presentText
-          inputValue.value = value
-          searchInputValue.value = value
+          syncPresentTextValue()
         }
 
         emit('visible-change', visible)
@@ -636,7 +634,16 @@ export default defineComponent({
 
     const handleClear = () => {
       panel.value?.clearCheckedNodes()
+      if (!popperVisible.value && props.filterable) {
+        syncPresentTextValue()
+      }
       togglePopperVisible(false)
+    }
+
+    const syncPresentTextValue = () => {
+      const { value } = presentText
+      inputValue.value = value
+      searchInputValue.value = value
     }
 
     const handleSuggestionClick = (node: CascaderNode) => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

给el-cascader组件同时设置clearable和filterable属性后，点击清空按钮后placeholder没有正常显示
复现地址: [here](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZGl2IGNsYXNzPVwiZXhhbXBsZS1ibG9ja1wiPlxuICAgIDxzcGFuIGNsYXNzPVwiZXhhbXBsZS1kZW1vbnN0cmF0aW9uXCJcbiAgICAgID5TZWxlY3QgYW55IGxldmVsIG9mIG9wdGlvbnMgKFNpbmdsZSBzZWxlY3Rpb24pPC9zcGFuXG4gICAgPlxuICAgIDxlbC1jYXNjYWRlciA6b3B0aW9ucz1cIm9wdGlvbnNcIiA6cHJvcHM9XCJwcm9wczFcIiBjbGVhcmFibGUgZmlsdGVyYWJsZSAvPlxuICA8L2Rpdj5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgbGFuZz1cInRzXCIgc2V0dXA+XG5jb25zdCBwcm9wczEgPSB7XG4gIGNoZWNrU3RyaWN0bHk6IHRydWUsXG59XG5cblxuY29uc3Qgb3B0aW9ucyA9IFtcbiAge1xuICAgIHZhbHVlOiAnZ3VpZGUnLFxuICAgIGxhYmVsOiAnR3VpZGUnLFxuICAgIGNoaWxkcmVuOiBbXG4gICAgICB7XG4gICAgICAgIHZhbHVlOiAnZGlzY2lwbGluZXMnLFxuICAgICAgICBsYWJlbDogJ0Rpc2NpcGxpbmVzJyxcbiAgICAgICAgY2hpbGRyZW46IFtcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2NvbnNpc3RlbmN5JyxcbiAgICAgICAgICAgIGxhYmVsOiAnQ29uc2lzdGVuY3knLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdmZWVkYmFjaycsXG4gICAgICAgICAgICBsYWJlbDogJ0ZlZWRiYWNrJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnZWZmaWNpZW5jeScsXG4gICAgICAgICAgICBsYWJlbDogJ0VmZmljaWVuY3knLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdjb250cm9sbGFiaWxpdHknLFxuICAgICAgICAgICAgbGFiZWw6ICdDb250cm9sbGFiaWxpdHknLFxuICAgICAgICAgIH0sXG4gICAgICAgIF0sXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICB2YWx1ZTogJ25hdmlnYXRpb24nLFxuICAgICAgICBsYWJlbDogJ05hdmlnYXRpb24nLFxuICAgICAgICBjaGlsZHJlbjogW1xuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnc2lkZSBuYXYnLFxuICAgICAgICAgICAgbGFiZWw6ICdTaWRlIE5hdmlnYXRpb24nLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICd0b3AgbmF2JyxcbiAgICAgICAgICAgIGxhYmVsOiAnVG9wIE5hdmlnYXRpb24nLFxuICAgICAgICAgIH0sXG4gICAgICAgIF0sXG4gICAgICB9LFxuICAgIF0sXG4gIH0sXG4gIHtcbiAgICB2YWx1ZTogJ2NvbXBvbmVudCcsXG4gICAgbGFiZWw6ICdDb21wb25lbnQnLFxuICAgIGNoaWxkcmVuOiBbXG4gICAgICB7XG4gICAgICAgIHZhbHVlOiAnYmFzaWMnLFxuICAgICAgICBsYWJlbDogJ0Jhc2ljJyxcbiAgICAgICAgY2hpbGRyZW46IFtcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2xheW91dCcsXG4gICAgICAgICAgICBsYWJlbDogJ0xheW91dCcsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2NvbG9yJyxcbiAgICAgICAgICAgIGxhYmVsOiAnQ29sb3InLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICd0eXBvZ3JhcGh5JyxcbiAgICAgICAgICAgIGxhYmVsOiAnVHlwb2dyYXBoeScsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2ljb24nLFxuICAgICAgICAgICAgbGFiZWw6ICdJY29uJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnYnV0dG9uJyxcbiAgICAgICAgICAgIGxhYmVsOiAnQnV0dG9uJyxcbiAgICAgICAgICB9LFxuICAgICAgICBdLFxuICAgICAgfSxcbiAgICAgIHtcbiAgICAgICAgdmFsdWU6ICdmb3JtJyxcbiAgICAgICAgbGFiZWw6ICdGb3JtJyxcbiAgICAgICAgY2hpbGRyZW46IFtcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ3JhZGlvJyxcbiAgICAgICAgICAgIGxhYmVsOiAnUmFkaW8nLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdjaGVja2JveCcsXG4gICAgICAgICAgICBsYWJlbDogJ0NoZWNrYm94JyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnaW5wdXQnLFxuICAgICAgICAgICAgbGFiZWw6ICdJbnB1dCcsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2lucHV0LW51bWJlcicsXG4gICAgICAgICAgICBsYWJlbDogJ0lucHV0TnVtYmVyJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnc2VsZWN0JyxcbiAgICAgICAgICAgIGxhYmVsOiAnU2VsZWN0JyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnY2FzY2FkZXInLFxuICAgICAgICAgICAgbGFiZWw6ICdDYXNjYWRlcicsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ3N3aXRjaCcsXG4gICAgICAgICAgICBsYWJlbDogJ1N3aXRjaCcsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ3NsaWRlcicsXG4gICAgICAgICAgICBsYWJlbDogJ1NsaWRlcicsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ3RpbWUtcGlja2VyJyxcbiAgICAgICAgICAgIGxhYmVsOiAnVGltZVBpY2tlcicsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2RhdGUtcGlja2VyJyxcbiAgICAgICAgICAgIGxhYmVsOiAnRGF0ZVBpY2tlcicsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2RhdGV0aW1lLXBpY2tlcicsXG4gICAgICAgICAgICBsYWJlbDogJ0RhdGVUaW1lUGlja2VyJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAndXBsb2FkJyxcbiAgICAgICAgICAgIGxhYmVsOiAnVXBsb2FkJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAncmF0ZScsXG4gICAgICAgICAgICBsYWJlbDogJ1JhdGUnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdmb3JtJyxcbiAgICAgICAgICAgIGxhYmVsOiAnRm9ybScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIHZhbHVlOiAnZGF0YScsXG4gICAgICAgIGxhYmVsOiAnRGF0YScsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICd0YWJsZScsXG4gICAgICAgICAgICBsYWJlbDogJ1RhYmxlJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAndGFnJyxcbiAgICAgICAgICAgIGxhYmVsOiAnVGFnJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAncHJvZ3Jlc3MnLFxuICAgICAgICAgICAgbGFiZWw6ICdQcm9ncmVzcycsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ3RyZWUnLFxuICAgICAgICAgICAgbGFiZWw6ICdUcmVlJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAncGFnaW5hdGlvbicsXG4gICAgICAgICAgICBsYWJlbDogJ1BhZ2luYXRpb24nLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdiYWRnZScsXG4gICAgICAgICAgICBsYWJlbDogJ0JhZGdlJyxcbiAgICAgICAgICB9LFxuICAgICAgICBdLFxuICAgICAgfSxcbiAgICAgIHtcbiAgICAgICAgdmFsdWU6ICdub3RpY2UnLFxuICAgICAgICBsYWJlbDogJ05vdGljZScsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdhbGVydCcsXG4gICAgICAgICAgICBsYWJlbDogJ0FsZXJ0JyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnbG9hZGluZycsXG4gICAgICAgICAgICBsYWJlbDogJ0xvYWRpbmcnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdtZXNzYWdlJyxcbiAgICAgICAgICAgIGxhYmVsOiAnTWVzc2FnZScsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ21lc3NhZ2UtYm94JyxcbiAgICAgICAgICAgIGxhYmVsOiAnTWVzc2FnZUJveCcsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ25vdGlmaWNhdGlvbicsXG4gICAgICAgICAgICBsYWJlbDogJ05vdGlmaWNhdGlvbicsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIHZhbHVlOiAnbmF2aWdhdGlvbicsXG4gICAgICAgIGxhYmVsOiAnTmF2aWdhdGlvbicsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdtZW51JyxcbiAgICAgICAgICAgIGxhYmVsOiAnTWVudScsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ3RhYnMnLFxuICAgICAgICAgICAgbGFiZWw6ICdUYWJzJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnYnJlYWRjcnVtYicsXG4gICAgICAgICAgICBsYWJlbDogJ0JyZWFkY3J1bWInLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdkcm9wZG93bicsXG4gICAgICAgICAgICBsYWJlbDogJ0Ryb3Bkb3duJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnc3RlcHMnLFxuICAgICAgICAgICAgbGFiZWw6ICdTdGVwcycsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIHZhbHVlOiAnb3RoZXJzJyxcbiAgICAgICAgbGFiZWw6ICdPdGhlcnMnLFxuICAgICAgICBjaGlsZHJlbjogW1xuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnZGlhbG9nJyxcbiAgICAgICAgICAgIGxhYmVsOiAnRGlhbG9nJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAndG9vbHRpcCcsXG4gICAgICAgICAgICBsYWJlbDogJ1Rvb2x0aXAnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdwb3BvdmVyJyxcbiAgICAgICAgICAgIGxhYmVsOiAnUG9wb3ZlcicsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2NhcmQnLFxuICAgICAgICAgICAgbGFiZWw6ICdDYXJkJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnY2Fyb3VzZWwnLFxuICAgICAgICAgICAgbGFiZWw6ICdDYXJvdXNlbCcsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2NvbGxhcHNlJyxcbiAgICAgICAgICAgIGxhYmVsOiAnQ29sbGFwc2UnLFxuICAgICAgICAgIH0sXG4gICAgICAgIF0sXG4gICAgICB9LFxuICAgIF0sXG4gIH0sXG4gIHtcbiAgICB2YWx1ZTogJ3Jlc291cmNlJyxcbiAgICBsYWJlbDogJ1Jlc291cmNlJyxcbiAgICBjaGlsZHJlbjogW1xuICAgICAge1xuICAgICAgICB2YWx1ZTogJ2F4dXJlJyxcbiAgICAgICAgbGFiZWw6ICdBeHVyZSBDb21wb25lbnRzJyxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIHZhbHVlOiAnc2tldGNoJyxcbiAgICAgICAgbGFiZWw6ICdTa2V0Y2ggVGVtcGxhdGVzJyxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIHZhbHVlOiAnZG9jcycsXG4gICAgICAgIGxhYmVsOiAnRGVzaWduIERvY3VtZW50YXRpb24nLFxuICAgICAgfSxcbiAgICBdLFxuICB9LFxuXVxuPC9zY3JpcHQ+XG5cbjxzdHlsZSBzY29wZWQ+XG4uZXhhbXBsZS1ibG9jayB7XG4gIG1hcmdpbjogMXJlbTtcbn1cbi5leGFtcGxlLWRlbW9uc3RyYXRpb24ge1xuICBtYXJnaW46IDFyZW07XG59XG48L3N0eWxlPlxuIiwiaW1wb3J0X21hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge31cbn0iLCJfbyI6e319)
gif演示
![bug](https://user-images.githubusercontent.com/73569598/182784749-d983e124-4bc1-4d07-94af-f91eefa9cf59.gif)

bug出现的原因是：[#7540](https://github.com/element-plus/element-plus/pull/7540)