### PR TITLE
fix(components): [table-column] column miss update due to key (#8528)

### DIFF
--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -1554,4 +1554,53 @@ describe('Table.vue', () => {
     await doubleWait()
     expect(wrapper.vm.selected.length).toEqual(3)
   })
+  it('change columns order when use v-for & key to render table', async () => {
+    const wrapper = mount({
+      components: {
+        ElTable,
+        ElTableColumn,
+      },
+      template: `
+            <button class="change-column" @click="changeColumnData"></button>
+            <el-table :data="testData">
+              <el-table-column
+                v-for="item in columnsData"
+                :prop="item.prop"
+                :label="item.label"
+                :key="item.prop" />
+            </el-table>
+          `,
+      data() {
+        const testData = getTestData() as any
+
+        return {
+          testData,
+          columnsData: [
+            { label: 'name', prop: 'name' },
+            { label: 'release', prop: 'release' },
+            { label: 'director', prop: 'director' },
+            { label: 'runtime', prop: 'runtime' },
+          ],
+        }
+      },
+
+      methods: {
+        changeColumnData() {
+          ;[this.columnsData[0], this.columnsData[1]] = [
+            this.columnsData[1],
+            this.columnsData[0],
+          ]
+        },
+      },
+    })
+    await doubleWait()
+    wrapper.find('.change-column').trigger('click')
+    await doubleWait()
+    expect(wrapper.find('.el-table__header').findAll('.cell')[0].text()).toBe(
+      'release'
+    )
+    expect(wrapper.find('.el-table__header').findAll('.cell')[1].text()).toBe(
+      'name'
+    )
+  })
 })

--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -90,7 +90,7 @@ function useStore<T>() {
       }
       sortColumn(newColumns)
       states._columns.value = newColumns
-      states.updateOrderFns.value.push(updateColumnOrder)
+      states.updateOrderFns.push(updateColumnOrder)
       if (column.type === 'selection') {
         states.selectable.value = column.selectable
         states.reserveSelection.value = column.reserveSelection
@@ -139,9 +139,8 @@ function useStore<T>() {
         }
       }
 
-      const updateFnIndex =
-        states.updateOrderFns.value.indexOf(updateColumnOrder)
-      updateFnIndex > -1 && states.updateOrderFns.value.splice(updateFnIndex, 1)
+      const updateFnIndex = states.updateOrderFns.indexOf(updateColumnOrder)
+      updateFnIndex > -1 && states.updateOrderFns.splice(updateFnIndex, 1)
 
       if (instance.$ready) {
         instance.store.updateColumns() // hack for dynamics remove column

--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -99,6 +99,17 @@ function useStore<T>() {
       }
     },
 
+    updateColumnOrder(states: StoreStates, keyList: Array<string>) {
+      const array = unref(states._columns)
+      states._columns.value = array.sort((a, b) => {
+        return keyList.indexOf(a.key) - keyList.indexOf(b.key)
+      })
+
+      if (instance.$ready) {
+        instance.store.updateColumns()
+      }
+    },
+
     removeColumn(
       states: StoreStates,
       column: TableColumnCtx<T>,

--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -101,66 +101,11 @@ function useStore<T>() {
       }
     },
 
