### PR TITLE
docs(other): focus on activated nav sidebar link

### DIFF
--- a/docs/.vitepress/vitepress/components/sidebar/vp-sidebar-link.vue
+++ b/docs/.vitepress/vitepress/components/sidebar/vp-sidebar-link.vue
@@ -1,23 +1,35 @@
 <script lang="ts" setup>
+import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vitepress'
 import { isActive } from '../../utils'
 
 import type { Link } from '../../types'
 
-defineProps<{
+const props = defineProps<{
   item: Link
 }>()
 
 defineEmits(['close'])
 
+const sidebarItem = ref<HTMLElement>()
+
 const route = useRoute()
+
+const activeLink = computed<boolean>(() => isActive(route, props.item.link))
+
+watch([activeLink, sidebarItem], ([active, el]) => {
+  if (active && el) {
+    el.scrollIntoView?.({ block: 'nearest' })
+  }
+})
 </script>
 
 <template>
   <a
+    ref="sidebarItem"
     :class="{
       link: true,
-      active: isActive(route, item.link),
+      active: activeLink,
       'flex items-center': item.promotion,
     }"
     :href="item.link"
@@ -51,6 +63,7 @@ const route = useRoute()
 
 .link.active {
   background-color: var(--link-active-bg-color);
+
   .link-text {
     font-weight: 600;
     color: var(--brand-color);


### PR DESCRIPTION
The navigation sidebar of documentation has a lot of content that required user to scroll to see all the content, but when you enter a documentation page directly from an external link, the navigation bar does not focus automatically the link item of the current page, the purpose of this PR is to improve this user experience problem.

## Demo

https://user-images.githubusercontent.com/19204772/217488692-0828fba5-9886-4733-9b7a-311e787595f4.mp4


## 
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
