### PR TITLE
fix(components): [calendar] show wrong weekday when set weekStart

### DIFF
--- a/packages/components/calendar/__tests__/calendar.test.tsx
+++ b/packages/components/calendar/__tests__/calendar.test.tsx
@@ -1,9 +1,19 @@
 import { nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
+import updateLocale from 'dayjs/plugin/updateLocale'
+import { dayjs } from '../../../element-plus/index'
 import Calendar from '../src/calendar.vue'
 
 const AXIOM = 'Rem is the best girl'
+
+const setDayjsWeekStart = (weekStart = 0) => {
+  dayjs.extend(updateLocale)
+  const dayjsLocale = dayjs.locale()
+  dayjs.updateLocale(dayjsLocale, {
+    weekStart,
+  })
+}
 
 describe('Calendar.vue', () => {
   it('create', async () => {
@@ -123,6 +133,26 @@ describe('Calendar.vue', () => {
     expect(firstRow?.lastElementChild?.innerHTML).toContain('6')
   })
 
+  it('firstDayOfWeek when set 1', async () => {
+    setDayjsWeekStart(1)
+    const wrapper = mount({
+      data: () => ({ value: new Date('2019-09-01') }),
+      render() {
+        return <Calendar v-model={this.value} />
+      },
+    })
+    const head = wrapper.element.querySelector('.el-calendar-table thead')
+    expect(head?.firstElementChild?.innerHTML).toBe('Mon')
+    expect(head?.lastElementChild?.innerHTML).toBe('Sun')
+    const firstRow = wrapper.element.querySelector('.el-calendar-table__row')
+    expect(firstRow?.firstElementChild?.innerHTML).toContain('26')
+    expect(firstRow?.lastElementChild?.innerHTML).toContain('1')
+    const rows = wrapper.element.querySelectorAll('.el-calendar-table__row')
+    expect(rows.length).toBe(6)
+    // reset weekStart 0
+    setDayjsWeekStart()
+  })
+
   it('firstDayOfWeek in range mode', async () => {
     const wrapper = mount({
       data: () => ({ value: new Date('2019-03-04') }),
@@ -130,9 +160,8 @@ describe('Calendar.vue', () => {
         return (
           <Calendar
             v-model={this.value}
-            first-day-of-week={7}
             range={[new Date(2019, 1, 3), new Date(2019, 2, 23)]}
-          ></Calendar>
+          />
         )
       },
     })

--- a/packages/components/calendar/__tests__/calendar.test.tsx
+++ b/packages/components/calendar/__tests__/calendar.test.tsx
@@ -2,7 +2,7 @@ import { nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import updateLocale from 'dayjs/plugin/updateLocale'
-import { dayjs } from '../../../element-plus/index'
+import dayjs from 'dayjs'
 import Calendar from '../src/calendar.vue'
 
 const AXIOM = 'Rem is the best girl'

--- a/packages/components/calendar/src/date-table.vue
+++ b/packages/components/calendar/src/date-table.vue
@@ -66,8 +66,8 @@ const nsTable = useNamespace('calendar-table')
 const nsDay = useNamespace('calendar-day')
 
 const now = dayjs().locale(lang.value)
-// todo better way to get Day.js locale object
-const firstDayOfWeek: number = (now as any).$locale().weekStart || 0
+// https://day.js.org/docs/en/i18n/locale-data
+const firstDayOfWeek: number = dayjs.localeData().firstDayOfWeek()
 
 const isInRange = computed(() => !!props.range && !!props.range.length)
 
@@ -95,7 +95,7 @@ const rows = computed(() => {
     const firstDay = props.date.startOf('month').day()
     const prevMonthDays: CalendarDateCell[] = getPrevMonthLastDays(
       props.date,
-      firstDay - firstDayOfWeek
+      (firstDay - firstDayOfWeek + 7) % 7
     ).map((day) => ({
       text: day,
       type: 'prev',


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

closed #9821 

by the way,the unit test  `firstDayOfWeek in range mode` looks outdated,it still use prop `first-day-of-week`

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
