### PR TITLE
docs(style): add pointer cursor for `summary` element

### DIFF
--- a/docs/.vitepress/vitepress/styles/base.scss
+++ b/docs/.vitepress/vitepress/styles/base.scss
@@ -255,6 +255,7 @@ details {
     margin: 16px 0;
     font-size: 18px;
     font-weight: 600;
+    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

The `<summary>` element on the documentation has no pointer cursor, which might not be clear and direct to the users that it can be expanded by click. So it would be more user-friendly if we add a `pointer` cursor to indicate this is an interactive element.
