### PR TITLE
fix(components): [select] Filter duplicate emits of "update options"

### DIFF
--- a/packages/components/select/src/options.ts
+++ b/packages/components/select/src/options.ts
@@ -6,6 +6,21 @@ export default defineComponent({
   name: 'ElOptions',
   emits: ['update-options'],
   setup(_, { slots, emit }) {
+    let oldOptions: any[] = []
+
+    function isSameOptions(a: any[], b: any[]) {
+      if (a.length === b.length) {
+        for (const [index] of a.entries()) {
+          if (a[index] != b[index]) {
+            return false
+          }
+        }
+      } else {
+        return false
+      }
+      return true
+    }
+
     return () => {
       const children = slots.default?.()!
 
@@ -19,7 +34,10 @@ export default defineComponent({
             )
             .map((item: VNode) => item.props?.label)
 
-          emit('update-options', filteredOptions)
+          if (!isSameOptions(filteredOptions, oldOptions)) {
+            oldOptions = filteredOptions
+            emit('update-options', filteredOptions)
+          }
         }
       }
 

--- a/packages/components/select/src/options.ts
+++ b/packages/components/select/src/options.ts
@@ -6,17 +6,14 @@ export default defineComponent({
   name: 'ElOptions',
   emits: ['update-options'],
   setup(_, { slots, emit }) {
-    let oldOptions: any[] = []
+    let cachedOptions: any[] = []
 
     function isSameOptions(a: any[], b: any[]) {
-      if (a.length === b.length) {
-        for (const [index] of a.entries()) {
-          if (a[index] != b[index]) {
-            return false
-          }
+      if (a.length !== b.length) return false
+      for (const [index] of a.entries()) {
+        if (a[index] != b[index]) {
+          return false
         }
-      } else {
-        return false
       }
       return true
     }
@@ -34,8 +31,8 @@ export default defineComponent({
             )
             .map((item: VNode) => item.props?.label)
 
-          if (!isSameOptions(filteredOptions, oldOptions)) {
-            oldOptions = filteredOptions
+          if (!isSameOptions(filteredOptions, cachedOptions)) {
+            cachedOptions = filteredOptions
             emit('update-options', filteredOptions)
           }
         }


### PR DESCRIPTION
closed #11890 

Another problem is found in https://github.com/element-plus/element-plus/issues/11878.

For example:
```vue
<script lang="tsx">
import { defineComponent, ref } from 'vue'
export default defineComponent({
  setup() {
    const options = ref([
      {
        value: 'Option1',
        label: 'Option1',
      },
      {
        value: 'Option2',
        label: 'Option2',
      },
    ])

    return () => (
      <el-select>
        {options.value.map((item) => (
          <el-option key={item.value} label={item.label} value={item.value} />
        ))}
      </el-select>
    )
  },
})
</script>

```

The following problems occur when using jsx:

![image](https://user-images.githubusercontent.com/1532716/223462878-a5a1d427-6544-4c68-b403-dd9cd826ad38.png)





Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
