### PR TITLE
fix(components): [form-item] rules meaningless increase

### DIFF
--- a/packages/components/form/src/form-item.vue
+++ b/packages/components/form/src/form-item.vue
@@ -189,7 +189,8 @@ const _rules = computed(() => {
   }
 
   if (props.required !== undefined) {
-    rules.push({ required: !!props.required })
+    const lastIndex = Math.max(rules.length - 1, 0)
+    rules.splice(lastIndex, 1, {...rules[lastIndex] || {}, ...{ required: !!props.required }})
   }
 
   return rules


### PR DESCRIPTION
如果 form-item 的 required 属性只要改变就会引起 form item rules 无意义地增加，为了解决这个问题，form-item 的 required 属性改变会将最后一个 form item rule 的 required 同步，如 form item rules 为空则增加一项。

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
