### PR TITLE
fix(components): [date-picker] default-time affects now result(#10729)

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -251,6 +251,8 @@ const currentViewRef = ref<{ focus: () => void }>()
 
 const innerDate = ref(dayjs().locale(lang.value))
 
+const isChangeToNow = ref(false)
+
 const defaultTimeD = computed(() => {
   return dayjs(defaultTime).locale(lang.value)
 })
@@ -273,7 +275,7 @@ const checkDateWithinRange = (date: ConfigType) => {
     : true
 }
 const formatEmit = (emitDayjs: Dayjs) => {
-  if (defaultTime && !visibleTime.value) {
+  if (defaultTime && !visibleTime.value && !isChangeToNow.value) {
     return defaultTimeD.value
       .year(emitDayjs.year())
       .month(emitDayjs.month())
@@ -293,6 +295,7 @@ const emit = (value: Dayjs | Dayjs[], ...args: any[]) => {
   }
   userInputDate.value = null
   userInputTime.value = null
+  isChangeToNow.value = false
 }
 const handleDatePick = (value: DateTableEmits, keepOpen?: boolean) => {
   if (selectionMode.value === 'date') {
@@ -458,6 +461,7 @@ const changeToNow = () => {
   //       consider disable "now" button in the future
   const now = dayjs().locale(lang.value)
   const nowDate = now.toDate()
+  isChangeToNow.value = true
   if (
     (!disabledDate || !disabledDate(nowDate)) &&
     checkDateWithinRange(nowDate)


### PR DESCRIPTION
Fix: [[Component] [date-picker] [Component] [date-picker] 设置default time后，选择now的时间不对 #10729](https://github.com/element-plus/element-plus/issues/10729)
