### PR TITLE
fix(components): [scrollbar] restore scroll position in onActivated hook

### DIFF
--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -28,6 +28,7 @@
 import {
   computed,
   nextTick,
+  onActivated,
   onMounted,
   onUpdated,
   provide,
@@ -57,6 +58,8 @@ const ns = useNamespace('scrollbar')
 
 let stopResizeObserver: (() => void) | undefined = undefined
 let stopResizeListener: (() => void) | undefined = undefined
+let wrapScrollTop = 0
+let wrapScrollLeft = 0
 
 const scrollbarRef = ref<HTMLDivElement>()
 const wrapRef = ref<HTMLDivElement>()
@@ -85,6 +88,8 @@ const resizeKls = computed(() => {
 const handleScroll = () => {
   if (wrapRef.value) {
     barRef.value?.handleScroll(wrapRef.value)
+    wrapScrollTop = wrapRef.value.scrollTop
+    wrapScrollLeft = wrapRef.value.scrollLeft
 
     emit('scroll', {
       scrollTop: wrapRef.value.scrollTop,
@@ -159,6 +164,11 @@ provide(
     wrapElement: wrapRef,
   })
 )
+
+onActivated(() => {
+  wrapRef.value!.scrollTop = wrapScrollTop
+  wrapRef.value!.scrollLeft = wrapScrollLeft
+})
 
 onMounted(() => {
   if (!props.native)


### PR DESCRIPTION
closes #11255
closes #16257 

[after](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6IjxzY3JpcHQgc2V0dXAgbGFuZz1cInRzXCI+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5pbXBvcnQgQ29tcDEgZnJvbSAnLi9Db21wMS52dWUnXG5cbmNvbnN0IHRhYiA9IHJlZignQ29tcDEnKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGVsLXRhYnMgdi1tb2RlbD1cInRhYlwiPlxuICAgIDxlbC10YWItcGFuZSBsYWJlbD1cIkNvbXAxXCIgbmFtZT1cIkNvbXAxXCI+PC9lbC10YWItcGFuZT5cbiAgICA8ZWwtdGFiLXBhbmUgbGFiZWw9XCJDb21wMlwiIG5hbWU9XCJDb21wMlwiPjwvZWwtdGFiLXBhbmU+XG4gIDwvZWwtdGFicz5cbiAgPEtlZXBBbGl2ZT5cbiAgICA8Q29tcDEgdi1pZj1cInRhYiA9PSAnQ29tcDEnXCI+PC9Db21wMT5cbiAgPC9LZWVwQWxpdmU+XG48L3RlbXBsYXRlPiIsInNyYy9QbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL3ByZXZpZXctMTEzNjMtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5mdWxsLm1pbi5tanNcIixcbiAgICBcImVsZW1lbnQtcGx1cy9cIjogXCJ1bnN1cHBvcnRlZFwiXG4gIH1cbn0iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcbiAgICBcImpzeFwiOiBcInByZXNlcnZlXCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJ0eXBlc1wiOiBbXCJlbGVtZW50LXBsdXMvZ2xvYmFsLmQudHNcIl0sXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwic3JjL2VsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcbmltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vcHJldmlldy0xMTM2My1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcycsICdodHRwczovL3ByZXZpZXctMTEzNjMtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5jc3MnXS5tYXAoKHN0eWxlKSA9PiB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgICBsaW5rLmhyZWYgPSBzdHlsZVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICAgIH0pXG4gIH0pXG4gIHJldHVybiBQcm9taXNlLmFsbChzdHlsZXMpXG59Iiwic3JjL0NvbXAxLnZ1ZSI6IjxzY3JpcHQgc2V0dXAgbGFuZz1cInRzXCI+XHJcbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcclxuXHJcbmNvbnN0IGxpc3QgPSByZWYoW3tyb3cxOiAnc3RhcnQnLCByb3cyOiAnZW5kJ31dKVxyXG48L3NjcmlwdD5cclxuXHJcbjx0ZW1wbGF0ZT5cclxuICA8ZWwtdGFibGUgOmRhdGE9XCJsaXN0XCIgYm9yZGVyPlxyXG4gICAgICA8ZWwtdGFibGUtY29sdW1uIGxhYmVsPVwicm93MVwiIHByb3A9XCJyb3cxXCIgd2lkdGg9XCI2MDBcIj48L2VsLXRhYmxlLWNvbHVtbj5cclxuICAgICAgPGVsLXRhYmxlLWNvbHVtbiBsYWJlbD1cInJvdzJcIiBwcm9wPVwicm93MlwiIHdpZHRoPVwiNjAwXCI+PC9lbC10YWJsZS1jb2x1bW4+XHJcbiAgICA8L2VsLXRhYmxlPlxyXG48L3RlbXBsYXRlPiIsIl9vIjp7InNob3dIaWRkZW4iOnRydWUsInN0eWxlU291cmNlIjoiaHR0cHM6Ly9wcmV2aWV3LTExMzYzLWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguY3NzIn19)