### PR TITLE
fix(components): [menu] change declartion of ulStyle to setup function

### DIFF
--- a/packages/components/menu/src/sub-menu.ts
+++ b/packages/components/menu/src/sub-menu.ts
@@ -195,6 +195,7 @@ export default defineComponent({
       active,
     })
 
+    const ulStyle = useMenuCssVar(rootMenu.props, subMenu.level + 1)
     const titleStyle = computed<CSSProperties>(() => {
       if (mode.value !== 'horizontal') {
         return {
@@ -352,8 +353,6 @@ export default defineComponent({
           }
         ),
       ]
-
-      const ulStyle = useMenuCssVar(rootMenu.props, subMenu.level + 1)
 
       // this render function is only used for bypass `Vue`'s compiler caused patching issue.
       // temporarily mark ElPopper as any due to type inconsistency.


### PR DESCRIPTION
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


The ulStyle property is declared in render function, it leads to a wrong dependencies collection and causes memory leak in sub-menu component.
[related issue](https://github.com/element-plus/element-plus/issues/12307)
