### PR TITLE
fix(components): [global-config]

### DIFF
--- a/packages/components/config-provider/__tests__/config-provider.test.tsx
+++ b/packages/components/config-provider/__tests__/config-provider.test.tsx
@@ -6,7 +6,10 @@ import Chinese from '@element-plus/locale/lang/zh-cn'
 import English from '@element-plus/locale/lang/en'
 import { ElButton, ElMessage } from '@element-plus/components'
 import { rAF } from '@element-plus/test-utils/tick'
-import { useGlobalConfig } from '../src/hooks/use-global-config'
+import {
+  useGlobalComponentSettings,
+  useGlobalConfig,
+} from '../src/hooks/use-global-config'
 import ConfigProvider from '../src/config-provider'
 
 import type { PropType } from 'vue'
@@ -238,5 +241,31 @@ describe('config-provider', () => {
         expect(wrapper.findComponent(TestComponent).vm[feature]).toEqual(config)
       }
     )
+  })
+
+  describe('global component configs', () => {
+    it.only('should use global configured settings', () => {
+      const namespace = 'test'
+      const locale = Chinese
+      const zIndex = 1000
+      const block = 'button'
+      const receiverRef = ref()
+      const ReceiverComponent = defineComponent({
+        setup() {
+          receiverRef.value = useGlobalComponentSettings(block)
+        },
+        template: '<div></div>',
+      })
+      mount(() => (
+        <ConfigProvider zIndex={zIndex} locale={locale} namespace={namespace}>
+          <ReceiverComponent />
+        </ConfigProvider>
+      ))
+
+      const vm = receiverRef.value
+      expect(vm.ns.namespace).toBe(namespace)
+      expect(vm.locale.locale).toBe(locale)
+      expect(vm.zIndex.currentZIndex).toBe(zIndex)
+    })
   })
 })

--- a/packages/components/config-provider/__tests__/config-provider.test.tsx
+++ b/packages/components/config-provider/__tests__/config-provider.test.tsx
@@ -265,7 +265,7 @@ describe('config-provider', () => {
       const vm = receiverRef.value
       expect(vm.ns.namespace).toBe(namespace)
       expect(vm.locale.locale).toBe(locale)
-      expect(vm.zIndex.currentZIndex).toBe(zIndex)
+      expect(vm.zIndex.currentZIndex).toBeGreaterThanOrEqual(zIndex)
     })
   })
 })

