### PR TITLE
feat(components): [select] add tag type property for option

### DIFF
--- a/docs/en-US/component/select.md
+++ b/docs/en-US/component/select.md
@@ -198,11 +198,12 @@ If the binding value of Select is an object, make sure to assign `value-key` as 
 
 ## Option Attributes
 
-| Name     | Description                                 | Type                               | Accepted Values | Default |
-| -------- | ------------------------------------------- | ---------------------------------- | --------------- | ------- |
-| value    | value of option                             | string / number / boolean / object | —               | —       |
-| label    | label of option, same as `value` if omitted | string/number                      | —               | —       |
-| disabled | whether option is disabled                  | boolean                            | —               | false   |
+| Name     | Description                                 | Type                                                                       | Accepted Values | Default |
+| -------- | ------------------------------------------- | -------------------------------------------------------------------------- | --------------- | ------- |
+| value    | value of option                             | string / number / boolean / object                                         | —               | —       |
+| label    | label of option, same as `value` if omitted | string/number                                                              | —               | —       |
+| disabled | whether option is disabled                  | boolean                                                                    | —               | false   |
+| tag-type | tag type                                    | ^[enum]`'success'\|'info'\|'warning'\|'danger'`                            | —               | —       |
 
 ## Option Slots
 

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -2169,4 +2169,52 @@ describe('Select', () => {
       expect(findInnerInput().value).toBe('z')
     })
   })
+
+  test('set type for option', async () => {
+    wrapper = _mount(
+      `
+      <el-select v-model="value" multiple>
+        <el-option
+          v-for="item in options"
+          :label="item.label"
+          :key="item.value"
+          :value="item.value"
+          :tag-type="item.type">
+        </el-option>
+      </el-select>
+    `,
+      () => ({
+        options: [
+          {
+            value: '选项1',
+            label: '黄金糕',
+            type: 'success',
+          },
+          {
+            value: '选项2',
+            label: '双皮奶',
+            type: 'info',
+          },
+          {
+            value: '选项3',
+            label: '蚵仔煎',
+            type: 'warning',
+          },
+          {
+            value: '选项4',
+            label: '龙须面',
+            type: 'danger',
+          },
+        ],
+        value: ['选项1', '选项2', '选项3', '选项4'],
+      })
+    )
+    await nextTick()
+
+    const tags = wrapper.findAll('.el-tag')
+    expect(tags[0].classes()).toContain('el-tag--success')
+    expect(tags[1].classes()).toContain('el-tag--info')
+    expect(tags[2].classes()).toContain('el-tag--warning')
+    expect(tags[3].classes()).toContain('el-tag--danger')
+  })
 })

--- a/packages/components/select/src/option.vue
+++ b/packages/components/select/src/option.vue
@@ -29,6 +29,7 @@ import {
   toRefs,
 } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
+import { tagProps } from '@element-plus/components/tag'
 import { useOption } from './useOption'
 import type { SelectOptionProxy } from './token'
 
@@ -47,6 +48,8 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    // eslint-disable-next-line vue/require-prop-types
+    tagType: { ...tagProps.type, default: null },
   },
 
   setup(props) {

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -55,7 +55,7 @@
                   :closable="!selectDisabled && !item.isDisabled"
                   :size="collapseTagSize"
                   :hit="item.hitState"
-                  :type="tagType"
+                  :type="item.tagType || tagType"
                   disable-transitions
                   @close="deleteTag($event, item)"
                 >
@@ -95,7 +95,7 @@
                             :closable="!selectDisabled && !item.isDisabled"
                             :size="collapseTagSize"
                             :hit="item.hitState"
-                            :type="tagType"
+                            :type="item.tagType || tagType"
                             disable-transitions
                             :style="{ margin: '2px' }"
                             @close="deleteTag($event, item)"
@@ -131,7 +131,7 @@
                   :closable="!selectDisabled && !item.isDisabled"
                   :size="collapseTagSize"
                   :hit="item.hitState"
-                  :type="tagType"
+                  :type="item.tagType || tagType"
                   disable-transitions
                   @close="deleteTag($event, item)"
                 >

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -532,6 +532,7 @@ export const useSelect = (props, states: States, ctx) => {
           value,
           currentLabel: cachedOption.currentLabel,
           isDisabled: cachedOption.isDisabled,
+          tagType: cachedOption.tagType,
         }
         break
       }


### PR DESCRIPTION
Just as select can set tag-type, I think should select option also support setting tag-type.

My changes include:

add tag type property for option

add test to tag type for option

add doc to tag type for option

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
