### PR TITLE
refactor(build): use pnpm `shell-emulator` instead of `cross-env`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 shamefully-hoist=true
 strict-peer-dependencies=false
+shell-emulator=true

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "scripts": {
     "dev": "pnpm gen-locale && vitepress dev .",
-    "build": "cross-env NODE_ENV=production && vitepress build . && tsx .vitepress/build/rebuild-pwa.ts",
-    "serve": "cross-env NODE_ENV=production vitepress serve . --port 5001",
+    "build": "NODE_ENV=production && vitepress build . && tsx .vitepress/build/rebuild-pwa.ts",
+    "serve": "NODE_ENV=production vitepress serve . --port 5001",
     "gen-locale": "rimraf .vitepress/i18n && tsx .vitepress/build/crowdin-generate.ts",
     "crowdin-credentials": "tsx .vitepress/build/crowdin-credentials.ts"
   },
@@ -34,7 +34,6 @@
     "@vitejs/plugin-vue-jsx": "^1.3.10",
     "chalk": "^4.1.2",
     "consola": "^2.15.3",
-    "cross-env": "^7.0.3",
     "escape-html": "^1.0.3",
     "fast-glob": "^3.2.11",
     "markdown-it-container": "^3.0.0",

--- a/internal/metadata/package.json
+++ b/internal/metadata/package.json
@@ -13,10 +13,10 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-p build:*",
+    "build": "run-p \"build:*\"",
     "build:contributor": "tsx src/contributor.ts",
     "build:components": "tsx src/components.ts",
-    "dev": "cross-env DEV=1 pnpm run build"
+    "dev": "DEV=1 pnpm run build"
   },
   "devDependencies": {
     "@element-plus/build": "^0.0.1",
@@ -25,7 +25,6 @@
     "@types/lodash-es": "^4.17.6",
     "chalk": "^5.0.1",
     "consola": "^2.15.3",
-    "cross-env": "^7.0.3",
     "fast-glob": "^3.2.11",
     "lodash-es": "^4.17.21",
     "npm-run-all": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,7 +172,6 @@ importers:
       chalk: ^4.1.2
       clipboard-copy: ^4.0.1
       consola: ^2.15.3
-      cross-env: ^7.0.3
       element-plus: npm:element-plus@latest
       escape-html: ^1.0.3
       fast-glob: ^3.2.11
@@ -201,7 +200,7 @@ importers:
       '@vueuse/core': 9.1.0_vue@3.2.37
       axios: 0.27.2
       clipboard-copy: 4.0.1
-      element-plus: 2.2.15_vue@3.2.37
+      element-plus: 2.2.16_vue@3.2.37
       markdown-it: 13.0.1
       normalize.css: 8.0.1
       nprogress: 0.2.0
@@ -218,7 +217,6 @@ importers:
       '@vitejs/plugin-vue-jsx': 1.3.10
       chalk: 4.1.2
       consola: 2.15.3
-      cross-env: 7.0.3
       escape-html: 1.0.3
       fast-glob: 3.2.11
       markdown-it-container: 3.0.0
@@ -349,7 +347,6 @@ importers:
       '@types/lodash-es': ^4.17.6
       chalk: ^5.0.1
       consola: ^2.15.3
-      cross-env: ^7.0.3
       fast-glob: ^3.2.11
       lodash-es: ^4.17.21
       npm-run-all: ^4.1.5
@@ -362,7 +359,6 @@ importers:
       '@types/lodash-es': 4.17.6
       chalk: 5.0.1
       consola: 2.15.3
-      cross-env: 7.0.3
       fast-glob: 3.2.11
       lodash-es: 4.17.21
       npm-run-all: 4.1.5
@@ -2016,18 +2012,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@floating-ui/core/0.7.3:
-    resolution: {integrity: sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==}
-    dev: false
-
   /@floating-ui/core/1.0.1:
     resolution: {integrity: sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==}
-    dev: false
-
-  /@floating-ui/dom/0.5.4:
-    resolution: {integrity: sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==}
-    dependencies:
-      '@floating-ui/core': 0.7.3
     dev: false
 
   /@floating-ui/dom/1.0.1:
@@ -4829,8 +4815,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -4898,14 +4884,6 @@ packages:
 
   /create-require/1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-    dev: true
-
-  /cross-env/7.0.3:
-    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
-    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
-    hasBin: true
-    dependencies:
-      cross-spawn: 7.0.3
     dev: true
 
   /cross-fetch/3.1.5:
@@ -5252,14 +5230,14 @@ packages:
   /electron-to-chromium/1.4.147:
     resolution: {integrity: sha512-czclPqxLMPqPMkahKcske4TaS5lcznsc26ByBlEFDU8grTBVK9C5W6K9I6oEEhm4Ai4jTihGnys90xY1yjXcRg==}
 
-  /element-plus/2.2.15_vue@3.2.37:
-    resolution: {integrity: sha512-SMIx8xKB1YawT9JocyFhbs3Av2rXFfxrCVTLMYS0DK0xnW+fKvwjZngLfwF6MyRzXIuzNW17XFtu0iP3tlJHbA==}
+  /element-plus/2.2.16_vue@3.2.37:
+    resolution: {integrity: sha512-rvaTMFIujec9YDC5lyaiQv2XVUCHuhVDq2k+9vQxP78N8Wd07iEOGa9pvEVOO2uYc75l4rSl2RE/IWPH/6Mdzw==}
     peerDependencies:
       vue: ^3.2.0
     dependencies:
       '@ctrl/tinycolor': 3.4.1
       '@element-plus/icons-vue': 2.0.9_vue@3.2.37
-      '@floating-ui/dom': 0.5.4
+      '@floating-ui/dom': 1.0.1
       '@popperjs/core': /@sxzz/popperjs-es/2.11.7
       '@types/lodash': 4.14.182
       '@types/lodash-es': 4.17.6


### PR DESCRIPTION
Reference: https://github.com/vitejs/vite/pull/10023


Use pnpm `shell-emulator` instead of `cross-env` dependencies


/cc @kecrily Nice trick, thx!