### PR TITLE
fix(components): [table]tooltipOptions.showAfter is not effective

### DIFF
--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -364,8 +364,24 @@ export function createTablePopper(
     arrow.className = `${ns}-popper__arrow`
     return arrow
   }
+  function togglePopperShow(display: 'none' | 'block') {
+    return {
+      name: 'updateState',
+      enabled: true,
+      phase: 'beforeWrite',
+      fn: ({ state }) => {
+        state.styles.popper.display = display
+      },
+      requires: ['computeStyles'],
+    }
+  }
   function showPopper() {
-    popperInstance && popperInstance.update()
+    if (tooltipOptions.showAfter) {
+      popperInstance?.setOptions({
+        modifiers: [togglePopperShow('block')],
+      })
+    }
+    popperInstance?.update()
   }
   removePopper?.()
   removePopper = () => {
@@ -411,6 +427,9 @@ export function createTablePopper(
       },
     })
   }
+  if (tooltipOptions.showAfter) {
+    modifiers.push(togglePopperShow('none'))
+  }
   const popperOptions = tooltipOptions.popperOptions || {}
   popperInstance = createPopper(trigger, content, {
     placement: tooltipOptions.placement || 'top',
@@ -423,6 +442,7 @@ export function createTablePopper(
   trigger.addEventListener('mouseenter', onOpen)
   trigger.addEventListener('mouseleave', onClose)
   scrollContainer?.addEventListener('scroll', removePopper)
+  onOpen()
   return popperInstance
 }
 


### PR DESCRIPTION
tooltipOptions.showAfter is not effective

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 30807d4</samp>

Add a feature to delay and control table tooltips with `togglePopperShow` and `onOpen` in `util.ts`

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 30807d4</samp>

* Add a modifier to control the display of the popper element based on a `display` parameter ([link](https://github.com/element-plus/element-plus/pull/13162/files?diff=unified&w=0#diff-e6d3319a7079fd77e391d7d2d10e68f50f7bc93bb031a254ab9f8170d58e2ac4L367-R384), [link](https://github.com/element-plus/element-plus/pull/13162/files?diff=unified&w=0#diff-e6d3319a7079fd77e391d7d2d10e68f50f7bc93bb031a254ab9f8170d58e2ac4R430-R432))
* Invoke the `onOpen` callback when the popper is created ([link](https://github.com/element-plus/element-plus/pull/13162/files?diff=unified&w=0#diff-e6d3319a7079fd77e391d7d2d10e68f50f7bc93bb031a254ab9f8170d58e2ac4R445))
