### PR TITLE
fix(components): [table]fix the problem that show-overflow-tooltip will also be displayed when the browser is zoomed

### DIFF
--- a/packages/components/table/src/table-body/events-helper.ts
+++ b/packages/components/table/src/table-body/events-helper.ts
@@ -89,7 +89,13 @@ function useEvents<T>(props: Partial<TableBodyProps<T>>) {
     const range = document.createRange()
     range.setStart(cellChild, 0)
     range.setEnd(cellChild, cellChild.childNodes.length)
-    const rangeWidth = range.getBoundingClientRect().width
+    /** detail: https://github.com/element-plus/element-plus/issues/10790
+     *  What went wrong?
+     *  UI > Browser > Zoom, In Blink/WebKit, getBoundingClientRect() sometimes returns inexact values, probably due to lost precision during internal calculations. In the example above:
+     *    - Expected: 188
+     *    - Actual: 188.00000762939453
+     */
+    const rangeWidth = Math.round(range.getBoundingClientRect().width)
     const padding =
       (Number.parseInt(getStyle(cellChild, 'paddingLeft'), 10) || 0) +
       (Number.parseInt(getStyle(cellChild, 'paddingRight'), 10) || 0)


### PR DESCRIPTION
fix the problem that show-overflow-tooltip will also be displayed when the browser is zoomed

closed #10790

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
