### PR TITLE
fix(components): [select] not setting bound value to undefined

### DIFF
--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -745,7 +745,7 @@ describe('Select', () => {
     const iconClear = wrapper.findComponent(CircleClose)
     expect(iconClear.exists()).toBe(true)
     await iconClear.trigger('click')
-    expect(vm.value).toBe('')
+    expect(vm.value).toBe(undefined)
   })
 
   test('suffix icon', async () => {

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -23,7 +23,6 @@ import {
   isFunction,
   isKorean,
   isNumber,
-  isString,
   scrollIntoView,
 } from '@element-plus/utils'
 import { useDeprecated, useLocale, useNamespace } from '@element-plus/hooks'
@@ -643,8 +642,8 @@ export const useSelect = (props, states: States, ctx) => {
 
   const deleteSelected = (event) => {
     event.stopPropagation()
-    const value: string | any[] = props.multiple ? [] : ''
-    if (!isString(value)) {
+    const value: undefined | any[] = props.multiple ? [] : undefined
+    if (Array.isArray(value)) {
       for (const item of states.selected) {
         if (item.isDisabled) value.push(item.value)
       }


### PR DESCRIPTION
Update the Select component to set the bound value to undefined instead of an empty string when the clearable property is true and the clear icon is clicked.

closed #13077

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a27f15</samp>

Fixed a bug in the `select` component that prevented model and event updates when deleting options. Refactored type checking logic in `useSelect.ts`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a27f15</samp>

* Fix a bug where deleting a selected option in single selection mode would not trigger the `change` event or update the model value ([link](https://github.com/element-plus/element-plus/pull/13078/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L646-R646))
* Remove the unused `isString` utility function from the imports in `useSelect.ts` ([link](https://github.com/element-plus/element-plus/pull/13078/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L26))
