### PR TITLE
perf(components): [input] remove useless calculation

### DIFF
--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -154,10 +154,8 @@
 <script lang="ts" setup>
 import {
   computed,
-  getCurrentInstance,
   nextTick,
   onMounted,
-  onUpdated,
   ref,
   shallowRef,
   toRef,
@@ -195,10 +193,6 @@ import { inputEmits, inputProps } from './input'
 import type { StyleValue } from 'vue'
 
 type TargetElement = HTMLInputElement | HTMLTextAreaElement
-const PENDANT_MAP = {
-  suffix: 'append',
-  prefix: 'prepend',
-} as const
 
 defineOptions({
   name: 'ElInput',
@@ -207,7 +201,6 @@ defineOptions({
 const props = defineProps(inputProps)
 const emit = defineEmits(inputEmits)
 
-const instance = getCurrentInstance()!
 const rawAttrs = useRawAttrs()
 const slots = useSlots()
 
@@ -345,31 +338,6 @@ const setNativeInputValue = () => {
   input.value = nativeInputValue.value
 }
 
-const calcIconOffset = (place: 'prefix' | 'suffix') => {
-  const { el } = instance.vnode
-  if (!el) return
-  const elList = Array.from(
-    (el as Element).querySelectorAll<HTMLSpanElement>(`.${nsInput.e(place)}`)
-  )
-  const target = elList.find((item) => item.parentNode === el)
-  if (!target) return
-
-  const pendant = PENDANT_MAP[place]
-
-  if (slots[pendant]) {
-    target.style.transform = `translateX(${place === 'suffix' ? '-' : ''}${
-      el.querySelector(`.${nsInput.be('group', pendant)}`).offsetWidth
-    }px)`
-  } else {
-    target.removeAttribute('style')
-  }
-}
-
-const updateIconOffset = () => {
-  calcIconOffset('prefix')
-  calcIconOffset('suffix')
-}
-
 const handleInput = async (event: Event) => {
   recordCursor()
 
@@ -500,7 +468,6 @@ watch(
     await nextTick()
     setNativeInputValue()
     resizeTextarea()
-    updateIconOffset()
   }
 )
 
@@ -512,12 +479,7 @@ onMounted(() => {
     )
   }
   setNativeInputValue()
-  updateIconOffset()
   nextTick(resizeTextarea)
-})
-
-onUpdated(() => {
-  nextTick(updateIconOffset)
 })
 
 defineExpose({


### PR DESCRIPTION
No need to calculate icon offset after changing to the `flex` layout.

Relative pr: https://github.com/element-plus/element-plus/pull/7179

After changing to the `flex` layout, there is no need to calculate the icon's offset. And the code will always stop in this line.

https://github.com/element-plus/element-plus/blob/359d2f6587012d2fbbed649f3937f581c70694e0/packages/components/input/src/input.vue#L355

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
