### PR TITLE
feat(components): [date-picker] Unified value-format return string type

### DIFF
--- a/breakings/2.3.0/time-picker.yml
+++ b/breakings/2.3.0/time-picker.yml
@@ -1,7 +1,7 @@
 - scope: 'component'
-  name: 'el-image'
+  name: 'el-time-picker'
   type: 'props'
-  version: '2.2.3'
+  version: '2.3.0'
   commit_hash: '9e01d4a'
   description: |
     PUsing value-format="x" will no longer return a number, but a string.

--- a/breakings/2.3.0/time-picker.yml
+++ b/breakings/2.3.0/time-picker.yml
@@ -1,0 +1,11 @@
+- scope: 'component'
+  name: 'el-image'
+  type: 'props'
+  version: '2.2.3'
+  commit_hash: '9e01d4a'
+  description: |
+    PUsing value-format="x" will no longer return a number, but a string.
+  props:
+    - api: 'value-format'
+      before: 'string|number'
+      after: 'string'

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -582,47 +582,6 @@ describe('DatePicker', () => {
       await nextTick()
       expect(wrapper.findComponent(Input).vm.modelValue).toBe('2021-05-31')
     })
-
-    it('with "x"', async () => {
-      const format = 'YYYY/MM/DD'
-      const dateStr = '2021/05/31'
-      const valueFormat = 'x'
-      const value = Date.now()
-      const wrapper = _mount(
-        `
-        <el-date-picker
-          ref="compo"
-          v-model="value"
-          type="date"
-          format="${format}"
-          value-format="${valueFormat}" />
-        <button @click="changeValue">click</button>
-      `,
-        () => {
-          return {
-            value,
-          }
-        },
-        {
-          methods: {
-            changeValue() {
-              this.value = +new Date(dateStr)
-            },
-          },
-        }
-      )
-      const vm = wrapper.vm as any
-      const input = wrapper.find('input')
-      await input.trigger('blur')
-      await input.trigger('focus')
-      await nextTick()
-      ;(document.querySelector('td.available') as HTMLElement).click()
-      await nextTick()
-      expect(vm.value).toBe(+dayjs().startOf('M'))
-      await wrapper.find('button').trigger('click')
-      await nextTick()
-      expect(wrapper.findComponent(Input).vm.modelValue).toBe(dateStr)
-    })
   })
 })
 

--- a/packages/components/time-picker/src/utils.ts
+++ b/packages/components/time-picker/src/utils.ts
@@ -76,7 +76,6 @@ export const formatter = function (
   lang: string
 ) {
   if (isEmpty(format)) return date
-  if (format === 'x') return +date
   return dayjs(date).locale(lang).format(format)
 }
 


### PR DESCRIPTION
# This is a breaking change.

According to the feedback of #11667, we conducted corresponding investigations and found that the performance of `X` and `x` were inconsistent. 

`X` returned a `string` according to the api command logic of `format`, while `x` returned a `number` after special processing in #5187 . 

We think that format should return the string type according to the api command, which is consistent with `dayjs`. So it is necessary to remove this part of the special treatment.

If you need to return a number, you can use `v-model.number`.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
