### PR TITLE
fix(components): [select-v2] pressing the up key may cause errors

### DIFF
--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -559,7 +559,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
       }
     } else if (direction === 'backward') {
       newIndex = hoveringIndex - 1
-      if (newIndex < 0) {
+      if (newIndex < 0 || newIndex >= options.length) {
         // navigate to the last one
         newIndex = options.length - 1
       }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

When using `filterable`, pressing the up key may cause errors.

[before](https://element-plus.run/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcbmNvbnN0IGluaXRpYWxzID0gWydhJywgJ2InLCAnYycsICdkJywgJ2UnLCAnZicsICdnJywgJ2gnLCAnaScsICdqJ11cbmNvbnN0IHZhbHVlID0gcmVmKFtdKVxuXG5jb25zdCBvcHRpb25zID0gQXJyYXkuZnJvbSh7IGxlbmd0aDogMjAgfSkubWFwKChfLCBpZHgpID0+ICh7XG4gIHZhbHVlOiBgT3B0aW9uICR7aWR4ICsgMX1gLFxuICBsYWJlbDogYCR7aW5pdGlhbHNbaWR4ICUgMTBdfSR7aWR4fWAsXG59KSlcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxwPjEuIFNlbGVjdCB0aGUgYGoxOWA8L3A+XG4gIDxwPjIuIENsaWNrIHRoZSBpbnB1dCBib3ggYW5kIGVudGVyIGBmYDwvcD5cbiAgPHA+My4gUHJlc3MgdGhlIHVwIGtleTwvcD5cbiAgPGVsLXNlbGVjdC12MlxuICAgIHYtbW9kZWw9XCJ2YWx1ZVwiXG4gICAgOm9wdGlvbnM9XCJvcHRpb25zXCJcbiAgICA6cmVzZXJ2ZS1rZXl3b3JkPVwiZmFsc2VcIlxuICAgIGZpbHRlcmFibGVcbiAgICBtdWx0aXBsZVxuICAgIGNsZWFyYWJsZVxuICAgIHBsYWNlaG9sZGVyPVwiUGxlYXNlIHNlbGVjdFwiXG4gICAgc3R5bGU9XCJ3aWR0aDogMjQwcHhcIlxuICAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydF9tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHt9XG59IiwiX28iOnt9fQ==)

[after](https://element-plus.run/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcbmNvbnN0IGluaXRpYWxzID0gWydhJywgJ2InLCAnYycsICdkJywgJ2UnLCAnZicsICdnJywgJ2gnLCAnaScsICdqJ11cbmNvbnN0IHZhbHVlID0gcmVmKFtdKVxuXG5jb25zdCBvcHRpb25zID0gQXJyYXkuZnJvbSh7IGxlbmd0aDogMjAgfSkubWFwKChfLCBpZHgpID0+ICh7XG4gIHZhbHVlOiBgT3B0aW9uICR7aWR4ICsgMX1gLFxuICBsYWJlbDogYCR7aW5pdGlhbHNbaWR4ICUgMTBdfSR7aWR4fWAsXG59KSlcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxwPjEuIFNlbGVjdCB0aGUgYGoxOWA8L3A+XG4gIDxwPjIuIENsaWNrIHRoZSBpbnB1dCBib3ggYW5kIGVudGVyIGBmYDwvcD5cbiAgPHA+My4gUHJlc3MgdGhlIHVwIGtleTwvcD5cbiAgPGVsLXNlbGVjdC12MlxuICAgIHYtbW9kZWw9XCJ2YWx1ZVwiXG4gICAgOm9wdGlvbnM9XCJvcHRpb25zXCJcbiAgICA6cmVzZXJ2ZS1rZXl3b3JkPVwiZmFsc2VcIlxuICAgIGZpbHRlcmFibGVcbiAgICBtdWx0aXBsZVxuICAgIGNsZWFyYWJsZVxuICAgIHBsYWNlaG9sZGVyPVwiUGxlYXNlIHNlbGVjdFwiXG4gICAgc3R5bGU9XCJ3aWR0aDogMjQwcHhcIlxuICAvPlxuPC90ZW1wbGF0ZT5cbiIsIlBsYXlncm91bmRNYWluLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgQXBwIGZyb20gJy4vQXBwLnZ1ZSdcbmltcG9ydCB7IHNldHVwRWxlbWVudFBsdXMgfSBmcm9tICcuL2VsZW1lbnQtcGx1cy5qcydcbnNldHVwRWxlbWVudFBsdXMoKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPEFwcCAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydF9tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vcHJldmlldy05ODE4LWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIlxuICB9XG59IiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly91bnBrZy5jb20vQHZ1ZS9ydW50aW1lLWRvbUBsYXRlc3QvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL3VucGtnLmNvbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vcHJldmlldy05ODE4LWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly91bnBrZy5jb20vQGVsZW1lbnQtcGx1cy9pY29ucy12dWVAMi9kaXN0L2luZGV4Lm1pbi5qc1wiXG4gIH0sXG4gIFwic2NvcGVzXCI6IHt9XG59IiwiZWxlbWVudC1wbHVzLmpzIjoiaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuaW1wb3J0IEVsZW1lbnRQbHVzIGZyb20gJ2VsZW1lbnQtcGx1cydcblxubGV0IGluc3RhbGxlZCA9IGZhbHNlXG5hd2FpdCBsb2FkU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gc2V0dXBFbGVtZW50UGx1cygpIHtcbiAgaWYgKGluc3RhbGxlZCkgcmV0dXJuXG4gIGNvbnN0IGluc3RhbmNlID0gZ2V0Q3VycmVudEluc3RhbmNlKClcbiAgaW5zdGFuY2UuYXBwQ29udGV4dC5hcHAudXNlKEVsZW1lbnRQbHVzKVxuICBpbnN0YWxsZWQgPSB0cnVlXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkU3R5bGUoKSB7XG4gIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgbGluay5ocmVmID0gJ2h0dHBzOi8vcHJldmlldy05ODE4LWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguY3NzJ1xuICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdlcnJvcicsIHJlamVjdClcbiAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICB9KVxufSIsIl9vIjp7InNob3dIaWRkZW4iOnRydWUsInN0eWxlU291cmNlIjoiaHR0cHM6Ly9wcmV2aWV3LTk4MTgtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5jc3MifX0=)

When using `filterable`, the length of the `options` may be less than the cache value(hoveringIndex).