### PR TITLE
fix(components): [date-picker] value-format years format

### DIFF
--- a/packages/components/date-picker/src/date-picker.tsx
+++ b/packages/components/date-picker/src/date-picker.tsx
@@ -1,6 +1,5 @@
 import { defineComponent, provide, reactive, ref, toRef } from 'vue'
 import dayjs from 'dayjs'
-import customParseFormat from 'dayjs/plugin/customParseFormat.js'
 import advancedFormat from 'dayjs/plugin/advancedFormat.js'
 import localeData from 'dayjs/plugin/localeData.js'
 import weekOfYear from 'dayjs/plugin/weekOfYear.js'
@@ -22,7 +21,6 @@ import { getPanel } from './panel-utils'
 
 dayjs.extend(localeData)
 dayjs.extend(advancedFormat)
-dayjs.extend(customParseFormat)
 dayjs.extend(weekOfYear)
 dayjs.extend(weekYear)
 dayjs.extend(dayOfYear)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


When the year exceeds 4 digits, Errors will occur in the '$y' generated by the customParseFormat .

Problems found in Elementplus date-picker use value-format attribute.

see: [年份异常](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZGl2PlxuICAgIDxoMT5cbiAgICAgIOW9k+W5tOS7vei2hei/hzTkvY3mlbDmmL7npLrlvILluLg6Ojo6IHt7IHZhbHVlMiB9fVxuICAgIDwvaDE+XG4gIDwvZGl2PlxuICA8ZGl2IGNsYXNzPVwiZGVtby1kYXRlLXBpY2tlclwiPlxuICAgIDxkaXYgY2xhc3M9XCJibG9ja1wiPlxuICAgICAgPHNwYW4gY2xhc3M9XCJkZW1vbnN0cmF0aW9uXCI+RGVmYXVsdDwvc3Bhbj5cbiAgICAgIDxlbC1kYXRlLXBpY2tlclxuICAgICAgICB2LW1vZGVsPVwidmFsdWUxXCJcbiAgICAgICAgdHlwZT1cImRhdGVcIlxuICAgICAgICBwbGFjZWhvbGRlcj1cIlBpY2sgYSBkYXlcIlxuICAgICAgLz5cbiAgICAgIDxlbC1kYXRlLXBpY2tlclxuICAgICAgICB2LW1vZGVsPVwidmFsdWUyXCJcbiAgICAgICAgdHlwZT1cImRhdGVcIlxuICAgICAgICB2YWx1ZS1mb3JtYXQ9XCJZWVlZL01NL0REXCJcbiAgICAgICAgcGxhY2Vob2xkZXI9XCJQaWNrIGEgZGF5XCJcbiAgICAgIC8+XG4gICAgPC9kaXY+XG4gIDwvZGl2PlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3QgdmFsdWUxID0gcmVmKCcyMDIyLTEwLTAxJylcbmNvbnN0IHZhbHVlMiA9IHJlZignMjU4NzEvMTAvMTknKVxuXG5cbjwvc2NyaXB0PlxuPHN0eWxlIHNjb3BlZD5cbi5kZW1vLWRhdGUtcGlja2VyIHtcbiAgZGlzcGxheTogZmxleDtcbiAgd2lkdGg6IDEwMCU7XG4gIHBhZGRpbmc6IDA7XG4gIGZsZXgtd3JhcDogd3JhcDtcbn1cbi5kZW1vLWRhdGUtcGlja2VyIC5ibG9jayB7XG4gIHBhZGRpbmc6IDMwcHggMDtcbiAgdGV4dC1hbGlnbjogY2VudGVyO1xuICBib3JkZXItcmlnaHQ6IHNvbGlkIDFweCB2YXIoLS1lbC1ib3JkZXItY29sb3IpO1xuICBmbGV4OiAxO1xufVxuLmRlbW8tZGF0ZS1waWNrZXIgLmJsb2NrOmxhc3QtY2hpbGQge1xuICBib3JkZXItcmlnaHQ6IG5vbmU7XG59XG4uZGVtby1kYXRlLXBpY2tlciAuZGVtb25zdHJhdGlvbiB7XG4gIGRpc3BsYXk6IGJsb2NrO1xuICBjb2xvcjogdmFyKC0tZWwtdGV4dC1jb2xvci1zZWNvbmRhcnkpO1xuICBmb250LXNpemU6IDE0cHg7XG4gIG1hcmdpbi1ib3R0b206IDIwcHg7XG59XG48L3N0eWxlPlxuIiwiaW1wb3J0X21hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge31cbn0iLCJfbyI6e319)
