### PR TITLE
feat(components): [tabs] add addIcon slot

### DIFF
--- a/docs/en-US/component/tabs.md
+++ b/docs/en-US/component/tabs.md
@@ -67,6 +67,14 @@ tabs/dynamic-tabs
 
 :::
 
+## Customized add button icon
+
+:::demo
+
+tabs/customized-add-button-icon
+
+:::
+
 ## Customized trigger button of new tab
 
 :::demo

--- a/docs/en-US/component/tabs.md
+++ b/docs/en-US/component/tabs.md
@@ -100,9 +100,10 @@ tabs/customized-trigger
 
 ## Tabs Slots
 
-| Name | Description               | Subtags  |
-| ---- | ------------------------- | -------- |
-| -    | customize default content | Tab-pane |
+| Name    | Description               | Subtags  |
+| ------- | ------------------------- | -------- |
+| -       | customize default content | Tab-pane |
+| addIcon | customize add button icon | -        |
 
 ## Tab-pane Attributes
 

--- a/docs/en-US/component/tabs.md
+++ b/docs/en-US/component/tabs.md
@@ -67,7 +67,7 @@ tabs/dynamic-tabs
 
 :::
 
-## Customized add button icon
+## Customized add button icon ^(2.3.15)
 
 :::demo
 
@@ -108,10 +108,10 @@ tabs/customized-trigger
 
 ## Tabs Slots
 
-| Name    | Description               | Subtags  |
-| ------- | ------------------------- | -------- |
-| -       | customize default content | Tab-pane |
-| addIcon | customize add button icon | -        |
+| Name              | Description               | Subtags  |
+| ----------------- | ------------------------- | -------- |
+| -                 | customize default content | Tab-pane |
+| addIcon ^(2.3.15) | customize add button icon | -        |
 
 ## Tab-pane Attributes
 

--- a/docs/examples/tabs/customized-add-button-icon.vue
+++ b/docs/examples/tabs/customized-add-button-icon.vue
@@ -1,0 +1,81 @@
+addIcon
+<template>
+  <el-tabs
+    v-model="editableTabsValue"
+    type="card"
+    class="demo-tabs"
+    editable
+    @edit="handleTabsEdit"
+  >
+    <template #addIcon>
+      <el-icon><Select /></el-icon>
+    </template>
+    <el-tab-pane
+      v-for="item in editableTabs"
+      :key="item.name"
+      :label="item.title"
+      :name="item.name"
+    >
+      {{ item.content }}
+    </el-tab-pane>
+  </el-tabs>
+</template>
+<script lang="ts" setup>
+import { ref } from 'vue'
+import { Select } from '@element-plus/icons-vue'
+import type { TabPaneName } from 'element-plus'
+
+let tabIndex = 2
+const editableTabsValue = ref('2')
+const editableTabs = ref([
+  {
+    title: 'Tab 1',
+    name: '1',
+    content: 'Tab 1 content',
+  },
+  {
+    title: 'Tab 2',
+    name: '2',
+    content: 'Tab 2 content',
+  },
+])
+
+const handleTabsEdit = (
+  targetName: TabPaneName | undefined,
+  action: 'remove' | 'add'
+) => {
+  if (action === 'add') {
+    const newTabName = `${++tabIndex}`
+    editableTabs.value.push({
+      title: 'New Tab',
+      name: newTabName,
+      content: 'New Tab content',
+    })
+    editableTabsValue.value = newTabName
+  } else if (action === 'remove') {
+    const tabs = editableTabs.value
+    let activeName = editableTabsValue.value
+    if (activeName === targetName) {
+      tabs.forEach((tab, index) => {
+        if (tab.name === targetName) {
+          const nextTab = tabs[index + 1] || tabs[index - 1]
+          if (nextTab) {
+            activeName = nextTab.name
+          }
+        }
+      })
+    }
+
+    editableTabsValue.value = activeName
+    editableTabs.value = tabs.filter((tab) => tab.name !== targetName)
+  }
+}
+</script>
+<style>
+.demo-tabs > .el-tabs__content {
+  padding: 32px;
+  color: #6b778c;
+  font-size: 32px;
+  font-weight: 600;
+}
+</style>

--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -186,6 +186,7 @@ export default defineComponent({
     })
 
     return () => {
+      const addSlot = slots.addIcon
       const newButton =
         props.editable || props.addable ? (
           <span
@@ -196,9 +197,13 @@ export default defineComponent({
               if (ev.code === EVENT_CODE.enter) handleTabAdd()
             }}
           >
-            <ElIcon class={ns.is('icon-plus')}>
-              <Plus />
-            </ElIcon>
+            {addSlot ? (
+              renderSlot(slots, 'addIcon')
+            ) : (
+              <ElIcon class={ns.is('icon-plus')}>
+                <Plus />
+              </ElIcon>
+            )}
           </span>
         ) : null
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f6cca1c</samp>

Added a new `addIcon` slot to the Tabs component and updated the documentation accordingly. This slot enables users to customize the appearance of the add button for editable tabs.

## Related Issue

feat #11795 .

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f6cca1c</samp>

* Add a new slot `addIcon` to the Tabs component to allow customizing the icon of the add button for editable tabs ([link](https://github.com/element-plus/element-plus/pull/12970/files?diff=unified&w=0#diff-7ab8b00681ca241d9708f4540d16c56af5e98b40b57b6c38acaba203fddfd115L103-R106), [link](https://github.com/element-plus/element-plus/pull/12970/files?diff=unified&w=0#diff-50e3b1682badc3cce7c21a7fe3eca91302c86aefaf2592c1d743cd249a5333e5R189), [link](https://github.com/element-plus/element-plus/pull/12970/files?diff=unified&w=0#diff-50e3b1682badc3cce7c21a7fe3eca91302c86aefaf2592c1d743cd249a5333e5L199-R206))
* Render the `addIcon` slot in the `tabs.tsx` file if it is provided, or fall back to the default plus icon ([link](https://github.com/element-plus/element-plus/pull/12970/files?diff=unified&w=0#diff-50e3b1682badc3cce7c21a7fe3eca91302c86aefaf2592c1d743cd249a5333e5L199-R206))
