### PR TITLE
fix(components): [dropdown] improve types

### DIFF
--- a/docs/examples/dropdown/dropdown-methods.vue
+++ b/docs/examples/dropdown/dropdown-methods.vue
@@ -34,8 +34,11 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-const dropdown1 = ref()
+import type { DropdownInstance } from 'element-plus'
+
+const dropdown1 = ref<DropdownInstance>()
 function handleVisible2(visible: any) {
+  if (!dropdown1.value) return
   if (visible) {
     dropdown1.value.handleClose()
   } else {
@@ -43,6 +46,7 @@ function handleVisible2(visible: any) {
   }
 }
 function showClick() {
+  if (!dropdown1.value) return
   dropdown1.value.handleOpen()
 }
 </script>

--- a/packages/components/dropdown/index.ts
+++ b/packages/components/dropdown/index.ts
@@ -12,4 +12,5 @@ export default ElDropdown
 export const ElDropdownItem = withNoopInstall(DropdownItem)
 export const ElDropdownMenu = withNoopInstall(DropdownMenu)
 export * from './src/dropdown'
+export * from './src/instance'
 export * from './src/tokens'

--- a/packages/components/dropdown/src/instance.ts
+++ b/packages/components/dropdown/src/instance.ts
@@ -1,0 +1,3 @@
+import type Dropdown from './dropdown.vue'
+
+export type DropdownInstance = InstanceType<typeof Dropdown>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

This PR improves `dropdown` types.

Previously, we have to write types to use dropdown ref to avoid `any`.

```typescript
const dropdown1 = ref()
import { ElDropdown } from 'element-plus'
const dropdown1 = ref<InstanceType<typeof ElDropdown>>()
```

After this, we can directly import and use the type.

```typescript
const dropdown1 = ref()
import type { DropdownInstance } from 'element-plus'
const dropdown1 = ref<DropdownInstance>()
```

Also, I updated the example file to use the new type.
