### PR TITLE
fix(components): [table] table-layout auto make fixed header failure

### DIFF
--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -1475,7 +1475,7 @@ describe('Table.vue', () => {
       },
     })
     await doubleWait()
-    expect(wrapper.findAll('.el-table__body thead').length).toBe(0)
+    expect(wrapper.find('.el-table__body thead').exists()).toBeFalsy()
     expect(wrapper.find('.el-table__body colgroup col').exists()).toBeFalsy()
     expect(wrapper.find('.el-table__body tbody').exists()).toBeTruthy()
   })
@@ -1601,6 +1601,38 @@ describe('Table.vue', () => {
     )
     expect(wrapper.find('.el-table__header').findAll('.cell')[1].text()).toBe(
       'name'
+    )
+  })
+
+  it('should be fixed thead when tableLayout is auto', async () => {
+    const wrapper = mount({
+      components: {
+        ElTable,
+        ElTableColumn,
+      },
+      template: `
+        <el-table :data="testData" table-layout="auto" height="100">
+          <el-table-column prop="id" />
+          <el-table-column prop="name" label="片名" />
+          <el-table-column prop="release" label="发行日期" />
+          <el-table-column prop="director" label="导演" />
+          <el-table-column prop="runtime" label="时长（分）" />
+        </el-table>
+      `,
+      created() {
+        this.testData = getTestData()
+      },
+    })
+    await doubleWait()
+    const theadTable = wrapper.find('.el-table__header')
+    const tbodyTable = wrapper.find('.el-table__body')
+    expect(tbodyTable.attributes('style')).toContain('table-layout: auto')
+    expect(theadTable.find('thead').exists()).toBeTruthy()
+    expect(tbodyTable.find('thead').exists()).toBeFalsy()
+    const theadCol = theadTable.find('.cell')
+    const tbodyCell = tbodyTable.find('.cell')
+    expect(getComputedStyle(theadCol.element).width).toBe(
+      getComputedStyle(tbodyCell.element).width
     )
   })
 })

--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -1475,7 +1475,7 @@ describe('Table.vue', () => {
       },
     })
     await doubleWait()
-    expect(wrapper.find('.el-table__body thead').exists()).toBeTruthy()
+    expect(wrapper.findAll('.el-table__body thead').length).toBe(0)
     expect(wrapper.find('.el-table__body colgroup col').exists()).toBeFalsy()
     expect(wrapper.find('.el-table__body tbody').exists()).toBeTruthy()
   })

--- a/packages/components/table/src/h-helper.ts
+++ b/packages/components/table/src/h-helper.ts
@@ -4,7 +4,9 @@ export function hColgroup(props) {
   const isAuto = props.tableLayout === 'auto'
   let columns = props.columns || []
   if (isAuto) {
-    if (columns.every((column) => column.width === undefined)) {
+    if (
+      columns.every((column) => column.width === undefined && !column.autoWidth)
+    ) {
       columns = []
     }
   }
@@ -18,9 +20,8 @@ export function hColgroup(props) {
       propsData.style = {
         width: `${column.width}px`,
       }
-    } else {
-      propsData.name = column.id
     }
+    propsData.name = column.id
     return propsData
   }
 

--- a/packages/components/table/src/layout-observer.ts
+++ b/packages/components/table/src/layout-observer.ts
@@ -48,7 +48,10 @@ function useLayoutObserver<T>(root: Table<T>) {
       const name = col.getAttribute('name')
       const column = columnsMap[name]
       if (column) {
-        col.setAttribute('width', column.realWidth || column.width)
+        col.setAttribute(
+          'width',
+          column.autoWidth || column.realWidth || column.width
+        )
       }
     }
   }

