### PR TITLE
fix(locale) : improve sr translation

### DIFF
--- a/packages/locale/lang/sr.ts
+++ b/packages/locale/lang/sr.ts
@@ -6,7 +6,7 @@ export default {
       clear: 'Поништи',
     },
     datepicker: {
-      now: 'Сад',
+      now: 'Сада',
       today: 'Данас',
       cancel: 'Откажи',
       clear: 'Бриши',
@@ -76,10 +76,10 @@ export default {
       pagesize: '/страни',
       total: 'Укупно {total}',
       pageClassifier: '',
-      page: 'Page', // to be translated
-      prev: 'Go to previous page', // to be translated
-      next: 'Go to next page', // to be translated
-      currentPage: 'page {pager}', // to be translated
+      page: 'Страна',
+      prev: 'Иди на претходну страну',
+      next: 'Иди на следећу страну',
+      currentPage: 'страна {pager}',
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
     },
@@ -109,19 +109,19 @@ export default {
       noMatch: 'Нема резултата',
       noData: 'Нема података',
       titles: ['Листа 1', 'Листа 2'], // to be translated
-      filterPlaceholder: 'Унеси кључну реч', // to be translated
-      noCheckedFormat: '{total} ставки', // to be translated
-      hasCheckedFormat: '{checked}/{total} обележених', // to be translated
+      filterPlaceholder: 'Унеси кључну реч',
+      noCheckedFormat: '{total} ставки',
+      hasCheckedFormat: '{checked}/{total} обележених',
     },
     image: {
-      error: 'FAILED', // to be translated
+      error: 'НЕУСПЕШНО',
     },
     pageHeader: {
-      title: 'Back', // to be translated
+      title: 'Назад',
     },
     popconfirm: {
-      confirmButtonText: 'Yes', // to be translated
-      cancelButtonText: 'No', // to be translated
+      confirmButtonText: 'Да',
+      cancelButtonText: 'Не',
     },
   },
 }


### PR DESCRIPTION
Apply changes to serbian language

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 059b425</samp>

This file updates the Serbian translation of some `element-plus` components. It corrects a typo, adds missing translations, and introduces new words for some UI elements.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes
Fixed and added new translation for Serbian
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 059b425</samp>

*  Fix a typo in the datepicker component for Serbian language ([link](https://github.com/element-plus/element-plus/pull/13125/files?diff=unified&w=0#diff-155f757da6f634468af3ff79d117208c90e4ba3c6ab9b20dc9e109573f827ab2L9-R9))
*  Translate pagination component to Serbian ([link](https://github.com/element-plus/element-plus/pull/13125/files?diff=unified&w=0#diff-155f757da6f634468af3ff79d117208c90e4ba3c6ab9b20dc9e109573f827ab2L79-R82))
*  Add Serbian translations for transfer, image, pageHeader, and popconfirm components ([link](https://github.com/element-plus/element-plus/pull/13125/files?diff=unified&w=0#diff-155f757da6f634468af3ff79d117208c90e4ba3c6ab9b20dc9e109573f827ab2L112-R124))
