### PR TITLE
fix(components): [scrollbar] update bar when container resize

### DIFF
--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -33,7 +33,7 @@ import {
   ref,
   watch,
 } from 'vue'
-import { useEventListener, useResizeObserver } from '@vueuse/core'
+import { useResizeObserver } from '@vueuse/core'
 import { addUnit, debugWarn, isNumber, isObject } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { GAP } from './util'
@@ -55,7 +55,6 @@ const emit = defineEmits(scrollbarEmits)
 const ns = useNamespace('scrollbar')
 
 let stopResizeObserver: (() => void) | undefined = undefined
-let stopResizeListener: (() => void) | undefined = undefined
 
 const scrollbarRef = ref<HTMLDivElement>()
 const wrapRef = ref<HTMLDivElement>()
@@ -153,10 +152,13 @@ watch(
   (noresize) => {
     if (noresize) {
       stopResizeObserver?.()
-      stopResizeListener?.()
     } else {
-      ;({ stop: stopResizeObserver } = useResizeObserver(resizeRef, update))
-      stopResizeListener = useEventListener('resize', update)
+      const { stop: resizeStop } = useResizeObserver(resizeRef, update)
+      const { stop: wrapResizeStop } = useResizeObserver(wrapRef, update)
+      stopResizeObserver = () => {
+        resizeStop()
+        wrapResizeStop()
+      }
     }
   },
   { immediate: true }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #11820 
link #1456 
不是很明白为啥是window resize时update，这里改成监听wrapRef的resize似乎更加合理。