--- a/packages/components/table/src/table-body/defaults.ts
+++ b/packages/components/table/src/table-body/defaults.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import type { TableLayoutProperty } from 'csstype'
 import type { PropType } from 'vue'
 import type { Store } from '../store'
 import type {
@@ -19,6 +20,7 @@ interface TableBodyProps<T> {
   highlight: boolean
   tooltipEffect?: string
   tooltipOptions?: TableOverflowTooltipOptions
+  tableLayout: TableLayoutProperty
 }
 
 const defaultProps = {
@@ -46,6 +48,7 @@ const defaultProps = {
     default: '',
   },
   highlight: Boolean,
+  tableLayout: String as TableLayoutProperty,
 }
 
 export { TableBodyProps }

--- a/packages/components/table/src/table-body/index.ts
+++ b/packages/components/table/src/table-body/index.ts
@@ -30,7 +30,7 @@ export default defineComponent({
       useRender(props)
     const { onColumnsChange, onScrollableChange } = useLayoutObserver(parent!)
 
-    const { unLayoutAutoObserve } = useLayoutAuto(props)
+    const { unLayoutAutoObserve } = useLayoutAuto(props, parent)
 
     watch(props.store.states.hoverRow, (newVal: any, oldVal: any) => {
       if (!props.store.states.isComplex.value || !isClient) return

--- a/packages/components/table/src/table-body/index.ts
+++ b/packages/components/table/src/table-body/index.ts
@@ -15,6 +15,7 @@ import { removePopper } from '../util'
 import { TABLE_INJECTION_KEY } from '../tokens'
 import useRender from './render-helper'
 import defaultProps from './defaults'
+import useLayoutAuto from './layout-auto-helper'
 
 import type { VNode } from 'vue'
 
@@ -28,6 +29,8 @@ export default defineComponent({
     const { wrappedRowRender, tooltipContent, tooltipTrigger } =
       useRender(props)
     const { onColumnsChange, onScrollableChange } = useLayoutObserver(parent!)
+
+    const { unLayoutAutoObserve } = useLayoutAuto(props)
 
     watch(props.store.states.hoverRow, (newVal: any, oldVal: any) => {
       if (!props.store.states.isComplex.value || !isClient) return
@@ -54,6 +57,7 @@ export default defineComponent({
 
     onUnmounted(() => {
       removePopper?.()
+      unLayoutAutoObserve()
     })
 
     return {

--- a/packages/components/table/src/table-body/index.ts
+++ b/packages/components/table/src/table-body/index.ts
@@ -30,7 +30,7 @@ export default defineComponent({
       useRender(props)
     const { onColumnsChange, onScrollableChange } = useLayoutObserver(parent!)
 
-    const { unLayoutAutoObserve } = useLayoutAuto(props, parent)
+    const { unLayoutAutoObserve, getDragInfo } = useLayoutAuto(props, parent)
 
     watch(props.store.states.hoverRow, (newVal: any, oldVal: any) => {
       if (!props.store.states.isComplex.value || !isClient) return
@@ -67,6 +67,7 @@ export default defineComponent({
       wrappedRowRender,
       tooltipContent,
       tooltipTrigger,
+      getDragInfo,
     }
   },
   render() {

--- a/packages/components/table/src/table-body/layout-auto-helper.ts
+++ b/packages/components/table/src/table-body/layout-auto-helper.ts
@@ -29,7 +29,6 @@ export default function useLayoutAuto<T>(props: Partial<TableBodyProps<T>>) {
     const tdList = firstTr.querySelectorAll('td')
     columns.forEach((column: TableColumnCtx<T>, index: number) => {
       column.autoWidth = Number.parseInt(`${tdList[index].offsetWidth}`)
-      console.log('width', tdList[index].offsetWidth)
     })
   }
 

--- a/packages/components/table/src/table-body/layout-auto-helper.ts
+++ b/packages/components/table/src/table-body/layout-auto-helper.ts
@@ -52,6 +52,10 @@ export default function useLayoutAuto<T>(
       const tdList = firstTr.querySelectorAll('td')
       columns.forEach((column: TableColumnCtx<T>, index: number) => {
         column.autoWidth = Number.parseInt(`${tdList[index]?.offsetWidth}`)
+        // 如果初始化存在 width（用户传入），layout布局时亦需要将其同步为浏览器最终计算的宽度值
+        if (column.width) {
+          column.width = column.autoWidth
+        }
       })
       debounceReset?.()
     }

--- a/packages/components/table/src/table-body/layout-auto-helper.ts
+++ b/packages/components/table/src/table-body/layout-auto-helper.ts
@@ -1,0 +1,85 @@
+import {
+  getCurrentInstance,
+  onBeforeUpdate,
+  onMounted,
+  shallowRef,
+  unref,
+} from 'vue'
+import type { TableColumnCtx } from '../table/defaults'
+import type { TableBodyProps } from './defaults'
+
+function isHTMLElement(h: HTMLElement | null): h is HTMLElement {
+  return (h as HTMLElement).querySelector !== undefined
+}
+
+const LAYOUT_AUTO = 'auto'
+
+export default function useLayoutAuto<T>(props: Partial<TableBodyProps<T>>) {
+  const instance = getCurrentInstance()
+  const columns = unref(props.store.states._columns)
+  const observer = shallowRef<ResizeObserver>()
+  const observerElList = shallowRef<HTMLElement[]>([])
+
+  const getFirstTrEl = () => {
+    const el = instance?.vnode.el as HTMLElement
+    return el.querySelector('tr')
+  }
+
+  const resizeCallback = (firstTr: HTMLElement) => {
+    const tdList = firstTr.querySelectorAll('td')
+    columns.forEach((column: TableColumnCtx<T>, index: number) => {
+      column.autoWidth = Number.parseInt(`${tdList[index].offsetWidth}`)
+      console.log('width', tdList[index].offsetWidth)
+    })
+  }
+
+  const initLayoutAuto = () => {
+    const firstTr = getFirstTrEl()
+    if (!isHTMLElement(firstTr)) return
+    const callback = resizeCallback.bind(null, firstTr)
+    observer.value = new ResizeObserver(callback)
+    observer.value.observe(firstTr)
+    observerElList.value.push(firstTr)
+  }
+
+  const updateLayoutAuto = () => {
+    const firstTr = getFirstTrEl()
+    if (!isHTMLElement(firstTr)) return
+    const tdList = firstTr.querySelectorAll('td')
+    const callback = resizeCallback.bind(null, firstTr)
+    observer.value = new ResizeObserver(callback)
+
+    for (const tdEl of tdList) {
+      if (observerElList.value.includes(tdEl)) continue
+      observer.value.observe(tdEl)
+      observerElList.value.push(tdEl)
+    }
+  }
+
+  const unLayoutAutoObserve = () => {
+    for (const el of observerElList.value) {
+      observer.value?.unobserve(el)
+    }
+    observerElList.value.length = 0
+    columns.forEach((item: TableColumnCtx<T>) => {
+      item.autoWidth = null
+    })
+  }
+
+  onMounted(() => {
+    if (props.tableLayout !== LAYOUT_AUTO) return
+    initLayoutAuto()
+  })
+
+  onBeforeUpdate(() => {
+    if (props.tableLayout !== LAYOUT_AUTO) {
+      unLayoutAutoObserve()
+      return
+    }
+    updateLayoutAuto()
+  })
+
+  return {
+    unLayoutAutoObserve,
+  }
+}

--- a/packages/components/table/src/table-body/layout-auto-helper.ts
+++ b/packages/components/table/src/table-body/layout-auto-helper.ts
@@ -21,7 +21,7 @@ export default function useLayoutAuto<T>(
 ) {
   const instance = getCurrentInstance()
   const columns = unref(props.store.states._columns)
-  const observer = shallowRef<ResizeObserver>()
+  const observer = shallowRef<ResizeObserver | null>(null)
   const observerElList = shallowRef<HTMLElement[]>([])
   let dragInfo: TableColumnCtx<T> | null = null
 
@@ -47,14 +47,23 @@ export default function useLayoutAuto<T>(
   }
 
   const resizeCallback = (firstTr: HTMLElement, resetColWidth?: () => void) => {
-    const debounceReset = resetColWidth && debounce(resetColWidth, 30)
+    const debounceReset = resetColWidth && debounce(resetColWidth, 16)
     return function callback() {
       const tdList = firstTr.querySelectorAll('td')
       columns.forEach((column: TableColumnCtx<T>, index: number) => {
+        // autoWidth 为瞬时变化的值，仅依靠浏览器计算结果
         column.autoWidth = Number.parseInt(`${tdList[index]?.offsetWidth}`)
-        // 如果初始化存在 width（用户传入），layout布局时亦需要将其同步为浏览器最终计算的宽度值
-        if (column.width) {
-          column.width = column.autoWidth
+
+        if (!dragInfo && column.width) {
+          // 保存用户初始设置的 width
+          column.userDefaultWidth =
+            column.userDefaultWidth ||
+            (column.width
+              ? Number.parseInt(column.width.toString())
+              : undefined)
+          // 记录瞬时变化的 width 值（应对用户设置了初始width后，窗口resize的场景）
+          column.width = column.autoWidth as number
+          return
         }
       })
       debounceReset?.()
@@ -64,8 +73,8 @@ export default function useLayoutAuto<T>(
   const initLayoutAuto = () => {
     const firstTr = getFirstTrEl()
     if (!isHTMLElement(firstTr)) return
-    const callback = resizeCallback(firstTr)
-    observer.value = new ResizeObserver(callback)
+    const callback = resizeCallback(firstTr, resetColWidth)
+    observer.value = observer.value || new ResizeObserver(callback)
     addObserver(firstTr)
   }
 
@@ -81,7 +90,7 @@ export default function useLayoutAuto<T>(
     const tdList = firstTr.querySelectorAll('td')
     const thList = firstHeadTr.querySelectorAll('th')
     const callback = resizeCallback(firstTr, resetColWidth)
-    observer.value = new ResizeObserver(callback)
+    observer.value = observer.value || new ResizeObserver(callback)
 
     for (const cell of [...tdList, ...thList]) {
       if (observerElList.value.includes(cell)) continue
@@ -94,12 +103,23 @@ export default function useLayoutAuto<T>(
       observer.value?.unobserve(el)
     }
     observerElList.value.length = 0
+    observer.value?.disconnect()
+    observer.value = null
     columns.forEach((item: TableColumnCtx<T>) => {
       item.autoWidth = null
     })
   }
 
-  // 处理「用户拖拽场景」表头列宽对齐表格列宽
+  const getMaxDefaultWidth = (column: TableColumnCtx<T>) => {
+    if (!column.autoWidth || !column.userDefaultWidth) return ''
+    if (column.autoWidth > column.userDefaultWidth) {
+      return column.userDefaultWidth
+    } else {
+      return column.autoWidth
+    }
+  }
+
+  // debounce延迟，于单元格发生变化 且 再无改变后触发（主要处理「用户拖拽」、「窗口改变」导致的非预期场景）
   const resetColWidth = () => {
     const firstColgroup = getColgroup()
     const colList = firstColgroup!.querySelectorAll('col')
@@ -107,12 +127,18 @@ export default function useLayoutAuto<T>(
       const col = colList[index]
       if (!col) return
       const name = col.getAttribute('name')
+      // 处理当窗口大小改变时，单元格宽度无限延伸（超出默认设置宽度）的问题
+      if (!dragInfo && column.width) {
+        column.width = getMaxDefaultWidth(column)
+        return
+      }
       // 仅处理用户拖拽过的列，其余保持初始
       if (
         name === dragInfo?.id &&
         Number.parseInt(col.style.width) !== column.autoWidth
       ) {
-        column.width = column.autoWidth as number
+        // 拖拽后需要将默认宽度同步为拖拽后的宽度
+        column.userDefaultWidth = column.width = column.autoWidth as number
         dragInfo = null
       }
     })
@@ -129,7 +155,7 @@ export default function useLayoutAuto<T>(
 
   onBeforeUpdate(() => {
     if (props.tableLayout !== LAYOUT_AUTO) {
-      unLayoutAutoObserve()
+      observer.value && unLayoutAutoObserve()
       return
     }
     updateLayoutAuto()

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -15,6 +15,7 @@ type FilterMethods<T> = (value, row: T, column: TableColumnCtx<T>) => void
 type ValueOf<T> = T[keyof T]
 
 interface TableColumnCtx<T> {
+  autoWidth: number | null
   id: string
   realWidth: number
   type: string

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -16,6 +16,7 @@ type ValueOf<T> = T[keyof T]
 
 interface TableColumnCtx<T> {
   autoWidth: number | null
+  userDefaultWidth?: number
   id: string
   realWidth: number
   type: string

--- a/packages/components/table/src/table-header/event-helper.ts
+++ b/packages/components/table/src/table-header/event-helper.ts
@@ -91,6 +91,7 @@ function useEvent<T>(props: TableHeaderProps<T>, emit) {
           draggingColumn.value = null
           dragState.value = {}
           emit('set-drag-visible', false)
+          table.refs.tableBodyRef?.getDragInfo(column)
         }
 
         document.removeEventListener('mousemove', handleMouseMove)

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -80,6 +80,7 @@
               :table-layout="tableLayout"
             />
             <table-body
+              ref="tableBodyRef"
               :context="context"
               :highlight="highlightCurrentRow"
               :row-class-name="rowClassName"

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -31,7 +31,7 @@
         <slot />
       </div>
       <div
-        v-if="showHeader && tableLayout === 'fixed'"
+        v-if="showHeader"
         ref="headerWrapper"
         v-mousewheel="handleHeaderFooterMousewheel"
         :class="ns.e('header-wrapper')"
@@ -79,14 +79,6 @@
               :columns="store.states.columns.value"
               :table-layout="tableLayout"
             />
-            <table-header
-              v-if="showHeader && tableLayout === 'auto'"
-              ref="tableHeaderRef"
-              :border="border"
-              :default-sort="defaultSort"
-              :store="store"
-              @set-drag-visible="setDragVisible"
-            />
             <table-body
               :context="context"
               :highlight="highlightCurrentRow"
@@ -96,6 +88,7 @@
               :row-style="rowStyle"
               :store="store"
               :stripe="stripe"
+              :table-layout="tableLayout"
             />
           </table>
           <div

--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -104,7 +104,6 @@ function useStyle<T>(
   const tableBodyStyles = computed(() => {
     return {
       width: layout.bodyWidth.value ? `${layout.bodyWidth.value}px` : '',
-      tableLayout: tableLayout.value,
     }
   })
 

--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -104,6 +104,7 @@ function useStyle<T>(
   const tableBodyStyles = computed(() => {
     return {
       width: layout.bodyWidth.value ? `${layout.bodyWidth.value}px` : '',
+      tableLayout: tableLayout.value,
     }
   })
 


### PR DESCRIPTION
fix: [#11353](https://github.com/element-plus/element-plus/issues/11353)

当前处理 `table-layout="auto"` 布局方式时，只用了一个 `table` 同时包裹 `thead` 和 `tbody` ，按照当前固定表头采用双 `table` 的实现方式，将会导致 `auto` 布局中所有固定表头的功能失效。

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
