### PR TITLE
fix(components): [InfiniteScroll] keep-alive dom undefined

### DIFF
--- a/packages/components/infinite-scroll/src/index.ts
+++ b/packages/components/infinite-scroll/src/index.ts
@@ -171,9 +171,11 @@ const InfiniteScroll: ObjectDirective<
     if (!el[SCOPE]) {
       await nextTick()
     }
-    const { containerEl, cb, observer } = el[SCOPE]
-    if (containerEl.clientHeight && observer) {
-      checkFull(el, cb)
+    if (el[SCOPE]) {
+      const { containerEl, cb, observer } = el[SCOPE]
+      if (containerEl.clientHeight && observer) {
+        checkFull(el, cb)
+      }
     }
   },
 }


### PR DESCRIPTION
当使用keep-alive后跳转， InfiniteScroll组件会报错
chunk-DPQKYHRF.js?v=4845e355:54261 
        
       Uncaught (in promise) TypeError: Cannot destructure property 'containerEl' of 'el[SCOPE9]' as it is undefined.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
