### PR TITLE
fix(components): [tree-node-content] fixing styling bug 

### DIFF
--- a/packages/components/tree/src/tree-node-content.vue
+++ b/packages/components/tree/src/tree-node-content.vue
@@ -24,11 +24,11 @@ export default defineComponent({
       const { data, store } = node
       return props.renderContent
         ? props.renderContent(h, { _self: nodeInstance, node, data, store })
-        : h('span', { class: ns.be('node', 'label') }, [
+        : h('span', { class: ns.be('node', 'label') }), [
             tree.ctx.slots.default
               ? tree.ctx.slots.default({ node, data })
               : node.label,
-          ])
+          ]
     }
   },
 })


### PR DESCRIPTION
Components [tree-node-content] fixing styling bug 

fix for component tree-node-content: bracket bug coming from #9613 (https://github.com/element-plus/element-plus/pull/9613)

With the change from #9613 the brackets were set wrong and the return value was not correct anymore.