### PR TITLE
fix(components): [table-column] first default column set placeholder

### DIFF
--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -152,10 +152,13 @@ function useRender<T>(
         } else {
           children = originRenderCell(data)
         }
+
+        const { columns } = owner.value.store.states
+        const firstUserColumnIndex = columns.value.findIndex(
+          (item) => item.type === 'default'
+        )
         const shouldCreatePlaceholder =
-          hasTreeColumn.value &&
-          data.cellIndex === 0 &&
-          data.column.type !== 'selection'
+          hasTreeColumn.value && data.cellIndex === firstUserColumnIndex
         const prefix = treeCellPrefix(data, shouldCreatePlaceholder)
         const props = {
           class: 'cell',


### PR DESCRIPTION
fixed: [#11694](https://github.com/element-plus/element-plus/issues/11694), #11803 

I think the problem is caused by `cellIndex === 0`. If first column is `selection ` or `index` or `expand` that the column which has `children` is not aligned.

![image](https://user-images.githubusercontent.com/30046649/220921006-40b1f4cf-01c1-4b31-8db9-65b6fc0e7e95.png)

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
