### PR TITLE
feat(components): [tree] Add some update data APIs for lazy-mode ELTree

### DIFF
--- a/docs/en-US/component/tree.md
+++ b/docs/en-US/component/tree.md
@@ -160,6 +160,7 @@ tree/draggable
 | --------------- | ---------------------------------------- | ---------------------------------------- |
 | filter | filter all tree nodes, filtered nodes will be hidden | Accept a parameter which will be used as first parameter for filter-node-method |
 | updateKeyChildren | set new data to node, only works when `node-key` is assigned | (key, data) Accept two parameters: 1. key of node 2. new data |
+| updateRootChildren | set new data to root node | (data) new data |
 | getCheckedNodes | If the node can be selected (`show-checkbox` is `true`), it returns the currently selected array of nodes | (leafOnly, includeHalfChecked) Accept two boolean type parameters: 1. default value is `false`. If the parameter is `true`, it only returns the currently selected array of sub-nodes. 2. default value is `false`. If the parameter is `true`, the return value contains halfchecked nodes |
 | setCheckedNodes | set certain nodes to be checked, only works when `node-key` is assigned | an array of nodes to be checked |
 | getCheckedKeys | If the node can be selected (`show-checkbox` is `true`), it returns the currently selected array of node's keys | (leafOnly) Accept a boolean type parameter whose default value is `false`. If the parameter is `true`, it only returns the currently selected array of sub-nodes. |
@@ -172,8 +173,10 @@ tree/draggable
 | setCurrentKey | set highlighted node by key, only works when `node-key` is assigned | (key, shouldAutoExpandParent=true) 1. the node's key to be highlighted. If `null`, cancel the currently highlighted node 2. whether to automatically expand parent node |
 | setCurrentNode | set highlighted node, only works when `node-key` is assigned | (node, shouldAutoExpandParent=true) 1. the node to be highlighted 2. whether to automatically expand parent node |
 | getNode | get node by data or key | (data) the node's data or key |
+| getRoot | get root node | - |
 | remove | remove a node, only works when node-key is assigned | (data) the node's data or node to be deleted |
 | append | append a child node to a given node in the tree | (data, parentNode) 1. child node's data to be appended 2. parent node's data, key or node |
+| update | set new data to node | (data, parentNode) 1. child node's data to be updated 2. parent node's data, key or node |
 | insertBefore | insert a node before a given node in the tree | (data, refNode) 1. node's data to be inserted 2. reference node's data, key or node |
 | insertAfter | insert a node after a given node in the tree | (data, refNode) 1. node's data to be inserted 2. reference node's data, key or node |
 

--- a/packages/components/tree/__tests__/tree.test.ts
+++ b/packages/components/tree/__tests__/tree.test.ts
@@ -714,6 +714,16 @@ describe('Tree.vue', () => {
     expect(node.data.id).toEqual(111)
   })
 
