### PR TITLE
fix(components): correct maxTop when modal exceeds viewport height

### DIFF
--- a/packages/hooks/use-draggable/index.ts
+++ b/packages/hooks/use-draggable/index.ts
@@ -29,8 +29,10 @@ export const useDraggable = (
     const minLeft = -targetLeft + offsetX
     const minTop = -targetTop + offsetY
     const maxLeft = clientWidth - targetLeft - targetWidth + offsetX
-    const maxTop = clientHeight - targetTop - targetHeight + offsetY
-
+    const maxTop =
+      targetHeight >= clientHeight
+        ? offsetY
+        : clientHeight - targetTop - targetHeight + offsetY
     const onMousemove = (e: MouseEvent) => {
       const moveX = Math.min(
         Math.max(offsetX + e.clientX - downX, minLeft),


### PR DESCRIPTION
closed #12187

I've made changes to the calculation of maxTop. When the height of the target element is greater than the height of the viewport, I have constrained the vertical offset to be within the range of [-targetTop + offsetY, 0 + offsetY] to ensure that the target element does not exceed the top of the viewport. Taking into account the offset from the last drag, the range of the vertical offset is set to [-targetTop + offsetY, 0 + offsetY]. Therefore, I have set the value of maxTop to be offsetY.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
