### PR TITLE
chore(components): [drawer] use restore active

### DIFF
--- a/packages/components/drawer/src/drawer.vue
+++ b/packages/components/drawer/src/drawer.vue
@@ -89,7 +89,12 @@ import ElFocusTrap from '@element-plus/components/focus-trap'
 import { useDialog } from '@element-plus/components/dialog'
 import { addUnit } from '@element-plus/utils'
 import ElIcon from '@element-plus/components/icon'
-import { useDeprecated, useLocale, useNamespace } from '@element-plus/hooks'
+import {
+  useDeprecated,
+  useLocale,
+  useNamespace,
+  useRestoreActive,
+} from '@element-plus/hooks'
 import { drawerEmits, drawerProps } from './drawer'
 
 export default defineComponent({
@@ -137,8 +142,11 @@ export default defineComponent({
     )
     const drawerSize = computed(() => addUnit(props.size))
 
+    const dialog = useDialog(props, drawerRef)
+    useRestoreActive(dialog.visible)
+
     return {
-      ...useDialog(props, drawerRef),
+      ...dialog,
       drawerRef,
       focusStartRef,
       isHorizontal,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

drawer关闭，drawer中内容被隐藏后不该有焦点停留，使用`useRestoreActive`把焦点移出。
似乎elFocusTrap也能移除焦点，但它似乎有条件。https://github.com/element-plus/element-plus/blob/dev/packages/components/focus-trap/src/focus-trap.vue#L290
useRestoreActive和elFocusTrap同时存在应该没啥问题，至少ElMessageBox是这么干的。

协助#11524 修复#10893 
fix #10893 close #10992 