### PR TITLE
fix(components): [input-number] v-model breaks after a change event

### DIFF
--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -483,4 +483,33 @@ describe('InputNumber.vue', () => {
       expect(formItem.attributes().role).toBe('group')
     })
   })
+
+  test('v-model should work after a change event emitted', async () => {
+    const INIT = 324
+    const NEW = 3245
+    const num = ref(0)
+    const wrapper = mount(() => (
+      <InputNumber controls={false} v-model={num.value} />
+    ))
+    const input = wrapper.find('input')
+
+    // input an initial value
+    input.element.value = `${INIT}`
+    await input.trigger('input')
+    await input.trigger('change')
+    await nextTick()
+    expect(num.value).toEqual(INIT)
+
+    // input a new value
+    input.element.value = `${NEW}`
+    await input.trigger('input')
+    await nextTick()
+    expect(num.value).toEqual(NEW)
+
+    // input back to initial value
+    input.element.value = `${INIT}`
+    await input.trigger('input')
+    await nextTick()
+    expect(num.value).toEqual(INIT)
+  })
 })

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -224,11 +224,11 @@ const setCurrentValue = (
 ) => {
   const oldVal = data.currentValue
   const newVal = verifyValue(value)
-  if (oldVal === newVal) return
   if (!emitChange) {
     emit(UPDATE_MODEL_EVENT, newVal!)
     return
   }
+  if (oldVal === newVal) return
   data.userInput = null
   emit(UPDATE_MODEL_EVENT, newVal!)
   emit(CHANGE_EVENT, newVal!, oldVal!)


### PR DESCRIPTION
closed #11259

Solved by @acyza

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
