### PR TITLE
docs: set avatar size as 64px rather than original image size to speed up loading

### DIFF
--- a/docs/.vitepress/vitepress/components/globals/contributors.vue
+++ b/docs/.vitepress/vitepress/components/globals/contributors.vue
@@ -8,6 +8,10 @@ const props = defineProps<{ id: string }>()
 const contributors = computed(() =>
   _contributors[props.id]?.filter((c) => c.login !== 'renovate[bot]')
 )
+
+const withSize = (rawURL: string) => {
+  return `${rawURL}${rawURL.includes('?') ? '&' : '?'}size=64`
+}
 </script>
 
 <template>
@@ -19,7 +23,11 @@ const contributors = computed(() =>
           class="flex gap-2 items-center link"
           no-icon
         >
-          <img :src="c.avatar" class="w-8 h-8 rounded-full" loading="lazy" />
+          <img
+            :src="withSize(c.avatar)"
+            class="w-8 h-8 rounded-full"
+            loading="lazy"
+          />
           {{ c.name }}
         </vp-link>
       </div>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

This PR follows up #12017 -

Currently, we don't explicitly specify the size of the avatar image, so it will be the original image size. It takes up many unnecessary network resources and slows down the loading speed. Thus I set the size as `64px` as per its container size to speed up loading.