### PR TITLE
fix(components): [select-v2] consistent value-key usage with Select

### DIFF
--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -350,17 +350,17 @@ describe('Select', () => {
           options: [
             {
               id: 'id 1',
-              value: 'value 1',
+              value: { id: 'id 11' },
               label: 'option 1',
             },
             {
               id: 'id 2',
-              value: 'value 2',
+              value: { id: 'id 22' },
               label: 'option 2',
             },
             {
               id: 'id 3',
-              value: 'value 3',
+              value: { id: 'id 33' },
               label: 'option 3',
             },
           ],
@@ -375,12 +375,12 @@ describe('Select', () => {
     const options = getOptions()
     options[1].click()
     await nextTick()
-    expect(vm.value).toBe(vm.options[1].id)
+    expect(vm.value.id).toBe(vm.options[1].value.id)
     vm.valueKey = 'value'
     await nextTick()
     options[2].click()
     await nextTick()
-    expect(vm.value).toBe(vm.options[2].value)
+    expect(vm.value.id).toBe(vm.options[2].value.id)
   })
 
   it('disabled option', async () => {
@@ -614,17 +614,17 @@ describe('Select', () => {
             options: [
               {
                 id: 'id 1',
-                value: 'value 1',
+                value: { id: 'id 11', value: 'value 1' },
                 label: 'option 1',
               },
               {
                 id: 'id 2',
-                value: 'value 2',
+                value: { id: 'id 22', value: 'value 2' },
                 label: 'option 2',
               },
               {
                 id: 'id 3',
-                value: 'value 3',
+                value: { id: 'id 33', value: 'value 3' },
                 label: 'option 3',
               },
             ],
@@ -641,13 +641,13 @@ describe('Select', () => {
       options[1].click()
       await nextTick()
       expect(vm.value.length).toBe(1)
-      expect(vm.value[0]).toBe(vm.options[1].id)
+      expect(vm.value[0].id).toBe(vm.options[1].value.id)
       vm.valueKey = 'value'
       await nextTick()
       options[2].click()
       await nextTick()
       expect(vm.value.length).toBe(2)
-      expect(vm.value[1]).toBe(vm.options[2].value)
+      expect(vm.value[1].value).toBe(vm.options[2].value.value)
     })
   })
 

--- a/packages/components/select-v2/src/select-dropdown.tsx
+++ b/packages/components/select-v2/src/select-dropdown.tsx
@@ -83,11 +83,10 @@ export default defineComponent({
     }
 
     const isItemSelected = (modelValue: any[] | any, target: Option) => {
-      const { valueKey } = select.props
       if (select.props.multiple) {
-        return contains(modelValue, get(target, valueKey))
+        return contains(modelValue, target.value)
       }
-      return isEqual(modelValue, get(target, valueKey))
+      return isEqual(modelValue, target.value)
     }
 
     const isItemDisabled = (modelValue: any[] | any, selected: boolean) => {

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -339,7 +339,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
     const valueKey = props.valueKey
     let index = -1
     arr.some((item, i) => {
-      if (get(item, valueKey) === get(value, valueKey)) {
+      if (get(item.value, valueKey) === get(value, valueKey)) {
         index = i
         return true
       }
@@ -393,7 +393,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
     if (props.multiple) {
       let selectedOptions = (props.modelValue as any[]).slice()
 
-      const index = getValueIndex(selectedOptions, getValueKey(option))
+      const index = getValueIndex(selectedOptions, option.value)
       if (index > -1) {
         selectedOptions = [
           ...selectedOptions.slice(0, index),
@@ -405,7 +405,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
         props.multipleLimit <= 0 ||
         selectedOptions.length < props.multipleLimit
       ) {
-        selectedOptions = [...selectedOptions, getValueKey(option)]
+        selectedOptions = [...selectedOptions, option.value]
         states.cachedOptions.push(option)
         selectNewOption(option)
         updateHoveringIndex(idx)
@@ -429,7 +429,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
     } else {
       selectedIndex.value = idx
       states.selectedLabel = option.label
-      update(getValueKey(option))
+      update(option.value)
       expanded.value = false
       states.isComposing = false
       states.isSilentBlur = byClick
@@ -657,7 +657,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
         states.previousValue = props.modelValue.toString()
         ;(props.modelValue as Array<any>).forEach((selected) => {
           const itemIndex = filteredOptions.value.findIndex(
-            (option) => getValueKey(option) === selected
+            (option) => getValueKey(option.value) === getValueKey(selected)
           )
           if (~itemIndex) {
             states.cachedOptions.push(
@@ -678,7 +678,8 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
         states.previousValue = props.modelValue
         const options = filteredOptions.value
         const selectedItemIndex = options.findIndex(
-          (option) => getValueKey(option) === getValueKey(props.modelValue)
+          (option) =>
+            getValueKey(option.value) === getValueKey(props.modelValue)
         )
         if (~selectedItemIndex) {
           states.selectedLabel = options[selectedItemIndex].label


### PR DESCRIPTION
Related issue: #11089
The usage of `value-key` prop that is slightly different between `SelectV2` and `Select`. If it is intentional, or there is a more reasonable solution,then this PR can be closed at any time.