### PR TITLE
fix(components): [input] scrollbar not hide after autosize

### DIFF
--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -337,7 +337,6 @@ const resizeTextarea = () => {
     // So we need to hide scrollbar first, and reset it in next tick.
     // see https://github.com/element-plus/element-plus/issues/8825
     textareaCalcStyle.value = {
-      ...calcTextareaHeight(textarea.value, minRows, maxRows),
       overflowY: 'hidden',
       ...textareaStyle,
     }

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -285,6 +285,7 @@ const resizeTextarea = () => {
     }
 
     nextTick(() => {
+      // NOTE: Force repaint to make sure the style set above is applied.
       textarea.value!.offsetHeight
       textareaCalcStyle.value = textareaStyle
     })

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -1,6 +1,13 @@
 <template>
-  <div v-show="type !== 'hidden'" v-bind="containerAttrs" :class="containerKls" :style="containerStyle"
-    :role="containerRole" @mouseenter="handleMouseEnter" @mouseleave="handleMouseLeave">
+  <div
+    v-show="type !== 'hidden'"
+    v-bind="containerAttrs"
+    :class="containerKls"
+    :style="containerStyle"
+    :role="containerRole"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
     <!-- input -->
     <template v-if="type !== 'textarea'">
       <!-- prepend slot -->
@@ -19,29 +26,56 @@
           </span>
         </span>
 
-        <input :id="inputId" ref="input" :class="nsInput.e('inner')" v-bind="attrs"
-          :type="showPassword ? (passwordVisible ? 'text' : 'password') : type" :disabled="inputDisabled"
-          :formatter="formatter" :parser="parser" :readonly="readonly" :autocomplete="autocomplete" :tabindex="tabindex"
-          :aria-label="label" :placeholder="placeholder" :style="inputStyle" :form="props.form"
-          @compositionstart="handleCompositionStart" @compositionupdate="handleCompositionUpdate"
-          @compositionend="handleCompositionEnd" @input="handleInput" @focus="handleFocus" @blur="handleBlur"
-          @change="handleChange" @keydown="handleKeydown" />
+        <input
+          :id="inputId"
+          ref="input"
+          :class="nsInput.e('inner')"
+          v-bind="attrs"
+          :type="showPassword ? (passwordVisible ? 'text' : 'password') : type"
+          :disabled="inputDisabled"
+          :formatter="formatter"
+          :parser="parser"
+          :readonly="readonly"
+          :autocomplete="autocomplete"
+          :tabindex="tabindex"
+          :aria-label="label"
+          :placeholder="placeholder"
+          :style="inputStyle"
+          :form="props.form"
+          @compositionstart="handleCompositionStart"
+          @compositionupdate="handleCompositionUpdate"
+          @compositionend="handleCompositionEnd"
+          @input="handleInput"
+          @focus="handleFocus"
+          @blur="handleBlur"
+          @change="handleChange"
+          @keydown="handleKeydown"
+        />
 
         <!-- suffix slot -->
         <span v-if="suffixVisible" :class="nsInput.e('suffix')">
           <span :class="nsInput.e('suffix-inner')" @click="focus">
-            <template v-if="!showClear || !showPwdVisible || !isWordLimitVisible">
+            <template
+              v-if="!showClear || !showPwdVisible || !isWordLimitVisible"
+            >
               <slot name="suffix" />
               <el-icon v-if="suffixIcon" :class="nsInput.e('icon')">
                 <component :is="suffixIcon" />
               </el-icon>
             </template>
-            <el-icon v-if="showClear" :class="[nsInput.e('icon'), nsInput.e('clear')]" @mousedown.prevent="NOOP"
-              @click="clear">
+            <el-icon
+              v-if="showClear"
+              :class="[nsInput.e('icon'), nsInput.e('clear')]"
+              @mousedown.prevent="NOOP"
+              @click="clear"
+            >
               <circle-close />
             </el-icon>
-            <el-icon v-if="showPwdVisible" :class="[nsInput.e('icon'), nsInput.e('password')]"
-              @click="handlePasswordVisible">
+            <el-icon
+              v-if="showPwdVisible"
+              :class="[nsInput.e('icon'), nsInput.e('password')]"
+              @click="handlePasswordVisible"
+            >
               <component :is="passwordIcon" />
             </el-icon>
             <span v-if="isWordLimitVisible" :class="nsInput.e('count')">
@@ -49,11 +83,14 @@
                 {{ textLength }} / {{ attrs.maxlength }}
               </span>
             </span>
-            <el-icon v-if="validateState && validateIcon && needStatusIcon" :class="[
-              nsInput.e('icon'),
-              nsInput.e('validateIcon'),
-              nsInput.is('loading', validateState === 'validating'),
-            ]">
+            <el-icon
+              v-if="validateState && validateIcon && needStatusIcon"
+              :class="[
+                nsInput.e('icon'),
+                nsInput.e('validateIcon'),
+                nsInput.is('loading', validateState === 'validating'),
+              ]"
+            >
               <component :is="validateIcon" />
             </el-icon>
           </span>
