### PR TITLE
build(components): fix generateExternal use wrong reference

### DIFF
--- a/internal/build/src/utils/rollup.ts
+++ b/internal/build/src/utils/rollup.ts
@@ -6,7 +6,7 @@ export const generateExternal = async (options: { full: boolean }) => {
   const { dependencies, peerDependencies } = getPackageDependencies(epPackage)
 
   return (id: string) => {
-    const packages: string[] = peerDependencies
+    const packages: string[] = [...peerDependencies]
     if (!options.full) {
       packages.push('@vue', ...dependencies)
     }


### PR DESCRIPTION
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

`generateExternal` is using a reference instead of shallow copy which might cause unnecessary memory usage which can slow the bundle process. 

``` plainText
before: 
[09:02:56] Finished 'buildModules' after 1.22 min
[09:02:56] Finished 'shellTask:buildModules' after 1.27 min

after: 
[08:57:45] Finished 'buildModules' after 18 s
[08:57:45] Finished 'shellTask:buildModules' after 21 s
```