### PR TITLE
fix(dev): fix the new developer startup service times vite. create filter is not a function

### DIFF
--- a/play/package.json
+++ b/play/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.3.3",
     "unplugin-vue-components": "^0.20.1",
-    "vite": "^2.9.15",
+    "vite": "^3.0.0",
     "vite-plugin-inspect": "^0.5.0",
     "vite-plugin-mkcert": "^1.7.2"
   }


### PR DESCRIPTION

新贡献者在安装完依赖以后，项目跑不起来，排查后发现是vite版本的问题
