### PR TITLE
style(components): [breadcrumb] item use inline-flex

### DIFF
--- a/packages/theme-chalk/src/breadcrumb.scss
+++ b/packages/theme-chalk/src/breadcrumb.scss
@@ -23,7 +23,7 @@
 
   @include e(item) {
     float: left;
-    display: flex;
+    display: inline-flex;
     align-items: center;
 
     @include e(inner) {


### PR DESCRIPTION
close #11679 

On the `item`, I think it is more reasonable to use `inline-flex`, which is the flex attribute that wraps child elements.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
