### PR TITLE
refactor(tokens): use Symbol as injection key

### DIFF
--- a/packages/components/descriptions/src/token.ts
+++ b/packages/components/descriptions/src/token.ts
@@ -1,5 +1,5 @@
 import type { InjectionKey } from 'vue'
 import type { IDescriptionsInject } from './descriptions.type'
 
-export const descriptionsKey =
-  'elDescriptions' as any as InjectionKey<IDescriptionsInject>
+export const descriptionsKey: InjectionKey<IDescriptionsInject> =
+  Symbol('elDescriptions')

--- a/packages/components/select-v2/src/token.ts
+++ b/packages/components/select-v2/src/token.ts
@@ -13,7 +13,8 @@ export interface SelectV2Context {
   onKeyboardSelect: () => void
 }
 
-export const selectV2InjectionKey =
-  'ElSelectV2Injection' as any as InjectionKey<SelectV2Context>
+export const selectV2InjectionKey: InjectionKey<SelectV2Context> = Symbol(
+  'ElSelectV2Injection'
+)
 export type IOptionProps = ExtractPropTypes<typeof OptionProps>
 export type ISelectProps = ExtractPropTypes<typeof SelectProps>

--- a/packages/components/select/src/token.ts
+++ b/packages/components/select/src/token.ts
@@ -35,10 +35,10 @@ export interface SelectContext {
 }
 
 // For individual build sharing injection key, we had to make `Symbol` to string
-export const selectGroupKey =
-  'ElSelectGroup' as unknown as InjectionKey<SelectGroupContext>
+export const selectGroupKey: InjectionKey<SelectGroupContext> =
+  Symbol('ElSelectGroup')
 
-export const selectKey = 'ElSelect' as unknown as InjectionKey<SelectContext>
+export const selectKey: InjectionKey<SelectContext> = Symbol('ElSelect')
 
 export interface SelectOptionProxy {
   value: string | number | Record<string, string>


### PR DESCRIPTION
The `string` type injection keys was originally introduced to fix issues like https://github.com/element-plus/element-plus/pull/1224, https://github.com/element-plus/element-plus/issues/1222, etc. Now those issues no longer exists, we can switch back to `Symbol`.

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
