### PR TITLE
fix(components): [space] complete the prop of space

### DIFF
--- a/docs/en-US/component/space.md
+++ b/docs/en-US/component/space.md
@@ -121,18 +121,18 @@ space/fill-ratio
 
 ## Space Attributes
 
-| Attribute  | Description                     | Type                                      | Available value                                                             | Default    |
-| ---------- | ------------------------------- | ----------------------------------------- | --------------------------------------------------------------------------- | ---------- |
-| alignment  | Controls the alignment of items | string                                    | [align-items](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items) | 'center'   |
-| class      | Classname                       | string / Array<Object \| String> / Object | -                                                                           | -          |
-| direction  | Placement direction             | string                                    | vertical/horizontal                                                         | horizontal |
-| prefixCls  | Prefix for space-items          | string                                    | el-space                                                                    | -          |
-| style      | Extra style rules               | string / Array<Object \| String> / Object | -                                                                           | -          |
-| spacer     | Spacer                          | string / number / VNode                   | -                                                                           | -          |
-| size       | Spacing size                    | string / number / [number, number]        | -                                                                           | 'small'    |
-| wrap       | Auto wrapping                   | boolean                                   | true / false                                                                | false      |
-| fill       | Whether to fill the container   | boolean                                   | true / false                                                                | false      |
-| fill-ratio | Ratio of fill                   | number                                    | -                                                                           | 100        |
+| Attribute  | Description                     | Type                                                                        | Available value                                                             | Default    |
+| ---------- | ------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ---------- |
+| alignment  | Controls the alignment of items | string                                                                      | [align-items](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items) | 'center'   |
+| class      | Classname                       | string / Array<Record<string, boolean> \| String> / Record<string, boolean> | -                                                                           | -          |
+| direction  | Placement direction             | string                                                                      | vertical/horizontal                                                         | horizontal |
+| prefixCls  | Prefix for space-items          | string                                                                      | el-space                                                                    | -          |
+| style      | Extra style rules               | string / Array<Object \| String> / Object                                   | -                                                                           | -          |
+| spacer     | Spacer                          | string / number / VNode                                                     | -                                                                           | -          |
+| size       | Spacing size                    | string / number / [number, number]                                          | -                                                                           | 'small'    |
+| wrap       | Auto wrapping                   | boolean                                                                     | true / false                                                                | false      |
+| fill       | Whether to fill the container   | boolean                                                                     | true / false                                                                | false      |
+| fill-ratio | Ratio of fill                   | number                                                                      | -                                                                           | 100        |
 
 ## Space Slot
 

--- a/packages/components/space/src/space.ts
+++ b/packages/components/space/src/space.ts
@@ -36,11 +36,9 @@ export const spaceProps = buildProps({
   },
 
   class: {
-    type: definePropType<string | string[] | Record<string, boolean>>([
-      String,
-      Object,
-      Array,
-    ]),
+    type: definePropType<
+      string | Array<Record<string, boolean> | string> | Record<string, boolean>
+    >([String, Object, Array]),
     default: '',
   },
 

--- a/packages/components/space/src/space.ts
+++ b/packages/components/space/src/space.ts
@@ -26,6 +26,7 @@ import type {
   VNodeArrayChildren,
   VNodeChild,
 } from 'vue'
+import type { Arrayable } from '@element-plus/utils'
 import type { AlignItemsProperty } from 'csstype'
 
 export const spaceProps = buildProps({
@@ -36,9 +37,11 @@ export const spaceProps = buildProps({
   },
 
   class: {
-    type: definePropType<
-      string | Array<Record<string, boolean> | string> | Record<string, boolean>
-    >([String, Object, Array]),
+    type: definePropType<Arrayable<Record<string, boolean> | string>>([
+      String,
+      Object,
+      Array,
+    ]),
     default: '',
   },
 


### PR DESCRIPTION
As docs mention, when `class` is in `Array` type , its inner element can be `object` type, but it does not specified in type declaration.
![image](https://user-images.githubusercontent.com/43134418/185580678-872702be-3d59-4000-8f63-3f64d0b8dcf0.png)

