### PR TITLE
fix(components): [popper] add missing id

### DIFF
--- a/packages/components/popper/src/content.vue
+++ b/packages/components/popper/src/content.vue
@@ -229,7 +229,7 @@ onMounted(() => {
           { immediate: true }
         )
       }
-      if (isElement(prevEl)) {
+      if (prevEl !== el && isElement(prevEl)) {
         ;['role', 'aria-label', 'aria-modal', 'id'].forEach((key) => {
           prevEl.removeAttribute(key)
         })


### PR DESCRIPTION
the currenct popperjs version in element-plus removes the "id"-property. So the aria-describedby reference is pointing to something which doesn't exist in the DOM. 
This issue applies for all places where popper is used, i.e. "select", "popover", "date-picker", ...

this fixes #9200 and fixes #8155