### PR TITLE
fix(components): [notification] closeAll invalid

### DIFF
--- a/packages/components/notification/src/notify.ts
+++ b/packages/components/notification/src/notify.ts
@@ -5,7 +5,7 @@ import { debugWarn, isElement, isString, isVNode } from '@element-plus/utils'
 import NotificationConstructor from './notification.vue'
 import { notificationTypes } from './notification'
 
-import type { AppContext, ComponentPublicInstance, Ref, VNode } from 'vue'
+import type { AppContext, Ref, VNode } from 'vue'
 import type {
   NotificationOptions,
   NotificationProps,
@@ -102,9 +102,8 @@ const notify: NotifyFn & Partial<Notify> & { _context: AppContext | null } =
       // instead of calling the onClose function directly, setting this value so that we can have the full lifecycle
       // for out component, so that all closing steps will not be skipped.
       close: () => {
-        ;(
-          vm.component!.proxy as ComponentPublicInstance<{ visible: boolean }>
-        ).visible = false
+        ;(vm.component!.exposed as { visible: Ref<boolean> }).visible.value =
+          false
       },
     }
   }

--- a/packages/components/notification/src/notify.ts
+++ b/packages/components/notification/src/notify.ts
@@ -5,7 +5,7 @@ import { debugWarn, isElement, isString, isVNode } from '@element-plus/utils'
 import NotificationConstructor from './notification.vue'
 import { notificationTypes } from './notification'
 
-import type { AppContext, ComponentPublicInstance, VNode } from 'vue'
+import type { AppContext, ComponentPublicInstance, Ref, VNode } from 'vue'
 import type {
   NotificationOptions,
   NotificationProps,
@@ -167,9 +167,8 @@ export function closeAll(): void {
   for (const orientedNotifications of Object.values(notifications)) {
     orientedNotifications.forEach(({ vm }) => {
       // same as the previous close method, we'd like to make sure lifecycle gets handle properly.
-      ;(
-        vm.component!.proxy as ComponentPublicInstance<{ visible: boolean }>
-      ).visible = false
+      ;(vm.component!.exposed as { visible: Ref<boolean> }).visible.value =
+        false
     })
   }
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

close #9398 .

Since `notification` is refactored into `setup syntax` in version `2.2.13`, it is invalid to write `visible` under `proxy` when `closeAll` is executed. Instead, set `visible` from `exposed`.
This is the `vm.component` printed by versions 2.2.12 and 2.2.13.

2.2.13
![4be2bf8808f20281f4114393ee8d7cc](https://user-images.githubusercontent.com/23251408/186219099-95f17d60-2506-4fa5-b708-062a3ed4ae87.jpg)

2.2.12
![image](https://user-images.githubusercontent.com/23251408/186219197-6d40ae95-36c4-435f-95f1-3572c2efc349.png)
