### PR TITLE
fix(components): [select] remote search only if remote prop is true

### DIFF
--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -270,7 +270,7 @@ export const useSelect = (props, states: States, ctx) => {
           if (isFunction(props.filterMethod)) {
             props.filterMethod('')
           }
-          if (isFunction(props.remoteMethod)) {
+          if (props.remote && isFunction(props.remoteMethod)) {
             props.remoteMethod('')
           }
         }


### PR DESCRIPTION
closes [[Component] [select] el-select组件设置filterable:true、remote:false在blur的时候会触发remote-method方法 #11984](https://github.com/element-plus/element-plus/issues/11984)