### PR TITLE
ci: use env files to replace the deprecated set-output command

### DIFF
--- a/.github/workflows/lint-commit-message-post.yml
+++ b/.github/workflows/lint-commit-message-post.yml
@@ -30,10 +30,10 @@ jobs:
 
       - name: Assert result
         id: assert
-        run: echo "::set-output name=succeeded::$(<lint-result.txt)"
+        run: echo "succeeded=$(<lint-result.txt)" >> $GITHUB_OUTPUT
       - name: Get PR number
         id: pr
-        run: echo "::set-output name=pr::$(<pr.txt)"
+        run: echo "pr=$(<pr.txt)" >> $GITHUB_OUTPUT
 
   on-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
@@ -42,7 +42,7 @@ jobs:
 
       - name: Lint commit
         id: lint_commit
-        run: pnpm lint:commit || echo "::set-output name=failed::true"
+        run: pnpm lint:commit || echo "failed=true" >> $GITHUB_OUTPUT
 
       - name: Set success result
         if: ${{ steps.lint_commit.outputs.failed != 'true' }}

--- a/.github/workflows/pr-docs-build.yml
+++ b/.github/workflows/pr-docs-build.yml
@@ -42,6 +42,7 @@ jobs:
         id: pnpm-cache
         run: |
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $env:GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/pr-docs-build.yml
+++ b/.github/workflows/pr-docs-build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/pr-docs-deploy.yml
+++ b/.github/workflows/pr-docs-deploy.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Output pr number
         id: pr
-        run: echo "::set-output name=id::$(<pr.txt)"
+        run: echo "id=$(<pr.txt)" >> $GITHUB_OUTPUT
 
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
@@ -89,7 +89,7 @@ jobs:
 
       - name: Output pr number
         id: pr
-        run: echo "::set-output name=id::$(<pr.txt)"
+        run: echo "id=$(<pr.txt)" >> $GITHUB_OUTPUT
 
       - name: Deploy has failed
         uses: actions-cool/maintain-one-comment@v3.0.0

--- a/.github/workflows/publish-build-product.yml
+++ b/.github/workflows/publish-build-product.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/publish-docs-deploy-manual.yml
+++ b/.github/workflows/publish-docs-deploy-manual.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/publish-docs-deploy.yml
+++ b/.github/workflows/publish-docs-deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/publish-npm-nightly.yml
+++ b/.github/workflows/publish-npm-nightly.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
@@ -63,7 +63,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
       - name: Get git head
         run: echo "GIT_HEAD=${GITHUB_SHA}" >> $GITHUB_ENV

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/publish-size-report.yml
+++ b/.github/workflows/publish-size-report.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/staging-docs.yml
+++ b/.github/workflows/staging-docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/test-ssr.yml
+++ b/.github/workflows/test-ssr.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
@@ -76,7 +76,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache


### PR DESCRIPTION
see
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
