### PR TITLE
docs(components): [dialog] add tip for the deprecated property `customClass`

### DIFF
--- a/docs/en-US/component/dialog.md
+++ b/docs/en-US/component/dialog.md
@@ -137,7 +137,7 @@ When using `modal` = false, please make sure that `append-to-body` was set to **
 
 :::warning
 
-`custom-class` has been **deprecated**, and **will be** removed in ^(2.3.0), please use `class`.
+`custom-class` has been **deprecated**, and **will be** removed in ^(2.4.0), please use `class`.
 
 :::
 

--- a/packages/components/dialog/src/dialog-content.ts
+++ b/packages/components/dialog/src/dialog-content.ts
@@ -12,6 +12,9 @@ export const dialogContentProps = buildProps({
   closeIcon: {
     type: iconPropType,
   },
+  /**
+   * @deprecated will be removed in version 2.4.0, please use class
+   */
   customClass: {
     type: String,
     default: '',


### PR DESCRIPTION
Since it was originally planned to remove customClass in version 2.3.0, but this link was ignored during the release, it is now postponed until version 2.4.0 to remove it, and a deprecation description is added to this attribute.


Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b23c6a</samp>

The `custom-class` attribute of the `dialog` component is deprecated and will be removed in version 2.4.0. The documentation and the code of the component are updated to reflect this change and to suggest using the `class` attribute instead.

## Related Issue

Fixes #13092.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b23c6a</samp>

* Update the warning message in the `dialog` component documentation to reflect the removal of the `custom-class` attribute in version 2.4.0 ([link](https://github.com/element-plus/element-plus/pull/13143/files?diff=unified&w=0#diff-abbb3d078da77db6d9ad1eed9a9356891f9119733d8e8bb4fc8771e3429dc626L140-R140))
* Annotate the `dialogContentProps` function with a `@deprecated` comment to indicate that the `custom-class` prop will be removed in version 2.4.0 ([link](https://github.com/element-plus/element-plus/pull/13143/files?diff=unified&w=0#diff-b1abdb1afe933b28864280eb5eab6d5d9edc5174b3a04d819515ee9f015b3befR15-R17))
