### PR TITLE
fix(components): [table] fix clearFilter type

### DIFF
--- a/packages/components/table/src/table/utils-helper.ts
+++ b/packages/components/table/src/table/utils-helper.ts
@@ -15,7 +15,7 @@ function useUtils<T>(store: Store<T>) {
   const clearSelection = () => {
     store.clearSelection()
   }
-  const clearFilter = (columnKeys: string[]) => {
+  const clearFilter = (columnKeys?: string[]) => {
     store.clearFilter(columnKeys)
   }
   const toggleAllSelection = () => {


### PR DESCRIPTION
## Description

The ElTable docs has the following description of clearFilter, but it cannot be no-parameter on TypeScript.

> clear filters of the columns whose `columnKey` are passed in. **"If no params, clear all filters"**

<img width="677" alt="image" src="https://github.com/element-plus/element-plus/assets/6340506/db26f784-1b97-4e03-b216-e9e12eb653df">

## Explanation of Changes

Set the columnKeys parameter type to optional.
