### PR TITLE
test: [notification] add zIndex test case

### DIFF
--- a/packages/components/notification/__tests__/notification.test.tsx
+++ b/packages/components/notification/__tests__/notification.test.tsx
@@ -81,12 +81,17 @@ describe('Notification.vue', () => {
     })
 
     test('should be able to render z-index style with zIndex flag', async () => {
-      const wrapper = _mount({})
+      const wrapper = _mount({
+        props: {
+          zIndex: 9999,
+        },
+      })
       await nextTick()
 
       expect(wrapper.vm.positionStyle).toEqual(
         expect.objectContaining({
           top: '0px',
+          zIndex: 9999,
         })
       )
     })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description
Supplement #12474
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77bb88a</samp>

Added a test for the `zIndex` flag of the notification component. Checked that the flag works as expected and affects the z-index style of the notification wrapper.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77bb88a</samp>

* Add a `zIndex` flag to the notification component to allow customizing the z-index of the notification popups (F0
