### PR TITLE
fix(components): [select] fix option-group get wrong visible

### DIFF
--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -1817,6 +1817,7 @@ describe('Select', () => {
       vm.debouncedQueryChange(event)
       await nextTick()
       const groups = wrapper.findAllComponents(Group)
+      await nextTick()
       expect(
         groups.filter((group) => {
           const vm = group.vm as any

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -1817,7 +1817,6 @@ describe('Select', () => {
       vm.debouncedQueryChange(event)
       await nextTick()
       const groups = wrapper.findAllComponents(Group)
-      await nextTick()
       expect(
         groups.filter((group) => {
           const vm = group.vm as any

--- a/packages/components/select/src/option-group.vue
+++ b/packages/components/select/src/option-group.vue
@@ -15,6 +15,7 @@ import {
   defineComponent,
   getCurrentInstance,
   inject,
+  nextTick,
   onMounted,
   provide,
   reactive,
@@ -78,7 +79,9 @@ export default defineComponent({
 
     const { groupQueryChange } = toRaw(select)
     watch(groupQueryChange, () => {
-      visible.value = children.value.some((option) => option.visible === true)
+      nextTick(() => {
+        visible.value = children.value.some((option) => option.visible === true)
+      })
     })
 
     return {

--- a/packages/components/select/src/option-group.vue
+++ b/packages/components/select/src/option-group.vue
@@ -15,7 +15,6 @@ import {
   defineComponent,
   getCurrentInstance,
   inject,
-  nextTick,
   onMounted,
   provide,
   reactive,
@@ -78,11 +77,13 @@ export default defineComponent({
     }
 
     const { groupQueryChange } = toRaw(select)
-    watch(groupQueryChange, () => {
-      nextTick(() => {
+    watch(
+      groupQueryChange,
+      () => {
         visible.value = children.value.some((option) => option.visible === true)
-      })
-    })
+      },
+      { flush: 'post' }
+    )
 
     return {
       visible,


### PR DESCRIPTION
closed https://github.com/element-plus/element-plus/issues/9711

it can fix this problem, with nextTick I can get current children visible
but I don't know what was modified in vue3.2.38 cause this problem

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
