### PR TITLE
fix(components): [select] support custom height (#10840)

### DIFF
--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -1985,6 +1985,12 @@ describe('Select', () => {
       large: 40,
     }
 
+    Object.defineProperty(inputEl, 'offsetParent', {
+      get() {
+        return {}
+      },
+    })
+
     for (const size in sizeMap) {
       await wrapper.setProps({
         size,

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -110,6 +110,7 @@ export const useSelect = (props, states: States, ctx) => {
       optionList.value = options
     }
   })
+  const originClientHeight = ref<number>(0)
 
   const { form, formItem } = useFormItem()
 
@@ -387,9 +388,17 @@ export const useSelect = (props, states: States, ctx) => {
       const input = reference.value.$el.querySelector(
         'input'
       ) as HTMLInputElement
+      originClientHeight.value =
+        originClientHeight.value ||
+        (input.clientHeight > 0 ? input.clientHeight + 2 : 0)
       const _tags = tags.value
+      const gotSize = getComponentSize(selectSize.value || form?.size)
 
-      const sizeInMap = getComponentSize(selectSize.value || form?.size)
+      const sizeInMap =
+        gotSize === originClientHeight.value || originClientHeight.value <= 0
+          ? gotSize
+          : originClientHeight.value
+
       // it's an inner input so reduce it by 2px.
       input.style.height = `${
         (states.selected.length === 0

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -100,6 +100,7 @@ export const useSelect = (props, states: States, ctx) => {
   const groupQueryChange = shallowRef('')
   const instance = getCurrentInstance()
   const optionList = ref<string[]>([])
+  let originClientHeight = 0
 
   onUpdated(() => {
     const childrens = instance?.slots.default?.()[0].children
@@ -110,7 +111,6 @@ export const useSelect = (props, states: States, ctx) => {
       optionList.value = options
     }
   })
-  const originClientHeight = ref<number>(0)
 
   const { form, formItem } = useFormItem()
 
@@ -388,28 +388,32 @@ export const useSelect = (props, states: States, ctx) => {
       const input = reference.value.$el.querySelector(
         'input'
       ) as HTMLInputElement
-      originClientHeight.value =
-        originClientHeight.value ||
+      originClientHeight =
+        originClientHeight ||
         (input.clientHeight > 0 ? input.clientHeight + 2 : 0)
       const _tags = tags.value
       const gotSize = getComponentSize(selectSize.value || form?.size)
 
       const sizeInMap =
-        gotSize === originClientHeight.value || originClientHeight.value <= 0
+        gotSize === originClientHeight || originClientHeight <= 0
           ? gotSize
-          : originClientHeight.value
+          : originClientHeight
+
+      const isElHidden = input.offsetParent === null
 
       // it's an inner input so reduce it by 2px.
-      input.style.height = `${
-        (states.selected.length === 0
-          ? sizeInMap
-          : Math.max(
-              _tags
-                ? _tags.clientHeight + (_tags.clientHeight > sizeInMap ? 6 : 0)
-                : 0,
-              sizeInMap
-            )) - 2
-      }px`
+      !isElHidden &&
+        (input.style.height = `${
+          (states.selected.length === 0
+            ? sizeInMap
+            : Math.max(
+                _tags
+                  ? _tags.clientHeight +
+                      (_tags.clientHeight > sizeInMap ? 6 : 0)
+                  : 0,
+                sizeInMap
+              )) - 2
+        }px`)
 
       states.tagInMultiLine = Number.parseFloat(input.style.height) >= sizeInMap
 


### PR DESCRIPTION
Fix: [[Component] [select] el-select的disabled属性切换时，如果自定义了line-height，里面input框的高度计算有问题](https://github.com/element-plus/element-plus/issues/10840)
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
