### PR TITLE
fix(components): [select] call filter-method after focus

### DIFF
--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -1838,15 +1838,17 @@ describe('Select', () => {
       )
       const inputEl = input.element as HTMLInputElement
       await input.trigger('click')
+      expect(method).toBeCalled()
+      expect(method.mock.calls[0][0]).toBe('')
       inputEl.value = firstInputLetter
       await input.trigger('input')
-      expect(method).toBeCalled()
-      expect(method.mock.calls[0][0]).toBe(firstInputLetter)
+      expect(method).toBeCalledTimes(2)
+      expect(method.mock.calls[1][0]).toBe(firstInputLetter)
 
       inputEl.value = secondInputLetter
       await input.trigger('input')
-      expect(method).toBeCalledTimes(2)
-      expect(method.mock.calls[1][0]).toBe(secondInputLetter)
+      expect(method).toBeCalledTimes(3)
+      expect(method.mock.calls[2][0]).toBe(secondInputLetter)
     }
 
     test('should call filter method', async () => {

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -841,6 +841,7 @@ describe('Select', () => {
     const selectVm = select.vm as any
     const input = wrapper.find('input')
     input.element.focus()
+    await nextTick()
     selectVm.selectedLabel = 'new'
     selectVm.debouncedOnInputChange()
     await nextTick()

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -22,6 +22,7 @@
       :gpu-acceleration="false"
       :persistent="persistent"
       @show="handleMenuEnter"
+      @hide="handleMenuLeave"
     >
       <template #default>
         <div
@@ -447,6 +448,7 @@ export default defineComponent({
       onOptionCreate,
       onOptionDestroy,
       handleMenuEnter,
+      handleMenuLeave,
       handleFocus,
       blur,
       handleBlur,
@@ -623,6 +625,7 @@ export default defineComponent({
       resetInputState,
       handleComposition,
       handleMenuEnter,
+      handleMenuLeave,
       handleFocus,
       blur,
       handleBlur,

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -22,7 +22,6 @@
       :gpu-acceleration="false"
       :persistent="persistent"
       @show="handleMenuEnter"
-      @hide="handleMenuLeave"
     >
       <template #default>
         <div
@@ -452,7 +451,6 @@ export default defineComponent({
       onOptionCreate,
       onOptionDestroy,
       handleMenuEnter,
-      handleMenuLeave,
       handleFocus,
       blur,
       handleBlur,
@@ -629,7 +627,6 @@ export default defineComponent({
       resetInputState,
       handleComposition,
       handleMenuEnter,
-      handleMenuLeave,
       handleFocus,
       blur,
       handleBlur,

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -749,6 +749,7 @@ export const useSelect = (props, states: States, ctx) => {
 
   const handleMenuLeave = () => {
     if (!states.visible && props.filterable && states.previousQuery) {
+      states.previousQuery = ''
       if (isFunction(props.filterMethod)) {
         props.filterMethod('')
       }

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -748,7 +748,7 @@ export const useSelect = (props, states: States, ctx) => {
   }
 
   const handleMenuLeave = () => {
-    if (!states.visible && props.filterable) {
+    if (!states.visible && props.filterable && states.previousQuery) {
       if (isFunction(props.filterMethod)) {
         props.filterMethod('')
       }

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -247,8 +247,6 @@ export const useSelect = (props, states: States, ctx) => {
     (val) => {
       if (!val) {
         input.value && input.value.blur()
-        states.query = ''
-        states.previousQuery = null
         states.selectedLabel = ''
         states.inputLength = 20
         states.menuVisibleOnFocus = false
@@ -749,7 +747,6 @@ export const useSelect = (props, states: States, ctx) => {
 
   const handleMenuLeave = () => {
     if (!states.visible && props.filterable && states.previousQuery) {
-      states.previousQuery = ''
       if (isFunction(props.filterMethod)) {
         props.filterMethod('')
       }
@@ -757,6 +754,8 @@ export const useSelect = (props, states: States, ctx) => {
         props.remoteMethod('')
       }
     }
+    states.query = ''
+    states.previousQuery = null
   }
 
   const handleFocus = (event: FocusEvent) => {

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -247,6 +247,8 @@ export const useSelect = (props, states: States, ctx) => {
     (val) => {
       if (!val) {
         input.value && input.value.blur()
+        states.query = ''
+        states.previousQuery = null
         states.selectedLabel = ''
         states.inputLength = 20
         states.menuVisibleOnFocus = false
@@ -285,7 +287,7 @@ export const useSelect = (props, states: States, ctx) => {
 
         if (props.filterable) {
           states.filteredOptionsCount = states.optionsCount
-          states.query = props.remote ? '' : states.selectedLabel
+          states.query = ''
           if (props.multiple) {
             input.value?.focus()
           } else {
@@ -383,13 +385,6 @@ export const useSelect = (props, states: States, ctx) => {
 
   const handleQueryChange = async (val) => {
     if (states.previousQuery === val || states.isOnComposition) return
-    if (
-      states.previousQuery === null &&
-      (isFunction(props.filterMethod) || isFunction(props.remoteMethod))
-    ) {
-      states.previousQuery = val
-      return
-    }
     states.previousQuery = val
     nextTick(() => {
       if (states.visible) tooltipRef.value?.updatePopper?.()
@@ -745,19 +740,6 @@ export const useSelect = (props, states: States, ctx) => {
     nextTick(() => scrollToOption(states.selected))
   }
 
-  const handleMenuLeave = () => {
-    if (!states.visible && props.filterable && states.previousQuery) {
-      if (isFunction(props.filterMethod)) {
-        props.filterMethod('')
-      }
-      if (isFunction(props.remoteMethod)) {
-        props.remoteMethod('')
-      }
-    }
-    states.query = ''
-    states.previousQuery = null
-  }
-
   const handleFocus = (event: FocusEvent) => {
     if (!states.softFocus) {
       if (props.automaticDropdown || props.filterable) {
@@ -911,7 +893,6 @@ export const useSelect = (props, states: States, ctx) => {
     onOptionCreate,
     onOptionDestroy,
     handleMenuEnter,
-    handleMenuLeave,
     handleFocus,
     blur,
     handleBlur,

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -246,14 +246,6 @@ export const useSelect = (props, states: States, ctx) => {
     () => states.visible,
     (val) => {
       if (!val) {
-        if (props.filterable) {
-          if (isFunction(props.filterMethod)) {
-            props.filterMethod('')
-          }
-          if (isFunction(props.remoteMethod)) {
-            props.remoteMethod('')
-          }
-        }
         input.value && input.value.blur()
         states.query = ''
         states.previousQuery = null
@@ -755,6 +747,17 @@ export const useSelect = (props, states: States, ctx) => {
     nextTick(() => scrollToOption(states.selected))
   }
 
+  const handleMenuLeave = () => {
+    if (!states.visible && props.filterable) {
+      if (isFunction(props.filterMethod)) {
+        props.filterMethod('')
+      }
+      if (isFunction(props.remoteMethod)) {
+        props.remoteMethod('')
+      }
+    }
+  }
+
   const handleFocus = (event: FocusEvent) => {
     if (!states.softFocus) {
       if (props.automaticDropdown || props.filterable) {
@@ -908,6 +911,7 @@ export const useSelect = (props, states: States, ctx) => {
     onOptionCreate,
     onOptionDestroy,
     handleMenuEnter,
+    handleMenuLeave,
     handleFocus,
     blur,
     handleBlur,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fixed #11614 
fixed #11095 
fixed #11608 

复现步骤：
1. 使用filter-method筛选内容
2. 输入内容进行筛选
3. 选择任意选项或移出焦点，使选项列表收回

当前结果：
&emsp;在选项列表收回动画结束之前调用filter-method还原列表，看上去好像闪了一下

预期结果：
&emsp;选项列表收回动画结束之后调用filter-method

补充：
&emsp;使用自带的筛选方法（只加filterable不用filter-method）没有这样的问题

issue #11095 中有样例