### PR TITLE
fix(components): [menu] trigger submenu focus

### DIFF
--- a/packages/components/menu/src/sub-menu.ts
+++ b/packages/components/menu/src/sub-menu.ts
@@ -114,7 +114,7 @@ export default defineComponent({
     const mouseInChild = ref(false)
     const verticalTitleRef = ref<HTMLDivElement>()
     const vPopper = ref<InstanceType<typeof ElTooltip> | null>(null)
-    const submenuRef = ref<HTMLDivElement>()
+    const subMenuRef = ref<HTMLDivElement>()
 
     // computed
     const currentPlacement = computed<Placement>(() =>
@@ -255,9 +255,16 @@ export default defineComponent({
       }
       subMenu.mouseInChild.value = true
 
+      if (
+        rootMenu.isMenuPopup &&
+        event.type === 'mouseenter' &&
+        rootMenu.props.menuTrigger === 'hover'
+      ) {
+        subMenuRef.value?.focus()
+      }
+
       timeout?.()
       ;({ stop: timeout } = useTimeoutFn(() => {
-        submenuRef.value?.focus()
         rootMenu.openMenu(props.index, indexPath.value)
       }, showTimeout))
 
@@ -461,7 +468,7 @@ export default defineComponent({
       return h(
         'li',
         {
-          ref: submenuRef,
+          ref: subMenuRef,
           class: [
             nsSubMenu.b(),
             nsSubMenu.is('active', active.value),

--- a/packages/components/menu/src/sub-menu.ts
+++ b/packages/components/menu/src/sub-menu.ts
@@ -114,6 +114,7 @@ export default defineComponent({
     const mouseInChild = ref(false)
     const verticalTitleRef = ref<HTMLDivElement>()
     const vPopper = ref<InstanceType<typeof ElTooltip> | null>(null)
+    const submenuRef = ref<HTMLDivElement>()
 
     // computed
     const currentPlacement = computed<Placement>(() =>
@@ -256,6 +257,7 @@ export default defineComponent({
 
       timeout?.()
       ;({ stop: timeout } = useTimeoutFn(() => {
+        submenuRef.value?.focus()
         rootMenu.openMenu(props.index, indexPath.value)
       }, showTimeout))
 
@@ -459,6 +461,7 @@ export default defineComponent({
       return h(
         'li',
         {
+          ref: submenuRef,
           class: [
             nsSubMenu.b(),
             nsSubMenu.is('active', active.value),


### PR DESCRIPTION
Fixed an issue where the focus remains when a submenu is selected on mouseover

closed #11640

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
