### PR TITLE
fix(components): [date-picker] fix date panel show same month

### DIFF
--- a/packages/components/date-picker/__tests__/date-time-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-time-picker.test.tsx
@@ -760,4 +760,30 @@ describe('Datetimerange', () => {
     expect(startInput.element.value).toBe('')
     expect(endInput.element.value).toBe('')
   })
+
+  it('time input and show current month', async () => {
+    const value = ref([
+      new Date(2000, 10, 10, 10, 10),
+      new Date(2000, 10, 10, 10, 10),
+    ])
+    const wrapper = _mount(() => (
+      <DatePicker v-model={value.value} type="datetimerange" />
+    ))
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+
+    const rightPanelHeader = document.querySelector(
+      '.el-date-range-picker__content.is-right .el-date-range-picker__header'
+    ) as HTMLElement
+
+    const endTimeInput = document.querySelector(
+      `input[placeholder='End Time']`
+    ) as HTMLInputElement
+    endTimeInput.value = ''
+    triggerEvent(endTimeInput, 'input', true)
+    triggerEvent(endTimeInput, 'change', true)
+    await nextTick()
+    expect(rightPanelHeader.innerHTML).contains('2000').contains('December')
+  })
 })

--- a/packages/components/date-picker/__tests__/date-time-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-time-picker.test.tsx
@@ -776,9 +776,11 @@ describe('Datetimerange', () => {
     const rightPanelHeader = document.querySelector(
       '.el-date-range-picker__content.is-right .el-date-range-picker__header'
     ) as HTMLElement
-
-    const endTimeInput = document.querySelector(
-      `input[placeholder='End Time']`
+    const pickers = document.querySelectorAll(
+      '.el-date-range-picker__time-header .el-date-range-picker__editors-wrap'
+    )
+    const endTimeInput = pickers[1].querySelector(
+      '.el-date-range-picker__time-picker-wrap:nth-child(2) input'
     ) as HTMLInputElement
     endTimeInput.value = ''
     triggerEvent(endTimeInput, 'input', true)

--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -631,10 +631,12 @@ const handleMinTimePick = (value: Dayjs, visible: boolean, first: boolean) => {
 
   if (!maxDate.value || maxDate.value.isBefore(minDate.value)) {
     maxDate.value = minDate.value
-    rightDate.value = rightDate.value
-      .hour(value.hour())
-      .minute(value.minute())
-      .second(value.second())
+    if (value) {
+      rightDate.value = rightDate.value
+        .hour(value.hour())
+        .minute(value.minute())
+        .second(value.second())
+    }
   }
 }
 
@@ -658,10 +660,12 @@ const handleMaxTimePick = (
 
   if (maxDate.value && maxDate.value.isBefore(minDate.value)) {
     minDate.value = maxDate.value
-    leftDate.value = leftDate.value
-      .hour(value.hour())
-      .minute(value.minute())
-      .second(value.second())
+    if (value) {
+      leftDate.value = leftDate.value
+        .hour(value.hour())
+        .minute(value.minute())
+        .second(value.second())
+    }
   }
 }
 

--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -267,6 +267,7 @@ import { panelDateRangeProps } from '../props/panel-date-range'
 import { useRangePicker } from '../composables/use-range-picker'
 import { getDefaultValue, isValidRange } from '../utils'
 import DateTable from './basic-date-table.vue'
+import type { Ref } from 'vue'
 
 import type { Dayjs } from 'dayjs'
 
@@ -298,8 +299,10 @@ const {
 const shortcuts = toRef(pickerBase.props, 'shortcuts')
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 const { lang } = useLocale()
-const leftDate = ref<Dayjs>(dayjs().locale(lang.value))
-const rightDate = ref<Dayjs>(dayjs().locale(lang.value).add(1, unit))
+const leftDate: Ref<Dayjs> = ref<Dayjs>(dayjs().locale(lang.value))
+const rightDate: Ref<Dayjs> = ref<Dayjs>(
+  dayjs().locale(lang.value).add(1, unit)
+)
 
 const {
   minDate,
@@ -628,7 +631,10 @@ const handleMinTimePick = (value: Dayjs, visible: boolean, first: boolean) => {
 
   if (!maxDate.value || maxDate.value.isBefore(minDate.value)) {
     maxDate.value = minDate.value
-    rightDate.value = value
+    rightDate.value = rightDate.value
+      .hour(value.hour())
+      .minute(value.minute())
+      .second(value.second())
   }
 }
 
@@ -652,6 +658,10 @@ const handleMaxTimePick = (
 
   if (maxDate.value && maxDate.value.isBefore(minDate.value)) {
     minDate.value = maxDate.value
+    leftDate.value = leftDate.value
+      .hour(value.hour())
+      .minute(value.minute())
+      .second(value.second())
   }
 }
 

--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -596,8 +596,7 @@ const handleTimeInput = (value: string | null, type: ChangeType) => {
         .hour(parsedValueD.hour())
         .minute(parsedValueD.minute())
         .second(parsedValueD.second())
-      rightDate.value = maxDate.value
-      if (maxDate.value && maxDate.value.isBefore(minDate.value)) {
+      if (!minDate.value || maxDate.value.isBefore(minDate.value)) {
         minDate.value = maxDate.value
       }
     }
@@ -607,10 +606,8 @@ const handleTimeInput = (value: string | null, type: ChangeType) => {
 const handleTimeChange = (value: string | null, type: ChangeType) => {
   timeUserInput.value[type] = null
   if (type === 'min') {
-    leftDate.value = minDate.value!
     minTimePickerVisible.value = false
   } else {
-    rightDate.value = maxDate.value!
     maxTimePickerVisible.value = false
   }
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

close #4904, close #1951,close #2052, close #8026
I found the latest version(2.2.18) still have the problem, and the pr #4915 is out of date
This code change also relates to #2290
I think the min(max) func should be mirrored, so I change it both in the two func
