### PR TITLE
docs: improve example

### DIFF
--- a/docs/examples/config-provider/usage.vue
+++ b/docs/examples/config-provider/usage.vue
@@ -12,8 +12,8 @@
 
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
-import zhCn from 'element-plus/dist/locale/zh-cn.mjs'
-import en from 'element-plus/dist/locale/en.mjs'
+import zhCn from 'element-plus/lib/locale/lang/zh-cn'
+import en from 'element-plus/lib/locale/lang/en'
 
 const language = ref('zh-cn')
 const locale = computed(() => (language.value === 'zh-cn' ? zhCn : en))


### PR DESCRIPTION
In the project using TS, import the error by the original method.

``` vue
<script lang="ts" setup>
import zhCn from 'element-plus/dist/locale/zh-cn.mjs' 
// Could not find a declaration file for module 'element-plus/dist/locale/zh-cn.mjs'.
</script>
```
Found another way in the [official documentation](https://element-plus.org/en-US/guide/i18n.html#global-configuration), which I think is more reasonable.