### PR TITLE
fix(components): [autocomplete] dynamic update the tooltip position

### DIFF
--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -102,6 +102,7 @@ import {
   onMounted,
   ref,
   useAttrs as useRawAttrs,
+  watch,
 } from 'vue'
 import { debounce } from 'lodash-unified'
 import { onClickOutside } from '@vueuse/core'
@@ -346,6 +347,13 @@ const highlight = (index: number) => {
 onClickOutside(listboxRef, () => {
   suggestionVisible.value && close()
 })
+
+watch(
+  () => suggestions.value,
+  () => {
+    popperRef.value?.updatePopper()
+  }
+)
 
 onMounted(() => {
   // TODO: use Volar generate dts to fix it.


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fix #10375

[link](https://element-plus.run/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IHJlZiwgb25Nb3VudGVkLCB2ZXJzaW9uIGFzIHZ1ZVZlcnNpb24gfSBmcm9tICd2dWUnXG5pbXBvcnQgeyB2ZXJzaW9uIGFzIEVwVmVyc2lvbiB9IGZyb20gJ2VsZW1lbnQtcGx1cydcbmltcG9ydCB7IEVsZW1lbnRQbHVzIH0gZnJvbSAnQGVsZW1lbnQtcGx1cy9pY29ucy12dWUnXG4gIFxuaW50ZXJmYWNlIFJlc3RhdXJhbnRJdGVtIHtcbiAgdmFsdWU6IHN0cmluZ1xuICBsaW5rOiBzdHJpbmdcbn1cblxuY29uc3Qgc3RhdGUxID0gcmVmKCcnKVxuY29uc3QgcmVzdGF1cmFudHMgPSByZWY8UmVzdGF1cmFudEl0ZW1bXT4oW10pXG5cbmNvbnN0IHF1ZXJ5U2VhcmNoID0gKHF1ZXJ5U3RyaW5nOiBzdHJpbmcsIGNiOiBhbnkpID0+IHtcbiAgY29uc3QgcmVzdWx0cyA9IHF1ZXJ5U3RyaW5nXG4gICAgPyByZXN0YXVyYW50cy52YWx1ZS5maWx0ZXIoY3JlYXRlRmlsdGVyKHF1ZXJ5U3RyaW5nKSlcbiAgICA6IHJlc3RhdXJhbnRzLnZhbHVlXG4gIC8vIGNhbGwgY2FsbGJhY2sgZnVuY3Rpb24gdG8gcmV0dXJuIHN1Z2dlc3Rpb25zXG4gIGNiKHJlc3VsdHMpXG59XG5jb25zdCBjcmVhdGVGaWx0ZXIgPSAocXVlcnlTdHJpbmc6IHN0cmluZykgPT4ge1xuICByZXR1cm4gKHJlc3RhdXJhbnQ6IFJlc3RhdXJhbnRJdGVtKSA9PiB7XG4gICAgcmV0dXJuIChcbiAgICAgIHJlc3RhdXJhbnQudmFsdWUudG9Mb3dlckNhc2UoKS5pbmRleE9mKHF1ZXJ5U3RyaW5nLnRvTG93ZXJDYXNlKCkpID09PSAwXG4gICAgKVxuICB9XG59XG5jb25zdCBsb2FkQWxsID0gKCkgPT4ge1xuICByZXR1cm4gW1xuICAgIHsgdmFsdWU6ICd2dWUnLCBsaW5rOiAnaHR0cHM6Ly9naXRodWIuY29tL3Z1ZWpzL3Z1ZScgfSxcbiAgICB7IHZhbHVlOiAnZWxlbWVudCcsIGxpbms6ICdodHRwczovL2dpdGh1Yi5jb20vRWxlbWVGRS9lbGVtZW50JyB9LFxuICAgIHsgdmFsdWU6ICdjb29raW5nJywgbGluazogJ2h0dHBzOi8vZ2l0aHViLmNvbS9FbGVtZUZFL2Nvb2tpbmcnIH0sXG4gICAgeyB2YWx1ZTogJ21pbnQtdWknLCBsaW5rOiAnaHR0cHM6Ly9naXRodWIuY29tL0VsZW1lRkUvbWludC11aScgfSxcbiAgICB7IHZhbHVlOiAndnVleCcsIGxpbms6ICdodHRwczovL2dpdGh1Yi5jb20vdnVlanMvdnVleCcgfSxcbiAgICB7IHZhbHVlOiAndnVlLXJvdXRlcicsIGxpbms6ICdodHRwczovL2dpdGh1Yi5jb20vdnVlanMvdnVlLXJvdXRlcicgfSxcbiAgICB7IHZhbHVlOiAnYmFiZWwnLCBsaW5rOiAnaHR0cHM6Ly9naXRodWIuY29tL2JhYmVsL2JhYmVsJyB9LFxuICBdXG59XG5cbmNvbnN0IGhhbmRsZVNlbGVjdCA9IChpdGVtOiBSZXN0YXVyYW50SXRlbSkgPT4ge1xuICBjb25zb2xlLmxvZyhpdGVtKVxufVxuXG5vbk1vdW50ZWQoKCkgPT4ge1xuICByZXN0YXVyYW50cy52YWx1ZSA9IGxvYWRBbGwoKVxufSlcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxlbC1hdXRvY29tcGxldGVcbiAgICB2LW1vZGVsPVwic3RhdGUxXCJcbiAgICA6ZmV0Y2gtc3VnZ2VzdGlvbnM9XCJxdWVyeVNlYXJjaFwiXG4gICAgY2xlYXJhYmxlXG4gICAgY2xhc3M9XCJpbmxpbmUtaW5wdXQgdy01MFwiXG4gICAgcGxhY2Vob2xkZXI9XCJQbGVhc2UgSW5wdXRcIlxuICAgIEBzZWxlY3Q9XCJoYW5kbGVTZWxlY3RcIlxuICAgIHBsYWNlbWVudD1cInRvcC1zdGFydFwiXG4gICAgc3R5bGU9XCJtYXJnaW4tdG9wOiAzMDBweFwiXG4gIC8+XG48L3RlbXBsYXRlPlxuIiwiUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0X21hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9wcmV2aWV3LTEwMzkxLWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIlxuICB9XG59IiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9AdnVlL3J1bnRpbWUtZG9tQGxhdGVzdC9kaXN0L3J1bnRpbWUtZG9tLmVzbS1icm93c2VyLmpzXCIsXG4gICAgXCJAdnVlL3NoYXJlZFwiOiBcImh0dHBzOi8vZmFzdGx5LmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9zaGFyZWRAbGF0ZXN0L2Rpc3Qvc2hhcmVkLmVzbS1idW5kbGVyLmpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL3ByZXZpZXctMTAzOTEtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5mdWxsLm1pbi5tanNcIixcbiAgICBcImVsZW1lbnQtcGx1cy9cIjogXCJ1bnN1cHBvcnRlZFwiLFxuICAgIFwiQGVsZW1lbnQtcGx1cy9pY29ucy12dWVcIjogXCJodHRwczovL2Zhc3RseS5qc2RlbGl2ci5uZXQvbnBtL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcbmltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgIGxpbmsuaHJlZiA9ICdodHRwczovL3ByZXZpZXctMTAzOTEtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5jc3MnXG4gICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gIH0pXG59IiwiX28iOnsic2hvd0hpZGRlbiI6dHJ1ZSwic3R5bGVTb3VyY2UiOiJodHRwczovL3ByZXZpZXctMTAzOTEtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5jc3MifX0=)
