### PR TITLE
docs(components): [icon] using shallowRef instead of ref

### DIFF
--- a/docs/.vitepress/vitepress/components/globals/icons.vue
+++ b/docs/.vitepress/vitepress/components/globals/icons.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 import clipboardCopy from 'clipboard-copy'
 import { ElMessage } from 'element-plus'
 import * as Icons from '@element-plus/icons-vue'
@@ -44,7 +44,7 @@ const copySvgIcon = async (name, refs) => {
   }
 }
 
-const categories = ref<CategoriesItem[]>([])
+const categories = shallowRef<CategoriesItem[]>([])
 const iconMap = new Map(Object.entries(Icons))
 
 IconCategories.categories.forEach((o) => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

> [Vue warn]: Vue received a Component which was made a reactive object. This can lead to unnecessary performance overhead, and should be avoided by marking the component with `markRaw` or using `shallowRef` instead of `ref`.