### PR TITLE
fix(components): [cascader-panel]

### DIFF
--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -225,7 +225,7 @@ export default defineComponent({
           .map((val) => store?.getNodeByValue(val))
           .filter((node) => !!node && !node.loaded && !node.loading) as Node[]
 
-        if (nodes.length) {
+        if (nodes.length && leafOnly) {
           nodes.forEach((node) => {
             lazyLoad(node, () => syncCheckedValue(false, forced))
           })
@@ -247,6 +247,7 @@ export default defineComponent({
       reserveExpandingState = true
     ) => {
       const { checkStrictly } = config.value
+      const leafOnly = !checkStrictly
       const oldNodes = checkedNodes.value
       const newNodes = newCheckedNodes.filter(
         (node) => !!node && (checkStrictly || node.isLeaf)
@@ -255,7 +256,7 @@ export default defineComponent({
       const newExpandingNode =
         (reserveExpandingState && oldExpandingNode) || newNodes[0]
 
-      if (newExpandingNode) {
+      if (newExpandingNode && leafOnly) {
         newExpandingNode.pathNodes.forEach((node) => expandNode(node, true))
       } else {
         expandingNode.value = null


### PR DESCRIPTION
设置 multiple & checkStrictly 为true, 且在懒加载模式下。 当双向绑定的值被修改, 选中的非叶子节点node的lazyLoad会自动执行

Please make sure these boxes are checked before submitting your PR, thank you!

- [*] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [*] Make sure you are merging your commits to `dev` branch.
- [*] Add some descriptions and refer to relative issues for your PR.
