### PR TITLE
fix(components): [table] selection column don't create table placeholder

### DIFF
--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -153,7 +153,9 @@ function useRender<T>(
           children = originRenderCell(data)
         }
         const shouldCreatePlaceholder =
-          hasTreeColumn.value && data.cellIndex === 0
+          hasTreeColumn.value &&
+          data.cellIndex === 0 &&
+          data.column.type !== 'selection'
         const prefix = treeCellPrefix(data, shouldCreatePlaceholder)
         const props = {
           class: 'cell',


### PR DESCRIPTION
closed #8363

Tree data doesn't create placeholder when first column type is selection.

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
