### PR TITLE
fix(components): [sub-menu] style error in collapsed state

### DIFF
--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -122,6 +122,9 @@
         height: 100%;
         border-bottom: 2px solid transparent;
         color: getCssVar('menu-text-color');
+        padding-right: calc(
+          #{getCssVar('menu-base-level-padding')} + #{getCssVar('menu-icon-width')}
+        );
 
         &:hover {
           background-color: getCssVar('bg-color', 'overlay');
@@ -250,9 +253,6 @@
 
   @include e(title) {
     @include menu-item;
-    padding-right: calc(
-      #{getCssVar('menu-base-level-padding')} + #{getCssVar('menu-icon-width')}
-    );
 
     &:hover {
       background-color: getCssVar('menu-hover-bg-color');

--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -73,6 +73,12 @@
     }
   }
 
+  &:not(.#{$namespace}-menu--collapse) .#{$namespace}-sub-menu__title {
+    padding-right: calc(
+      #{getCssVar('menu-base-level-padding')} + #{getCssVar('menu-icon-width')}
+    );
+  }
+
   @include m(horizontal) {
     display: flex;
     flex-wrap: nowrap;
@@ -122,9 +128,6 @@
         height: 100%;
         border-bottom: 2px solid transparent;
         color: getCssVar('menu-text-color');
-        padding-right: calc(
-          #{getCssVar('menu-base-level-padding')} + #{getCssVar('menu-icon-width')}
-        );
 
         &:hover {
           background-color: getCssVar('bg-color', 'overlay');


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ead0fe3</samp>

Improve menu item styling in `theme-chalk`. Adjust `menu.scss` to account for submenu icons.

## Related Issue

Fixes #13133.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ead0fe3</samp>

* Add padding-right to menu item label with submenu icon to align with icon and prevent overlap ([link](https://github.com/element-plus/element-plus/pull/13135/files?diff=unified&w=0#diff-451ad66686a31c13be1b990962362c2ef9421c307729380fde9251ec87ea91baR125-R127))
* Remove padding-right from menu item label without submenu icon to avoid extra space ([link](https://github.com/element-plus/element-plus/pull/13135/files?diff=unified&w=0#diff-451ad66686a31c13be1b990962362c2ef9421c307729380fde9251ec87ea91baL253-L255))
