### PR TITLE
fix(components): [popper] el-select bug with multiple and filterable.

### DIFF
--- a/packages/components/popper/src/content.vue
+++ b/packages/components/popper/src/content.vue
@@ -3,7 +3,6 @@
     ref="popperContentRef"
     :style="contentStyle"
     :class="contentClass"
-    tabindex="-1"
     @mouseenter="(e) => $emit('mouseenter', e)"
     @mouseleave="(e) => $emit('mouseleave', e)"
   >


### PR DESCRIPTION
由于el-select依赖的el-tooltip>el-popper默认有一个tabindex="-1"的值，造成multiple多选带filterable筛选的情况下，鼠标点选时输入框失去焦点（键盘↑↓回车键选择没有问题），详情参看如下问题：
https://github.com/element-plus/element-plus/issues/9244
https://github.com/element-plus/element-plus/issues/8640

建议tabindex属性如果真的需要的话，作为变量传入，且默认应该不添加此属性（或者另有类似useTabindex的属性来决策是否启用tabIndex属性）。