### PR TITLE
feat(components): [breadcrumb] support set separator for breadcrumb item

### DIFF
--- a/docs/en-US/component/breadcrumb.md
+++ b/docs/en-US/component/breadcrumb.md
@@ -23,6 +23,14 @@ breadcrumb/icon
 
 :::
 
+## Custom BreadcrumbItem separator
+
+:::demo Set `separator` or `separator-icon` to custom separator for `el-breadcrumb-item`，it will cover `separator` or `separator-icon` for `el-breadcrumb`.
+
+breadcrumb/custom-item-separator
+
+:::
+
 ## Breadcrumb API
 
 ### Breadcrumb Attributes
@@ -42,10 +50,12 @@ breadcrumb/icon
 
 ### BreadcrumbItem Attributes
 
-| Name    | Description                                               | Type                                    | Default |
-| ------- | --------------------------------------------------------- | --------------------------------------- | ------- |
-| to      | target route of the link, same as `to` of `vue-router`    | ^[string] / ^[object]`RouteLocationRaw` | ''      |
-| replace | if `true`, the navigation will not leave a history record | ^[boolean]                              | false   |
+| Name           | Description                                               | Type                                    | Default |
+| -------------- | --------------------------------------------------------- | --------------------------------------- | ------- |
+| to             | target route of the link, same as `to` of `vue-router`    | ^[string] / ^[object]`RouteLocationRaw` | ''      |
+| replace        | if `true`, the navigation will not leave a history record | ^[boolean]                              | false   |
+| separator      | separator character                                       | ^[string]                               | -       |
+| separator-icon | icon component of icon separator                          | ^[string] / ^[Component]                | -       |
 
 ### BreadcrumbItem Slots
 

--- a/docs/examples/breadcrumb/custom-item-separator.vue
+++ b/docs/examples/breadcrumb/custom-item-separator.vue
@@ -1,0 +1,12 @@
+<template>
+  <el-breadcrumb separator="/">
+    <el-breadcrumb-item separator="：" :to="{ path: '/' }"
+      >homepage</el-breadcrumb-item
+    >
+    <el-breadcrumb-item
+      ><a href="/">promotion management</a></el-breadcrumb-item
+    >
+    <el-breadcrumb-item>promotion list</el-breadcrumb-item>
+    <el-breadcrumb-item>promotion detail</el-breadcrumb-item>
+  </el-breadcrumb>
+</template>

--- a/packages/components/breadcrumb/__tests__/breadcrumb.test.tsx
+++ b/packages/components/breadcrumb/__tests__/breadcrumb.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
-import { Check } from '@element-plus/icons-vue'
+import { Check, View } from '@element-plus/icons-vue'
 import Breadcrumb from '../src/breadcrumb.vue'
 import BreadcrumbItem from '../src/breadcrumb-item.vue'
 import type { VNode } from 'vue'
@@ -100,6 +100,25 @@ describe('Breadcrumb.vue', () => {
 
       await wrapper.find('.el-breadcrumb__inner').trigger('click')
       expect(replace).toHaveBeenCalled()
+    })
+
+    it('BreadcrumbItem separator', () => {
+      const wrapper = _mount(() => (
+        <Breadcrumb separator="?">
+          <BreadcrumbItem separator="!">A</BreadcrumbItem>
+        </Breadcrumb>
+      ))
+      expect(wrapper.find('.el-breadcrumb__separator').text()).toBe('!')
+    })
+
+    it('BreadcrumbItem separatorIcon', () => {
+      const wrapper = _mount(() => (
+        <Breadcrumb separatorIcon={Check}>
+          <BreadcrumbItem separatorIcon={View}>A</BreadcrumbItem>
+        </Breadcrumb>
+      ))
+      expect(wrapper.find('.el-breadcrumb__separator').text()).toBe('')
+      expect(wrapper.findComponent(View).exists()).toBe(true)
     })
   })
 })

--- a/packages/components/breadcrumb/src/breadcrumb-item.ts
+++ b/packages/components/breadcrumb/src/breadcrumb-item.ts
@@ -1,4 +1,4 @@
-import { buildProps, definePropType } from '@element-plus/utils'
+import { buildProps, definePropType, iconPropType } from '@element-plus/utils'
 import type { ExtractPropTypes } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
 
@@ -16,6 +16,19 @@ export const breadcrumbItemProps = buildProps({
   replace: {
     type: Boolean,
     default: false,
+  },
+  /**
+   * @description separator character
+   */
+  separator: {
+    type: String,
+    default: '',
+  },
+  /**
+   * @description icon component of icon separator
+   */
+  separatorIcon: {
+    type: iconPropType,
   },
 } as const)
 export type BreadcrumbItemProps = ExtractPropTypes<typeof breadcrumbItemProps>

--- a/packages/components/breadcrumb/src/breadcrumb-item.vue
+++ b/packages/components/breadcrumb/src/breadcrumb-item.vue
@@ -36,10 +36,12 @@ const instance = getCurrentInstance()!
 const breadcrumbContext = inject(breadcrumbKey, undefined)!
 const ns = useNamespace('breadcrumb')
 
-const separator = computed(() => props.separator || breadcrumbContext.separator)
+const separator = computed(
+  () => props.separator || breadcrumbContext?.separator
+)
 
 const separatorIcon = computed(
-  () => props.separatorIcon || breadcrumbContext.separatorIcon
+  () => props.separatorIcon || breadcrumbContext?.separatorIcon
 )
 
 const router = instance.appContext.config.globalProperties.$router as Router

--- a/packages/components/breadcrumb/src/breadcrumb-item.vue
+++ b/packages/components/breadcrumb/src/breadcrumb-item.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts" setup>
-import { getCurrentInstance, inject, ref, toRefs } from 'vue'
+import { computed, getCurrentInstance, inject, ref } from 'vue'
 import ElIcon from '@element-plus/components/icon'
 import { useNamespace } from '@element-plus/hooks'
 import { breadcrumbKey } from './constants'
@@ -36,7 +36,12 @@ const instance = getCurrentInstance()!
 const breadcrumbContext = inject(breadcrumbKey, undefined)!
 const ns = useNamespace('breadcrumb')
 
-const { separator, separatorIcon } = toRefs(breadcrumbContext)
+const separator = computed(() => props.separator || breadcrumbContext.separator)
+
+const separatorIcon = computed(
+  () => props.separatorIcon || breadcrumbContext.separatorIcon
+)
+
 const router = instance.appContext.config.globalProperties.$router as Router
 
 const link = ref<HTMLSpanElement>()


### PR DESCRIPTION

Sometimes we might want to set a separate breadcrumb item separator,my changes include:

* support set separator and separator icon for breadcrumb item

* update breadcrumb component doc

* update test for breadcrumb item

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
