### PR TITLE
fix(components): [tree] revert inherits the label class

### DIFF
--- a/packages/components/tree/src/tree-node-content.vue
+++ b/packages/components/tree/src/tree-node-content.vue
@@ -24,11 +24,9 @@ export default defineComponent({
       const { data, store } = node
       return props.renderContent
         ? props.renderContent(h, { _self: nodeInstance, node, data, store })
-        : h('span', { class: ns.be('node', 'label') }, [
-            tree.ctx.slots.default
-              ? tree.ctx.slots.default({ node, data })
-              : node.label,
-          ])
+        : tree.ctx.slots.default
+        ? tree.ctx.slots.default({ node, data })
+        : h('span', { class: ns.be('node', 'label') }, [node.label])
     }
   },
 })

--- a/packages/theme-chalk/src/tree.scss
+++ b/packages/theme-chalk/src/tree.scss
@@ -12,6 +12,7 @@
   cursor: default;
   background: getCssVar('fill-color', 'blank');
   color: getCssVar('tree-text-color');
+  font-size: getCssVar('font-size', 'base');
 
   @include e(empty-block) {
     position: relative;
@@ -105,10 +106,6 @@
     &.is-hidden {
       visibility: hidden;
     }
-  }
-
-  @include e(label) {
-    font-size: getCssVar('font-size', 'base');
   }
 
   @include e(loading-icon) {


### PR DESCRIPTION
* revert slot inherit style
* Adjust the size style attribute to tree

close #10718
before: 
![image](https://user-images.githubusercontent.com/23251408/204432103-e1503ae7-7c42-406c-8c3d-553103a68f02.png)

after:
![image](https://user-images.githubusercontent.com/23251408/204432143-a04277a2-abf9-449d-aaa5-7bd8cffbd532.png)

The size is extracted from the label to the tree, which should be a more reasonable solution.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
