### PR TITLE
style(theme-chalk): [menu] horizontal mode submenu line-high

### DIFF
--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -135,6 +135,7 @@
         display: flex;
         align-items: center;
         height: getCssVar('menu-horizontal-sub-item-height');
+        line-height: getCssVar('menu-horizontal-sub-item-height');
         padding: 0 10px;
         color: getCssVar('menu-text-color');
       }


### PR DESCRIPTION
When you hover over the lower part of a menu-item, the next menu-item will be selected

closed N

The reason is found by checking the css, because the height of menu-item is 36px, but the line-height is 56px.
