### PR TITLE
fix(components): [global-config] global provide

### DIFF
--- a/packages/components/config-provider/src/hooks/use-global-config.ts
+++ b/packages/components/config-provider/src/hooks/use-global-config.ts
@@ -61,7 +61,6 @@ export function useGlobalComponentSettings(
     computed(() => config.value?.zIndex || defaultInitialZIndex)
   )
   const size = computed(() => unref(sizeFallback) || config.value?.size || '')
-  provideGlobalConfig(computed(() => unref(config) || {}))
 
   return {
     ns,


### PR DESCRIPTION
fix: https://github.com/element-plus/element-plus/issues/12418

出现这个问题的原因是，我的项目在mount app之前，调用了ElLoading，然后ElLoading provide 了一个空对象的 config。
导致后续el-config-provider在调用`provideGlobalConfig`的时候，发现已经有global config（空对象）了，然后Message这种组件就会发现所有的global config都是空对象

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
