### PR TITLE
fix(components): [tooltip] get real active element

### DIFF
--- a/packages/components/tooltip/__tests__/utils.test.ts
+++ b/packages/components/tooltip/__tests__/utils.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { getActiveElement } from '../src/utils'
+
+describe('tooltip utils', () => {
+  const buildDOM = (html: string) => {
+    const parser = new DOMParser()
+    const dom = parser.parseFromString(html, 'text/html')
+
+    Array.from(dom.children).forEach((child) => {
+      document.body.appendChild(child)
+    })
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  describe('getActiveElement', () => {
+    it('should return document.activeElement if nothing is focused', () => {
+      buildDOM(`<div></div>`)
+      expect(getActiveElement()).toBe(document.activeElement)
+    })
+
+    it('should return document.activeElement if is defined and does not have shadowRoot', () => {
+      buildDOM(`<div>
+        <button id="btn">Btn</button>
+      </div>`)
+      const btn = document.querySelector('#btn') as HTMLElement
+      btn.focus()
+      expect(getActiveElement()).toBe(btn)
+    })
+
+    it('should return shadowRoot.activeElement if document.activeElement has a shadowRoot', () => {
+      const documentHTML = `
+        <html>
+          <body>
+            <custom-element>
+              <button id="btn">Btn</button>
+            </custom-element>
+          </body>
+        </html>
+      `
+      document.body.innerHTML = documentHTML
+
+      const customElement = document.querySelector('custom-element')
+      const shadowRoot = customElement!.attachShadow({ mode: 'open' })
+      shadowRoot.innerHTML = documentHTML
+
+      const btn = customElement?.shadowRoot?.querySelector(
+        '#btn'
+      ) as HTMLElement
+      btn.focus()
+      expect(getActiveElement()).toBe(shadowRoot.activeElement)
+    })
+  })
+})

--- a/packages/components/tooltip/src/tooltip.vue
+++ b/packages/components/tooltip/src/tooltip.vue
@@ -68,6 +68,7 @@ import {
 } from '@element-plus/hooks'
 import { TOOLTIP_INJECTION_KEY } from '@element-plus/tokens'
 import { tooltipEmits, useTooltipModelToggle, useTooltipProps } from './tooltip'
+import { getActiveElement } from './utils'
 import ElTooltipTrigger from './trigger.vue'
 import ElTooltipContent from './content.vue'
 
@@ -174,7 +175,7 @@ watch(
 const isFocusInsideContent = () => {
   const popperContent: HTMLElement | undefined =
     contentRef.value?.contentRef?.popperContentRef
-  return popperContent && popperContent.contains(document.activeElement)
+  return popperContent && popperContent.contains(getActiveElement())
 }
 
 onDeactivated(() => open.value && hide())

--- a/packages/components/tooltip/src/utils.ts
+++ b/packages/components/tooltip/src/utils.ts
@@ -23,3 +23,19 @@ export const whenTrigger = (
     isTriggerType(unref(trigger), type) && handler(e)
   }
 }
+
+export const getActiveElement = (
+  root: Document | ShadowRoot = document
+): Element | null => {
+  const activeEl = root.activeElement
+
+  if (!activeEl) {
+    return null
+  }
+
+  if (activeEl.shadowRoot) {
+    return getActiveElement(activeEl.shadowRoot)
+  } else {
+    return activeEl
+  }
+}


### PR DESCRIPTION
When the tooltip is used inside Vue Custom elements, the document.activeElement is not returning the good element.
This fix makes sure to get the real active element including shadowDom if present.
The select with the option Multiple would always close the dropdown each time you select a value.

https://vuejs.org/guide/extras/web-components.html

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
