### PR TITLE
docs: error when frontmatter does not exist

### DIFF
--- a/docs/.vitepress/plugins/markdown-transform.ts
+++ b/docs/.vitepress/plugins/markdown-transform.ts
@@ -48,9 +48,9 @@ export function MarkdownTransform(): Plugin {
 }
 
 const combineScriptSetup = (codes: string[]) =>
-  `\n<script setup>
+  `<script setup>
 ${codes.join('\n')}
-</script>
+</script>\n
 `
 
 const combineMarkdown = (
@@ -58,9 +58,14 @@ const combineMarkdown = (
   headers: string[],
   footers: string[]
 ) => {
-  const frontmatterEnds = code.indexOf('---\n\n') + 4
-  const firstSubheader = code.search(/\n## \w/)
-  const sliceIndex = firstSubheader < 0 ? frontmatterEnds : firstSubheader
+  const frontmatterEnds = code.indexOf('---\n\n')
+  const firstSubheader = code.search(/## \w/)
+  const sliceIndex =
+    firstSubheader < 0
+      ? frontmatterEnds < 0
+        ? 0
+        : frontmatterEnds + 5
+      : firstSubheader
 
   if (headers.length > 0)
     code =


### PR DESCRIPTION
The value of `sliceIndex` is wrong when `firstSubheader` returns -1 and no frontmatter exists.

## When the content has no frontmatter and there is no secondary title

Eg.

``` md
# Button

Commonly used button.
```

![image](https://user-images.githubusercontent.com/53554371/201243379-c73e9f82-88bf-4cef-b3f7-1cdd3f73cd0b.png)
