### PR TITLE
fix(components): [select] Clear value change

### DIFF
--- a/docs/en-US/component/select.md
+++ b/docs/en-US/component/select.md
@@ -43,7 +43,7 @@ select/disabled
 
 You can clear Select using a clear icon.
 
-:::demo Set `clearable` attribute for `el-select` and a clear icon will appear. Note that `clearable` is only for single select.
+:::demo Set `clearable` attribute for `el-select` and a clear icon will appear. Note that `clearable` is only for single select. The Select's value will be updated to `undefined`.
 
 select/clearable
 

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -736,7 +736,7 @@ describe('Select', () => {
     const iconClear = wrapper.findComponent(CircleClose)
     expect(iconClear.exists()).toBe(true)
     await iconClear.trigger('click')
-    expect(vm.value).toBe('')
+    expect(vm.value).toBe(undefined)
   })
 
   test('suffix icon', async () => {

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -23,7 +23,6 @@ import {
   isFunction,
   isKorean,
   isNumber,
-  isString,
   scrollIntoView,
 } from '@element-plus/utils'
 import {
@@ -613,7 +612,7 @@ export const useSelect = (props, states: States, ctx) => {
   const deleteSelected = (event) => {
     event.stopPropagation()
     const value: string | any[] = props.multiple ? [] : ''
-    if (!isString(value)) {
+    if (props.multiple) {
       for (const item of states.selected) {
         if (item.isDisabled) value.push(item.value)
       }


### PR DESCRIPTION
Changed emitted value on 'clear' event from `''` to `undefined`

**Description**

Each time user interacts with the "clearable" button in select, the value changes to an empty string, which is incorrect behaviour. The "value" should be changed to `undefined` so it really "clears" the previously selected value. 

**Use case example**

For example, I have a custom component that uses `el-select` inside. It has a typing for a value, which can be `number | number[]`. The same is related to the emitted events of this custom component: it can emit the "update" event with a value that needs to be `number | number[]`. Currently, the `el-select` always emits an empty string which may cause type-related warnings. Furthermore, `undefined` is a more consistent value when we "clear" the select.