### PR TITLE
fix(components): [table-v2] reduce unnecessary update of cell component

### DIFF
--- a/packages/components/table-v2/src/table-v2.tsx
+++ b/packages/components/table-v2/src/table-v2.tsx
@@ -273,11 +273,7 @@ const TableV2 = defineComponent({
                     {slots.cell(props)}
                   </Cell>
                 ) : (
-                  <Cell
-                    {...props}
-                    {...tableCellProps}
-                    style={_columnsStyles[props.column.key]}
-                  />
+                  <Cell {...{ ...props, ...tableCellProps }} />
                 ),
             }}
           </Row>


### PR DESCRIPTION
This PR could solve the performance problem which is mentioned in #11650  to a certain extent.
I removed `style={_columnsStyles[props.column.key]}` because `props.style` and `_columnsStyles[props.column.key]` seem to be the same object.