### PR TITLE
fix(components): [time-picker] fix popup not showing

### DIFF
--- a/packages/components/focus-trap/src/focus-trap.vue
+++ b/packages/components/focus-trap/src/focus-trap.vue
@@ -17,6 +17,7 @@ import { EVENT_CODE } from '@element-plus/constants'
 import { useEscapeKeydown } from '@element-plus/hooks'
 import { isString } from '@element-plus/utils'
 import {
+  createFocusOutPreventedEvent,
   focusFirstDescendant,
   focusableStack,
   getEdges,
@@ -96,21 +97,36 @@ export default defineComponent({
         const isTabbable = first && last
         if (!isTabbable) {
           if (currentFocusingEl === container) {
-            e.preventDefault()
-            emit('focusout-prevented', focusReason.value)
+            const focusoutPreventedEvent = createFocusOutPreventedEvent({
+              focusReason: focusReason.value,
+            })
+            emit('focusout-prevented', focusoutPreventedEvent)
+            if (!focusoutPreventedEvent.defaultPrevented) {
+              e.preventDefault()
+            }
           }
         } else {
           if (!shiftKey && currentFocusingEl === last) {
-            e.preventDefault()
-            if (loop) tryFocus(first, true)
-            emit('focusout-prevented', focusReason.value)
+            const focusoutPreventedEvent = createFocusOutPreventedEvent({
+              focusReason: focusReason.value,
+            })
+            emit('focusout-prevented', focusoutPreventedEvent)
+            if (!focusoutPreventedEvent.defaultPrevented) {
+              e.preventDefault()
+              if (loop) tryFocus(first, true)
+            }
           } else if (
             shiftKey &&
             [first, container].includes(currentFocusingEl as HTMLElement)
           ) {
-            e.preventDefault()
-            if (loop) tryFocus(last, true)
-            emit('focusout-prevented', focusReason.value)
+            const focusoutPreventedEvent = createFocusOutPreventedEvent({
+              focusReason: focusReason.value,
+            })
+            emit('focusout-prevented', focusoutPreventedEvent)
+            if (!focusoutPreventedEvent.defaultPrevented) {
+              e.preventDefault()
+              if (loop) tryFocus(last, true)
+            }
           }
         }
       }
@@ -190,8 +206,13 @@ export default defineComponent({
           // And only reclaim focus if it should currently be trapping
           setTimeout(() => {
             if (!focusLayer.paused && props.trapped) {
-              tryFocus(lastFocusAfterTrapped, true)
-              emit('focusout-prevented', focusReason.value)
+              const focusoutPreventedEvent = createFocusOutPreventedEvent({
+                focusReason: focusReason.value,
+              })
+              emit('focusout-prevented', focusoutPreventedEvent)
+              if (!focusoutPreventedEvent.defaultPrevented) {
+                tryFocus(lastFocusAfterTrapped, true)
+              }
             }
           }, 0)
         }

--- a/packages/components/focus-trap/src/focus-trap.vue
+++ b/packages/components/focus-trap/src/focus-trap.vue
@@ -38,8 +38,6 @@ import {
 import type { PropType } from 'vue'
 import type { FocusLayer } from './utils'
 
-const { focusReason } = useFocusReason()
-
 export default defineComponent({
   name: 'ElFocusTrap',
   inheritAttrs: false,
@@ -64,6 +62,8 @@ export default defineComponent({
     const forwardRef = ref<HTMLElement | undefined>()
     let lastFocusBeforeTrapped: HTMLElement | null
     let lastFocusAfterTrapped: HTMLElement | null
+
+    const { focusReason } = useFocusReason()
 
     useEscapeKeydown((event) => {
       if (props.trapped && !focusLayer.paused) {

--- a/packages/components/focus-trap/src/focus-trap.vue
+++ b/packages/components/focus-trap/src/focus-trap.vue
@@ -37,7 +37,7 @@ import {
 import type { PropType } from 'vue'
 import type { FocusLayer } from './utils'
 
-const { focusReason, lastUserFocusTimestamp } = useFocusReason()
+const { focusReason } = useFocusReason()
 
 export default defineComponent({
   name: 'ElFocusTrap',

--- a/packages/components/focus-trap/src/tokens.ts
+++ b/packages/components/focus-trap/src/tokens.ts
@@ -2,7 +2,12 @@ import type { InjectionKey, Ref } from 'vue'
 
 export const FOCUS_AFTER_TRAPPED = 'focus-trap.focus-after-trapped'
 export const FOCUS_AFTER_RELEASED = 'focus-trap.focus-after-released'
+export const FOCUSOUT_PREVENTED = 'focus-trap.focusout-prevented'
 export const FOCUS_AFTER_TRAPPED_OPTS: EventInit = {
+  cancelable: true,
+  bubbles: false,
+}
+export const FOCUSOUT_PREVENTED_OPTS: EventInit = {
   cancelable: true,
   bubbles: false,
 }

--- a/packages/components/focus-trap/src/utils.ts
+++ b/packages/components/focus-trap/src/utils.ts
@@ -1,4 +1,5 @@
 import { ref } from 'vue'
+import { FOCUSOUT_PREVENTED, FOCUSOUT_PREVENTED_OPTS } from './tokens'
 
 const focusReason = ref<'pointer' | 'keyboard'>()
 const lastUserFocusTimestamp = ref<number>(0)
@@ -152,22 +153,33 @@ export const useFocusReason = (): {
 } => {
   if (!isFocusReasonHandlersAttached) {
     isFocusReasonHandlersAttached = true
-    document.addEventListener('mousedown', () => {
-      focusReason.value = 'pointer'
-      lastUserFocusTimestamp.value = window.performance.now()
-    })
-    document.addEventListener('touchstart', () => {
-      focusReason.value = 'pointer'
-      lastUserFocusTimestamp.value = window.performance.now()
-    })
-    document.addEventListener('keydown', () => {
-      focusReason.value = 'keyboard'
-      lastUserFocusTimestamp.value = window.performance.now()
-    })
+    if (window.document) {
+      window.document.addEventListener('mousedown', () => {
+        focusReason.value = 'pointer'
+        lastUserFocusTimestamp.value = window.performance.now()
+      })
+      window.document.addEventListener('touchstart', () => {
+        focusReason.value = 'pointer'
+        lastUserFocusTimestamp.value = window.performance.now()
+      })
+      window.document.addEventListener('keydown', () => {
+        focusReason.value = 'keyboard'
+        lastUserFocusTimestamp.value = window.performance.now()
+      })
+    }
   }
   return {
     focusReason,
     lastUserFocusTimestamp,
     lastAutomatedFocusTimestamp,
   }
+}
+
+export const createFocusOutPreventedEvent = (
+  detail: CustomEventInit['detail']
+) => {
+  return new CustomEvent(FOCUSOUT_PREVENTED, {
+    ...FOCUSOUT_PREVENTED_OPTS,
+    detail,
+  })
 }

--- a/packages/components/focus-trap/src/utils.ts
+++ b/packages/components/focus-trap/src/utils.ts
@@ -153,16 +153,16 @@ export const useFocusReason = (): {
 } => {
   if (!isFocusReasonHandlersAttached) {
     isFocusReasonHandlersAttached = true
-    if (window.document) {
-      window.document.addEventListener('mousedown', () => {
+    if (typeof document !== 'undefined') {
+      document.addEventListener('mousedown', () => {
         focusReason.value = 'pointer'
         lastUserFocusTimestamp.value = window.performance.now()
       })
-      window.document.addEventListener('touchstart', () => {
+      document.addEventListener('touchstart', () => {
         focusReason.value = 'pointer'
         lastUserFocusTimestamp.value = window.performance.now()
       })
-      window.document.addEventListener('keydown', () => {
+      document.addEventListener('keydown', () => {
         focusReason.value = 'keyboard'
         lastUserFocusTimestamp.value = window.performance.now()
       })

--- a/packages/components/focus-trap/src/utils.ts
+++ b/packages/components/focus-trap/src/utils.ts
@@ -162,7 +162,7 @@ export const useFocusReason = (): {
   lastAutomatedFocusTimestamp: typeof lastAutomatedFocusTimestamp
 } => {
   onMounted(() => {
-    if (focusReasonUserCount === 0 && typeof document !== 'undefined') {
+    if (focusReasonUserCount === 0) {
       document.addEventListener('mousedown', notifyFocusReasonPointer)
       document.addEventListener('touchstart', notifyFocusReasonPointer)
       document.addEventListener('keydown', notifyFocusReasonKeydown)
@@ -172,7 +172,7 @@ export const useFocusReason = (): {
 
   onBeforeUnmount(() => {
     focusReasonUserCount--
-    if (focusReasonUserCount <= 0 && typeof document !== 'undefined') {
+    if (focusReasonUserCount <= 0) {
       document.removeEventListener('mousedown', notifyFocusReasonPointer)
       document.removeEventListener('touchstart', notifyFocusReasonPointer)
       document.removeEventListener('keydown', notifyFocusReasonKeydown)

--- a/packages/components/popper/src/content.vue
+++ b/packages/components/popper/src/content.vue
@@ -147,9 +147,11 @@ const onFocusAfterTrapped = () => {
   emit('focus')
 }
 
-const onFocusAfterReleased = () => {
-  focusStartRef.value = 'first'
-  emit('blur')
+const onFocusAfterReleased = (event: CustomEvent) => {
+  if (event.detail?.focusReason !== 'pointer') {
+    focusStartRef.value = 'first'
+    emit('blur')
+  }
 }
 
 const onFocusInTrap = (event: FocusEvent) => {
@@ -158,9 +160,6 @@ const onFocusInTrap = (event: FocusEvent) => {
       focusStartRef.value = event.target as typeof focusStartRef.value
     }
     trapped.value = true
-    if (event.relatedTarget) {
-      ;(event.relatedTarget as HTMLElement)?.focus()
-    }
   }
 }
 

--- a/packages/components/popper/src/content.vue
+++ b/packages/components/popper/src/content.vue
@@ -163,10 +163,10 @@ const onFocusInTrap = (event: FocusEvent) => {
   }
 }
 
-const onFocusoutPrevented = (e) => {
+const onFocusoutPrevented = (event: CustomEvent) => {
   if (!props.trapping) {
-    if (e.detail.focusReason === 'pointer') {
-      e.preventDefault()
+    if (event.detail.focusReason === 'pointer') {
+      event.preventDefault()
     }
     trapped.value = false
   }

--- a/packages/components/popper/src/content.vue
+++ b/packages/components/popper/src/content.vue
@@ -163,8 +163,11 @@ const onFocusInTrap = (event: FocusEvent) => {
   }
 }
 
-const onFocusoutPrevented = () => {
+const onFocusoutPrevented = (e) => {
   if (!props.trapping) {
+    if (e.detail.focusReason === 'pointer') {
+      e.preventDefault()
+    }
     trapped.value = false
   }
 }

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -793,7 +793,9 @@ export const useSelect = (props, states: States, ctx) => {
       if (states.menuVisibleOnFocus) {
         states.menuVisibleOnFocus = false
       } else {
-        states.visible = !states.visible
+        if (!tooltipRef.value || !tooltipRef.value.isFocusInsideContent()) {
+          states.visible = !states.visible
+        }
       }
       if (states.visible) {
         ;(input.value || reference.value)?.focus()

--- a/packages/components/time-picker/__tests__/time-picker.test.tsx
+++ b/packages/components/time-picker/__tests__/time-picker.test.tsx
@@ -845,8 +845,12 @@ describe('TimePicker(range)', () => {
       await nextTick()
       const picker = findPicker()
       const input = findInput()
-      picker.vm.onPick('', false)
+      input.vm.$emit('input', 'a')
       await rAF()
+      expect(document.querySelector('.el-time-panel')).toBeTruthy()
+      picker.vm.onPick('', false)
+      await rAF() // Picker triggers popup close, event propagation
+      await rAF() // Focus trap recognizes focusout event, and propagation
       expect(document.activeElement).toBe(wrapper.find('input').element)
       expect(document.querySelector('.el-time-panel')).toBeFalsy()
       input.vm.$emit('input', 'a')

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -169,7 +169,7 @@
 </template>
 <script lang="ts" setup>
 import { computed, inject, nextTick, provide, ref, unref, watch } from 'vue'
-import { isEqual, isNil } from 'lodash-unified'
+import { isEqual } from 'lodash-unified'
 import { onClickOutside } from '@vueuse/core'
 import {
   useFormItem,
@@ -243,7 +243,11 @@ watch(pickerVisible, (val) => {
       emitChange(props.modelValue)
     })
   } else {
-    valueOnOpen.value = props.modelValue
+    nextTick(() => {
+      if (val) {
+        valueOnOpen.value = props.modelValue
+      }
+    })
   }
 })
 const emitChange = (
@@ -367,7 +371,7 @@ const handleFocusInput = (e?: FocusEvent) => {
   ) {
     return
   }
-  pickerVisible.value = isNil(e?.relatedTarget)
+  pickerVisible.value = true
   emit('focus', e)
 }
 

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -308,7 +308,7 @@ const focusOnInputBox = () => {
 
 const onPick = (date: any = '', visible = false) => {
   if (!visible) {
-    focusOnInputBox()
+    ignoreFocusEvent = true
   }
   pickerVisible.value = visible
   let result

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -338,6 +338,7 @@ const onKeydownPopperContent = (event: KeyboardEvent) => {
 
 const onHide = () => {
   pickerActualVisible.value = false
+  pickerVisible.value = false
   ignoreFocusEvent = false
   emit('visible-change', false)
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

**SUMMARY**

The timepicker popup doesn't always show when you click on it.

Fixes https://github.com/element-plus/element-plus/issues/9842

Broken in this PR:
- https://github.com/element-plus/element-plus/pull/9669

Previous issues that lead to the breaking change:
- https://github.com/element-plus/element-plus/issues/9460
- https://github.com/element-plus/element-plus/issues/8501

Additional focus trap changes:
- 'focusout-prevented' event is emitted when focusout of trap container is detected (previously only emitted when reaching the edges of the container by tabbing with the keyboard)
- 'focusout-prevented' can be canceled, to stop the default prevention behavior. It also provides info on whether pointer (mouse/touch) or keyboard triggered the focusout
- Previously el-focus-trap relied on document.activeElement at trap start to be the return element. Setting this manually in the popper content caused issues where the browser refused to change focus. So instead, the 'focusin' event tracks the return element, and that's used if document.activeElement is already inside the focus trap when the trap starts.