+  test('getRoot', async () => {
+    const { wrapper } = getTreeVm(
+      `:props="defaultProps" show-checkbox node-key="id"`
+    )
+    const treeWrapper = wrapper.findComponent(Tree)
+    const tree = treeWrapper.vm as InstanceType<typeof Tree>
+
+    expect(tree.getRoot()).toEqual(tree.store.root)
+  })
+
   test('remove', async () => {
     const { wrapper } = getTreeVm(`:props="defaultProps" node-key="id"`)
     const treeWrapper = wrapper.findComponent(Tree)
@@ -738,6 +748,22 @@ describe('Tree.vue', () => {
 
     expect(tree.data[0].children.length).toEqual(2)
     expect(tree.getNode(88).data).toEqual(nodeData)
+  })
+
+  test('update', async () => {
+    const { wrapper } = getTreeVm(`:props="defaultProps" node-key="id"`)
+    const treeWrapper = wrapper.findComponent(Tree)
+    const tree = treeWrapper.vm as InstanceType<typeof Tree>
+
+    const nodeData = [
+      { id: 88, label: '88' },
+      { id: 99, label: '99' },
+    ]
+    tree.update(nodeData, tree.getNode(1))
+
+    expect(tree.data[0].children.length).toEqual(2)
+    expect(tree.getNode(88).data).toEqual(nodeData[0])
+    expect(tree.getNode(99).data).toEqual(nodeData[1])
   })
 
   test('insertBefore', async () => {
@@ -1124,6 +1150,45 @@ describe('Tree.vue', () => {
     expect(tree.store.nodesMap['11']).toEqual(undefined)
     expect(tree.store.nodesMap['1'].childNodes[0].data.id).toEqual(111)
     expect(nodeLabelWrapper.text()).toEqual('三级 1-1')
+  })
+
+  test('updateRootChildren', async () => {
+    const { wrapper } = getTreeVm(
+      `:props="defaultProps" show-checkbox node-key="id" default-expand-all`
+    )
+
+    const treeWrapper = wrapper.findComponent(Tree)
+    const tree = treeWrapper.vm as InstanceType<typeof Tree>
+
+    tree.updateRootChildren([
+      {
+        id: 5,
+        label: '一级 5',
+        children: [
+          {
+            id: 51,
+            label: '二级 5-1',
+            children: [
+              {
+                id: 111,
+                label: '三级 5-1-1',
+                disabled: true,
+              },
+            ],
+          },
+        ],
+      },
+    ])
+
+    await nextTick()
+
+    const nodeContentWrapper = wrapper.findAll('.el-tree-node__content')[0]
+    const nodeLabelWrapper = nodeContentWrapper.find('.el-tree-node__label')
+
+    expect(tree.store.nodesMap['1']).toEqual(undefined)
+    expect(tree.store.nodesMap['11']).toEqual(undefined)
+    expect(tree.store.root.childNodes[0].data.id).toEqual(5)
+    expect(nodeLabelWrapper.text()).toEqual('一级 5')
   })
 
   test('update multi tree data', async () => {

--- a/packages/components/tree/src/model/tree-store.ts
+++ b/packages/components/tree/src/model/tree-store.ts
@@ -261,9 +261,7 @@ export default class TreeStore {
     return allNodes
   }
 
-  updateChildren(key: TreeKey, data: TreeData): void {
-    const node = this.nodesMap[key]
-    if (!node) return
+  _updateChildren(node: Node, data: TreeData): void {
     const childNodes = node.childNodes
     for (let i = childNodes.length - 1; i >= 0; i--) {
       const child = childNodes[i]
@@ -271,8 +269,26 @@ export default class TreeStore {
     }
     for (let i = 0, j = data.length; i < j; i++) {
       const child = data[i]
-      this.append(child, node.data)
+      this.append(child, node)
     }
+  }
+
+  updateRootChildren(data: TreeData): void {
+    this._updateChildren(this.root, data)
+  }
+
+  updateKeyChildren(key: TreeKey, data: TreeData): void {
+    const node = this.nodesMap[key]
+    if (!node) return
+    this._updateChildren(node, data)
+  }
+
+  updateNodeChildren(
+    data: TreeData,
+    nodeData: TreeNodeData | TreeKey | Node
+  ): void {
+    const node = nodeData ? this.getNode(nodeData) : this.root
+    this._updateChildren(node, data)
   }
 
   _setCheckedKeys(
@@ -400,5 +416,9 @@ export default class TreeStore {
         this.currentNode.parent.expand(null, true)
       }
     }
+  }
+
+  getRoot() {
+    return this.root
   }
 }

--- a/packages/components/tree/src/tree.vue
+++ b/packages/components/tree/src/tree.vue
@@ -320,6 +320,10 @@ export default defineComponent({
       return store.value.getNode(data)
     }
 
+    const getRoot = (): TreeNodeData => {
+      return store.value.getRoot()
+    }
+
     const remove = (data: TreeNodeData | Node) => {
       store.value.remove(data)
     }
@@ -329,6 +333,10 @@ export default defineComponent({
       parentNode: TreeNodeData | TreeKey | Node
     ) => {
       store.value.append(data, parentNode)
+    }
+
+    const update = (data: TreeData, node: TreeNodeData | TreeKey | Node) => {
+      store.value.updateNodeChildren(data, node)
     }
 
     const insertBefore = (
@@ -354,10 +362,14 @@ export default defineComponent({
       ctx.emit('node-expand', nodeData, node, instance)
     }
 
+    const updateRootChildren = (data: TreeData) => {
+      store.value.updateRootChildren(data)
+    }
+
     const updateKeyChildren = (key: TreeKey, data: TreeData) => {
       if (!props.nodeKey)
         throw new Error('[Tree] nodeKey is required in updateKeyChild')
-      store.value.updateChildren(key, data)
+      store.value.updateKeyChildren(key, data)
     }
 
     provide('RootTree', {
@@ -401,11 +413,14 @@ export default defineComponent({
       setCurrentKey,
       t,
       getNode,
+      getRoot,
       remove,
       append,
+      update,
       insertBefore,
       insertAfter,
       handleNodeExpand,
+      updateRootChildren,
       updateKeyChildren,
     }
   },


### PR DESCRIPTION
Old ELTree APIs are not friendly to update root node's children and don't expose the root node.

Users may get confused when updating root node's children data,
howerver it's possible.

So add these APIs:

- `getRoot` is to get root node
- `update` is like `append` and `remove`, but update children
- `updateRootChildren` is like `updateKeyChildren`

Discussion is in #9311

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
