### PR TITLE
fix(components): [message-box] Allow set action for ElMessageBox.close

### DIFF
--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -291,7 +291,7 @@ export default defineComponent({
       type: '',
       title: undefined,
       showInput: false,
-      action: '' as Action,
+      action: 'cancel' as Action,
       confirmButtonLoading: false,
       cancelButtonLoading: false,
       confirmButtonDisabled: false,

--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -291,7 +291,7 @@ export default defineComponent({
       type: '',
       title: undefined,
       showInput: false,
-      action: 'cancel' as Action,
+      action: '' as Action,
       confirmButtonLoading: false,
       cancelButtonLoading: false,
       confirmButtonDisabled: false,
@@ -382,9 +382,12 @@ export default defineComponent({
       }
     })
 
-    function doClose() {
+    function doClose(action?: Action) {
       if (!visible.value) return
       visible.value = false
+      if (action) {
+        state.action = action
+      }
       nextTick(() => {
         if (state.action) emit('action', state.action)
       })

--- a/packages/components/message-box/src/message-box.type.ts
+++ b/packages/components/message-box/src/message-box.type.ts
@@ -212,5 +212,5 @@ export interface IElMessageBox {
   prompt: ElMessageBoxShortcutMethod
 
   /** Close current message box */
-  close(): void
+  close(close?: Action): void
 }

--- a/packages/components/message-box/src/messageBox.ts
+++ b/packages/components/message-box/src/messageBox.ts
@@ -26,7 +26,7 @@ import type {
 // component default merge props & data
 
 const messageInstance = new Map<
-  ComponentPublicInstance<{ doClose: () => void }>, // marking doClose as function
+  ComponentPublicInstance<{ doClose: (action?: any) => void }>, // marking doClose as function
   {
     options: any
     callback: Callback | undefined
@@ -226,15 +226,21 @@ function messageBoxFactory(boxType: typeof MESSAGE_BOX_VARIANTS[number]) {
   }
 }
 
-MessageBox.close = () => {
+MessageBox.close = (action?: Action) => {
   // instance.setupInstall.doClose()
   // instance.setupInstall.state.visible = false
+  if (!action && typeof action != 'undefined') {
+    action = 'cancel'
+  }
 
   messageInstance.forEach((_, vm) => {
-    vm.doClose()
+    if (action === 'close') {
+      const options = messageInstance.get(vm)?.options
+      if (options) options.distinguishCancelAndClose = true
+    }
+    vm.doClose(action)
   })
-
-  messageInstance.clear()
+  // clear messageInstance in onVanish
 }
 ;(MessageBox as IElMessageBox)._context = null
 


### PR DESCRIPTION
Allow set action for `ElMessageBox.close`
- Added support for setting close actions to allow callback and promise execution after closing
- Fixed an issue where executing close would not execute a promise

closed #12363

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
