### PR TITLE
fix(components): [focus-trap] adding new prop to fix 9077

### DIFF
--- a/packages/components/focus-trap/src/focus-trap.vue
+++ b/packages/components/focus-trap/src/focus-trap.vue
@@ -46,6 +46,7 @@ export default defineComponent({
       type: [Object, String] as PropType<'container' | 'first' | HTMLElement>,
       default: 'first',
     },
+    focusLastActive: Boolean,
   },
   emits: [
     ON_TRAP_FOCUS_EVT,
@@ -243,7 +244,7 @@ export default defineComponent({
         trapContainer.addEventListener(FOCUS_AFTER_RELEASED, releaseOnFocus)
         trapContainer.dispatchEvent(releasedEvent)
 
-        if (!releasedEvent.defaultPrevented) {
+        if (focusLastActive && !releasedEvent.defaultPrevented) {
           tryFocus(lastFocusBeforeTrapped ?? document.body, true)
         }
 


### PR DESCRIPTION
Fix #9077
Adding a new prop `focusLastActive: Boolean` to  `<el-focus-trap>`, to decide whether it should re-focus to the last active element or not.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
