### PR TITLE
fix(theme-chalk): [input] scss variables transpile

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -204,7 +204,7 @@
         var(
             #{getCssVarName('input-height')},
             #{map.get($input-height, 'default')}
-          ) - $border-width * 2
+          ) - #{$border-width} * 2
       )
     );
 
@@ -358,7 +358,7 @@
             var(
                 #{getCssVarName('input-height')},
                 #{map.get($input-height, $size)}
-              ) - $border-width * 2
+              ) - #{$border-width} * 2
           )
         );
       }


### PR DESCRIPTION
![企业微信截图_20220817103629](https://user-images.githubusercontent.com/25497230/185022204-6f452d20-6304-4163-91e6-0d90d1b7694d.png)
如图，input打包后报错，原因是因为calc中变量没有用`#{}`套起来，这里已经套起来了，请PR一下