### PR TITLE
fix(components): [table] render column children

### DIFF
--- a/packages/components/table/__tests__/table-column.test.ts
+++ b/packages/components/table/__tests__/table-column.test.ts
@@ -701,6 +701,40 @@ describe('table column', () => {
       wrapper.unmount()
     })
 
+    it('should work in one column', async () => {
+      const wrapper = mount({
+        components: {
+          ElTable,
+          ElTableColumn,
+        },
+        template: `
+          <el-table :data="testData">
+            <el-table-column label="group">
+              <el-table-column v-for="item in ['col1', 'col2']" :key="item">
+                <template #header>{{item}}</template>
+              </el-table-column>
+            </el-table-column>
+          </el-table>
+        `,
+
+        created() {
+          this.testData = null
+        },
+      })
+
+      await doubleWait()
+      const trs = wrapper.findAll('.el-table__header tr')
+      expect(trs.length).toEqual(2)
+      const firstRowLength = trs[0].findAll('th .cell').length
+      const secondRowLength = trs[1].findAll('th .cell').length
+      expect(firstRowLength).toEqual(1)
+      expect(secondRowLength).toEqual(2)
+
+      expect(trs[0].find('th:first-child').attributes('rowspan')).toEqual('1')
+      expect(trs[0].find('th:first-child').attributes('colspan')).toEqual('2')
+      wrapper.unmount()
+    })
+
     it('el-table-column should callback itself', async () => {
       const TableColumn = {
         name: 'TableColumn',

--- a/packages/components/table/src/table-column/index.ts
+++ b/packages/components/table/src/table-column/index.ts
@@ -176,8 +176,13 @@ export default defineComponent({
             Array.isArray(childNode.children)
           ) {
             childNode.children.forEach((vnode) => {
-              // No rendering when vnode is dynamic slot or text
-              if (vnode?.patchFlag !== 1024 && !isString(vnode?.children)) {
+              if (vnode.type?.name === 'ElTableColumn' || vnode.shapeFlag & 2) {
+                children.push(vnode)
+              } else if (
+                vnode?.patchFlag !== 1024 &&
+                !isString(vnode?.children)
+              ) {
+                // No rendering when vnode is dynamic slot or text
                 children.push(vnode)
               }
             })


### PR DESCRIPTION
 * render column children in Fragment

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

[playground url](https://element-plus.run/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3QgdGFibGVUaXRsZXMgPSByZWYoWydzdWJUaXQxJywgJ3N1YlRpdDInLCAnc3ViVGl0MyddKVxuY29uc3QgdGFibGVEYXRhID0gcmVmKFtdKVxuPC9zY3JpcHQ+XG5cblxuPHRlbXBsYXRlPlxuICA8ZGl2PlxuXG4gICAgPGgzIHN0eWxlPVwiY29sb3I6IGdyZWVuO1wiPlxuICAgICAg4oiaIOS4i+e6p+agh+mimOa4suafk+ato+W4uFxuICAgIDwvaDM+XG4gICAgPGVsLXRhYmxlIDpkYXRhPVwidGFibGVEYXRhXCI+XG4gICAgICA8ZWwtdGFibGUtY29sdW1uIGxhYmVsPVwiVDFcIiAvPlxuICAgICAgPGVsLXRhYmxlLWNvbHVtbiBsYWJlbD1cIlQyXCI+XG4gICAgICAgIDxlbC10YWJsZS1jb2x1bW4gdi1mb3I9XCJ0IG9mIHRhYmxlVGl0bGVzXCIgOmxhYmVsPVwidFwiIC8+XG4gICAgICA8L2VsLXRhYmxlLWNvbHVtbj5cbiAgICA8L2VsLXRhYmxlPlxuXG4gICAgPGgzIHN0eWxlPVwiY29sb3I6IGdyZWVuO1wiPlxuICAgICAg4oiaIOS4i+e6p+agh+mimOebtOaOpea4suafk+S5n+ato+W4uFxuICAgIDwvaDM+XG4gICAgPGVsLXRhYmxlIDpkYXRhPVwidGFibGVEYXRhXCI+XG4gICAgICA8ZWwtdGFibGUtY29sdW1uIGxhYmVsPVwiVDFcIiAvPlxuICAgICAgPGVsLXRhYmxlLWNvbHVtbiB2LWZvcj1cInQgb2YgdGFibGVUaXRsZXNcIj5cbiAgICAgICAgPHRlbXBsYXRlICNoZWFkZXI+XG4gICAgICAgICAge3t0fX1cbiAgICAgICAgPC90ZW1wbGF0ZT5cbiAgICAgIDwvZWwtdGFibGUtY29sdW1uPlxuICAgIDwvZWwtdGFibGU+XG5cbiAgICA8aDMgc3R5bGU9XCJjb2xvcjogcmVkXCI+XG4gICAgICDinJYg5LiL57qn5qCH6aKY5riy5p+T5aSx6LSlXG4gICAgPC9oMz5cbiAgICA8ZWwtdGFibGUgOmRhdGE9XCJ0YWJsZURhdGFcIj5cbiAgICAgIDxlbC10YWJsZS1jb2x1bW4gbGFiZWw9XCJUMVwiIC8+XG4gICAgICA8ZWwtdGFibGUtY29sdW1uIGxhYmVsPVwiVDJcIj5cbiAgICAgICAgPGVsLXRhYmxlLWNvbHVtbiB2LWZvcj1cInQgb2YgdGFibGVUaXRsZXNcIj5cbiAgICAgICAgICA8dGVtcGxhdGUgI2hlYWRlcj5cbiAgICAgICAgICAgIHt7dH19XG4gICAgICAgICAgPC90ZW1wbGF0ZT5cbiAgICAgICAgPC9lbC10YWJsZS1jb2x1bW4+XG4gICAgICA8L2VsLXRhYmxlLWNvbHVtbj5cbiAgICA8L2VsLXRhYmxlPlxuXG4gIDwvZGl2PlxuICBcbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnRfbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7fVxufSIsIl9vIjp7fX0=)
