### PR TITLE
fix(components): [date-picker] set weekStart error

### DIFF
--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1035,7 +1035,7 @@ describe('DatePicker keyboard events', () => {
 })
 
 describe('DatePicker date weekStart', () => {
-  vi.setSystemTime(new Date(2023, 5, 1))
+  vi.setSystemTime(new Date(2023, 5, 31))
   it('create', async () => {
     dayjs.en.weekStart = 2
     const wrapper = _mount(

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1064,6 +1064,7 @@ describe('DatePicker date weekStart', () => {
     await nextTick()
     expect(vm.value.getDate()).toBe(31)
   })
+  vi.setSystemTime(new Date())
 })
 
 describe('DateRangePicker', () => {

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1036,9 +1036,6 @@ describe('DatePicker keyboard events', () => {
 
 describe('DatePicker date weekStart', () => {
   it('create', async () => {
-    const date = new Date(2023, 4, 31)
-    vi.useFakeTimers()
-    vi.setSystemTime(date)
     dayjs.en.weekStart = 2
     const wrapper = _mount(
       `<el-date-picker
@@ -1065,15 +1062,11 @@ describe('DatePicker date weekStart', () => {
     today.click()
     await nextTick()
     const curDate = new Date()
-    console.log('before', curDate, curDate.getDate())
-    expect(vm.value.getDate()).toBe(31)
-    vi.useRealTimers()
+    expect(vm.value.getDate()).toBe(curDate.getDate())
   })
 })
 
 describe('DateRangePicker', () => {
-  const curDate = new Date()
-  console.log('after', curDate, curDate.getDate())
   it('create & custom class & style', async () => {
     let calendarChangeValue = null
     const changeHandler = vi.fn()

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1036,12 +1036,15 @@ describe('DatePicker keyboard events', () => {
 
 describe('DatePicker date weekStart', () => {
   it('create', async () => {
+    const date = new Date(2023, 4, 31)
+    vi.useFakeTimers()
+    vi.setSystemTime(date)
     dayjs.en.weekStart = 2
     const wrapper = _mount(
       `<el-date-picker
     v-model="value"
   />`,
-      () => ({ value: new Date(2023, 4, 31) })
+      () => ({ value: new Date(2023, 4, 1) })
     )
     const input = wrapper.find('input')
     input.trigger('blur')
@@ -1062,6 +1065,7 @@ describe('DatePicker date weekStart', () => {
     today.click()
     await nextTick()
     expect(vm.value.getDate()).toBe(31)
+    vi.useRealTimers()
   })
 })
 

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1035,14 +1035,14 @@ describe('DatePicker keyboard events', () => {
 })
 
 describe('DatePicker date weekStart', () => {
-  vi.setSystemTime(new Date(2023, 5, 31))
+  vi.setSystemTime(new Date(2023, 4, 31))
   it('create', async () => {
     dayjs.en.weekStart = 2
     const wrapper = _mount(
       `<el-date-picker
     v-model="value"
   />`,
-      () => ({ value: new Date(2023, 5, 1) })
+      () => ({ value: new Date(2023, 4, 1) })
     )
     const input = wrapper.find('input')
     input.trigger('blur')

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1064,12 +1064,16 @@ describe('DatePicker date weekStart', () => {
     ) as HTMLElement
     today.click()
     await nextTick()
+    const curDate = new Date()
+    console.log('before', curDate, curDate.getDate())
     expect(vm.value.getDate()).toBe(31)
     vi.useRealTimers()
   })
 })
 
 describe('DateRangePicker', () => {
+  const curDate = new Date()
+  console.log('after', curDate, curDate.getDate())
   it('create & custom class & style', async () => {
     let calendarChangeValue = null
     const changeHandler = vi.fn()

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1034,39 +1034,6 @@ describe('DatePicker keyboard events', () => {
   })
 })
 
-describe('DatePicker date weekStart', () => {
-  vi.setSystemTime(new Date(2023, 4, 31))
-  it('create', async () => {
-    dayjs.en.weekStart = 2
-    const wrapper = _mount(
-      `<el-date-picker
-    v-model="value"
-  />`,
-      () => ({ value: new Date(2023, 4, 1) })
-    )
-    const input = wrapper.find('input')
-    input.trigger('blur')
-    input.trigger('focus')
-    await nextTick()
-    const td = document.querySelectorAll(
-      '.el-date-table__row .available'
-    ) as NodeListOf<HTMLElement>
-    const vm = wrapper.vm as any
-    // Check offset check calculation
-    td[2].click()
-    await nextTick()
-    expect(vm.value.getDate()).toBe(3)
-    // Check to see if today's flag is ok
-    const today = document.querySelector(
-      '.el-date-table__row .available.today'
-    ) as HTMLElement
-    today.click()
-    await nextTick()
-    expect(vm.value.getDate()).toBe(31)
-  })
-  vi.setSystemTime(new Date())
-})
-
 describe('DateRangePicker', () => {
   it('create & custom class & style', async () => {
     let calendarChangeValue = null
@@ -1592,5 +1559,37 @@ describe('MonthRange', () => {
     ;(document.querySelector('td.available') as HTMLElement).click()
     await nextTick()
     expect(pickHandler).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('DatePicker date weekStart', () => {
+  vi.setSystemTime(new Date(2023, 4, 31))
+  it('create', async () => {
+    dayjs.en.weekStart = 2
+    const wrapper = _mount(
+      `<el-date-picker
+    v-model="value"
+  />`,
+      () => ({ value: new Date(2023, 4, 1) })
+    )
+    const input = wrapper.find('input')
+    input.trigger('blur')
+    input.trigger('focus')
+    await nextTick()
+    const td = document.querySelectorAll(
+      '.el-date-table__row .available'
+    ) as NodeListOf<HTMLElement>
+    const vm = wrapper.vm as any
+    // Check offset check calculation
+    td[2].click()
+    await nextTick()
+    expect(vm.value.getDate()).toBe(3)
+    // Check to see if today's flag is ok
+    const today = document.querySelector(
+      '.el-date-table__row .available.today'
+    ) as HTMLElement
+    today.click()
+    await nextTick()
+    expect(vm.value.getDate()).toBe(31)
   })
 })

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1034,6 +1034,37 @@ describe('DatePicker keyboard events', () => {
   })
 })
 
+describe('DatePicker date weekStart', () => {
+  it('create', async () => {
+    dayjs.en.weekStart = 2
+    const wrapper = _mount(
+      `<el-date-picker
+    v-model="value"
+  />`,
+      () => ({ value: new Date(2023, 4, 31) })
+    )
+    const input = wrapper.find('input')
+    input.trigger('blur')
+    input.trigger('focus')
+    await nextTick()
+    const td = document.querySelectorAll(
+      '.el-date-table__row .available'
+    ) as NodeListOf<HTMLElement>
+    const vm = wrapper.vm as any
+    // Check offset check calculation
+    td[2].click()
+    await nextTick()
+    expect(vm.value.getDate()).toBe(3)
+    // Check to see if today's flag is ok
+    const today = document.querySelector(
+      '.el-date-table__row .available.today'
+    ) as HTMLElement
+    today.click()
+    await nextTick()
+    expect(vm.value.getDate()).toBe(31)
+  })
+})
+
 describe('DateRangePicker', () => {
   it('create & custom class & style', async () => {
     let calendarChangeValue = null
@@ -1559,37 +1590,5 @@ describe('MonthRange', () => {
     ;(document.querySelector('td.available') as HTMLElement).click()
     await nextTick()
     expect(pickHandler).toHaveBeenCalledTimes(1)
-  })
-})
-
-describe('DatePicker date weekStart', () => {
-  vi.setSystemTime(new Date(2023, 4, 31))
-  it('create', async () => {
-    dayjs.en.weekStart = 2
-    const wrapper = _mount(
-      `<el-date-picker
-    v-model="value"
-  />`,
-      () => ({ value: new Date(2023, 4, 1) })
-    )
-    const input = wrapper.find('input')
-    input.trigger('blur')
-    input.trigger('focus')
-    await nextTick()
-    const td = document.querySelectorAll(
-      '.el-date-table__row .available'
-    ) as NodeListOf<HTMLElement>
-    const vm = wrapper.vm as any
-    // Check offset check calculation
-    td[2].click()
-    await nextTick()
-    expect(vm.value.getDate()).toBe(3)
-    // Check to see if today's flag is ok
-    const today = document.querySelector(
-      '.el-date-table__row .available.today'
-    ) as HTMLElement
-    today.click()
-    await nextTick()
-    expect(vm.value.getDate()).toBe(31)
   })
 })

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1034,6 +1034,38 @@ describe('DatePicker keyboard events', () => {
   })
 })
 
+describe('DatePicker date weekStart', () => {
+  vi.setSystemTime(new Date(2023, 5, 1))
+  it('create', async () => {
+    dayjs.en.weekStart = 2
+    const wrapper = _mount(
+      `<el-date-picker
+    v-model="value"
+  />`,
+      () => ({ value: new Date(2023, 5, 1) })
+    )
+    const input = wrapper.find('input')
+    input.trigger('blur')
+    input.trigger('focus')
+    await nextTick()
+    const td = document.querySelectorAll(
+      '.el-date-table__row .available'
+    ) as NodeListOf<HTMLElement>
+    const vm = wrapper.vm as any
+    // Check offset check calculation
+    td[2].click()
+    await nextTick()
+    expect(vm.value.getDate()).toBe(3)
+    // Check to see if today's flag is ok
+    const today = document.querySelector(
+      '.el-date-table__row .available.today'
+    ) as HTMLElement
+    today.click()
+    await nextTick()
+    expect(vm.value.getDate()).toBe(31)
+  })
+})
+
 describe('DateRangePicker', () => {
   it('create & custom class & style', async () => {
     let calendarChangeValue = null

--- a/packages/components/date-picker/src/date-picker-com/basic-date-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-date-table.vue
@@ -83,7 +83,8 @@ const WEEKS_CONSTANT = props.date
 
 const offsetDay = computed(() => {
   // Sunday 7(0), cal the left and right offset days, 3217654, such as Monday is -1, the is to adjust the position of the first two rows of dates
-  return firstDayOfWeek > 3 ? 7 - firstDayOfWeek : -firstDayOfWeek
+  const offset = firstDayOfWeek > 3 ? 7 - firstDayOfWeek : -firstDayOfWeek
+  return offset < 0 ? 7 + offset : offset
 })
 
 const startDate = computed(() => {
@@ -236,7 +237,7 @@ const rows = computed(() => {
     now: dayjs().locale(unref(lang)).startOf(dateUnit),
     unit: dateUnit,
     relativeDateGetter: (idx: number) =>
-      startDate.value.add(idx - offset, dateUnit),
+      startDate.value.add(idx - (offset < 0 ? 7 + offset : offset), dateUnit),
     setCellMetadata: (...args) => {
       if (setCellMetadata(...args, count)) {
         count += 1

--- a/packages/components/date-picker/src/date-picker-com/basic-date-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-date-table.vue
@@ -237,7 +237,7 @@ const rows = computed(() => {
     now: dayjs().locale(unref(lang)).startOf(dateUnit),
     unit: dateUnit,
     relativeDateGetter: (idx: number) =>
-      startDate.value.add(idx - (offset < 0 ? 7 + offset : offset), dateUnit),
+      startDate.value.add(idx - offset, dateUnit),
     setCellMetadata: (...args) => {
       if (setCellMetadata(...args, count)) {
         count += 1


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- fixed click value error
- fixed today error

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e3548b</samp>

Fix and test `DatePicker` component's offset calculation for different `weekStart` values. Ensure that the component respects the `weekStart` option and the `dayjs` locale in both display and selection.

## Related Issue

Fixes #12925.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e3548b</samp>

*  Fix offset calculation for date picker component when weekStart option is set to a value greater than 3 ([link](https://github.com/element-plus/element-plus/pull/13014/files?diff=unified&w=0#diff-7c2b41b03655351f7363a7e4b199cd9d2a2c6a8e07c8ba79a77cefc04dc09740L86-R87), [link](https://github.com/element-plus/element-plus/pull/13014/files?diff=unified&w=0#diff-7c2b41b03655351f7363a7e4b199cd9d2a2c6a8e07c8ba79a77cefc04dc09740L239-R240))
*  Add test case for date picker component with different weekStart values in `date-picker.test.ts` ([link](https://github.com/element-plus/element-plus/pull/13014/files?diff=unified&w=0#diff-341b6dbc39d522f565c4cf2cca59cbdcd62f2d8a770aa838b6097219a27c05d0R1037-R1068))
