### PR TITLE
fix(hooks): [use-z-index] update currentZIndex mechanism

### DIFF
--- a/packages/hooks/use-z-index/index.ts
+++ b/packages/hooks/use-z-index/index.ts
@@ -1,14 +1,32 @@
 import { computed, ref } from 'vue'
 import { useGlobalConfig } from '../use-global-config'
 
+const maximumValueOfZIndexAtDocument = () => {
+  const minimumValueOfZIndex = 1
+  let result = minimumValueOfZIndex
+  // Check if it is server-side rendering or not
+  if (typeof window !== 'undefined') {
+    // In client side
+    result = Math.max(
+      minimumValueOfZIndex,
+      ...Array.from(window.document.querySelectorAll('*'))
+        .map((el) => getComputedStyle(el).zIndex)
+        .filter((v) => !Number.isNaN(Number.parseInt(v[1])))
+        .map((o) => Number.parseInt(o))
+    )
+  }
+  return result
+}
 const zIndex = ref(0)
 
 export const useZIndex = () => {
   const initialZIndex = useGlobalConfig('zIndex', 2000) // TODO: move to @element-plus/constants
-  const currentZIndex = computed(() => initialZIndex.value + zIndex.value)
+  const currentZIndex = computed(() =>
+    Math.max(initialZIndex.value, zIndex.value)
+  )
 
   const nextZIndex = () => {
-    zIndex.value++
+    zIndex.value = maximumValueOfZIndexAtDocument()
     return currentZIndex.value
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
---

I found dafault z-index will be 2000 and add by 1 **(nextZIndex)**, But it maybe will make a problem.

For example If I make a dialog component and style it z-index be 3000, At the same time, I also use date picker in my dialog. The date picker is behind the dialog component.


https://user-images.githubusercontent.com/18310281/186333892-12b719fa-9da6-4a83-bc83-646a0fb490ef.mov



I figure out source code of date-picker. and find it use useZIndex.

I also check the component to find which component is used useZIndex.
Here is the component list.

1. tooltip
2. dialog
3. loading
4. message
5. notification
6. image-viewer (for image Preview)
7. Message Box
8. Table (for showing overflow tooltip)

In my option, Those component must be on the top in website. They should not be covered by other component.

So I just Modified **useZIndex**

```javascript
const maximumValueOfZIndexAtDocument = () => {
  const minimumValueOfZIndex = 1
  let result = minimumValueOfZIndex
  // Check if it is server-side rendering or not
  if (typeof window !== 'undefined') {
    // In client side
    result = Math.max(
      minimumValueOfZIndex,
      ...Array.from(window.document.querySelectorAll('*'))
        .map((el) => getComputedStyle(el).zIndex)
        .filter((v) => !Number.isNaN(Number.parseInt(v[1])))
        .map((o) => Number.parseInt(o))
    )
  }
  return result
}
const zIndex = ref(0)

export const useZIndex = () => {
  const initialZIndex = useGlobalConfig('zIndex', 2000) // TODO: move to @element-plus/constants
  const currentZIndex = computed(() =>
    Math.max(initialZIndex.value, zIndex.value)
  )

  const nextZIndex = () => {
    zIndex.value = maximumValueOfZIndexAtDocument()
    return currentZIndex.value
  }

  return {
    initialZIndex,
    currentZIndex,
    nextZIndex,
  }
}

```

It will find the maximum value of z-index at the document, and calculate which value is bigger. (initialZIndex or zIndex)

So that can guarantee the component must be on the top.

https://user-images.githubusercontent.com/18310281/186333907-c23b3ee8-5e44-4375-9143-9029c93326e0.mov


