### PR TITLE
feat(components): [dropdown] add dropdown item group component

### DIFF
--- a/docs/en-US/component/dropdown.md
+++ b/docs/en-US/component/dropdown.md
@@ -145,3 +145,16 @@ dropdown/sizes
 | Name | Description                |
 | ---- | -------------------------- |
 | —    | customize of Dropdown Item |
+
+## Dropdown-Item-Group Attributes
+
+| Name     | Description                                                 | Type                  | Accepted Values | Default |
+| -------- | ----------------------------------------------------------- | --------------------- | --------------- | ------- |
+| title    | group title                                                 | string                | —               | —       |
+
+## Dropdown-Item-Group Slots
+
+| Name  | Description                |
+| ----- | -------------------------- |
+| —     | customize of Dropdown Item |
+| title | customize group title      |

--- a/packages/components/dropdown-item-group/style/css.ts
+++ b/packages/components/dropdown-item-group/style/css.ts
@@ -1,0 +1,2 @@
+import '@element-plus/components/base/style/css'
+import '@element-plus/theme-chalk/el-dropdown-item-group.css'

--- a/packages/components/dropdown-item-group/style/index.ts
+++ b/packages/components/dropdown-item-group/style/index.ts
@@ -1,0 +1,2 @@
+import '@element-plus/components/base/style'
+import '@element-plus/theme-chalk/src/dropdown-item-group.scss'

--- a/packages/components/dropdown/__tests__/dropdown.test.ts
+++ b/packages/components/dropdown/__tests__/dropdown.test.ts
@@ -10,6 +10,7 @@ import { usePopperContainerId } from '@element-plus/hooks'
 import Dropdown from '../src/dropdown.vue'
 import DropdownItem from '../src/dropdown-item.vue'
 import DropdownMenu from '../src/dropdown-menu.vue'
+import DropdownItemGroup from '../src/dropdown-item-group.vue'
 
 const MOUSE_ENTER_EVENT = 'mouseenter'
 const MOUSE_LEAVE_EVENT = 'mouseleave'
@@ -22,6 +23,7 @@ const _mount = (template: string, data, otherObj?) =>
       [Dropdown.name]: Dropdown,
       [DropdownItem.name]: DropdownItem,
       [DropdownMenu.name]: DropdownMenu,
+      [DropdownItemGroup.name]: DropdownItemGroup,
     },
     template,
     data,
@@ -759,6 +761,28 @@ describe('Dropdown', () => {
       const menuItem = menu.find('.el-dropdown-menu__item')
       expect(menu.attributes()['role']).toBe('group')
       expect(menuItem.attributes()['role']).toBe('button')
+    })
+
+    test('Menu items group', async () => {
+      const wrapper = _mount(
+        `
+        <el-dropdown>
+          <template #dropdown>
+            <el-dropdown-menu ref="menu">
+              <el-dropdown-item-group ref="menu-group" title="Group Title">
+                <el-dropdown-item ref="menu-item">Item</el-dropdown-item>
+              </el-dropdown-item-group>
+            </el-dropdown-menu>
+          </template>
+        </el-dropdown>
+        `,
+        () => ({})
+      )
+      const group = wrapper.findComponent({ ref: 'menu-group' })
+      expect(
+        group.vm.$el.querySelector('.el-dropdown-menu__item-group--title')
+          .innerHTML
+      ).toEqual('Group Title')
     })
   })
 

--- a/packages/components/dropdown/index.ts
+++ b/packages/components/dropdown/index.ts
@@ -2,6 +2,7 @@ import { withInstall, withNoopInstall } from '@element-plus/utils'
 
 import Dropdown from './src/dropdown.vue'
 import DropdownItem from './src/dropdown-item.vue'
+import DropdownItemGroup from './src/dropdown-item-group.vue'
 import DropdownMenu from './src/dropdown-menu.vue'
 
 export const ElDropdown = withInstall(Dropdown, {
@@ -10,6 +11,7 @@ export const ElDropdown = withInstall(Dropdown, {
 })
 export default ElDropdown
 export const ElDropdownItem = withNoopInstall(DropdownItem)
+export const ElDropdownItemGroup = withNoopInstall(DropdownItemGroup)
 export const ElDropdownMenu = withNoopInstall(DropdownMenu)
 export * from './src/dropdown'
 export * from './src/instance'

--- a/packages/components/dropdown/src/dropdown-item-group.vue
+++ b/packages/components/dropdown/src/dropdown-item-group.vue
@@ -1,0 +1,33 @@
+<template>
+  <li :class="ns.be('menu', 'item-group')">
+    <div :class="ns.bem('menu', 'item-group', 'title')">
+      <template v-if="!$slots.title">{{ title }}</template>
+      <slot v-else name="title" />
+    </div>
+    <ul>
+      <slot />
+    </ul>
+  </li>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { useNamespace } from '@element-plus/hooks'
+import { dropdownItemGroupProps } from './dropdown'
+
+const COMPONENT_NAME = 'ElDropdownItemGroup'
+
+export default defineComponent({
+  name: COMPONENT_NAME,
+
+  props: dropdownItemGroupProps,
+
+  setup() {
+    const ns = useNamespace('dropdown')
+
+    return {
+      ns,
+    }
+  },
+})
+</script>

--- a/packages/components/dropdown/src/dropdown.ts
+++ b/packages/components/dropdown/src/dropdown.ts
@@ -103,6 +103,10 @@ export const dropdownItemProps = buildProps({
   },
 } as const)
 
+export const dropdownItemGroupProps = buildProps({
+  title: String,
+} as const)
+
 export const dropdownMenuProps = buildProps({
   onKeydown: { type: definePropType<(e: KeyboardEvent) => void>(Function) },
 })

--- a/packages/theme-chalk/src/dropdown.scss
+++ b/packages/theme-chalk/src/dropdown.scss
@@ -179,6 +179,7 @@ $dropdown-menu-padding-vertical: map.merge(
     }
 
     @include m(divided) {
+      height: 0;
       margin: map.get($dropdown-item-divided-margin, 'default');
       border-top: 1px solid getCssVar('border-color-lighter');
     }
@@ -186,6 +187,19 @@ $dropdown-menu-padding-vertical: map.merge(
     @include when(disabled) {
       cursor: not-allowed;
       color: getCssVar('text-color-disabled');
+    }
+  }
+
+  @include e(item-group) {
+    > ul {
+      padding: 0;
+    }
+
+    @include m(title) {
+      padding: map.get($dropdown-item-padding, 'default');
+      line-height: map.get($dropdown-item-line-height, 'default');
+      font-size: getCssVar('font-size', 'base');
+      color: getCssVar('text-color', 'secondary');
     }
   }
 

--- a/packages/theme-chalk/src/index.scss
+++ b/packages/theme-chalk/src/index.scss
@@ -33,6 +33,7 @@
 @use './dialog.scss';
 @use './divider.scss';
 @use './drawer.scss';
+@use './dropdown-item-group.scss';
 @use './dropdown-item.scss';
 @use './dropdown-menu.scss';
 @use './dropdown.scss';


### PR DESCRIPTION
Just as menu component has menu item group, our drop-down component probably needs group?

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
