### PR TITLE
fix(components): [Component] [popover] fix #12933 popover bug

### DIFF
--- a/packages/components/popover/src/popover.vue
+++ b/packages/components/popover/src/popover.vue
@@ -103,7 +103,6 @@ const afterEnter = () => {
 }
 
 const afterLeave = () => {
-  emit('update:visible', false)
   emit('after-leave')
 }
 


### PR DESCRIPTION
stop emit update:visible in after-leave hook which will cause the transition to be abnormal

BREAKING CHANGE :
no

closed #12933

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c72034e</samp>

Fixed a popover closing bug by removing an unnecessary event emission in `popover.vue`. Simplified the logic of the `visible` prop and its `v-model` binding.

## Related Issue

Fixes #12933 .

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c72034e</samp>

* Remove redundant `update:visible` event emission ([link](https://github.com/element-plus/element-plus/pull/12994/files?diff=unified&w=0#diff-3268ce9cbab861dd883450db7a2e88bcf62f72d964df3bc11e93302991a1d6d0L106)) to fix popover closing bug
