### PR TITLE
fix(hooks): [use-lockscreen] prevent flaky unit tests

### DIFF
--- a/packages/hooks/use-lockscreen/index.ts
+++ b/packages/hooks/use-lockscreen/index.ts
@@ -40,8 +40,8 @@ export const useLockscreen = (trigger: Ref<boolean>) => {
 
   const cleanup = () => {
     setTimeout(() => {
-      removeClass(document.body, hiddenCls.value)
-      if (withoutHiddenClass) {
+      removeClass(document?.body, hiddenCls.value)
+      if (withoutHiddenClass && document) {
         document.body.style.width = bodyWidth
       }
     }, 200)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [✅] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [✅] Make sure you are merging your commits to `dev` branch.
- [✅] Add some descriptions and refer to relative issues for your PR.

Description and Context:
We're using the element-plus library in our project with ~6k unit tests that are run in parallel using vitest. On M1 Mac Chips the amount of tests causes flaky unit tests since the CPU has only 4 high performance cores and 4 high efficiency cores.
Although we've limited the max threads to 6, some unit tests of components using dialogs failed randomly on a regular basis due to element-plus' use-lockscreen hook which accesses the body of the `document` object in its `cleanup()` function.
The hardware setup is only a catalyst to the core issue here.

I could narrow down the cause to the `cleanup()` function. Unfortunately, I was unable to trigger the fail in the use-lockscreen hook unit test using `it.each(arrayOf1To5000)`. The reason why we've seen the unit tests fail randomly is quite likely due to the fact, that we've multiple test files for different dialogs and they might be treated differently by Vitest when run in parallel as compared to using `.each` on a single test.

Anyways, I suspected the following: 
When we test our components that use dialogs we usually test for an expected event value or DOM change caused by some interaction in that dialog. In the `afterEach` function the wrapper is unmounted. During that unmount, the use-lockscreen hook's `cleanup()` function gets called eventually.

Now, it appears that Vitest is sometimes so fast to destruct the `document` object, that when the `cleanup()` function is called the document is not available anymore.
The fix I provided in that PR definitely remedied the issue as we've never seen ".body is not available on undefined" errors in the use-lockscreen hook anymore since I've patched it.

In a browser, when closing a tab or reloading a page, the current implementation might cause that `body` access on undefined error as well. However, no user would ever notice it as the tab is closed or the page is reloaded anyways.

It's just an issue in unit tests. That PR fixes that.