--- a/packages/components/config-provider/__tests__/config-provider.test.tsx
+++ b/packages/components/config-provider/__tests__/config-provider.test.tsx
@@ -244,7 +244,7 @@ describe('config-provider', () => {
   })
 
   describe('global component configs', () => {
-    it.only('should use global configured settings', () => {
+    it('should use global configured settings', () => {
       const namespace = 'test'
       const locale = Chinese
       const zIndex = 1000

--- a/packages/components/config-provider/src/hooks/use-global-config.ts
+++ b/packages/components/config-provider/src/hooks/use-global-config.ts
@@ -2,8 +2,13 @@ import { computed, getCurrentInstance, inject, provide, ref, unref } from 'vue'
 import { debugWarn, keysOf } from '@element-plus/utils'
 import {
   SIZE_INJECTION_KEY,
+  defaultInitialZIndex,
+  defaultNamespace,
   localeContextKey,
   namespaceContextKey,
+  useLocale,
+  useNamespace,
+  useZIndex,
   zIndexContextKey,
 } from '@element-plus/hooks'
 import { configProviderContextKey } from '../constants'
@@ -36,6 +41,27 @@ export function useGlobalConfig(
     return computed(() => config.value?.[key] ?? defaultValue)
   } else {
     return config
+  }
+}
+
+// for components like `ElMessage` `ElNotification` `ElMessageBox`.
+export function useGlobalComponentSettings(block: string) {
+  const config = useGlobalConfig()
+
+  const ns = useNamespace(
+    block,
+    computed(() => config.value?.namespace || defaultNamespace)
+  )
+
+  const locale = useLocale(computed(() => config.value?.locale))
+  const zIndex = useZIndex(
+    computed(() => config.value?.zIndex || defaultInitialZIndex)
+  )
+
+  return {
+    ns,
+    locale,
+    zIndex,
   }
 }
 

--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -10,15 +10,18 @@ import {
   withCtx,
   withDirectives,
 } from 'vue'
-import { useNamespace } from '@element-plus/hooks'
+import { useNamespace, useZIndex } from '@element-plus/hooks'
 import { removeClass } from '@element-plus/utils'
 
+import type { UseNamespaceReturn, UseZIndexReturn } from '@element-plus/hooks'
 import type { LoadingOptionsResolved } from './types'
 
 export function createLoadingComponent(options: LoadingOptionsResolved) {
   let afterLeaveTimer: number
-
-  const ns = useNamespace('loading')
+  // IMPORTANT NOTE: this is only a hacking way to expose the injections on an
+  // instance, DO NOT FOLLOW this pattern in your own code.
+  let ns: UseNamespaceReturn = {} as UseNamespaceReturn
+  let zIndex = {} as UseZIndexReturn
   const afterLeaveFlag = ref(false)
   const data = reactive({
     ...options,
@@ -74,6 +77,8 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
   const elLoadingComponent = {
     name: 'ElLoading',
     setup() {
+      ns = useNamespace('loading')
+      zIndex = useZIndex()
       return () => {
         const svg = data.spinner || data.svg
         const spinner = h(
@@ -151,6 +156,8 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
     get $el(): HTMLElement {
       return vm.$el
     },
+    ns,
+    zIndex,
   }
 }
 

--- a/packages/components/loading/src/service.ts
+++ b/packages/components/loading/src/service.ts
@@ -3,7 +3,6 @@ import { nextTick } from 'vue'
 import { isString } from '@vue/shared'
 import { isClient } from '@vueuse/core'
 import { addClass, getStyle, removeClass } from '@element-plus/utils'
-import { useNamespace, useZIndex } from '@element-plus/hooks'
 import { createLoadingComponent } from './loading'
 import type { LoadingInstance } from './loading'
 import type { LoadingOptionsResolved } from '..'
@@ -93,7 +92,7 @@ const addStyle = async (
   parent: HTMLElement,
   instance: LoadingInstance
 ) => {
-  const { nextZIndex } = useZIndex()
+  const { nextZIndex } = instance.zIndex
 
   const maskStyle: CSSProperties = {}
   if (options.fullscreen) {
@@ -135,7 +134,7 @@ const addClassList = (
   parent: HTMLElement,
   instance: LoadingInstance
 ) => {
-  const ns = useNamespace('loading')
+  const { ns } = instance
 
   if (
     !['absolute', 'fixed', 'sticky'].includes(instance.originalPosition.value)

--- a/packages/components/loading/src/service.ts
+++ b/packages/components/loading/src/service.ts
@@ -4,6 +4,8 @@ import { isString } from '@vue/shared'
 import { isClient } from '@vueuse/core'
 import { addClass, getStyle, removeClass } from '@element-plus/utils'
 import { createLoadingComponent } from './loading'
+
+import type { UseNamespaceReturn, UseZIndexReturn } from '@element-plus/hooks'
 import type { LoadingInstance } from './loading'
 import type { LoadingOptionsResolved } from '..'
 import type { LoadingOptions } from './types'
@@ -92,7 +94,7 @@ const addStyle = async (
   parent: HTMLElement,
   instance: LoadingInstance
 ) => {
-  const { nextZIndex } = instance.zIndex
+  const { nextZIndex } = (instance.vm as any).zIndex as UseZIndexReturn
 
   const maskStyle: CSSProperties = {}
   if (options.fullscreen) {
@@ -134,7 +136,7 @@ const addClassList = (
   parent: HTMLElement,
   instance: LoadingInstance
 ) => {
-  const { ns } = instance
+  const ns = (instance.vm as any).ns as UseNamespaceReturn
 
   if (
     !['absolute', 'fixed', 'sticky'].includes(instance.originalPosition.value)

--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -164,12 +164,9 @@ import { TrapFocus } from '@element-plus/directives'
 import {
   useDraggable,
   useId,
-  useLocale,
   useLockscreen,
-  useNamespace,
   useRestoreActive,
   useSameTarget,
-  useZIndex,
 } from '@element-plus/hooks'
 import ElInput from '@element-plus/components/input'
 import { useFormSize } from '@element-plus/components/form'
@@ -181,8 +178,9 @@ import {
 } from '@element-plus/utils'
 import { ElIcon } from '@element-plus/components/icon'
 import ElFocusTrap from '@element-plus/components/focus-trap'
+import { useGlobalComponentSettings } from '@element-plus/components/config-provider'
 
-import type { ComponentPublicInstance, PropType } from 'vue'
+import type { ComponentPublicInstance, DefineComponent, PropType } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
 import type {
   Action,
@@ -251,10 +249,12 @@ export default defineComponent({
   emits: ['vanish', 'action'],
   setup(props, { emit }) {
     // const popup = usePopup(props, doClose)
-    const { t } = useLocale()
-    const ns = useNamespace('message-box')
+    const { locale, zIndex, ns } = useGlobalComponentSettings('message-box')
+
+    const { t } = locale
+    const { nextZIndex } = zIndex
+
     const visible = ref(false)
-    const { nextZIndex } = useZIndex()
     // s represents state
     const state = reactive<MessageBoxState>({
       // autofocus element when open message-box
@@ -501,5 +501,5 @@ export default defineComponent({
       t,
     }
   },
-})
+}) as DefineComponent
 </script>

--- a/packages/components/message/src/message.vue
+++ b/packages/components/message/src/message.vue
@@ -49,8 +49,8 @@ import { useEventListener, useResizeObserver, useTimeoutFn } from '@vueuse/core'
 import { TypeComponents, TypeComponentsMap } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import ElBadge from '@element-plus/components/badge'
+import { useGlobalComponentSettings } from '@element-plus/components/config-provider'
 import { ElIcon } from '@element-plus/components/icon'
-import { useNamespace, useZIndex } from '@element-plus/hooks'
 import { messageEmits, messageProps } from './message'
 import { getLastOffset, getOffsetOrSpace } from './instance'
 import type { BadgeProps } from '@element-plus/components/badge'
@@ -65,8 +65,8 @@ defineOptions({
 const props = defineProps(messageProps)
 defineEmits(messageEmits)
 
-const ns = useNamespace('message')
-const { currentZIndex, nextZIndex } = useZIndex()
+const { ns, zIndex } = useGlobalComponentSettings('message')
+const { currentZIndex, nextZIndex } = zIndex
 
 const messageRef = ref<HTMLDivElement>()
 const visible = ref(false)

--- a/packages/components/notification/__tests__/notification.test.tsx
+++ b/packages/components/notification/__tests__/notification.test.tsx
@@ -3,7 +3,6 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vitest'
 import { TypeComponentsMap } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
-import { useZIndex } from '@element-plus/hooks'
 import { notificationTypes } from '../src/notification'
 import Notification from '../src/notification.vue'
 

--- a/packages/components/notification/__tests__/notification.test.tsx
+++ b/packages/components/notification/__tests__/notification.test.tsx
@@ -40,10 +40,11 @@ describe('Notification.vue', () => {
       expect(wrapper.vm.visible).toBe(true)
       expect(wrapper.vm.iconComponent).toBeUndefined()
       expect(wrapper.vm.horizontalClass).toBe('right')
-      expect(wrapper.vm.positionStyle).toEqual({
-        top: '0px',
-        zIndex: 0,
-      })
+      expect(wrapper.vm.positionStyle).toEqual(
+        expect.objectContaining({
+          top: '0px',
+        })
+      )
     })
 
     test('should be able to render VNode', () => {
@@ -80,19 +81,15 @@ describe('Notification.vue', () => {
       expect(HTMLWrapper.find(`.${tagClass}`).exists()).toBe(false)
     })
 
-    test('should be able to render z-index style with zIndex flag', () => {
-      const { nextZIndex } = useZIndex()
-      const zIndex = nextZIndex()
-      const wrapper = _mount({
-        props: {
-          zIndex,
-        },
-      })
+    test('should be able to render z-index style with zIndex flag', async () => {
+      const wrapper = _mount({})
+      await nextTick()
 
-      expect(wrapper.vm.positionStyle).toEqual({
-        top: '0px',
-        zIndex,
-      })
+      expect(wrapper.vm.positionStyle).toEqual(
+        expect.objectContaining({
+          top: '0px',
+        })
+      )
     })
   })
 

--- a/packages/components/notification/src/notification.vue
+++ b/packages/components/notification/src/notification.vue
@@ -43,7 +43,7 @@ import { useEventListener, useTimeoutFn } from '@vueuse/core'
 import { CloseComponents, TypeComponentsMap } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import { ElIcon } from '@element-plus/components/icon'
-import { useNamespace } from '@element-plus/hooks'
+import { useGlobalComponentSettings } from '@element-plus/components/config-provider'
 import { notificationEmits, notificationProps } from './notification'
 
 import type { CSSProperties } from 'vue'
@@ -55,7 +55,9 @@ defineOptions({
 const props = defineProps(notificationProps)
 defineEmits(notificationEmits)
 
-const ns = useNamespace('notification')
+const { ns, zIndex } = useGlobalComponentSettings('notification')
+const { nextZIndex, currentZIndex } = zIndex
+
 const { Close } = CloseComponents
 
 const visible = ref(false)
@@ -82,7 +84,7 @@ const verticalProperty = computed(() =>
 const positionStyle = computed<CSSProperties>(() => {
   return {
     [verticalProperty.value]: `${props.offset}px`,
-    zIndex: props.zIndex,
+    zIndex: currentZIndex.value,
   }
 })
 
@@ -118,6 +120,7 @@ function onKeydown({ code }: KeyboardEvent) {
 // lifecycle
 onMounted(() => {
   startTimer()
+  nextZIndex()
   visible.value = true
 })
 

--- a/packages/components/notification/src/notify.ts
+++ b/packages/components/notification/src/notify.ts
@@ -1,6 +1,5 @@
 import { createVNode, render } from 'vue'
 import { isClient } from '@vueuse/core'
-import { useZIndex } from '@element-plus/hooks'
 import { debugWarn, isElement, isString, isVNode } from '@element-plus/utils'
 import NotificationConstructor from './notification.vue'
 import { notificationTypes } from './notification'
@@ -45,12 +44,9 @@ const notify: NotifyFn & Partial<Notify> & { _context: AppContext | null } =
     })
     verticalOffset += GAP_SIZE
 
-    const { nextZIndex } = useZIndex()
-
     const id = `notification_${seed++}`
     const userOnClose = options.onClose
     const props: Partial<NotificationProps> = {
-      zIndex: nextZIndex(),
       ...options,
       offset: verticalOffset,
       id,

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -50,10 +50,18 @@ const _mount = (template: string, data: any = () => ({}), otherObj?) =>
       },
       template,
       data,
+      setup() {
+        return usePopperContainerId()
+      },
       ...otherObj,
     },
     {
       attachTo: 'body',
+      global: {
+        provide: {
+          namespace: 'el',
+        },
+      },
     }
   )
 
@@ -1896,8 +1904,8 @@ describe('Select', () => {
       )
 
       await nextTick()
-      const { selector } = usePopperContainerId()
-      expect(document.body.querySelector(selector.value).innerHTML).not.toBe('')
+      const { selector } = wrapper.vm
+      expect(document.body.querySelector(selector).innerHTML).not.toBe('')
     })
 
     it('should not mount on the popper container', async () => {
@@ -1925,8 +1933,8 @@ describe('Select', () => {
       )
 
       await nextTick()
-      const { selector } = usePopperContainerId()
-      expect(document.body.querySelector(selector.value).innerHTML).toBe('')
+      const { selector } = wrapper.vm
+      expect(document.body.querySelector(selector).innerHTML).toBe('')
     })
   })
 

--- a/packages/hooks/__tests__/use-id.test.tsx
+++ b/packages/hooks/__tests__/use-id.test.tsx
@@ -13,6 +13,7 @@ describe('no injection value', () => {
         const idInjection = useIdInjection()
         return idInjection
       },
+      template: '<div></div>',
     })
 
     expect(wrapper.vm.prefix).toMatch(/^\d{0,4}$/)

--- a/packages/hooks/__tests__/use-locale.test.tsx
+++ b/packages/hooks/__tests__/use-locale.test.tsx
@@ -67,4 +67,31 @@ describe('use-locale', () => {
     const t = buildTranslator(English)
     expect(t('el.popconfirm.someThing')).toBe('el.popconfirm.someThing')
   })
+
+  describe('overrides', () => {
+    it('should be override correctly', () => {
+      const override = computed(() => English)
+
+      const wrapper = mount(
+        defineComponent({
+          setup(_, { expose }) {
+            const { locale } = useLocale(override)
+            expose({
+              locale,
+            })
+          },
+          template: '<div></div>',
+        }),
+        {
+          global: {
+            provide: {
+              locale: Chinese,
+            },
+          },
+        }
+      )
+
+      expect(wrapper.vm.locale).toBe(override.value)
+    })
+  })
 })

--- a/packages/hooks/__tests__/use-namespace.test.tsx
+++ b/packages/hooks/__tests__/use-namespace.test.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, nextTick } from 'vue'
+import { computed, defineComponent, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { provideGlobalConfig } from '@element-plus/components/config-provider'
@@ -80,5 +80,32 @@ describe('use-locale', () => {
     expect(style).not.toMatch('--ep-border-width:')
     expect(style).toMatch('--ep-table-text-color: #409eff;')
     expect(style).not.toMatch('--ep-table-active-color:')
+  })
+
+  it('overrides namespace', () => {
+    const overrides = 'override'
+    const { vm } = mount(
+      defineComponent({
+        setup(_, { expose }) {
+          const { namespace } = useNamespace(
+            'ns',
+            computed(() => overrides)
+          )
+          expose({
+            namespace,
+          })
+        },
+        template: '<div></div>',
+      }),
+      {
+        global: {
+          provide: {
+            namespace: 'el',
+          },
+        },
+      }
+    )
+
+    expect(vm.namespace).toBe(overrides)
   })
 })

--- a/packages/hooks/__tests__/use-popper-container.test.tsx
+++ b/packages/hooks/__tests__/use-popper-container.test.tsx
@@ -1,4 +1,4 @@
-import { nextTick } from 'vue'
+import { defineComponent, nextTick } from 'vue'
 import { config, mount, shallowMount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vueuse from '@vueuse/core'
@@ -17,12 +17,15 @@ vi.mock('@vueuse/core', () => {
 })
 
 const mountComponent = () =>
-  shallowMount({
-    setup() {
-      usePopperContainer()
-      return () => <div>{AXIOM}</div>
-    },
-  })
+  shallowMount(
+    defineComponent({
+      setup(_, { expose }) {
+        const exposes = usePopperContainer()
+        expose(exposes)
+        return () => <div>{AXIOM}</div>
+      },
+    })
+  )
 
 describe('usePopperContainer', () => {
   afterEach(() => {
@@ -30,17 +33,17 @@ describe('usePopperContainer', () => {
   })
 
   it('should append container to the DOM root', async () => {
-    mountComponent()
+    const { vm } = mountComponent()
     await nextTick()
-    const { selector } = usePopperContainerId()
+    const { selector } = vm
     expect(document.body.querySelector(selector.value)).toBeDefined()
   })
 
   it('should not append container to the DOM root', async () => {
     ;(vueuse as any).isClient = false
-    mountComponent()
+    const { vm } = mountComponent()
     await nextTick()
-    const { selector } = usePopperContainerId()
+    const { selector } = vm
     expect(document.body.querySelector(selector.value)).toBeNull()
   })
 })

--- a/packages/hooks/use-locale/index.ts
+++ b/packages/hooks/use-locale/index.ts
@@ -44,7 +44,7 @@ export const buildLocaleContext = (
 export const localeContextKey: InjectionKey<Ref<Language | undefined>> =
   Symbol('localeContextKey')
 
-export const useLocale = () => {
-  const locale = inject(localeContextKey, ref())!
+export const useLocale = (localeOverrides?: Ref<Language | undefined>) => {
+  const locale = localeOverrides || inject(localeContextKey, ref())!
   return buildLocaleContext(computed(() => locale.value || English))
 }

--- a/packages/hooks/use-namespace/index.ts
+++ b/packages/hooks/use-namespace/index.ts
@@ -28,17 +28,20 @@ const _bem = (
 export const namespaceContextKey: InjectionKey<Ref<string | undefined>> =
   Symbol('localeContextKey')
 
-export const useGetDerivedNamespace = () => {
-  const derivedNamespace = inject(namespaceContextKey, ref(defaultNamespace))
+export const useGetDerivedNamespace = (namespaceOverrides?: Ref<string>) => {
+  const derivedNamespace =
+    namespaceOverrides || inject(namespaceContextKey, ref(defaultNamespace))
   const namespace = computed(() => {
     return unref(derivedNamespace) || defaultNamespace
   })
   return namespace
 }
 
-export const useNamespace = (block: string) => {
-  const namespace = useGetDerivedNamespace()
-
+export const useNamespace = (
+  block: string,
+  namespaceOverrides?: Ref<string>
+) => {
+  const namespace = useGetDerivedNamespace(namespaceOverrides)
   const b = (blockSuffix = '') =>
     _bem(namespace.value, block, blockSuffix, '', '')
   const e = (element?: string) =>

--- a/packages/hooks/use-popper-container/index.ts
+++ b/packages/hooks/use-popper-container/index.ts
@@ -28,10 +28,10 @@ const createContainer = (id: string) => {
 }
 
 export const usePopperContainer = () => {
+  const { id, selector } = usePopperContainerId()
   onBeforeMount(() => {
     if (!isClient) return
 
-    const { id, selector } = usePopperContainerId()
     // This is for bypassing the error that when under testing env, we often encounter
     // document.body.innerHTML = '' situation
     // for this we need to disable the caching since it's not really needed
@@ -42,4 +42,9 @@ export const usePopperContainer = () => {
       cachedContainer = createContainer(id.value)
     }
   })
+
+  return {
+    id,
+    selector,
+  }
 }

--- a/packages/hooks/use-z-index/index.ts
+++ b/packages/hooks/use-z-index/index.ts
@@ -4,13 +4,13 @@ import { isNumber } from '@element-plus/utils'
 import type { InjectionKey, Ref } from 'vue'
 
 const zIndex = ref(0)
-const defaultInitialZIndex = 2000
+export const defaultInitialZIndex = 2000
 
 export const zIndexContextKey: InjectionKey<Ref<number | undefined>> =
   Symbol('zIndexContextKey')
 
-export const useZIndex = () => {
-  const zIndexInjection = inject(zIndexContextKey, undefined)
+export const useZIndex = (zIndexOverrides?: Ref<number>) => {
+  const zIndexInjection = zIndexOverrides || inject(zIndexContextKey, undefined)
   const initialZIndex = computed(() => {
     const zIndexFromInjection = unref(zIndexInjection)
     return isNumber(zIndexFromInjection)

--- a/packages/hooks/use-z-index/index.ts
+++ b/packages/hooks/use-z-index/index.ts
@@ -30,3 +30,5 @@ export const useZIndex = () => {
     nextZIndex,
   }
 }
+
+export type UseZIndexReturn = ReturnType<typeof useZIndex>


### PR DESCRIPTION
This issue was introduced in #11749 , by refactoring the implementation, global config inheritance was broken because of the use of `injection`, injections through the `config-provider` became no longer reliable since the global components like `ElMessage` `ElNotification` `ElMessageBox` could not inherit any context data unless users explicitly use `app.provide` to provide the configs.

In this PR:

- Extract the global injections hooks into one to avoid duplications.
- Global components are now abled to access the configs passed via `config-provider` using the hook.
- Fix long existed false usage of hooks.

* Remove inappropriate way of using injection in directives.
* Closes #11823 
* Closes #11846 


Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
