### PR TITLE
fix(components):[select]blur事件触发异常 

### DIFF
--- a/packages/components/select/src/option.vue
+++ b/packages/components/select/src/option.vue
@@ -86,7 +86,7 @@ export default defineComponent({
 
     function selectOptionClick() {
       if (props.disabled !== true && states.groupDisabled !== true) {
-        select.handleOptionSelect(vm, true)
+        select.handleOptionSelect(vm)
       }
     }
 

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -254,7 +254,7 @@
         </div>
       </template>
       <template #content>
-        <el-select-menu @click="avoidBlur">
+        <el-select-menu>
           <el-scrollbar
             v-show="options.size > 0 && !loading"
             ref="scrollbar"
@@ -498,7 +498,6 @@ export default defineComponent({
       getValueKey,
       navigateOptions,
       dropMenuVisible,
-      setSoftFocus,
 
       reference,
       input,
@@ -531,7 +530,6 @@ export default defineComponent({
       currentPlaceholder,
       menuVisibleOnFocus,
       isOnComposition,
-      isSilentBlur,
       options,
       cachedOptions,
       optionsCount,
@@ -630,11 +628,6 @@ export default defineComponent({
       optionList.value = v
     }
 
-    const avoidBlur = () => {
-      setSoftFocus()
-      isSilentBlur.value = true
-    }
-
     return {
       isIOS,
       onOptionsRendered,
@@ -664,7 +657,6 @@ export default defineComponent({
       currentPlaceholder,
       menuVisibleOnFocus,
       isOnComposition,
-      isSilentBlur,
       options,
       resetInputHeight,
       managePlaceholder,
@@ -690,7 +682,6 @@ export default defineComponent({
       navigateOptions,
       dropMenuVisible,
       focus,
-      avoidBlur,
 
       reference,
       input,

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -254,7 +254,7 @@
         </div>
       </template>
       <template #content>
-        <el-select-menu>
+        <el-select-menu @click="avoidBlur">
           <el-scrollbar
             v-show="options.size > 0 && !loading"
             ref="scrollbar"
@@ -498,6 +498,7 @@ export default defineComponent({
       getValueKey,
       navigateOptions,
       dropMenuVisible,
+      setSoftFocus,
 
       reference,
       input,
@@ -629,6 +630,11 @@ export default defineComponent({
       optionList.value = v
     }
 
+    const avoidBlur = () => {
+      setSoftFocus()
+      isSilentBlur.value = true
+    }
+
     return {
       isIOS,
       onOptionsRendered,
@@ -684,6 +690,7 @@ export default defineComponent({
       navigateOptions,
       dropMenuVisible,
       focus,
+      avoidBlur,
 
       reference,
       input,

--- a/packages/components/select/src/token.ts
+++ b/packages/components/select/src/token.ts
@@ -31,7 +31,7 @@ export interface SelectContext {
   setSelected(): void
   onOptionCreate(vm: SelectOptionProxy): void
   onOptionDestroy(key: number | string | Record<string, any>): void
-  handleOptionSelect(vm: unknown, byClick: boolean): void
+  handleOptionSelect(vm: unknown): void
 }
 
 // For individual build sharing injection key, we had to make `Symbol` to string

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -56,7 +56,6 @@ export function useSelectStates(props) {
     currentPlaceholder: t('el.select.placeholder') as string | (() => string),
     menuVisibleOnFocus: false,
     isOnComposition: false,
-    isSilentBlur: false,
     prefixWidth: 11,
     tagInMultiLine: false,
     mouseEnter: false,
@@ -648,7 +647,7 @@ export const useSelect = (props, states: States, ctx) => {
     ctx.emit('clear')
   }
 
-  const handleOptionSelect = (option, byClick) => {
+  const handleOptionSelect = (option) => {
     if (props.multiple) {
       const value = (props.modelValue || []).slice()
       const optionIndex = getValueIndex(value, option.value)
@@ -673,7 +672,6 @@ export const useSelect = (props, states: States, ctx) => {
       emitChange(option.value)
       states.visible = false
     }
-    states.isSilentBlur = byClick
     setSoftFocus()
     if (states.visible) return
     nextTick(() => {
@@ -800,13 +798,12 @@ export const useSelect = (props, states: States, ctx) => {
 
   const handleBlur = (event: FocusEvent) => {
     // https://github.com/ElemeFE/element/pull/10822
-    setTimeout(() => {
-      if (states.isSilentBlur) {
-        states.isSilentBlur = false
-      } else {
-        ctx.emit('blur', event)
-      }
-    }, 200)
+    if (
+      event.relatedTarget !==
+      tooltipRef.value.contentRef.contentRef.popperContentRef
+    ) {
+      ctx.emit('blur', event)
+    }
     states.softFocus = false
   }
 
@@ -849,7 +846,7 @@ export const useSelect = (props, states: States, ctx) => {
       toggleMenu()
     } else {
       if (optionsArray.value[states.hoverIndex]) {
-        handleOptionSelect(optionsArray.value[states.hoverIndex], undefined)
+        handleOptionSelect(optionsArray.value[states.hoverIndex])
       }
     }
   }

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -800,13 +800,13 @@ export const useSelect = (props, states: States, ctx) => {
 
   const handleBlur = (event: FocusEvent) => {
     // https://github.com/ElemeFE/element/pull/10822
-    nextTick(() => {
+    setTimeout(() => {
       if (states.isSilentBlur) {
         states.isSilentBlur = false
       } else {
         ctx.emit('blur', event)
       }
-    })
+    }, 200)
     states.softFocus = false
   }
 
@@ -956,6 +956,7 @@ export const useSelect = (props, states: States, ctx) => {
     groupQueryChange,
     showTagList,
     collapseTagList,
+    setSoftFocus,
 
     // DOM ref
     reference,


### PR DESCRIPTION
 Select组件的blur事件存在两个问题：
1.选择Option时会意外触发blur事件，并在真实失去焦点时，不会再次触发blur。
2.点击下拉弹出框的边缘空白位置，会发送blur事件，此时该组件应该处在focus状态。

原有的逻辑通过点击option的click事件来判断是否发出blur事件，但blur事件发生在option的click事件之前，无法拦截
修改为通过判断focus事件的relatedTarget是否为弹出窗来决定是否要发出blur事件

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