@@ -68,12 +105,33 @@
 
     <!-- textarea -->
     <template v-else>
-      <textarea :id="inputId" ref="textarea" :class="nsTextarea.e('inner')" v-bind="attrs" :tabindex="tabindex"
-        :disabled="inputDisabled" :readonly="readonly" :autocomplete="autocomplete" :style="textareaStyle"
-        :aria-label="label" :placeholder="placeholder" :form="props.form" @compositionstart="handleCompositionStart"
-        @compositionupdate="handleCompositionUpdate" @compositionend="handleCompositionEnd" @input="handleInput"
-        @focus="handleFocus" @blur="handleBlur" @change="handleChange" @keydown="handleKeydown" />
-      <span v-if="isWordLimitVisible" :style="countStyle" :class="nsInput.e('count')">
+      <textarea
+        :id="inputId"
+        ref="textarea"
+        :class="nsTextarea.e('inner')"
+        v-bind="attrs"
+        :tabindex="tabindex"
+        :disabled="inputDisabled"
+        :readonly="readonly"
+        :autocomplete="autocomplete"
+        :style="textareaStyle"
+        :aria-label="label"
+        :placeholder="placeholder"
+        :form="props.form"
+        @compositionstart="handleCompositionStart"
+        @compositionupdate="handleCompositionUpdate"
+        @compositionend="handleCompositionEnd"
+        @input="handleInput"
+        @focus="handleFocus"
+        @blur="handleBlur"
+        @change="handleChange"
+        @keydown="handleKeydown"
+      />
+      <span
+        v-if="isWordLimitVisible"
+        :style="countStyle"
+        :class="nsInput.e('count')"
+      >
         {{ textLength }} / {{ attrs.maxlength }}
       </span>
     </template>
@@ -272,7 +330,7 @@ const resizeTextarea = () => {
   if (autosize) {
     const minRows = isObject(autosize) ? autosize.minRows : undefined
     const maxRows = isObject(autosize) ? autosize.maxRows : undefined
-    const textareaStyle = calcTextareaHeight(textarea.value!, minRows, maxRows)
+    const textareaStyle = calcTextareaHeight(textarea.value, minRows, maxRows)
 
     // If the scrollbar is displayed, the height of the textarea needs more space than the calculated height.
     // If set textarea height in this case, the scrollbar will not hide.

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -1,13 +1,6 @@
 <template>
-  <div
-    v-show="type !== 'hidden'"
-    v-bind="containerAttrs"
-    :class="containerKls"
-    :style="containerStyle"
-    :role="containerRole"
-    @mouseenter="handleMouseEnter"
-    @mouseleave="handleMouseLeave"
-  >
+  <div v-show="type !== 'hidden'" v-bind="containerAttrs" :class="containerKls" :style="containerStyle"
+    :role="containerRole" @mouseenter="handleMouseEnter" @mouseleave="handleMouseLeave">
     <!-- input -->
     <template v-if="type !== 'textarea'">
       <!-- prepend slot -->
@@ -26,56 +19,29 @@
           </span>
         </span>
 
-        <input
-          :id="inputId"
-          ref="input"
-          :class="nsInput.e('inner')"
-          v-bind="attrs"
-          :type="showPassword ? (passwordVisible ? 'text' : 'password') : type"
-          :disabled="inputDisabled"
-          :formatter="formatter"
-          :parser="parser"
-          :readonly="readonly"
-          :autocomplete="autocomplete"
-          :tabindex="tabindex"
-          :aria-label="label"
-          :placeholder="placeholder"
-          :style="inputStyle"
-          :form="props.form"
-          @compositionstart="handleCompositionStart"
-          @compositionupdate="handleCompositionUpdate"
-          @compositionend="handleCompositionEnd"
-          @input="handleInput"
-          @focus="handleFocus"
-          @blur="handleBlur"
-          @change="handleChange"
-          @keydown="handleKeydown"
-        />
+        <input :id="inputId" ref="input" :class="nsInput.e('inner')" v-bind="attrs"
+          :type="showPassword ? (passwordVisible ? 'text' : 'password') : type" :disabled="inputDisabled"
+          :formatter="formatter" :parser="parser" :readonly="readonly" :autocomplete="autocomplete" :tabindex="tabindex"
+          :aria-label="label" :placeholder="placeholder" :style="inputStyle" :form="props.form"
+          @compositionstart="handleCompositionStart" @compositionupdate="handleCompositionUpdate"
+          @compositionend="handleCompositionEnd" @input="handleInput" @focus="handleFocus" @blur="handleBlur"
+          @change="handleChange" @keydown="handleKeydown" />
 
         <!-- suffix slot -->
         <span v-if="suffixVisible" :class="nsInput.e('suffix')">
           <span :class="nsInput.e('suffix-inner')" @click="focus">
-            <template
-              v-if="!showClear || !showPwdVisible || !isWordLimitVisible"
-            >
+            <template v-if="!showClear || !showPwdVisible || !isWordLimitVisible">
               <slot name="suffix" />
               <el-icon v-if="suffixIcon" :class="nsInput.e('icon')">
                 <component :is="suffixIcon" />
               </el-icon>
             </template>
-            <el-icon
-              v-if="showClear"
-              :class="[nsInput.e('icon'), nsInput.e('clear')]"
-              @mousedown.prevent="NOOP"
-              @click="clear"
-            >
+            <el-icon v-if="showClear" :class="[nsInput.e('icon'), nsInput.e('clear')]" @mousedown.prevent="NOOP"
+              @click="clear">
               <circle-close />
             </el-icon>
-            <el-icon
-              v-if="showPwdVisible"
-              :class="[nsInput.e('icon'), nsInput.e('password')]"
-              @click="handlePasswordVisible"
-            >
+            <el-icon v-if="showPwdVisible" :class="[nsInput.e('icon'), nsInput.e('password')]"
+              @click="handlePasswordVisible">
               <component :is="passwordIcon" />
             </el-icon>
             <span v-if="isWordLimitVisible" :class="nsInput.e('count')">
@@ -83,14 +49,11 @@
                 {{ textLength }} / {{ attrs.maxlength }}
               </span>
             </span>
-            <el-icon
-              v-if="validateState && validateIcon && needStatusIcon"
-              :class="[
-                nsInput.e('icon'),
-                nsInput.e('validateIcon'),
-                nsInput.is('loading', validateState === 'validating'),
-              ]"
-            >
+            <el-icon v-if="validateState && validateIcon && needStatusIcon" :class="[
+              nsInput.e('icon'),
+              nsInput.e('validateIcon'),
+              nsInput.is('loading', validateState === 'validating'),
+            ]">
               <component :is="validateIcon" />
             </el-icon>
           </span>
