### PR TITLE
fix(utils): add generic constraints

### DIFF
--- a/packages/utils/objects.ts
+++ b/packages/utils/objects.ts
@@ -2,8 +2,10 @@ import { get, set } from 'lodash-unified'
 import type { Entries } from 'type-fest'
 import type { Arrayable } from '.'
 
-export const keysOf = <T>(arr: T) => Object.keys(arr) as Array<keyof T>
-export const entriesOf = <T>(arr: T) => Object.entries(arr) as Entries<T>
+export const keysOf = <T extends Record<any, any>>(arr: T) =>
+  Object.keys(arr) as Array<keyof T>
+export const entriesOf = <T extends Record<any, any>>(arr: T) =>
+  Object.entries(arr) as Entries<T>
 export { hasOwn } from '@vue/shared'
 
 export const getProp = <T = any>(


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

Add generic constraints to the keyOf and entryOf functions in object.ts, otherwise the following TS error will be reported:

No overload matches this call.
  Overload 1 of 2, '(o: {}): string[]', gave the following error.
    Argument of type 'T' is not assignable to parameter of type '{}'.
  Overload 2 of 2, '(o: object): string[]', gave the following error.
    Argument of type 'T' is not assignable to parameter of type 'object'.ts(2769)
objects.ts(5, 24): This type parameter might need an `extends {}` constraint.
objects.ts(5, 24): This type parameter might need an `extends object` constraint.


No overload matches this call.
  Overload 1 of 2, '(o: { [s: string]: unknown; } | ArrayLike<unknown>): [string, unknown][]', gave the following error.
    Argument of type 'T' is not assignable to parameter of type '{ [s: string]: unknown; } | ArrayLike<unknown>'.
      Type 'T' is not assignable to type 'ArrayLike<unknown>'.
  Overload 2 of 2, '(o: {}): [string, any][]', gave the following error.
    Argument of type 'T' is not assignable to parameter of type '{}'.ts(2769)
objects.ts(6, 27): This type parameter might need an `extends ArrayLike<unknown>` constraint.
objects.ts(6, 27): This type parameter might need an `extends { [s: string]: unknown; } | ArrayLike<unknown>` constraint.
objects.ts(6, 27): This type parameter might need an `extends {}` constraint.

The generic T of the keysOf/entriesOf function needs to provide some default constraints to restrict the type of input. This is because the keysOf/entriesOf function attempts to perform an Object. keys operation on input arr, which means that T must be an object. We can solve this problem by adding an extension object constraint to T. This will limit T to only one object type.



## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c364bd</samp>

*  Update `keysOf` and `entriesOf` functions to use generic type constraint ([link](https://github.com/element-plus/element-plus/pull/13129/files?diff=unified&w=0#diff-f99d3dfb90d84a1e84e7f390efb5b16e444bec111107f781607680ca684bbb28L5-R8))
