### PR TITLE
fix(components): [popper] default flip feature

### DIFF
--- a/packages/components/popper/src/content.ts
+++ b/packages/components/popper/src/content.ts
@@ -15,7 +15,7 @@ export const usePopperCoreConfigProps = buildProps({
   },
   fallbackPlacements: {
     type: definePropType<Placement[]>(Array),
-    default: () => [],
+    default: undefined,
   },
   gpuAcceleration: {
     type: Boolean,

--- a/packages/components/popper/src/utils.ts
+++ b/packages/components/popper/src/utils.ts
@@ -58,7 +58,7 @@ function genModifiers(options: UsePopperCoreConfigProps) {
       name: 'flip',
       options: {
         padding: 5,
-        fallbackPlacements: fallbackPlacements ?? [],
+        fallbackPlacements,
       },
     },
     {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

The `fallbackPlacements` should not be an empty array, that will disable the default flip feature.
#9582