@@ -105,33 +68,12 @@
 
     <!-- textarea -->
     <template v-else>
-      <textarea
-        :id="inputId"
-        ref="textarea"
-        :class="nsTextarea.e('inner')"
-        v-bind="attrs"
-        :tabindex="tabindex"
-        :disabled="inputDisabled"
-        :readonly="readonly"
-        :autocomplete="autocomplete"
-        :style="textareaStyle"
-        :aria-label="label"
-        :placeholder="placeholder"
-        :form="props.form"
-        @compositionstart="handleCompositionStart"
-        @compositionupdate="handleCompositionUpdate"
-        @compositionend="handleCompositionEnd"
-        @input="handleInput"
-        @focus="handleFocus"
-        @blur="handleBlur"
-        @change="handleChange"
-        @keydown="handleKeydown"
-      />
-      <span
-        v-if="isWordLimitVisible"
-        :style="countStyle"
-        :class="nsInput.e('count')"
-      >
+      <textarea :id="inputId" ref="textarea" :class="nsTextarea.e('inner')" v-bind="attrs" :tabindex="tabindex"
+        :disabled="inputDisabled" :readonly="readonly" :autocomplete="autocomplete" :style="textareaStyle"
+        :aria-label="label" :placeholder="placeholder" :form="props.form" @compositionstart="handleCompositionStart"
+        @compositionupdate="handleCompositionUpdate" @compositionend="handleCompositionEnd" @input="handleInput"
+        @focus="handleFocus" @blur="handleBlur" @change="handleChange" @keydown="handleKeydown" />
+      <span v-if="isWordLimitVisible" :style="countStyle" :class="nsInput.e('count')">
         {{ textLength }} / {{ attrs.maxlength }}
       </span>
     </template>
@@ -330,9 +272,22 @@ const resizeTextarea = () => {
   if (autosize) {
     const minRows = isObject(autosize) ? autosize.minRows : undefined
     const maxRows = isObject(autosize) ? autosize.maxRows : undefined
+    const textareaStyle = calcTextareaHeight(textarea.value!, minRows, maxRows)
+
+    // If the scrollbar is displayed, the height of the textarea needs more space than the calculated height.
+    // If set textarea height in this case, the scrollbar will not hide.
+    // So we need to hide scrollbar first, and reset it in next tick.
+    // see https://github.com/element-plus/element-plus/issues/8825
     textareaCalcStyle.value = {
       ...calcTextareaHeight(textarea.value, minRows, maxRows),
+      overflowY: 'hidden',
+      ...textareaStyle,
     }
+
+    nextTick(() => {
+      textarea.value!.offsetHeight
+      textareaCalcStyle.value = textareaStyle
+    })
   } else {
     textareaCalcStyle.value = {
       minHeight: calcTextareaHeight(textarea.value).minHeight,


### PR DESCRIPTION
closed #8825

If the scrollbar is displayed, the height of the textarea needs more space than the calculated height.
If set height in this case, the scrollbar will not hide.
So we need to hide the scrollbar first and reset it in next tick.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
