### PR TITLE
fix(components): [tree-node-content] fill slot wrapper (#10718)

### DIFF
--- a/packages/components/tree/src/tree-node-content.vue
+++ b/packages/components/tree/src/tree-node-content.vue
@@ -24,11 +24,17 @@ export default defineComponent({
       const { data, store } = node
       return props.renderContent
         ? props.renderContent(h, { _self: nodeInstance, node, data, store })
-        : h('span', { class: ns.be('node', 'label') }, [
-            tree.ctx.slots.default
-              ? tree.ctx.slots.default({ node, data })
-              : node.label,
-          ])
+        : h(
+            'span',
+            {
+              class: [ns.be('node', 'label'), ns.bem('node', 'label', 'full')],
+            },
+            [
+              tree.ctx.slots.default
+                ? tree.ctx.slots.default({ node, data })
+                : node.label,
+            ]
+          )
     }
   },
 })

--- a/packages/theme-chalk/src/tree.scss
+++ b/packages/theme-chalk/src/tree.scss
@@ -109,6 +109,9 @@
 
   @include e(label) {
     font-size: getCssVar('font-size', 'base');
+    @include m(full) {
+      flex: 1;
+    }
   }
 
   @include e(loading-icon) {


### PR DESCRIPTION
Fix: [[Style] [tree] el-tree 自定义节点内容，官网文档上演示有问题](https://github.com/element-plus/element-plus/issues/10718)

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
