### PR TITLE
fix(components): [dropdown] fix focus after close

### DIFF
--- a/packages/components/dropdown/src/dropdown.vue
+++ b/packages/components/dropdown/src/dropdown.vue
@@ -164,7 +164,7 @@ export default defineComponent({
     // that are triggered through pointer enter/leave events.
     watch(
       [triggeringElementRef, toRef(props, 'trigger')],
-      ([triggeringElement, trigger], [prevTriggeringElement, prevTrigger]) => {
+      ([triggeringElement, trigger], [prevTriggeringElement]) => {
         const triggerArray = isArray(trigger) ? trigger : [trigger]
         if (prevTriggeringElement?.$el?.removeEventListener) {
           prevTriggeringElement.$el.removeEventListener(

--- a/packages/components/dropdown/src/dropdown.vue
+++ b/packages/components/dropdown/src/dropdown.vue
@@ -96,6 +96,7 @@ import {
   computed,
   defineComponent,
   getCurrentInstance,
+  onUnmounted,
   provide,
   ref,
   toRef,
@@ -190,6 +191,15 @@ export default defineComponent({
       },
       { immediate: true }
     )
+
+    onUnmounted(() => {
+      if (triggeringElement?.$el?.removeEventListener) {
+        triggeringElement.$el.removeEventListener(
+          'pointerenter',
+          onAutofocusTriggerEnter
+        )
+      }
+    })
 
     function handleClick() {
       handleClose()

--- a/packages/components/focus-trap/src/focus-trap.vue
+++ b/packages/components/focus-trap/src/focus-trap.vue
@@ -284,10 +284,11 @@ export default defineComponent({
         })
         trapContainer.addEventListener(FOCUS_AFTER_RELEASED, releaseOnFocus)
         trapContainer.dispatchEvent(releasedEvent)
-
         if (
           !releasedEvent.defaultPrevented &&
-          (focusReason.value == 'keyboard' || !isFocusCausedByUserEvent())
+          (focusReason.value == 'keyboard' ||
+            !isFocusCausedByUserEvent() ||
+            trapContainer.contains(document.activeElement))
         ) {
           tryFocus(lastFocusBeforeTrapped ?? document.body)
         }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Continuation of #9941

"Since version 2.2.18, When using the mouse to close the Dialog, the focus will not return to the previous button. It is works normally in 2.2.17. [demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtYnV0dG9uIHRleHQgQGNsaWNrPVwiZGlhbG9nVmlzaWJsZSA9IHRydWVcIj5cbiAgICBjbGljayBtZVxuICA8L2VsLWJ1dHRvbj5cbiAgPGVsLWRpYWxvZyB2LW1vZGVsPVwiZGlhbG9nVmlzaWJsZVwiPlxuICAgIDxzcGFuPkNsaWNrIHRoZSBDb25maXJtIGJ1dHRvbiB3aXRoIHRoZSBtb3VzZTwvc3Bhbj5cbiAgICA8dGVtcGxhdGUgI2Zvb3Rlcj5cbiAgICAgIDxzcGFuIGNsYXNzPVwiZGlhbG9nLWZvb3RlclwiPlxuICAgICAgICA8ZWwtYnV0dG9uIEBjbGljaz1cImRpYWxvZ1Zpc2libGUgPSBmYWxzZVwiPkNhbmNlbDwvZWwtYnV0dG9uPlxuICAgICAgICA8ZWwtYnV0dG9uIHR5cGU9XCJwcmltYXJ5XCIgQGNsaWNrPVwiZGlhbG9nVmlzaWJsZSA9IGZhbHNlXCI+XG4gICAgICAgICAgQ29uZmlybVxuICAgICAgICA8L2VsLWJ1dHRvbj5cbiAgICAgIDwvc3Bhbj5cbiAgICA8L3RlbXBsYXRlPlxuICA8L2VsLWRpYWxvZz5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgbGFuZz1cInRzXCIgc2V0dXA+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5cbmNvbnN0IGRpYWxvZ1Zpc2libGUgPSByZWYoZmFsc2UpXG48L3NjcmlwdD5cbiIsImltcG9ydF9tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHt9XG59IiwiX28iOnt9fQ==)"

**Focus Trap**

Added `trapContainer.contains(document.activeElement)` condition to check if you are still focused inside the focus trap when it is closed, and go ahead and focus on last element focused before the trap was opened if so.

I am weary of this change, but I cannot find a previous test case that it breaks... so...

**Dropdown**

I have implemented a quick fix for https://github.com/element-plus/element-plus/issues/9837 here. Ultimately, it would be good to remove any sort of `.focus()` calls that occur during pointer enter/leave, as this is unnecessary. But it looks like that's more of a significant change I don't want to tackle and risk breaking things right now.

I ended up changing the code so if the user hovers over the tooltip target (that opens the dropdown), that target is focused. This works in-line with each item in the dropdown receiving focus during hover, and gives the focus trap a sane element to return to when the dropdown closes.