### PR TITLE
fix(components): [checkbox] only propagate click event of checkbox input

### DIFF
--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -83,7 +83,7 @@ describe('Checkbox', () => {
         </ElFormItem>
       ))
 
-      await wrapper.findComponent(Checkbox).trigger('click')
+      await wrapper.find('.el-checkbox__inner').trigger('click')
       expect(data.value).toBe(true)
     })
 
@@ -211,7 +211,7 @@ describe('Checkbox', () => {
         </ElFormItem>
       ))
 
-      const checkbox = wrapper.findComponent(Checkbox)
+      const checkbox = wrapper.find('.el-checkbox__inner')
       await checkbox.trigger('click')
       await nextTick()
       expect(checked.value).toBe(3)

--- a/packages/components/checkbox/src/checkbox.vue
+++ b/packages/components/checkbox/src/checkbox.vue
@@ -9,7 +9,6 @@
       ns.is('checked', isChecked),
     ]"
     :aria-controls="indeterminate ? controls : null"
-    @click="onClickRoot"
   >
     <span
       :class="[
@@ -54,9 +53,9 @@
         @focus="isFocused = true"
         @blur="isFocused = false"
       />
-      <span :class="ns.e('inner')" />
+      <span :class="ns.e('inner')" @click.stop="attachToInput" />
     </span>
-    <span v-if="hasOwnLabel" :class="ns.e('label')">
+    <span v-if="hasOwnLabel" :class="ns.e('label')" @click.stop>
       <slot />
       <template v-if="!$slots.default">{{ label }}</template>
     </span>
@@ -68,7 +67,6 @@ import { useSlots } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { checkboxEmits, checkboxProps } from './checkbox'
 import { useCheckbox } from './composables'
-
 defineOptions({
   name: 'ElCheckbox',
 })
@@ -87,7 +85,7 @@ const {
   hasOwnLabel,
   model,
   handleChange,
-  onClickRoot,
+  attachToInput,
 } = useCheckbox(props, slots)
 
 const ns = useNamespace('checkbox')

--- a/packages/components/checkbox/src/composables/use-checkbox-event.ts
+++ b/packages/components/checkbox/src/composables/use-checkbox-event.ts
@@ -1,4 +1,4 @@
-import { computed, getCurrentInstance, inject, nextTick, watch } from 'vue'
+import { computed, getCurrentInstance, inject, watch } from 'vue'
 import { useFormItem } from '@element-plus/hooks'
 import { checkboxGroupContextKey } from '@element-plus/tokens'
 import { NOOP, debugWarn } from '@element-plus/utils'
@@ -14,12 +14,11 @@ import type {
 export const useCheckboxEvent = (
   props: CheckboxProps,
   {
-    model,
     isLimitExceeded,
     hasOwnLabel,
     isDisabled,
     isLabeledByFormItem,
-  }: Pick<CheckboxModel, 'model' | 'isLimitExceeded'> &
+  }: Pick<CheckboxModel, 'isLimitExceeded'> &
     Pick<CheckboxStatus, 'hasOwnLabel'> &
     Pick<CheckboxDisabled, 'isDisabled'> &
     Pick<ReturnType<typeof useFormItemInputId>, 'isLabeledByFormItem'>
@@ -32,13 +31,6 @@ export const useCheckboxEvent = (
     return value === props.trueLabel || value === true
       ? props.trueLabel ?? true
       : props.falseLabel ?? false
-  }
-
-  function emitChangeEvent(
-    checked: string | number | boolean,
-    e: InputEvent | MouseEvent
-  ) {
-    emit('change', getLabeledValue(checked), e)
   }
 
   function handleChange(e: Event) {

--- a/packages/components/checkbox/src/composables/use-checkbox-event.ts
+++ b/packages/components/checkbox/src/composables/use-checkbox-event.ts
@@ -1,7 +1,7 @@
 import { computed, getCurrentInstance, inject, watch } from 'vue'
 import { useFormItem } from '@element-plus/hooks'
 import { checkboxGroupContextKey } from '@element-plus/tokens'
-import { NOOP, debugWarn } from '@element-plus/utils'
+import { debugWarn } from '@element-plus/utils'
 
 import type { useFormItemInputId } from '@element-plus/hooks'
 import type { CheckboxProps } from '../checkbox'
@@ -57,9 +57,9 @@ export const useCheckboxEvent = (
   }
 
   function attachToInput(e: Event) {
-    return !isLimitExceeded.value && !isDisabled.value && !wrappedByLabel(e)
-      ? vnode.el?.querySelector('input:first-of-type').click()
-      : NOOP
+    if (!isLimitExceeded.value && !isDisabled.value && !wrappedByLabel(e)) {
+      vnode.el?.querySelector('input:first-of-type').click()
+    }
   }
 
   const validateEvent = computed(

--- a/packages/components/checkbox/src/composables/use-checkbox.ts
+++ b/packages/components/checkbox/src/composables/use-checkbox.ts
@@ -44,7 +44,7 @@ export const useCheckbox = (
     disableIdGeneration: hasOwnLabel,
     disableIdManagement: isGroup,
   })
-  const { handleChange, onClickRoot } = useCheckboxEvent(props, {
+  const { handleChange, attachToInput } = useCheckboxEvent(props, {
     model,
     isLimitExceeded,
     hasOwnLabel,
@@ -65,6 +65,6 @@ export const useCheckbox = (
     hasOwnLabel,
     model,
     handleChange,
-    onClickRoot,
+    attachToInput,
   }
 }

--- a/packages/components/checkbox/src/composables/use-checkbox.ts
+++ b/packages/components/checkbox/src/composables/use-checkbox.ts
@@ -45,7 +45,6 @@ export const useCheckbox = (
     disableIdManagement: isGroup,
   })
   const { handleChange, attachToInput } = useCheckboxEvent(props, {
-    model,
     isLimitExceeded,
     hasOwnLabel,
     isDisabled,


### PR DESCRIPTION
I referred to pr #9883 and #9991. And  I am aware of two points.

- In general, the checkbox input is wrapped with label,  we just need to stop click event propagation of other element.
- It is possible that the check input isn't wrapped with label and we need to manually trigger click event  of it.

Let me know if there is any problem.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
