### PR TITLE
fix(components): Inactive elements under keep-alive should not fire resize events

### DIFF
--- a/packages/components/table-v2/src/composables/use-auto-resize.ts
+++ b/packages/components/table-v2/src/composables/use-auto-resize.ts
@@ -11,6 +11,9 @@ const useAutoResize = (props: AutoResizerProps) => {
   let resizerStopper: ReturnType<typeof useResizeObserver>['stop']
   onMounted(() => {
     resizerStopper = useResizeObserver(sizer, ([entry]) => {
+      // Prevent inactive elements under keep-alive from firing resize events
+      if (typeof document !== 'undefined' && !document.contains(entry.target)) return;
+
       const { width, height } = entry.contentRect
       const { paddingLeft, paddingRight, paddingTop, paddingBottom } =
         getComputedStyle(entry.target)


### PR DESCRIPTION
TableV2 still respond to resize events after they're hidden by keep-alive, causing performance issues.
Ignoring this event after it's detached from DOM tree fixes this issue.

Please make sure these boxes are checked before submitting your PR, thank you!

- [✓] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [✓] Make sure you are merging your commits to `dev` branch.
- [✓] Add some descriptions and refer to relative issues for your PR.
