### PR TITLE
fix(components): [tooltip] Delete v-if for el-popper-content

### DIFF
--- a/packages/components/tooltip/src/content.vue
+++ b/packages/components/tooltip/src/content.vue
@@ -8,7 +8,6 @@
       @before-leave="onBeforeLeave"
     >
       <el-popper-content
-        v-if="shouldRender"
         v-show="shouldShow"
         :id="id"
         ref="contentRef"
@@ -63,7 +62,7 @@ const props = defineProps(useTooltipContentProps)
 const { selector } = usePopperContainerId()
 const ns = useNamespace('tooltip')
 // TODO any is temporary, replace with `InstanceType<typeof ElPopperContent> | null` later
-const contentRef = ref<any>(null)
+const contentRef = ref<InstanceType<typeof ElPopperContent> | null>(null)
 const destroyed = ref(false)
 const {
   controlled,


### PR DESCRIPTION
在tooltip组件中的el-popper-content在同一组件使用了v-show v-if 切判断条件一样 导致组件重复渲染 before-enter方法调用两次

closed #12724

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
