### PR TITLE
style(theme-chalk): [color-picker] Fix focus-visible outline

### DIFF
--- a/packages/theme-chalk/src/color-picker.scss
+++ b/packages/theme-chalk/src/color-picker.scss
@@ -244,6 +244,19 @@ $color-picker-size: map.merge($common-component-size, $color-picker-size);
   display: inline-block;
   position: relative;
   line-height: normal;
+  outline: none;
+
+  &:hover:not(.is-disabled) {
+    .#{$namespace}-color-picker__trigger {
+      border: 1px solid getCssVar('border-color-hover');
+    }
+  }
+
+  &:focus-visible:not(.is-disabled) {
+    .#{$namespace}-color-picker__trigger {
+      border: 1px solid getCssVar('color-primary');
+    }
+  }
 
   @include when(disabled) {
     .#{$namespace}-color-picker__trigger {
@@ -275,8 +288,8 @@ $color-picker-size: map.merge($common-component-size, $color-picker-size);
   }
 
   @include e(mask) {
-    height: 38px;
-    width: 38px;
+    height: map.get($color-picker-size, 'default')-2px;
+    width: map.get($color-picker-size, 'default')-2px;
     border-radius: 4px;
     position: absolute;
     top: 1px;

--- a/packages/theme-chalk/src/color-picker.scss
+++ b/packages/theme-chalk/src/color-picker.scss
@@ -254,7 +254,8 @@ $color-picker-size: map.merge($common-component-size, $color-picker-size);
 
   &:focus-visible:not(.is-disabled) {
     .#{$namespace}-color-picker__trigger {
-      border: 1px solid getCssVar('color-primary');
+      outline: 2px solid getCssVar('color-primary');
+      outline-offset: 1px;
     }
   }
 


### PR DESCRIPTION
1. Add border hover color.
2. Fix outline.
Before:
![image](https://user-images.githubusercontent.com/38392315/205650755-f405384a-75b7-47cf-8b25-a5612eac1ae2.png)
After:
![image](https://user-images.githubusercontent.com/38392315/205876773-e14f93c2-7baa-4ad5-aea8-aa2a549ddea5.png)
3. Fix disabled mask.