### PR TITLE
fix(components): [date-picker] adjust the `WEEKS` data source

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/basic-date-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-date-table.vue
@@ -75,11 +75,6 @@ let focusWithClick = false
 
 // todo better way to get Day.js locale object
 const firstDayOfWeek = (props.date as any).$locale().weekStart || 7
-const WEEKS_CONSTANT = props.date
-  .locale('en')
-  .localeData()
-  .weekdaysShort()
-  .map((_) => _.toLowerCase())
 
 const offsetDay = computed(() => {
   // Sunday 7(0), cal the left and right offset days, 3217654, such as Monday is -1, the is to adjust the position of the first two rows of dates
@@ -91,12 +86,7 @@ const startDate = computed(() => {
   return startDayOfMonth.subtract(startDayOfMonth.day() || 7, 'day')
 })
 
-const WEEKS = computed(() => {
-  return WEEKS_CONSTANT.concat(WEEKS_CONSTANT).slice(
-    firstDayOfWeek,
-    firstDayOfWeek + 7
-  )
-})
+const WEEKS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
 
 const hasCurrent = computed<boolean>(() => {
   return flatten(rows.value).some((row) => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

```js
dayjs.updateLocale('en', {
  weekdaysShort: ['Sun.', 'Mon.', 'Tue.', 'Wed.', 'Thu.', 'Fri.', 'Sat.']
})
```

When I modify the English language `weekdaysShort` configuration through the `updateLocale` plugin of dayjs, the date picker renders wrong weeks.


recurrent:
1. [Playgound](https://element-plus.run/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcbmltcG9ydCB7IGRheWpzIH0gZnJvbSAnZWxlbWVudC1wbHVzJ1xuaW1wb3J0IHVwZGF0ZUxvY2FsZSBmcm9tICdVcGRhdGVMb2NhbGUnXG5cbmRheWpzLmV4dGVuZCh1cGRhdGVMb2NhbGUpXG5cbmRheWpzLnVwZGF0ZUxvY2FsZSgnZW4nLCB7XG4gIHdlZWtkYXlzU2hvcnQ6IFsnU3VuLicsICdNb24uJywgJ1R1ZS4nLCAnV2VkLicsICdUaHUuJywgJ0ZyaS4nLCAnU2F0LiddXG59KVxuICBcbmNvbnN0IHZhbHVlID0gcmVmKFtdKVxuICBcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxlbC1kYXRlLXBpY2tlclxuICAgIHYtbW9kZWw9XCJ2YWx1ZVwiXG4gICAgdHlwZT1cImRhdGVyYW5nZVwiXG4gICAgcmFuZ2Utc2VwYXJhdG9yPVwiVG9cIlxuICAgIHN0YXJ0LXBsYWNlaG9sZGVyPVwiU3RhcnQgZGF0ZVwiXG4gICAgZW5kLXBsYWNlaG9sZGVyPVwiRW5kIGRhdGVcIlxuICAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydF9tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcIlVwZGF0ZUxvY2FsZVwiOiBcImh0dHBzOi8vdW5wa2cuY29tL2RheWpzQDEuMTEuNy9lc20vcGx1Z2luL3VwZGF0ZUxvY2FsZVwiXG4gIH1cbn0iLCJfbyI6e319)
2. Click to open date picker