### PR TITLE
fix(components): [select-v2] Use isEmpty instead of isNil

### DIFF
--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -1,7 +1,13 @@
 // @ts-nocheck
 import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue'
 import { isArray, isFunction, isObject } from '@vue/shared'
-import { get, isEqual, isNil, debounce as lodashDebounce } from 'lodash-unified'
+import {
+  get,
+  isEmpty,
+  isEqual,
+  isNil,
+  debounce as lodashDebounce,
+} from 'lodash-unified'
 import { useResizeObserver } from '@vueuse/core'
 import {
   useFormItem,
@@ -226,7 +232,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
 
   const currentPlaceholder = computed(() => {
     const _placeholder = props.placeholder || t('el.select.placeholder')
-    return props.multiple || isNil(props.modelValue)
+    return props.multiple || isEmpty(props.modelValue)
       ? _placeholder
       : states.selectedLabel
   })


### PR DESCRIPTION
使用isEmpty代替isNil检测modelValue的初始值，单选的情况下检测modelValue初始值是否为空(`isEmpty([] | '' | undefined | null)` -> `true`)，而不是根据初始值的类型检测是否存在值（`isNil([])`-> `false`）

同时关闭[#10701](https://github.com/element-plus/element-plus/issues/10701)