### PR TITLE
fix(theme-chalk): fix datepicker sidebar of panel is covered by footer

### DIFF
--- a/packages/theme-chalk/src/date-picker/date-range-picker.scss
+++ b/packages/theme-chalk/src/date-picker/date-range-picker.scss
@@ -13,6 +13,10 @@
     width: 756px;
   }
 
+  &.has-time .#{$namespace}-picker-panel__body-wrapper {
+    position: relative;
+  }
+
   table {
     table-layout: fixed;
     width: 100%;


### PR DESCRIPTION
.date-picker has set panel_body-wrapper position:relative, but .date-range-picker hasn't

closed #9350

![image](https://user-images.githubusercontent.com/30902641/185069638-38c3e193-54e1-42af-80af-d17f6b4ca8ba.png)

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
