### PR TITLE
feat(components): [tabs] add tab-pane provide

### DIFF
--- a/packages/components/tabs/src/constants.ts
+++ b/packages/components/tabs/src/constants.ts
@@ -1,4 +1,11 @@
-import type { ComputedRef, InjectionKey, Ref, Slots, UnwrapRef } from 'vue'
+import type {
+  ComputedRef,
+  DeepReadonly,
+  InjectionKey,
+  Ref,
+  Slots,
+  UnwrapRef,
+} from 'vue'
 import type { TabsProps } from './tabs'
 import type { TabPaneProps } from './tab-pane'
 
@@ -21,3 +28,13 @@ export interface TabsRootContext {
 
 export const tabsRootContextKey: InjectionKey<TabsRootContext> =
   Symbol('tabsRootContextKey')
+
+export const tabsPaneContextKey: InjectionKey<
+  DeepReadonly<{
+    props: TabPaneProps
+    isClosable: boolean
+    active: boolean
+    loaded: boolean
+    paneName: string | number | undefined
+  }>
+> = Symbol('tabsPaneContextKey')

--- a/packages/components/tabs/src/tab-pane.vue
+++ b/packages/components/tabs/src/tab-pane.vue
@@ -19,7 +19,9 @@ import {
   inject,
   onMounted,
   onUnmounted,
+  provide,
   reactive,
+  readonly,
   ref,
   useSlots,
   watch,
@@ -27,7 +29,7 @@ import {
 import { eagerComputed } from '@vueuse/core'
 import { throwError } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
-import { tabsRootContextKey } from './constants'
+import { tabsPaneContextKey, tabsRootContextKey } from './constants'
 import { tabPaneProps } from './tab-pane'
 
 const COMPONENT_NAME = 'ElTabPane'
@@ -77,4 +79,15 @@ onMounted(() => {
 onUnmounted(() => {
   tabsRoot.unregisterPane(pane.uid)
 })
+
+provide(
+  tabsPaneContextKey,
+  readonly({
+    active,
+    isClosable,
+    loaded,
+    paneName,
+    props,
+  })
+)
 </script>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

I need to get the current TabPane props/state (such as `active` and the `label`) in the components inside TabPane to perform corresponding operations.

`provide` work well.
