### PR TITLE
fix(components): [notification] option zIndex for notification can't effect

### DIFF
--- a/packages/components/notification/src/notify.ts
+++ b/packages/components/notification/src/notify.ts
@@ -50,8 +50,8 @@ const notify: NotifyFn & Partial<Notify> & { _context: AppContext | null } =
     const id = `notification_${seed++}`
     const userOnClose = options.onClose
     const props: Partial<NotificationProps> = {
-      ...options,
       zIndex: nextZIndex(),
+      ...options,
       offset: verticalOffset,
       id,
       onClose: () => {


### PR DESCRIPTION
File:`/packages/components/notification/src/notify.ts`
```javascript
const props = {
  ...options,
  zIndex: nextZIndex(),
  offset: verticalOffset,
  id,
  onClose: () => {
    close(id, position, userOnClose);
  }
};
```

`options.zIndex` will not effective since it is write before `zIndex: nextZIndex()`, it will be overode.
