### PR TITLE
style(components): [rate] in safari has outline

### DIFF
--- a/packages/theme-chalk/src/rate.scss
+++ b/packages/theme-chalk/src/rate.scss
@@ -25,7 +25,7 @@ $rate-height: map.merge(
 
   &:focus,
   &:active {
-    outline-width: 0;
+    outline: none;
   }
 
   @include e(item) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

close #9364 
![image](https://user-images.githubusercontent.com/23251408/185782461-232de1b3-433c-4ee6-9119-9740ed612c25.png)
=》
![image](https://user-images.githubusercontent.com/23251408/185782500-4d8499b4-2f56-4f65-919a-275bf8d4db42.png)


The test found that the `outline-width: 0` cannot cover the `outline` on some safari.