### PR TITLE
fix(components): [loading] remove `el-loading-parent--relative` correctly

### DIFF
--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -31,17 +31,28 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
     data.text = text
   }
 
+  function getLoadingNumber() {
+    const target = data.parent
+    let loadingNumber: number | string | null =
+      target.getAttribute('loading-number')
+    loadingNumber = Number.parseInt(loadingNumber as any)
+    return loadingNumber
+  }
+  function setLoadingNumber(loadingNumber: number | string | null) {
+    const target = data.parent
+    if (!loadingNumber) {
+      removeClass(target, ns.bm('parent', 'relative'))
+      target.removeAttribute('loading-number')
+    } else {
+      target.setAttribute('loading-number', loadingNumber.toString())
+    }
+  }
   function destroySelf() {
     const target = data.parent
     if (!target.vLoadingAddClassList) {
-      let loadingNumber: number | string | null =
-        target.getAttribute('loading-number')
-      loadingNumber = Number.parseInt(loadingNumber as any) - 1
+      const loadingNumber = getLoadingNumber()
       if (!loadingNumber) {
         removeClass(target, ns.bm('parent', 'relative'))
-        target.removeAttribute('loading-number')
-      } else {
-        target.setAttribute('loading-number', loadingNumber.toString())
       }
       removeClass(target, ns.bm('parent', 'hidden'))
     }
@@ -56,6 +67,7 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
 
     const target = data.parent
     target.vLoadingAddClassList = undefined
+    setLoadingNumber(getLoadingNumber() - 1)
     afterLeaveFlag.value = true
     clearTimeout(afterLeaveTimer)
 

--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -31,28 +31,17 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
     data.text = text
   }
 
-  function getLoadingNumber() {
-    const target = data.parent
-    let loadingNumber: number | string | null =
-      target.getAttribute('loading-number')
-    loadingNumber = Number.parseInt(loadingNumber as any)
-    return loadingNumber
-  }
-  function setLoadingNumber(loadingNumber: number | string | null) {
-    const target = data.parent
-    if (!loadingNumber) {
-      removeClass(target, ns.bm('parent', 'relative'))
-      target.removeAttribute('loading-number')
-    } else {
-      target.setAttribute('loading-number', loadingNumber.toString())
-    }
-  }
   function destroySelf() {
     const target = data.parent
     if (!target.vLoadingAddClassList) {
-      const loadingNumber = getLoadingNumber()
+      let loadingNumber: number | string | null =
+        target.getAttribute('loading-number')
+      loadingNumber = Number.parseInt(loadingNumber as any) - 1
       if (!loadingNumber) {
         removeClass(target, ns.bm('parent', 'relative'))
+        target.removeAttribute('loading-number')
+      } else {
+        target.setAttribute('loading-number', loadingNumber.toString())
       }
       removeClass(target, ns.bm('parent', 'hidden'))
     }
@@ -65,18 +54,10 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
   function close() {
     if (options.beforeClose && !options.beforeClose()) return
 
-    const target = data.parent
-    target.vLoadingAddClassList = undefined
-    setLoadingNumber(getLoadingNumber() - 1)
     afterLeaveFlag.value = true
     clearTimeout(afterLeaveTimer)
 
-    afterLeaveTimer = window.setTimeout(() => {
-      if (afterLeaveFlag.value) {
-        afterLeaveFlag.value = false
-        destroySelf()
-      }
-    }, 400)
+    afterLeaveTimer = window.setTimeout(handleAfterLeave, 400)
     data.visible = false
 
     options.closed?.()
@@ -84,7 +65,9 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
 
   function handleAfterLeave() {
     if (!afterLeaveFlag.value) return
+    const target = data.parent
     afterLeaveFlag.value = false
+    target.vLoadingAddClassList = undefined
     destroySelf()
   }
 


### PR DESCRIPTION
fix #9627

loadingNumber cannot be reduced by one, if there is a new loading immediately after close

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
