### PR TITLE
style(theme-chalk): use variable instead of '-'

### DIFF
--- a/packages/theme-chalk/src/mixins/mixins.scss
+++ b/packages/theme-chalk/src/mixins/mixins.scss
@@ -54,7 +54,7 @@
 
 // BEM
 @mixin b($block) {
-  $B: $namespace + '-' + $block !global;
+  $B: $namespace + $common-separator + $block !global;
 
   .#{$B} {
     @content;


### PR DESCRIPTION
Sorry,I closed it unexpectedly,PR again .

It does not work if change $common-separator.

so use variable $common-separator instead of '-'.

closed #11796