### PR TITLE
fix(components): [input] Write Chinese in parenthesis, letters repeat

### DIFF
--- a/packages/utils/i18n.ts
+++ b/packages/utils/i18n.ts
@@ -1,2 +1,2 @@
 export const isKorean = (text: string) =>
-  /([(\uAC00-\uD7AF)|(\u3130-\u318F)])+/gi.test(text)
+  /([\uAC00-\uD7AF|\u3130-\u318F])+/gi.test(text)

--- a/packages/utils/i18n.ts
+++ b/packages/utils/i18n.ts
@@ -1,2 +1,2 @@
 export const isKorean = (text: string) =>
-  /([\uAC00-\uD7AF|\u3130-\u318F])+/gi.test(text)
+  /([\uAC00-\uD7AF\u3130-\u318F])+/gi.test(text)


### PR DESCRIPTION
closed #11723

Write Chinese among parenthesis in the safari browser, letters repeat.

The parentheses are unnecessary because they create a capture group that is not used.  Also, this will make the reg match the parentheses, which causes composition judgment wrong.

Before:
![20230322141418_rec_](https://user-images.githubusercontent.com/10278227/226817742-0a0c6172-1006-4b87-94b3-1ec8bf45aa21.gif)

After:
![20230322141129_rec_](https://user-images.githubusercontent.com/10278227/226817298-6d9b98ce-1cd7-4086-a371-49e220de3d1b.gif)


Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
