### PR TITLE
chore: format docs

### DIFF
--- a/docs/en-US/component/result.md
+++ b/docs/en-US/component/result.md
@@ -27,11 +27,11 @@ result/customized-content
 
 ### Attributes
 
-| Name      | Description         | Type                                                 | Default  |
-| --------- | ------------------- | ---------------------------------------------------- | -------- |
-| title     | title of result     | ^[string]                                            | ''       |
-| sub-title | sub title of result | ^[string]                                            | ''       |
-| icon      | icon type of result | ^[enum]`'success' \| 'warning' \| 'info' \| 'error'` | info     |
+| Name      | Description         | Type                                                 | Default |
+| --------- | ------------------- | ---------------------------------------------------- | ------- |
+| title     | title of result     | ^[string]                                            | ''      |
+| sub-title | sub title of result | ^[string]                                            | ''      |
+| icon      | icon type of result | ^[enum]`'success' \| 'warning' \| 'info' \| 'error'` | info    |
 
 ### Slots
 

--- a/docs/en-US/component/tag.md
+++ b/docs/en-US/component/tag.md
@@ -101,7 +101,6 @@ tag/checkable
 | ---- | ------------------------- |
 | —    | customize default content |
 
-
 ## CheckTag API
 
 ### CheckTag Attributes


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5abe620</samp>

This pull request fixes some minor formatting issues in the documentation of the `result` and `tag` components. It removes extra spaces and empty code blocks from the markdown files `result.md` and `tag.md`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5abe620</samp>

* Remove extra space in attributes table of result component ([link](https://github.com/element-plus/element-plus/pull/12973/files?diff=unified&w=0#diff-7a02978c36bbd4ed6785576960a0bf5d9ddca6d2fae701282ee20931aff5dc4bL30-R34))
* Delete empty code block in tag slots section of tag component ([link](https://github.com/element-plus/element-plus/pull/12973/files?diff=unified&w=0#diff-89679eded6231fc7528daf16d2982a97f63274a1e07af7841702a27d488207a8L104))
