### PR TITLE
fix(components): 修复Select组件的blur事件触发异常

### DIFF
--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -254,7 +254,7 @@
         </div>
       </template>
       <template #content>
-        <el-select-menu>
+        <el-select-menu @click="avoidBlur">
           <el-scrollbar
             v-show="options.size > 0 && !loading"
             ref="scrollbar"
@@ -498,6 +498,7 @@ export default defineComponent({
       getValueKey,
       navigateOptions,
       dropMenuVisible,
+      setSoftFocus,
 
       reference,
       input,
@@ -629,6 +630,11 @@ export default defineComponent({
       optionList.value = v
     }
 
+    const avoidBlur = () => {
+      setSoftFocus()
+      isSilentBlur.value = true
+    }
+
     return {
       isIOS,
       onOptionsRendered,
@@ -684,6 +690,7 @@ export default defineComponent({
       navigateOptions,
       dropMenuVisible,
       focus,
+      avoidBlur,
 
       reference,
       input,

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -800,13 +800,13 @@ export const useSelect = (props, states: States, ctx) => {
 
   const handleBlur = (event: FocusEvent) => {
     // https://github.com/ElemeFE/element/pull/10822
-    nextTick(() => {
+    setTimeout(() => {
       if (states.isSilentBlur) {
         states.isSilentBlur = false
       } else {
         ctx.emit('blur', event)
       }
-    })
+    }, 200)
     states.softFocus = false
   }
 
@@ -956,6 +956,7 @@ export const useSelect = (props, states: States, ctx) => {
     groupQueryChange,
     showTagList,
     collapseTagList,
+    setSoftFocus,
 
     // DOM ref
     reference,


### PR DESCRIPTION
Select组件的blur事件存在两个问题：
1.选择Option时会意外触发blur事件，并在真实失去焦点时，不会再次触发blur。
2.点击下拉弹出框的边缘空白位置，会发送blur事件，此时该组件应该处在focus状态。

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
