### PR TITLE
fix(utils): [icon] icon type support webstorm

### DIFF
--- a/packages/components/image-viewer/src/image-viewer.ts
+++ b/packages/components/image-viewer/src/image-viewer.ts
@@ -5,7 +5,8 @@ import {
   mutable,
 } from '@element-plus/utils'
 
-import type { Component, ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes } from 'vue'
+import type { IconComponent } from '@element-plus/utils'
 import type ImageViewer from './image-viewer.vue'
 
 export type ImageViewerAction =
@@ -57,7 +58,7 @@ export type ImageViewerEmits = typeof imageViewerEmits
 
 export interface ImageViewerMode {
   name: string
-  icon: Component
+  icon: IconComponent
 }
 
 export type ImageViewerInstance = InstanceType<typeof ImageViewer>

--- a/packages/components/rate/src/rate.ts
+++ b/packages/components/rate/src/rate.ts
@@ -3,13 +3,14 @@ import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import {
   buildProps,
   definePropType,
+  iconArrayPropType,
   iconPropType,
   isNumber,
   isValidComponentSize,
   mutable,
 } from '@element-plus/utils'
 import type { ComponentSize } from '@element-plus/constants'
-import type { Component, ExtractPropTypes, PropType } from 'vue'
+import type { ExtractPropTypes, PropType } from 'vue'
 import type Rate from './rate.vue'
 
 export const rateProps = buildProps({
@@ -46,9 +47,7 @@ export const rateProps = buildProps({
     default: '',
   },
   icons: {
-    type: definePropType<
-      Array<string | Component> | Record<number, string | Component>
-    >([Array, Object]),
+    type: iconArrayPropType,
     default: () => [StarFilled, StarFilled, StarFilled],
   },
   voidIcon: {

--- a/packages/components/rate/src/rate.vue
+++ b/packages/components/rate/src/rate.vue
@@ -56,8 +56,8 @@ import { formContextKey, formItemContextKey } from '@element-plus/tokens'
 import { ElIcon } from '@element-plus/components/icon'
 import { useFormItemInputId, useNamespace, useSize } from '@element-plus/hooks'
 import { rateEmits, rateProps } from './rate'
-import type { iconPropType } from '@element-plus/utils'
-import type { CSSProperties, Component } from 'vue'
+import type { IconArrayComponent, IconComponent } from '@element-plus/utils'
+import type { CSSProperties } from 'vue'
 
 function getValueFromMap<T>(
   value: number,
@@ -151,9 +151,7 @@ const decimalStyle = computed(() => {
 })
 const componentMap = computed(() => {
   let icons = isArray(props.icons) ? [...props.icons] : { ...props.icons }
-  icons = markRaw(icons) as
-    | Array<string | Component>
-    | Record<number, string | Component>
+  icons = markRaw(icons) as IconArrayComponent
   return isArray(icons)
     ? {
         [props.lowThreshold]: icons[0],
@@ -172,10 +170,10 @@ const voidComponent = computed(() =>
   rateDisabled.value
     ? isString(props.disabledVoidIcon)
       ? props.disabledVoidIcon
-      : (markRaw(props.disabledVoidIcon) as typeof iconPropType)
+      : (markRaw(props.disabledVoidIcon) as IconComponent)
     : isString(props.voidIcon)
     ? props.voidIcon
-    : (markRaw(props.voidIcon) as typeof iconPropType)
+    : (markRaw(props.voidIcon) as IconComponent)
 )
 const activeComponent = computed(() =>
   getValueFromMap(currentValue.value, componentMap.value)

--- a/packages/components/select-v2/src/defaults.ts
+++ b/packages/components/select-v2/src/defaults.ts
@@ -1,8 +1,12 @@
 import { placements } from '@popperjs/core'
-import { definePropType, isValidComponentSize } from '@element-plus/utils'
+import {
+  definePropType,
+  iconPropType,
+  isValidComponentSize,
+} from '@element-plus/utils'
 import { useTooltipContentProps } from '@element-plus/components/tooltip'
 import { CircleClose } from '@element-plus/icons-vue'
-import type { Component, PropType } from 'vue'
+import type { PropType } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
 import type { OptionType } from './select.types'
 import type { Options, Placement } from '@element-plus/components/popper'
@@ -16,7 +20,7 @@ export const SelectProps = {
   automaticDropdown: Boolean,
   clearable: Boolean,
   clearIcon: {
-    type: [String, Object] as PropType<string | Component>,
+    type: iconPropType,
     default: CircleClose,
   },
   effect: {

--- a/packages/components/time-picker/src/common/props.ts
+++ b/packages/components/time-picker/src/common/props.ts
@@ -1,9 +1,9 @@
-import { buildProps, definePropType } from '@element-plus/utils'
+import { buildProps, definePropType, iconPropType } from '@element-plus/utils'
 import { useSizeProp } from '@element-plus/hooks'
 import { CircleClose } from '@element-plus/icons-vue'
 import { disabledTimeListsProps } from '../props/shared'
 
-import type { Component, ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes } from 'vue'
 import type { Options } from '@popperjs/core'
 import type { Dayjs } from 'dayjs'
 
@@ -49,7 +49,7 @@ export const timePickerDefaultProps = buildProps({
     default: true,
   },
   clearIcon: {
-    type: definePropType<string | Component>([String, Object]),
+    type: iconPropType,
     default: CircleClose,
   },
   editable: {
@@ -57,7 +57,7 @@ export const timePickerDefaultProps = buildProps({
     default: true,
   },
   prefixIcon: {
-    type: definePropType<string | Component>([String, Object]),
+    type: iconPropType,
     default: '',
   },
   size: useSizeProp,

--- a/packages/components/time-select/src/time-select.ts
+++ b/packages/components/time-select/src/time-select.ts
@@ -1,8 +1,8 @@
-import { buildProps, definePropType } from '@element-plus/utils'
+import { buildProps, iconPropType } from '@element-plus/utils'
 import { CircleClose, Clock } from '@element-plus/icons-vue'
 import { useSizeProp } from '@element-plus/hooks'
 import type TimeSelect from './time-select.vue'
-import type { Component, ExtractPropTypes, PropType } from 'vue'
+import type { ExtractPropTypes, PropType } from 'vue'
 
 export const timeSelectProps = buildProps({
   format: {
@@ -41,11 +41,11 @@ export const timeSelectProps = buildProps({
   maxTime: String,
   name: String,
   prefixIcon: {
-    type: definePropType<string | Component>([String, Object]),
+    type: iconPropType,
     default: () => Clock,
   },
   clearIcon: {
-    type: definePropType<string | Component>([String, Object]),
+    type: iconPropType,
     default: () => CircleClose,
   },
 } as const)

--- a/packages/components/tree/src/tree.type.ts
+++ b/packages/components/tree/src/tree.type.ts
@@ -1,5 +1,4 @@
 import type {
-  Component,
   ComponentInternalInstance,
   Ref,
   SetupContext,
@@ -8,6 +7,7 @@ import type {
 } from 'vue'
 import type Node from './model/node'
 import type TreeStore from './model/tree-store'
+import type { IconComponent } from '@element-plus/utils'
 
 export interface RootTreeType {
   ctx: SetupContext<any>
@@ -122,7 +122,7 @@ export declare interface TreeComponentProps {
   filterNodeMethod: FilterNodeMethodFunction
   accordion: boolean
   indent: number
-  icon: string | Component
+  icon: IconComponent
 }
 
 export declare type NodeDropType = 'before' | 'after' | 'inner' | 'none'

--- a/packages/utils/vue/icon.ts
+++ b/packages/utils/vue/icon.ts
@@ -10,12 +10,20 @@ import {
 } from '@element-plus/icons-vue'
 import { definePropType } from './props'
 
-import type { Component } from 'vue'
+import type { DefineComponent, VNode } from 'vue'
 
-export const iconPropType = definePropType<string | Component>([
-  String,
+export type IconComponent =
+  | string
+  | VNode
+  | DefineComponent<object, object, any>
+
+export type IconArrayComponent = IconComponent[] | Record<number, IconComponent>
+
+export const iconPropType = definePropType<IconComponent>([String, Object])
+
+export const iconArrayPropType = definePropType<IconArrayComponent>([
   Object,
-  Function,
+  Array,
 ])
 
 export const CloseComponents = {


### PR DESCRIPTION
DefineComponent is not assignable to type Component ,and support jsx.

![image](https://user-images.githubusercontent.com/49021590/211189875-a127eb15-cf10-4ff3-9606-37b7a8f4fbd1.png)
实际返回类型
![image](https://user-images.githubusercontent.com/49021590/211195284-92e55514-54fb-414c-8608-09ad4d4b7b67.png)
相关问题 https://github.com/element-plus/element-plus-icons/pull/58

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
