### PR TITLE
fix(components): [menu] ellipsis mode show correct menu items

### DIFF
--- a/packages/components/menu/src/menu.ts
+++ b/packages/components/menu/src/menu.ts
@@ -250,7 +250,7 @@ export default defineComponent({
       items.forEach((item, index) => {
         calcWidth += item.offsetWidth || 0
         if (calcWidth <= menuWidth - moreItemWidth) {
-          sliceIndex = index + 1
+          sliceIndex = index
         }
       })
       return sliceIndex === items.length ? -1 : sliceIndex


### PR DESCRIPTION
# fix menu ellipsis mode

# when menu is ellipsis, one extra menu item was hidden

sliceIndex value is used in slice, it should be equal to the target menu index