### PR TITLE
feat(components): [select] add label-key prop (#11637)

### DIFF
--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -366,6 +366,10 @@ export default defineComponent({
       type: String,
       default: 'value',
     },
+    labelKey: {
+      type: String,
+      default: 'label',
+    },
     collapseTags: Boolean,
     collapseTagsTooltip: {
       type: Boolean,

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -540,7 +540,7 @@ export const useSelect = (props, states: States, ctx) => {
     }
     if (option) return option
     const label = isObjectValue
-      ? value.label
+      ? value[props.labelKey]
       : !isNull && !isUndefined
       ? value
       : ''


### PR DESCRIPTION
if the options data is got from server-side and the value is object, maybe the label can not show immediate. In the code, the label-key of the object value is fixed, maybe better to provide a label-key prop to the user to set.