### PR TITLE
Revert "docs: error when frontmatter does not exist"

### DIFF
--- a/docs/.vitepress/plugins/markdown-transform.ts
+++ b/docs/.vitepress/plugins/markdown-transform.ts
@@ -48,9 +48,9 @@ export function MarkdownTransform(): Plugin {
 }
 
 const combineScriptSetup = (codes: string[]) =>
-  `<script setup>
+  `\n<script setup>
 ${codes.join('\n')}
-</script>\n
+</script>
 `
 
 const combineMarkdown = (
@@ -58,14 +58,9 @@ const combineMarkdown = (
   headers: string[],
   footers: string[]
 ) => {
-  const frontmatterEnds = code.indexOf('---\n\n')
-  const firstSubheader = code.search(/## \w/)
-  const sliceIndex =
-    firstSubheader < 0
-      ? frontmatterEnds < 0
-        ? 0
-        : frontmatterEnds + 5
-      : firstSubheader
+  const frontmatterEnds = code.indexOf('---\n\n') + 4
+  const firstSubheader = code.search(/\n## \w/)
+  const sliceIndex = firstSubheader < 0 ? frontmatterEnds : firstSubheader
 
   if (headers.length > 0)
     code =


### PR DESCRIPTION
Reverts element-plus/element-plus#10561

this breaks the doc build

<img width="937" alt="image" src="https://user-images.githubusercontent.com/17680888/222761549-603338cb-ff87-4027-a534-86222982f0bd.png">

https://github.com/element-plus/element-plus/actions/runs/4323453699/jobs/7549825789
