### PR TITLE
fix(components): [tabs] correct the position of tab-bar when scaling

### DIFF
--- a/packages/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/components/tabs/__tests__/tabs.test.tsx
@@ -450,9 +450,9 @@ describe('Tabs.vue', () => {
 
     const tabsWrapper = wrapper.findComponent(Tabs)
     await nextTick()
-    const mockCRect = vi
-      .spyOn(wrapper.find('#tab-C').element, 'getBoundingClientRect')
-      .mockReturnValue({ left: 300 } as DOMRect)
+    const mockOffsetLeft = vi
+      .spyOn(wrapper.find('#tab-C').element, 'offsetLeft' as any, 'get')
+      .mockImplementation(() => 300)
     const mockComputedStyle = vi
       .spyOn(window, 'getComputedStyle')
       .mockReturnValue({ paddingLeft: '0px' } as CSSStyleDeclaration)
@@ -465,9 +465,9 @@ describe('Tabs.vue', () => {
 
     tabPosition.value = 'left'
     await nextTick()
-    const mockCYRect = vi
-      .spyOn(wrapper.find('#tab-C').element, 'getBoundingClientRect')
-      .mockReturnValue({ top: 200 } as DOMRect)
+    const mockOffsetTop = vi
+      .spyOn(wrapper.find('#tab-C').element, 'offsetTop' as any, 'get')
+      .mockImplementation(() => 200)
     await wrapper.find('#tab-A').trigger('click')
     await wrapper.find('#tab-C').trigger('click')
 
@@ -476,8 +476,8 @@ describe('Tabs.vue', () => {
       'translateY(200px)'
     )
 
-    mockCRect.mockRestore()
-    mockCYRect.mockRestore()
+    mockOffsetLeft.mockRestore()
+    mockOffsetTop.mockRestore()
     mockComputedStyle.mockRestore()
     wrapper.unmount()
   })
@@ -621,9 +621,9 @@ describe('Tabs.vue', () => {
     const tabsWrapper = wrapper.findComponent(Tabs)
     await nextTick()
 
-    const mockRect = vi
-      .spyOn(wrapper.find('#tab-4999').element, 'getBoundingClientRect')
-      .mockReturnValue({ left: 5000 } as DOMRect)
+    const mockOffsetLeft = vi
+      .spyOn(wrapper.find('#tab-4999').element, 'offsetLeft' as any, 'get')
+      .mockImplementation(() => 5000)
     const mockComputedStyle = vi
       .spyOn(window, 'getComputedStyle')
       .mockReturnValue({ paddingLeft: '0px' } as CSSStyleDeclaration)
@@ -635,7 +635,7 @@ describe('Tabs.vue', () => {
       'translateX(5000px)'
     )
 
-    mockRect.mockRestore()
+    mockOffsetLeft.mockRestore()
     mockComputedStyle.mockRestore()
     wrapper.unmount()
   })

--- a/packages/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/components/tabs/__tests__/tabs.test.tsx
@@ -451,7 +451,7 @@ describe('Tabs.vue', () => {
     const tabsWrapper = wrapper.findComponent(Tabs)
     await nextTick()
     const mockOffsetLeft = vi
-      .spyOn(wrapper.find('#tab-C').element, 'offsetLeft' as any, 'get')
+      .spyOn(wrapper.find('#tab-C').element as HTMLElement, 'offsetLeft', 'get')
       .mockImplementation(() => 300)
     const mockComputedStyle = vi
       .spyOn(window, 'getComputedStyle')
@@ -466,7 +466,7 @@ describe('Tabs.vue', () => {
     tabPosition.value = 'left'
     await nextTick()
     const mockOffsetTop = vi
-      .spyOn(wrapper.find('#tab-C').element, 'offsetTop' as any, 'get')
+      .spyOn(wrapper.find('#tab-C').element as HTMLElement, 'offsetTop', 'get')
       .mockImplementation(() => 200)
     await wrapper.find('#tab-A').trigger('click')
     await wrapper.find('#tab-C').trigger('click')
@@ -622,7 +622,11 @@ describe('Tabs.vue', () => {
     await nextTick()
 
     const mockOffsetLeft = vi
-      .spyOn(wrapper.find('#tab-4999').element, 'offsetLeft' as any, 'get')
+      .spyOn(
+        wrapper.find('#tab-4999').element as HTMLElement,
+        'offsetLeft',
+        'get'
+      )
       .mockImplementation(() => 5000)
     const mockComputedStyle = vi
       .spyOn(window, 'getComputedStyle')

--- a/packages/components/tabs/src/tab-bar.vue
+++ b/packages/components/tabs/src/tab-bar.vue
@@ -50,9 +50,19 @@ const getBarStyle = (): CSSProperties => {
 
     tabSize = $el[`client${capitalize(sizeName)}`]
     const position = sizeDir === 'x' ? 'left' : 'top'
+
     offset =
-      $el.getBoundingClientRect()[position] -
-      ($el.parentElement?.getBoundingClientRect()[position] ?? 0)
+      $el[`offset${capitalize(position)}`] -
+      ($el.parentElement?.[`offset${capitalize(position)}`] ?? 0)
+
+    const scrollwrapEl = $el.closest('.is-scrollable')
+    if (scrollwrapEl) {
+      const scrollWrapStyle = window.getComputedStyle(scrollwrapEl)
+      offset += Number.parseFloat(
+        scrollWrapStyle[`padding${capitalize(position)}`]
+      )
+    }
+
     const tabStyles = window.getComputedStyle($el)
 
     if (sizeName === 'width') {


### PR DESCRIPTION
closes #9882

[Before](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtcmFkaW8tZ3JvdXAgdi1tb2RlbD1cInRhYlBvc2l0aW9uXCIgc3R5bGU9XCJtYXJnaW4tYm90dG9tOiAxMHB4XCI+XG4gICAgPGVsLXJhZGlvLWJ1dHRvbiBsYWJlbD1cInRvcFwiPnRvcDwvZWwtcmFkaW8tYnV0dG9uPlxuICAgIDxlbC1yYWRpby1idXR0b24gbGFiZWw9XCJyaWdodFwiPnJpZ2h0PC9lbC1yYWRpby1idXR0b24+XG4gICAgPGVsLXJhZGlvLWJ1dHRvbiBsYWJlbD1cImJvdHRvbVwiPmJvdHRvbTwvZWwtcmFkaW8tYnV0dG9uPlxuICAgIDxlbC1yYWRpby1idXR0b24gbGFiZWw9XCJsZWZ0XCI+bGVmdDwvZWwtcmFkaW8tYnV0dG9uPlxuICA8L2VsLXJhZGlvLWdyb3VwPlxuICA8ZGl2IHN0eWxlPVwibWFyZ2luLWJvdHRvbTogMzBweFwiPlxuICAgIDxlbC1jaGVja2JveCBsYWJlbD1cInNjcm9sbFwiIGJvcmRlciB2LW1vZGVsPVwic2Nyb2xsXCIgLz5cbiAgICA8ZWwtY2hlY2tib3ggbGFiZWw9XCJzY2FsZVwiIGJvcmRlciB2LW1vZGVsPVwic2NhbGVcIiAvPlxuICA8L2Rpdj5cblxuICA8ZWwtdGFicyB2LW1vZGVsPVwidmFsdWVcIiA6dGFiLXBvc2l0aW9uPVwidGFiUG9zaXRpb25cIiA6c3R5bGU9XCJ0YWJzU3R5bGVcIj5cbiAgICA8ZWwtdGFiLXBhbmUgbGFiZWw9XCJVc2VyXCIgbmFtZT1cIjFcIj5Vc2VyPC9lbC10YWItcGFuZT5cbiAgICA8ZWwtdGFiLXBhbmUgbGFiZWw9XCJDb25maWdcIiBuYW1lPVwiMlwiPkNvbmZpZzwvZWwtdGFiLXBhbmU+XG4gICAgPGVsLXRhYi1wYW5lIGxhYmVsPVwiUm9sZVwiIG5hbWU9XCIzXCI+Um9sZTwvZWwtdGFiLXBhbmU+XG4gICAgPGVsLXRhYi1wYW5lIGxhYmVsPVwiVGFza1wiIG5hbWU9XCI0XCI+VGFzazwvZWwtdGFiLXBhbmU+XG4gIDwvZWwtdGFicz5cbjwvdGVtcGxhdGU+XG48c2NyaXB0IGxhbmc9XCJ0c1wiIHNldHVwPlxuaW1wb3J0IHsgcmVmLCBjb21wdXRlZCB9IGZyb20gJ3Z1ZSdcbmltcG9ydCB7IFRhYnNQcm9wcyB9IGZyb20gJ2VsZW1lbnQtcGx1cydcblxuY29uc3QgdmFsdWUgPSByZWYoJzInKVxuY29uc3QgdGFiUG9zaXRpb24gPSByZWY8VGFic1Byb3BzWyd0YWJQb3NpdGlvbiddPigndG9wJylcbmNvbnN0IHNjcm9sbCA9IHJlZihmYWxzZSlcbmNvbnN0IHNjYWxlID0gcmVmKHRydWUpXG5cbmNvbnN0IGlzSG9yaXpvbnRhbCA9IGNvbXB1dGVkKCgpID0+XG4gIFsndG9wJywgJ2JvdHRvbSddLmluY2x1ZGVzKHRhYlBvc2l0aW9uLnZhbHVlKVxuKVxuXG5jb25zdCB0YWJzU3R5bGUgPSBjb21wdXRlZCgoKSA9PiB7XG4gIHJldHVybiB7XG4gICAgd2lkdGg6IHNjcm9sbC52YWx1ZSAmJiBpc0hvcml6b250YWwudmFsdWUgPyAnMjAwcHgnIDogJ2F1dG8nLFxuICAgIGhlaWdodDogc2Nyb2xsLnZhbHVlICYmIGlzSG9yaXpvbnRhbC52YWx1ZSA/ICdhdXRvJyA6ICcyMDBweCcsXG4gICAgc2NhbGU6IHNjYWxlLnZhbHVlID8gMC41IDogMSxcbiAgfVxufSlcbjwvc2NyaXB0PlxuIiwiaW1wb3J0X21hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge31cbn0iLCJfbyI6e319)

[After](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtcmFkaW8tZ3JvdXAgdi1tb2RlbD1cInRhYlBvc2l0aW9uXCIgc3R5bGU9XCJtYXJnaW4tYm90dG9tOiAxMHB4XCI+XG4gICAgPGVsLXJhZGlvLWJ1dHRvbiBsYWJlbD1cInRvcFwiPnRvcDwvZWwtcmFkaW8tYnV0dG9uPlxuICAgIDxlbC1yYWRpby1idXR0b24gbGFiZWw9XCJyaWdodFwiPnJpZ2h0PC9lbC1yYWRpby1idXR0b24+XG4gICAgPGVsLXJhZGlvLWJ1dHRvbiBsYWJlbD1cImJvdHRvbVwiPmJvdHRvbTwvZWwtcmFkaW8tYnV0dG9uPlxuICAgIDxlbC1yYWRpby1idXR0b24gbGFiZWw9XCJsZWZ0XCI+bGVmdDwvZWwtcmFkaW8tYnV0dG9uPlxuICA8L2VsLXJhZGlvLWdyb3VwPlxuICA8ZGl2IHN0eWxlPVwibWFyZ2luLWJvdHRvbTogMzBweFwiPlxuICAgIDxlbC1jaGVja2JveCBsYWJlbD1cInNjcm9sbFwiIGJvcmRlciB2LW1vZGVsPVwic2Nyb2xsXCIgLz5cbiAgICA8ZWwtY2hlY2tib3ggbGFiZWw9XCJzY2FsZVwiIGJvcmRlciB2LW1vZGVsPVwic2NhbGVcIiAvPlxuICA8L2Rpdj5cblxuICA8ZWwtdGFicyB2LW1vZGVsPVwidmFsdWVcIiA6dGFiLXBvc2l0aW9uPVwidGFiUG9zaXRpb25cIiA6c3R5bGU9XCJ0YWJzU3R5bGVcIj5cbiAgICA8ZWwtdGFiLXBhbmUgbGFiZWw9XCJVc2VyXCIgbmFtZT1cIjFcIj5Vc2VyPC9lbC10YWItcGFuZT5cbiAgICA8ZWwtdGFiLXBhbmUgbGFiZWw9XCJDb25maWdcIiBuYW1lPVwiMlwiPkNvbmZpZzwvZWwtdGFiLXBhbmU+XG4gICAgPGVsLXRhYi1wYW5lIGxhYmVsPVwiUm9sZVwiIG5hbWU9XCIzXCI+Um9sZTwvZWwtdGFiLXBhbmU+XG4gICAgPGVsLXRhYi1wYW5lIGxhYmVsPVwiVGFza1wiIG5hbWU9XCI0XCI+VGFzazwvZWwtdGFiLXBhbmU+XG4gIDwvZWwtdGFicz5cbjwvdGVtcGxhdGU+XG48c2NyaXB0IGxhbmc9XCJ0c1wiIHNldHVwPlxuaW1wb3J0IHsgcmVmLCBjb21wdXRlZCB9IGZyb20gJ3Z1ZSdcbmltcG9ydCB7IFRhYnNQcm9wcyB9IGZyb20gJ2VsZW1lbnQtcGx1cydcblxuY29uc3QgdmFsdWUgPSByZWYoJzInKVxuY29uc3QgdGFiUG9zaXRpb24gPSByZWY8VGFic1Byb3BzWyd0YWJQb3NpdGlvbiddPigndG9wJylcbmNvbnN0IHNjcm9sbCA9IHJlZihmYWxzZSlcbmNvbnN0IHNjYWxlID0gcmVmKHRydWUpXG5cbmNvbnN0IGlzSG9yaXpvbnRhbCA9IGNvbXB1dGVkKCgpID0+XG4gIFsndG9wJywgJ2JvdHRvbSddLmluY2x1ZGVzKHRhYlBvc2l0aW9uLnZhbHVlKVxuKVxuXG5jb25zdCB0YWJzU3R5bGUgPSBjb21wdXRlZCgoKSA9PiB7XG4gIHJldHVybiB7XG4gICAgd2lkdGg6IHNjcm9sbC52YWx1ZSAmJiBpc0hvcml6b250YWwudmFsdWUgPyAnMjAwcHgnIDogJ2F1dG8nLFxuICAgIGhlaWdodDogc2Nyb2xsLnZhbHVlICYmIGlzSG9yaXpvbnRhbC52YWx1ZSA/ICdhdXRvJyA6ICcyMDBweCcsXG4gICAgc2NhbGU6IHNjYWxlLnZhbHVlID8gMC41IDogMSxcbiAgfVxufSlcbjwvc2NyaXB0PlxuIiwiUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0X21hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9wcmV2aWV3LTk4OTYtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5mdWxsLm1pbi5tanNcIixcbiAgICBcImVsZW1lbnQtcGx1cy9cIjogXCJ1bnN1cHBvcnRlZFwiXG4gIH1cbn0iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Zhc3RseS5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AbGF0ZXN0L2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvc2hhcmVkXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vcHJldmlldy05ODk2LWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9AZWxlbWVudC1wbHVzL2ljb25zLXZ1ZUAyL2Rpc3QvaW5kZXgubWluLmpzXCJcbiAgfSxcbiAgXCJzY29wZXNcIjoge31cbn0iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5pbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICBsaW5rLmhyZWYgPSAnaHR0cHM6Ly9wcmV2aWV3LTk4OTYtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5jc3MnXG4gICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gIH0pXG59IiwiX28iOnsic2hvd0hpZGRlbiI6dHJ1ZSwic3R5bGVTb3VyY2UiOiJodHRwczovL3ByZXZpZXctOTg5Ni1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcyJ9fQ==)

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
