### PR TITLE
chore: move the types entry point to the very beginning

### DIFF
--- a/packages/element-plus/package.json
+++ b/packages/element-plus/package.json
@@ -21,8 +21,8 @@
   "exports": {
     ".": {
       "types": "./es/index.d.ts",
-      "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "require": "./lib/index.js"
     },
     "./es": "./es/index.mjs",
     "./lib": "./lib/index.js",

--- a/packages/element-plus/package.json
+++ b/packages/element-plus/package.json
@@ -20,9 +20,9 @@
   "types": "es/index.d.ts",
   "exports": {
     ".": {
+      "types": "./es/index.d.ts",
       "require": "./lib/index.js",
-      "import": "./es/index.mjs",
-      "types": "./es/index.d.ts"
+      "import": "./es/index.mjs"
     },
     "./es": "./es/index.mjs",
     "./lib": "./lib/index.js",


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing
![image](https://user-images.githubusercontent.com/24516654/204075189-73ad5bbf-6de6-497a-b9cb-b8b25888944d.png)


