### PR TITLE
feat(components): [tree] support customize content when data is empty

### DIFF
--- a/docs/en-US/component/tree.md
+++ b/docs/en-US/component/tree.md
@@ -197,6 +197,7 @@ tree/draggable
 
 ## Slots
 
-| Name | Description                                                            |
-| ---- | ---------------------------------------------------------------------- |
-| —    | Custom content for tree nodes. The scope parameter is `{ node, data }` |
+| Name  | Description                                                            |
+| ----- | ---------------------------------------------------------------------- |
+| —     | Custom content for tree nodes. The scope parameter is `{ node, data }` |
+| empty | empty you can customize content when data is empty.                    |

--- a/packages/components/tree/src/tree.vue
+++ b/packages/components/tree/src/tree.vue
@@ -22,9 +22,11 @@
       @node-expand="handleNodeExpand"
     />
     <div v-if="isEmpty" :class="ns.e('empty-block')">
-      <span :class="ns.e('empty-text')">{{
-        emptyText ?? t('el.tree.emptyText')
-      }}</span>
+      <slot name="empty">
+        <span :class="ns.e('empty-text')">
+          {{ emptyText ?? t('el.tree.emptyText') }}
+        </span>
+      </slot>
     </div>
     <div
       v-show="dragState.showDropIndicator"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

Description/描述：

这个PR解决了一个问题，即在数据为空的情况下，没有提供一个可自定义的功能。我们添加了一个名为"empty"的插槽，允许开发者在需要时为其提供自定义内容。

This PR addresses an issue where customization was not provided when the data was empty. We have added a slot named "empty" that allows developers to provide custom content when needed.

Discussion:

[[Enhancement] [tree] Tree 组件能否支持自定义 empty 内容](https://github.com/element-plus/element-plus/discussions/12458)


