### PR TITLE
docs: fix import locale path

### DIFF
--- a/docs/en-US/guide/i18n.md
+++ b/docs/en-US/guide/i18n.md
@@ -14,7 +14,7 @@ Element Plus provides global configurations
 
 ```typescript
 import ElementPlus from 'element-plus'
-import zhCn from 'element-plus/es/locale/lang/zh-cn'
+import zhCn from 'element-plus/dist/locale/zh-cn.mjs'
 
 app.use(ElementPlus, {
   locale: zhCn,
@@ -37,7 +37,7 @@ for globally configuring locale and other settings.
   import { defineComponent } from 'vue'
   import { ElConfigProvider } from 'element-plus'
 
-  import zhCn from 'element-plus/lib/locale/lang/zh-cn'
+  import zhCn from 'element-plus/dist/locale/zh-cn.mjs'
 
   export default defineComponent({
     components: {

--- a/docs/examples/config-provider/usage.vue
+++ b/docs/examples/config-provider/usage.vue
@@ -12,8 +12,8 @@
 
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
-import zhCn from 'element-plus/dist/locale/zh-cn.mjs'
-import en from 'element-plus/dist/locale/en.mjs'
+import zhCn from 'element-plus/lib/locale/lang/zh-cn'
+import en from 'element-plus/lib/locale/lang/en'
 
 const language = ref('zh-cn')
 const locale = computed(() => (language.value === 'zh-cn' ? zhCn : en))

--- a/docs/examples/config-provider/usage.vue
+++ b/docs/examples/config-provider/usage.vue
@@ -12,8 +12,8 @@
 
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
-import zhCn from 'element-plus/lib/locale/lang/zh-cn'
-import en from 'element-plus/lib/locale/lang/en'
+import zhCn from 'element-plus/es/locale/lang/zh-cn'
+import en from 'element-plus/es/locale/lang/en'
 
 const language = ref('zh-cn')
 const locale = computed(() => (language.value === 'zh-cn' ? zhCn : en))

--- a/docs/examples/config-provider/usage.vue
+++ b/docs/examples/config-provider/usage.vue
@@ -12,8 +12,8 @@
 
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
-import zhCn from 'element-plus/es/locale/lang/zh-cn'
-import en from 'element-plus/es/locale/lang/en'
+import zhCn from 'element-plus/dist/locale/zh-cn.mjs'
+import en from 'element-plus/dist/locale/en.mjs'
 
 const language = ref('zh-cn')
 const locale = computed(() => (language.value === 'zh-cn' ? zhCn : en))


### PR DESCRIPTION
In the project using TS, import the error by the original method.

``` vue
<script lang="ts" setup>
import zhCn from 'element-plus/dist/locale/zh-cn.mjs' 
// Could not find a declaration file for module 'element-plus/dist/locale/zh-cn.mjs'.
</script>
```
Found another way in the [official documentation](https://element-plus.org/en-US/guide/i18n.html#global-configuration), which I think is more reasonable.

reopen #9241  