### PR TITLE
fix(components): [form] improve types

### DIFF
--- a/docs/examples/form/custom-validation.vue
+++ b/docs/examples/form/custom-validation.vue
@@ -73,13 +73,18 @@ const validatePass2 = (rule: any, value: any, callback: any) => {
   }
 }
 
-const ruleForm = reactive({
+interface RuleForm {
+  pass: string
+  checkPass: string
+  age: string
+}
+const ruleForm = reactive<RuleForm>({
   pass: '',
   checkPass: '',
   age: '',
 })
 
-const rules = reactive<FormRules>({
+const rules = reactive<FormRules<RuleForm>>({
   pass: [{ validator: validatePass, trigger: 'blur' }],
   checkPass: [{ validator: validatePass2, trigger: 'blur' }],
   age: [{ validator: checkAge, trigger: 'blur' }],

--- a/docs/examples/form/custom-validation.vue
+++ b/docs/examples/form/custom-validation.vue
@@ -73,18 +73,13 @@ const validatePass2 = (rule: any, value: any, callback: any) => {
   }
 }
 
-interface RuleForm {
-  pass: string
-  checkPass: string
-  age: string
-}
-const ruleForm = reactive<RuleForm>({
+const ruleForm = reactive({
   pass: '',
   checkPass: '',
   age: '',
 })
 
-const rules = reactive<FormRules<RuleForm>>({
+const rules = reactive<FormRules<typeof ruleForm>>({
   pass: [{ validator: validatePass, trigger: 'blur' }],
   checkPass: [{ validator: validatePass2, trigger: 'blur' }],
   age: [{ validator: checkAge, trigger: 'blur' }],

--- a/docs/examples/form/validation.vue
+++ b/docs/examples/form/validation.vue
@@ -83,9 +83,21 @@
 import { reactive, ref } from 'vue'
 import type { FormInstance, FormRules } from 'element-plus'
 
+interface RuleForm {
+  name: string
+  region: string
+  count: string
+  date1: string
+  date2: string
+  delivery: boolean
+  type: string[]
+  resource: string
+  desc: string
+}
+
 const formSize = ref('default')
 const ruleFormRef = ref<FormInstance>()
-const ruleForm = reactive({
+const ruleForm = reactive<RuleForm>({
   name: 'Hello',
   region: '',
   count: '',
@@ -97,7 +109,7 @@ const ruleForm = reactive({
   desc: '',
 })
 
-const rules = reactive<FormRules>({
+const rules = reactive<FormRules<RuleForm>>({
   name: [
     { required: true, message: 'Please input Activity name', trigger: 'blur' },
     { min: 3, max: 5, message: 'Length should be 3 to 5', trigger: 'blur' },

--- a/packages/components/form/src/types.ts
+++ b/packages/components/form/src/types.ts
@@ -20,11 +20,52 @@ export type FormLabelWidthContext = ReturnType<typeof useFormLabelWidth>
 export interface FormItemRule extends RuleItem {
   trigger?: Arrayable<string>
 }
+
+// Reference https://stackoverflow.com/questions/58434389/typescript-deep-keyof-of-a-nested-object/58436959
+// Concatenates two strings with a dot in the middle, unless the last string is empty
+// Join<"a","b"> => "a.b"
+// Join<"a",""> => "a"
+type Join<K, P> = K extends string | number
+  ? P extends string | number
+    ? `${K}${'' extends P ? '' : '.'}${P}`
+    : never
+  : never
+// Limit the recursion to avoid typescript error
+type Prev = [
+  never,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  ...0[]
+]
+type Leaves<T, D extends number = 10> = [D] extends [never]
+  ? never
+  : T extends object
+  ? { [K in keyof T]-?: Join<K, Leaves<T[K], Prev[D]>> }[keyof T]
+  : ''
 export type FormRules<
   T extends MaybeRef<Record<string, any> | string> = string
 > = Partial<
   Record<
-    UnwrapRef<T> extends string ? UnwrapRef<T> : keyof UnwrapRef<T>,
+    UnwrapRef<T> extends string ? UnwrapRef<T> : Leaves<UnwrapRef<T>>,
     Arrayable<FormItemRule>
   >
 >

--- a/packages/components/form/src/types.ts
+++ b/packages/components/form/src/types.ts
@@ -86,7 +86,7 @@ type Path<T> = T extends ReadonlyArray<infer V>
  * 通过一个类型收集所有路径的类型
  *
  * @example
- * FieldPath<{ a: number; b: string; c: { d: number; e: string }; f: [{ value: string }]; g: { value: string }[] }> => 'a' | 'b' | 'c.d' | 'c.e' | 'f.0' | 'f.0.value' | 'g.number' | 'g.number.value'
+ * FieldPath<{ 1: number; a: number; b: string; c: { d: number; e: string }; f: [{ value: string }]; g: { value: string }[] }> => '1' | 'a' | 'b' | 'c' | 'f' | 'g' | 'c.d' | 'c.e' | 'f.0' | 'f.0.value' | 'g.number' | 'g.number.value'
  */
 type FieldPath<T> = T extends object ? Path<T> : never
 export type FormRules<

--- a/packages/components/form/src/types.ts
+++ b/packages/components/form/src/types.ts
@@ -74,11 +74,11 @@ type PathImpl<K extends string | number, V> = V extends Primitive
 type Path<T> = T extends ReadonlyArray<infer V>
   ? IsTuple<T> extends true
     ? {
-        [K in TupleKey<T>]-?: PathImpl<K & string, T[K]>
+        [K in TupleKey<T>]-?: PathImpl<Exclude<K, symbol>, T[K]>
       }[TupleKey<T>] // tuple
     : PathImpl<ArrayKey, V> // array
   : {
-      [K in keyof T]-?: PathImpl<K & string, T[K]>
+      [K in keyof T]-?: PathImpl<Exclude<K, symbol>, T[K]>
     }[keyof T] // object
 /**
  * Type which collects all paths through a type

--- a/packages/components/form/src/types.ts
+++ b/packages/components/form/src/types.ts
@@ -1,4 +1,3 @@
-import { ref } from 'vue'
 import type { SetupContext, UnwrapRef } from 'vue'
 import type {
   RuleItem,

--- a/packages/components/form/src/types.ts
+++ b/packages/components/form/src/types.ts
@@ -6,6 +6,7 @@ import type {
 } from 'async-validator'
 import type { ComponentSize } from '@element-plus/constants'
 import type { Arrayable } from '@element-plus/utils'
+import type { MaybeRef } from '@vueuse/core'
 import type {
   FormItemProp,
   FormItemProps,
@@ -19,7 +20,14 @@ export type FormLabelWidthContext = ReturnType<typeof useFormLabelWidth>
 export interface FormItemRule extends RuleItem {
   trigger?: Arrayable<string>
 }
-export type FormRules = Partial<Record<string, Arrayable<FormItemRule>>>
+export type FormRules<
+  T extends MaybeRef<Record<string, any> | string> = string
+> = Partial<
+  Record<
+    UnwrapRef<T> extends string ? UnwrapRef<T> : keyof UnwrapRef<T>,
+    Arrayable<FormItemRule>
+  >
+>
 
 export type FormValidationResult = Promise<boolean>
 export type FormValidateCallback = (


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

This PR was started as a discussion at https://github.com/element-plus/element-plus/discussions/12373.

In element-plus@2.3.3, we have `export declare type FormRules = Partial<Record<string, Arrayable<FormItemRule>>>;`, which means the keys of the rules object can be any string and it may causes unexpected errors. An example shows below.

```typescript
// use reactive from vue
const form = reactive({
  id: 0,
  name: '',
});
// or use ref from vue
const form = ref({
  id: 0,
  name: '',
});

// the keys of the rules object can be any string
// even not in the `form` model
const formRules: FormRules = {
  id: { ... },
  name: { ... },
  // no ts error
  code: { ... },
  ...,
};
```

This PR adds an optional generic to the `FormRules` type and brings better type assertion if someone needs it.

```typescript
const formRules: FormRules<typeof form> = {
  id: { ... },
  name: { ... },
  // ts error
  // Type '{ id: {}; name: {}; code: {}; }' is not assignable to type 'Partial<Record<"id" | "name", Arrayable<FormItemRule>>>'.
  // Object literal may only specify known properties, and 'code' does not exist in type 'Partial<Record<"id" | "name", Arrayable<FormItemRule>>>'.ts(2322)
  code: { ... },
  ...,
};
```

Previous codes still work because the generic is optional.

```typescript
const formRules: FormRules = {
  id: { ... },
  name: { ... },
  // no ts error
  code: { ... },
  ...,
};
```
