### PR TITLE
fix(components): [time-picker] prefix trigger date-pane method

### DIFF
--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -187,7 +187,6 @@ import { formatter, parseDate, valueEquals } from '../utils'
 import { timePickerDefaultProps } from './props'
 
 import type { Dayjs } from 'dayjs'
-import type { ComponentPublicInstance } from 'vue'
 import type { Options } from '@popperjs/core'
 import type {
   DateModelType,
@@ -199,6 +198,7 @@ import type {
   UserInput,
 } from './props'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
+import type { InputInstance } from '@element-plus/components/input'
 
 // Date object and string
 
@@ -228,7 +228,7 @@ const { form, formItem } = useFormItem()
 const elPopperOptions = inject('ElPopperOptions', {} as Options)
 
 const refPopper = ref<TooltipInstance>()
-const inputRef = ref<HTMLElement | ComponentPublicInstance>()
+const inputRef = ref<InputInstance>()
 const pickerVisible = ref(false)
 const pickerActualVisible = ref(false)
 const valueOnOpen = ref<TimePickerDefaultProps['modelValue'] | null>(null)
@@ -280,9 +280,7 @@ const emitKeydown = (e: KeyboardEvent) => {
 
 const refInput = computed<HTMLInputElement[]>(() => {
   if (inputRef.value) {
-    const _r = isRangeInput.value
-      ? inputRef.value
-      : (inputRef.value as any as ComponentPublicInstance).$el
+    const _r = isRangeInput.value ? inputRef.value : inputRef.value.$el
     return Array.from<HTMLInputElement>(_r.querySelectorAll('input'))
   }
   return []
@@ -505,7 +503,7 @@ const onMouseDownInput = async (event: MouseEvent) => {
     (event.target as HTMLElement)?.tagName !== 'INPUT' ||
     refInput.value.includes(document.activeElement as HTMLInputElement)
   ) {
-    pickerVisible.value = true
+    inputRef.value!.focus()
   }
 }
 const onMouseEnter = () => {
@@ -538,7 +536,7 @@ const actualInputRef = computed(() => {
     return unref(inputRef)
   }
 
-  return (unref(inputRef) as ComponentPublicInstance)?.$el
+  return unref(inputRef)?.$el
 })
 
 onClickOutside(actualInputRef, (e: PointerEvent) => {


### PR DESCRIPTION
- close #10367 

before:
![date1](https://user-images.githubusercontent.com/23251408/199523267-95bf303c-1266-4f9c-a6df-18c62c4a5f03.gif)

The difference between clicking the prefix icon and clicking the text box is that the former does not focus on the component. I think the performance of the two should be consistent, after all, it is a whole.

after:
![date2](https://user-images.githubusercontent.com/23251408/199523669-76cf84a0-bdc8-4a2c-8a1a-431f6b37e1eb.gif)

Through this component I found some cases, for example, in the `el-input` component, clicking the `prefix` icon or the edge of the component cannot `focus` the component, but they are a whole, because we only give the `focus` time to the `native`  input tag.

![image](https://user-images.githubusercontent.com/23251408/199531023-78f92e64-aee2-454e-bf0a-a26f3ec89cac.png)

Click to focus the event only in the blue area.

- fix inputRef type

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
