### PR TITLE
fix(components): [carousel] delete the indicator props

### DIFF
--- a/packages/components/carousel/src/carousel.ts
+++ b/packages/components/carousel/src/carousel.ts
@@ -28,10 +28,6 @@ export const carouselProps = buildProps({
     values: ['', 'none', 'outside'],
     default: '',
   },
-  indicator: {
-    type: Boolean,
-    default: true,
-  },
   arrow: {
     type: String,
     values: ['always', 'hover', 'never'],


### PR DESCRIPTION
## Description

The `indicator` props are neither in the documentation nor used in the actual code and should be removed.

## Reference

- [carousel docs](https://element-plus.org/en-US/component/carousel.html#carousel-attributes)

---

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
