### PR TITLE
fix(components): [backtop] fix a display bug

### DIFF
--- a/packages/components/backtop/src/backtop.vue
+++ b/packages/components/backtop/src/backtop.vue
@@ -66,7 +66,7 @@ const handleClick = (event: MouseEvent) => {
   emit('click', event)
 }
 
-const handleScrollThrottled = useThrottleFn(handleScroll, 300)
+const handleScrollThrottled = useThrottleFn(handleScroll, 300, true)
 
 useEventListener(container, 'scroll', handleScrollThrottled)
 onMounted(() => {


### PR DESCRIPTION
The component is not hidden when the scroll bar rolls to the top within 300 ms. Add [trailing=true] attributes to the useThrottleFn() function,that call handleScroll again after the time is up, and the bug is fixed.

BREAKING CHANGE :
no

closed no

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
