### PR TITLE
progress进度条组件，width属性应为string / number

### DIFF
--- a/packages/components/progress/src/progress.ts
+++ b/packages/components/progress/src/progress.ts
@@ -69,7 +69,7 @@ export const progressProps = buildProps({
    * @description the canvas width of circle progress bar
    */
   width: {
-    type: Number,
+    type: Number | String,
     default: 126,
   },
   /**


### PR DESCRIPTION
width属性应为string / number，否则如下情况会出现报错：
```
   <template #default="scope">
                    <el-progress type="circle" :percentage="scope.row.progress"
                                 width="50"/>
   </template>
```
报错：
error TS2322: Type 'string' is not assignable to type 'number | undefined'. 经过测试，strokeWidth属性应该进行同样修改

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
