### PR TITLE
fix(components): [table] column using `type`, `min-width`will not effect

### DIFF
--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -65,6 +65,9 @@ function useRender<T>(
     if (realMinWidth.value) {
       column.minWidth = realMinWidth.value
     }
+    if (!realWidth.value && realMinWidth.value) {
+      column.width = undefined
+    }
     if (!column.minWidth) {
       column.minWidth = 80
     }


### PR DESCRIPTION
fix #9540 

我的想法是如果设置了`type` `min-width`，并且没有`width`，那么可以认为用户也想让这里一列可以动态变化宽度，所以碰到这种情况，就不在使用初始时的width，而应该和没有type的列一样，width是undefined

My idea is that if the `type` `min-width` is set and there is no `width`, then it can be assumed that the user also wants the width of a column to change dynamically, so in this case, instead of using the initial width, it should be the same as the column without type, and the width is undefined

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
