### PR TITLE
fix(components): [tabs] prevent scroll tab into view after focusing it

### DIFF
--- a/packages/components/tabs/src/tab-nav.tsx
+++ b/packages/components/tabs/src/tab-nav.tsx
@@ -233,7 +233,7 @@ const TabNav = defineComponent({
           nextIndex = 0
         }
       }
-      tabList[nextIndex].focus() // 改变焦点元素
+      tabList[nextIndex].focus({ preventScroll: true }) // 改变焦点元素
       tabList[nextIndex].click() // 选中下一个tab
       setFocus()
     }


### PR DESCRIPTION
closed #9980

By default the browser will scroll the element into view after focusing it, and it will break `scrollToActiveTab`  method of `tab-nav` component.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
