### PR TITLE
docs: enable lazy loading for contributor avatars to improve page loading speed

### DIFF
--- a/docs/.vitepress/vitepress/components/globals/contributors.vue
+++ b/docs/.vitepress/vitepress/components/globals/contributors.vue
@@ -19,7 +19,7 @@ const contributors = computed(() =>
           class="flex gap-2 items-center link"
           no-icon
         >
-          <img :src="c.avatar" class="w-8 h-8 rounded-full" />
+          <img :src="c.avatar" class="w-8 h-8 rounded-full" loading="lazy" />
           {{ c.name }}
         </vp-link>
       </div>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

The accessors from the Chinese mainland may be slow or even unavailable to load the avatars from the GitHub assets server and the images may slow down the page loading speed, so I think it's better if we enable lazy loading for these bottom images.