### PR TITLE
fix(components): [upload] `onPreview` not work when `picture` list type

### DIFF
--- a/packages/components/upload/src/upload-list.vue
+++ b/packages/components/upload/src/upload-list.vue
@@ -38,7 +38,7 @@
         >
           <a
             :class="nsUpload.be('list', 'item-name')"
-            @click.prevent="handleClick(file)"
+            @click.prevent="handlePreview(file)"
           >
             <el-icon :class="nsIcon.m('document')"><Document /></el-icon>
             <span :class="nsUpload.be('list', 'item-file-name')">
@@ -125,7 +125,7 @@ defineOptions({
   name: 'ElUploadList',
 })
 
-const props = defineProps(uploadListProps)
+defineProps(uploadListProps)
 const emit = defineEmits(uploadListEmits)
 
 const { t } = useLocale()
@@ -134,10 +134,6 @@ const nsIcon = useNamespace('icon')
 const nsList = useNamespace('list')
 
 const focusing = ref(false)
-
-const handleClick = (file: UploadFile) => {
-  props.handlePreview(file)
-}
 
 const handleRemove = (file: UploadFile) => {
   emit('remove', file)

--- a/packages/components/upload/src/upload-list.vue
+++ b/packages/components/upload/src/upload-list.vue
@@ -33,10 +33,7 @@
           alt=""
         />
         <div
-          v-if="
-            listType !== 'picture' &&
-            (file.status === 'uploading' || listType !== 'picture-card')
-          "
+          v-if="file.status === 'uploading' || listType !== 'picture-card'"
           :class="nsUpload.be('list', 'item-info')"
         >
           <a

--- a/packages/theme-chalk/src/upload.scss
+++ b/packages/theme-chalk/src/upload.scss
@@ -440,6 +440,8 @@
       box-sizing: border-box;
       margin-top: 10px;
       padding: 10px;
+      display: inline-flex;
+      align-items: center;
 
       .#{bem('icon', '' ,'check')},
       .#{bem('icon', '' ,'circle-check')} {

--- a/packages/theme-chalk/src/upload.scss
+++ b/packages/theme-chalk/src/upload.scss
@@ -440,7 +440,7 @@
       box-sizing: border-box;
       margin-top: 10px;
       padding: 10px;
-      display: inline-flex;
+      display: flex;
       align-items: center;
 
       .#{bem('icon', '' ,'check')},


### PR DESCRIPTION
closes #9437, #9452

Before:

<img width="805" alt="before" src="https://user-images.githubusercontent.com/23100055/186555902-bced269a-6045-4443-9e5e-accfb4c46efe.png">

After:

https://user-images.githubusercontent.com/23100055/186555926-e34a197d-3381-404d-8bd1-bff15a43a4de.mov

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
