### PR TITLE
feat(components): [form-item] Optimize verification experience 优化校验体验

### DIFF
--- a/packages/components/form/src/form-item.ts
+++ b/packages/components/form/src/form-item.ts
@@ -40,6 +40,9 @@ export const formItemProps = buildProps({
     type: Boolean,
     default: false,
   },
+  validateMsgUseLabel: {
+    type: [Boolean, String],
+  },
   for: String,
   inlineMessage: {
     type: [String, Boolean],

--- a/packages/components/form/src/form-item.ts
+++ b/packages/components/form/src/form-item.ts
@@ -36,6 +36,10 @@ export const formItemProps = buildProps({
     type: String,
     values: formItemValidateStates,
   },
+  validateTrim: {
+    type: Boolean,
+    default: false,
+  },
   for: String,
   inlineMessage: {
     type: [String, Boolean],

--- a/packages/components/form/src/form-item.vue
+++ b/packages/components/form/src/form-item.vue
@@ -250,11 +250,40 @@ const currentLabel = computed(
   () => `${props.label || ''}${formContext?.labelSuffix || ''}`
 )
 
+const currentValidateMessageInfo = computed<{
+  needReplace: boolean
+  targetValue: string
+}>(() => {
+  if (
+    typeof props.validateMsgUseLabel === 'boolean' &&
+    props.validateMsgUseLabel &&
+    props.label
+  ) {
+    return {
+      needReplace: true,
+      targetValue: props.label,
+    }
+  }
+  if (
+    typeof props.validateMsgUseLabel === 'string' &&
+    props.validateMsgUseLabel
+  ) {
+    return {
+      needReplace: true,
+      targetValue: props.validateMsgUseLabel,
+    }
+  }
+  return {
+    needReplace: false,
+    targetValue: '',
+  }
+})
+
 const setValidationState = (state: FormItemValidateState) => {
   validateState.value = state
 }
 
-const onValidationFailed = (error: FormValidateFailure) => {
+const onValidationFailed = (error: FormValidateFailure, rules: RuleItem[]) => {
   const { errors, fields } = error
   if (!errors || !fields) {
     console.error(error)
@@ -264,6 +293,17 @@ const onValidationFailed = (error: FormValidateFailure) => {
   validateMessage.value = errors
     ? errors?.[0]?.message ?? `${props.prop} is required`
     : ''
+
+  const isCustomRuleMessage =
+    rules.find((_: RuleItem) => _.message === errors?.[0]?.message)?.message ||
+    errors?.[0]?.stack
+
+  if (!isCustomRuleMessage && currentValidateMessageInfo.value.needReplace) {
+    validateMessage.value = validateMessage.value.replace(
+      `${props.prop}`,
+      currentValidateMessageInfo.value?.targetValue
+    )
+  }
 
   formContext?.emit('validate', props.prop!, false, validateMessage.value)
 }
@@ -295,7 +335,7 @@ const doValidate = async (rules: RuleItem[]): Promise<true> => {
       return true as const
     })
     .catch((err: FormValidateFailure) => {
-      onValidationFailed(err as FormValidateFailure)
+      onValidationFailed(err as FormValidateFailure, rules)
       return Promise.reject(err)
     })
 }

--- a/packages/components/form/src/form-item.vue
+++ b/packages/components/form/src/form-item.vue
@@ -278,8 +278,18 @@ const doValidate = async (rules: RuleItem[]): Promise<true> => {
   const validator = new AsyncValidator({
     [modelName]: rules,
   })
+  const toValidateFieldValue =
+    typeof fieldValue.value === 'string' && props.validateTrim
+      ? fieldValue.value.trim()
+      : fieldValue.value
+
   return validator
-    .validate({ [modelName]: fieldValue.value }, { firstFields: true })
+    .validate(
+      {
+        [modelName]: toValidateFieldValue,
+      },
+      { firstFields: true }
+    )
     .then(() => {
       onValidationSucceeded()
       return true as const

--- a/packages/tokens/form.ts
+++ b/packages/tokens/form.ts
@@ -26,7 +26,7 @@ export type FormValidateCallback = (
   invalidFields?: ValidateFieldsError
 ) => void
 export interface FormValidateFailure {
-  errors: ValidateError[] | null
+  errors: Array<ValidateError & { stack?: string }> | null
   fields: ValidateFieldsError
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### 💻 [Demo preview](https://github.com/guMcrey/element-plus/tree/feature/dev-playground)

### 中文
#### 1. 新增 validateTrim prop, 避免只输入空格就通过校验
- 需求背景: 在必选项或自定义校验中, 操作人容易通过只输入空格, 使校验通过
- 解决方案: 开启 validateTrim prop, 会在校验时过滤首尾空格, 以保证表单输入了有效的数据
- [效果展示](https://user-images.githubusercontent.com/26329117/199003162-4ab93202-0605-4a26-9bde-4a054a3cf373.mp4)


#### 2. 新增 validateMsgUseLabel prop, 以支持在校验的错误提示中, 字段名使用 label 而非 prop
- 需求背景: 在默认情况下, 校验错误提示中的字段名使用了 prop; 在实际开发中, 大多时候可能更偏向于用 label 作为错误提示的字段名
- 解决方案: 开启 validateMsgUseLabel prop (支持 boolean, 或 string 类型), 会将错误提示中的 prop 替换为 label 或期望替换的文本
  - `typeof props.validateMsgUseLabel === 'boolean'  && props.validateMsgUseLabel  && props.label` 为真时, 替换为 label
  - `typeof props.validateMsgUseLabel === 'string' && props.validateMsgUseLabel` 为真时, 替换为 validateMsgUseLabel
  - 其余情况, 不处理, 仍然为默认 prop
  - 若设置了自定义错误提示或校验函数, 也都不处理, 仍为默认 prop
- [效果展示](https://user-images.githubusercontent.com/26329117/199005025-e9ca7539-c929-406b-a327-55cfab73393e.mp4)

<hr>

### English
#### 1. Added validateTrim prop to support validation exclusion with only entering spaces
- Background: In required or custom verification, it is easy for the operator to pass the verification by entering only spaces
- Solution: Enable validateTrim prop, which will filter trailing spaces during validation to ensure that the form has entered valid data
- [Effect display](https://user-images.githubusercontent.com/26329117/199003162-4ab93202-0605-4a26-9bde-4a054a3cf373.mp4)


#### 2. Add validateMsgUseLabel prop to support the use of label instead of prop in the verification error message
- Background: By default, prop is used for the field name in the validation error message; in practice, it may be preferable to use label as the field name in the error message
- Solution: Enable validateMsgUseLabel prop (supports boolean, or string type), which will replace the prop in the error message with the label or the field name you want to replace
  - `typeof props.validateMsgUseLabel === 'boolean'  && props.validateMsgUseLabel  && props.label` is true, replace with label
  - `typeof props.validateMsgUseLabel === 'string' && props.validateMsgUseLabel` is true, repleace with validateMsgUseLabel
  - In other cases, it is still the default prop
  - If a custom error message or verification function is set, it will not be handled
- [Effect display](https://user-images.githubusercontent.com/26329117/199005025-e9ca7539-c929-406b-a327-55cfab73393e.mp4)