-    updateColumnOrder(
-      states: StoreStates,
-      targetTreePath: Array<number>,
-      column: TableColumnCtx<T>
-    ) {
-      const getColumnTreePath = (columns: TableColumnCtx<T>[]) => {
-        if (!columns || !columns.length) return
+    updateColumnOrder(states: StoreStates, column: TableColumnCtx<T>) {
+      const newColumnIndex = column.getColumnIndex?.()
+      if (newColumnIndex === column.no) return
 
-        const stack = []
-        let pathRes = null
-
-        const dfs = (columns) => {
-          if (!columns?.length) return
-
-          const res = Array.prototype.indexOf.call(columns, column)
-          if (res > -1) {
-            stack.push(res)
-            pathRes = stack.slice()
-            return
-          }
-
-          for (const [i, column_] of columns.entries()) {
-            stack.push(i)
-            dfs(column_.children)
-            stack.pop()
-          }
-        }
-
-        dfs(columns)
-
-        return pathRes
-      }
-
-      const sourceTreePath = getColumnTreePath(states._columns.value)
-
-      if (
-        !targetTreePath ||
-        !sourceTreePath ||
-        targetTreePath.toString() === sourceTreePath.toString()
-      )
-        return
-
-      const maxLen = Math.max(targetTreePath.length, sourceTreePath.length)
-      let sourceStr = 'states._columns.value',
-        targetStr = 'states._columns.value'
-      for (let i = 0; i < maxLen; i++) {
-        if (i <= 0) {
-          sourceStr += `[${sourceTreePath[i]}]`
-          targetStr += `[${targetTreePath[i]}]`
-          continue
-        }
-        if (typeof sourceTreePath[i] !== 'undefined')
-          sourceStr += `.children[${sourceTreePath[i]}]`
-        if (typeof targetTreePath[i] !== 'undefined')
-          targetStr += `.children[${targetTreePath[i]}]`
-      }
-
-      try {
-        eval(`[${sourceStr},${targetStr}]=[${targetStr},${sourceStr}];`)
-      } catch {}
+      sortColumn(states._columns.value)
 
       if (instance.$ready) {
         instance.store.updateColumns()

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -14,7 +14,7 @@ import useCurrent from './current'
 import useTree from './tree'
 
 import type { Ref } from 'vue'
-import type { TableColumnCtx } from '../table-column/defaults'
+import type { TableColumn, TableColumnCtx } from '../table-column/defaults'
 import type { Table, TableRefs } from '../table/defaults'
 import type { StoreFilter } from '.'
 
@@ -60,6 +60,7 @@ function useWatcher<T>() {
   const leafColumns: Ref<TableColumnCtx<T>[]> = ref([])
   const fixedLeafColumns: Ref<TableColumnCtx<T>[]> = ref([])
   const rightFixedLeafColumns: Ref<TableColumnCtx<T>[]> = ref([])
+  const updateOrderFns: Ref<(() => void)[]> = ref([])
   const leafColumnsLength = ref(0)
   const fixedLeafColumnsLength = ref(0)
   const rightFixedLeafColumnsLength = ref(0)
@@ -517,6 +518,7 @@ function useWatcher<T>() {
       leafColumns,
       fixedLeafColumns,
       rightFixedLeafColumns,
+      updateOrderFns,
       leafColumnsLength,
       fixedLeafColumnsLength,
       rightFixedLeafColumnsLength,

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -60,7 +60,7 @@ function useWatcher<T>() {
   const leafColumns: Ref<TableColumnCtx<T>[]> = ref([])
   const fixedLeafColumns: Ref<TableColumnCtx<T>[]> = ref([])
   const rightFixedLeafColumns: Ref<TableColumnCtx<T>[]> = ref([])
-  const updateOrderFns: Ref<(() => void)[]> = ref([])
+  const updateOrderFns: () => void[] = []
   const leafColumnsLength = ref(0)
   const fixedLeafColumnsLength = ref(0)
   const rightFixedLeafColumnsLength = ref(0)

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -61,8 +61,6 @@ function useWatcher<T>() {
   const fixedLeafColumns: Ref<TableColumnCtx<T>[]> = ref([])
   const rightFixedLeafColumns: Ref<TableColumnCtx<T>[]> = ref([])
   const updateOrderFns: (() => void)[] = []
-  // or
-  const updateOrderFns: Array<() => void> = []
   const leafColumnsLength = ref(0)
   const fixedLeafColumnsLength = ref(0)
   const rightFixedLeafColumnsLength = ref(0)

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -14,7 +14,7 @@ import useCurrent from './current'
 import useTree from './tree'
 
 import type { Ref } from 'vue'
-import type { TableColumn, TableColumnCtx } from '../table-column/defaults'
+import type { TableColumnCtx } from '../table-column/defaults'
 import type { Table, TableRefs } from '../table/defaults'
 import type { StoreFilter } from '.'
 

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -60,7 +60,9 @@ function useWatcher<T>() {
   const leafColumns: Ref<TableColumnCtx<T>[]> = ref([])
   const fixedLeafColumns: Ref<TableColumnCtx<T>[]> = ref([])
   const rightFixedLeafColumns: Ref<TableColumnCtx<T>[]> = ref([])
-  const updateOrderFns: () => void[] = []
+  const updateOrderFns: (() => void)[] = []
+  // or
+  const updateOrderFns: Array<() => void> = []
   const leafColumnsLength = ref(0)
   const fixedLeafColumnsLength = ref(0)
   const rightFixedLeafColumnsLength = ref(0)

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -23,6 +23,7 @@ interface TableColumnCtx<T> {
   labelClassName: string
   property: string
   prop: string
+  key: string | number
   width: string | number
   minWidth: string | number
   renderHeader: (data: CI<T>) => VNode

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -23,7 +23,6 @@ interface TableColumnCtx<T> {
   labelClassName: string
   property: string
   prop: string
-  key: string | number
   width: string | number
   minWidth: string | number
   renderHeader: (data: CI<T>) => VNode

--- a/packages/components/table/src/table-column/index.ts
+++ b/packages/components/table/src/table-column/index.ts
@@ -55,6 +55,7 @@ export default defineComponent({
       getPropsData,
       getColumnElIndex,
       realAlign,
+      updateColumnOrder,
     } = useRender(props as unknown as TableColumnCtx<unknown>, slots, owner)
 
     const parent = columnOrTableParent.value
@@ -140,14 +141,16 @@ export default defineComponent({
         owner.value.store.commit(
           'insertColumn',
           columnConfig.value,
-          isSubColumn.value ? parent.columnConfig.value : null
+          isSubColumn.value ? parent.columnConfig.value : null,
+          updateColumnOrder
         )
     })
     onBeforeUnmount(() => {
       owner.value.store.commit(
         'removeColumn',
         columnConfig.value,
-        isSubColumn.value ? parent.columnConfig.value : null
+        isSubColumn.value ? parent.columnConfig.value : null,
+        updateColumnOrder
       )
     })
     instance.columnId = columnId.value

--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -189,6 +189,53 @@ function useRender<T>(
     return Array.prototype.indexOf.call(children, child)
   }
 
+  const getTreePath = (wrapper: HTMLElement, column: HTMLElement) => {
+    if (!wrapper || !wrapper.childNodes) return
+
+    const stack = []
+    let pathRes = null
+
+    const dfs = (node) => {
+      // filter dom which from TableColumn
+      const columnNodes = Array.prototype.filter.call(
+        node.childNodes,
+        (_) => _.__vnode
+      )
+      if (!columnNodes.length) return
+
+      const res = Array.prototype.indexOf.call(columnNodes, column)
+      if (res > -1) {
+        stack.push(res)
+        pathRes = stack.slice()
+        return
+      }
+
+      for (const [i, columnNode] of columnNodes.entries()) {
+        stack.push(i)
+        dfs(columnNode)
+        stack.pop()
+      }
+    }
+
+    dfs(wrapper)
+
+    return pathRes
+  }
+
+  const updateColumnOrder = () => {
+    const tableEl = owner.value.vnode.el
+    const columnEl = instance.vnode.el
+    const columnsWrapper = (tableEl as HTMLElement).querySelector(
+      '.hidden-columns'
+    )
+    const targetTreePath = getTreePath(columnsWrapper, columnEl)
+    owner.value.store.commit(
+      'updateColumnOrder',
+      targetTreePath,
+      instance.columnConfig.value
+    )
+  }
+
   return {
     columnId,
     realAlign,
@@ -200,6 +247,7 @@ function useRender<T>(
     setColumnRenders,
     getPropsData,
     getColumnElIndex,
+    updateColumnOrder,
   }
 }
 

--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -189,51 +189,8 @@ function useRender<T>(
     return Array.prototype.indexOf.call(children, child)
   }
 
-  const getTreePath = (wrapper: HTMLElement, column: HTMLElement) => {
-    if (!wrapper || !wrapper.childNodes) return
-
-    const stack = []
-    let pathRes = null
-
-    const dfs = (node) => {
-      // filter dom which from TableColumn
-      const columnNodes = Array.prototype.filter.call(
-        node.childNodes,
-        (_) => _.__vnode
-      )
-      if (!columnNodes.length) return
-
-      const res = Array.prototype.indexOf.call(columnNodes, column)
-      if (res > -1) {
-        stack.push(res)
-        pathRes = stack.slice()
-        return
-      }
-
-      for (const [i, columnNode] of columnNodes.entries()) {
-        stack.push(i)
-        dfs(columnNode)
-        stack.pop()
-      }
-    }
-
-    dfs(wrapper)
-
-    return pathRes
-  }
-
   const updateColumnOrder = () => {
-    const tableEl = owner.value.vnode.el
-    const columnEl = instance.vnode.el
-    const columnsWrapper = (tableEl as HTMLElement).querySelector(
-      '.hidden-columns'
-    )
-    const targetTreePath = getTreePath(columnsWrapper, columnEl)
-    owner.value.store.commit(
-      'updateColumnOrder',
-      targetTreePath,
-      instance.columnConfig.value
-    )
+    owner.value.store.commit('updateColumnOrder', instance.columnConfig.value)
   }
 
   return {

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -145,7 +145,16 @@
 
 <script lang="ts">
 // @ts-nocheck
-import { computed, defineComponent, getCurrentInstance, provide } from 'vue'
+import {
+  computed,
+  defineComponent,
+  getCurrentInstance,
+  onMounted,
+  onUnmounted,
+  provide,
+  ref,
+  useSlots,
+} from 'vue'
 import { debounce } from 'lodash-unified'
 import { Mousewheel } from '@element-plus/directives'
 import { useLocale, useNamespace } from '@element-plus/hooks'
@@ -206,6 +215,8 @@ export default defineComponent({
     provide(TABLE_INJECTION_KEY, table)
     const store = createStore<Row>(table, props)
     table.store = store
+    const slots = useSlots()
+    const observer = ref(null)
     const layout = new TableLayout<Row>({
       store: table.store,
       table,
@@ -270,6 +281,44 @@ export default defineComponent({
 
     const computedEmptyText = computed(() => {
       return props.emptyText || t('el.table.emptyText')
+    })
+
+    const initWatchDom = () => {
+      // fix https://github.com/element-plus/element-plus/issues/8528
+      // 仅处理 keyed fragment 情况
+      const keyedFragment = getKeyedFragment()
+      if (!keyedFragment?.length) return
+
+      const el = table.vnode.el
+      const columnsWrapper = el.querySelector('.hidden-columns')
+      const config = { childList: true }
+      observer.value = new MutationObserver(() => {
+        const keyedFragment = getKeyedFragment()
+        const keyList = keyedFragment
+          .reduce((acc, cur) => {
+            acc = [...acc, ...cur.children]
+            return acc
+          }, [])
+          .map((_) => _?.key)
+
+        table.store.commit('updateColumnOrder', keyList)
+      })
+
+      observer.value.observe(columnsWrapper, config)
+
+      function getKeyedFragment() {
+        if (!slots || !slots.default) return
+        const slotIns = slots.default()
+        return slotIns.filter((_) => _.patchFlag & 128 /* KEYED_FRAGMENT */)
+      }
+    }
+
+    onMounted(() => {
+      initWatchDom()
+    })
+
+    onUnmounted(() => {
+      observer.value?.disconnect()
     })
 
     return {

--- a/packages/components/table/src/table/key-render-helper.ts
+++ b/packages/components/table/src/table/key-render-helper.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+import { onMounted, onUnmounted, ref, unref, useSlots } from 'vue'
+import type { Ref } from 'vue'
+import type { Table } from './defaults'
+
+export default function useKeyRender(table: Table<[]>) {
+  const slots = useSlots()
+  const observer: Ref = ref(null)
+
+  const initWatchDom = () => {
+    // 仅在首层存在 keyed fragment 的时候监测 column组件 的 dom 变化
+    const keyedFragment = getKeyedFragment(slots)
+    if (!keyedFragment?.length) return
+
+    const el = table.vnode.el
+    const columnsWrapper = (el as HTMLElement).querySelector('.hidden-columns')
+    const config = { childList: true, subtree: true }
+    const updateOrderFns = unref(table.store.states.updateOrderFns)
+    observer.value = new MutationObserver(() => {
+      updateOrderFns.forEach((fn: () => void) => fn())
+    })
+
+    observer.value.observe(columnsWrapper, config)
+  }
+
+  onMounted(() => {
+    // fix https://github.com/element-plus/element-plus/issues/8528
+    initWatchDom()
+  })
+
+  onUnmounted(() => {
+    observer.value?.disconnect()
+  })
+}
+
+function getKeyedFragment(slots) {
+  if (!slots || !slots.default) return
+  const slotIns = slots.default()
+  return slotIns.filter((_) => _.patchFlag & 128 /* KEYED_FRAGMENT */)
+}

--- a/packages/components/table/src/table/key-render-helper.ts
+++ b/packages/components/table/src/table/key-render-helper.ts
@@ -10,7 +10,7 @@ export default function useKeyRender(table: Table<[]>) {
     const el = table.vnode.el
     const columnsWrapper = (el as HTMLElement).querySelector('.hidden-columns')
     const config = { childList: true, subtree: true }
-    const updateOrderFns = unref(table.store.states.updateOrderFns)
+    const updateOrderFns = table.store.states.updateOrderFns
     observer.value = new MutationObserver(() => {
       updateOrderFns.forEach((fn: () => void) => fn())
     })

--- a/packages/components/table/src/table/key-render-helper.ts
+++ b/packages/components/table/src/table/key-render-helper.ts
@@ -1,17 +1,12 @@
 // @ts-nocheck
-import { onMounted, onUnmounted, ref, unref, useSlots } from 'vue'
+import { onMounted, onUnmounted, ref, unref } from 'vue'
 import type { Ref } from 'vue'
 import type { Table } from './defaults'
 
 export default function useKeyRender(table: Table<[]>) {
-  const slots = useSlots()
   const observer: Ref = ref(null)
 
   const initWatchDom = () => {
-    // 仅在首层存在 keyed fragment 的时候监测 column组件 的 dom 变化
-    const keyedFragment = getKeyedFragment(slots)
-    if (!keyedFragment?.length) return
-
     const el = table.vnode.el
     const columnsWrapper = (el as HTMLElement).querySelector('.hidden-columns')
     const config = { childList: true, subtree: true }
@@ -31,10 +26,4 @@ export default function useKeyRender(table: Table<[]>) {
   onUnmounted(() => {
     observer.value?.disconnect()
   })
-}
-
-function getKeyedFragment(slots) {
-  if (!slots || !slots.default) return
-  const slotIns = slots.default()
-  return slotIns.filter((_) => _.patchFlag & 128 /* KEYED_FRAGMENT */)
 }

--- a/packages/components/table/src/table/key-render-helper.ts
+++ b/packages/components/table/src/table/key-render-helper.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { onMounted, onUnmounted, ref, unref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 import type { Ref } from 'vue'
 import type { Table } from './defaults'
 

--- a/packages/components/table/src/table/key-render-helper.ts
+++ b/packages/components/table/src/table/key-render-helper.ts
@@ -1,10 +1,8 @@
-// @ts-nocheck
 import { onMounted, onUnmounted, ref } from 'vue'
-import type { Ref } from 'vue'
 import type { Table } from './defaults'
 
 export default function useKeyRender(table: Table<[]>) {
-  const observer: Ref = ref(null)
+  const observer = ref<MutationObserver>()
 
   const initWatchDom = () => {
     const el = table.vnode.el
@@ -15,7 +13,7 @@ export default function useKeyRender(table: Table<[]>) {
       updateOrderFns.forEach((fn: () => void) => fn())
     })
 
-    observer.value.observe(columnsWrapper, config)
+    observer.value.observe(columnsWrapper!, config)
   }
 
   onMounted(() => {


### PR DESCRIPTION
Fix: [[Component] [table-column, table] 使用 v-for 循环生成列，在 el-table-column 组件加上 key属性时，无法修改列的顺序 #8528](https://github.com/element-plus/element-plus/issues/8528)

Specific analysis of the problem: [为什么v-for key导致table无法修改列顺序](https://juejin.cn/post/7168308855623909406/)