### PR TITLE
fix(components): [checkbox] label is object in group

### DIFF
--- a/packages/components/checkbox/src/checkbox.ts
+++ b/packages/components/checkbox/src/checkbox.ts
@@ -190,7 +190,7 @@ const useCheckboxStatus = (
     if (toTypeString(value) === '[object Boolean]') {
       return value
     } else if (Array.isArray(value)) {
-      return value.map((o) => toRaw(o)).includes(props.label)
+      return value.map(toRaw).includes(props.label)
     } else if (value !== null && value !== undefined) {
       return value === props.trueLabel
     } else {

--- a/packages/components/checkbox/src/checkbox.ts
+++ b/packages/components/checkbox/src/checkbox.ts
@@ -1,4 +1,12 @@
-import { computed, getCurrentInstance, inject, nextTick, ref, watch } from 'vue'
+import {
+  computed,
+  getCurrentInstance,
+  inject,
+  nextTick,
+  ref,
+  toRaw,
+  watch,
+} from 'vue'
 import { toTypeString } from '@vue/shared'
 import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import {
@@ -182,7 +190,7 @@ const useCheckboxStatus = (
     if (toTypeString(value) === '[object Boolean]') {
       return value
     } else if (Array.isArray(value)) {
-      return value.includes(props.label)
+      return value.map((o) => toRaw(o)).includes(props.label)
     } else if (value !== null && value !== undefined) {
       return value === props.trueLabel
     } else {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

close #9266 

![image](https://user-images.githubusercontent.com/23251408/183967582-d2d5f507-8c03-457c-9f50-85b134a8bb2c.png)

When the `proxy object` is used as `props`, it will be restored to the `original object`. The currently selected value is a proxy object, and the value of `includes` must be `false`, so it must be restored to the original value and then judged.