### PR TITLE
fix: width of tags wrapper takes into account of width of slot prefix

### DIFF
--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -43,12 +43,7 @@
               v-if="collapseTags && selected.length"
               @after-leave="resetInputHeight"
             >
-              <span
-                :class="[
-                  nsSelect.b('tags-wrapper'),
-                  { 'has-prefix': prefixWidth && selected.length },
-                ]"
-              >
+              <span :class="[nsSelect.b('tags-wrapper')]">
                 <el-tag
                   v-for="item in showTagList"
                   :key="getValueKey(item)"
@@ -119,12 +114,7 @@
               </span>
             </transition>
             <transition v-if="!collapseTags" @after-leave="resetInputHeight">
-              <span
-                :class="[
-                  nsSelect.b('tags-wrapper'),
-                  { 'has-prefix': prefixWidth && selected.length },
-                ]"
-              >
+              <span :class="[nsSelect.b('tags-wrapper')]">
                 <el-tag
                   v-for="item in selected"
                   :key="getValueKey(item)"
@@ -548,10 +538,20 @@ export default defineComponent({
       return classList
     })
 
-    const selectTagsStyle = computed(() => ({
-      maxWidth: `${unref(inputWidth) - 32}px`,
-      width: '100%',
-    }))
+    const selectTagsStyle = computed(() => {
+      const tagsGap = 6
+      const suffixWidth = 32
+      const inputWrapperPaddingLeft = 11
+      const marginLeft = ctx.slots.prefix
+        ? unref(prefixWidth) + tagsGap
+        : inputWrapperPaddingLeft
+
+      return {
+        marginLeft: `${marginLeft}px`,
+        width: '100%',
+        maxWidth: `${unref(inputWidth) - marginLeft + tagsGap - suffixWidth}px`,
+      } as CSSProperties
+    })
 
     const tagTextStyle = computed(() => {
       const maxWidth =


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

add margin left to tags-wrapper. In general, marginLeft === inputWidth - suffixWidth - prefixWidth

## Related Issue

fix: #12386 

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7636c0d</samp>

* Remove the conditional class `has-prefix` from the `span` element that wraps the tags in the select component to fix a bug that causes the tags to overflow the input when there is a prefix slot ([link](https://github.com/element-plus/element-plus/pull/13167/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540L46-R46), [link](https://github.com/element-plus/element-plus/pull/13167/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540L122-R117)) in `select.vue`
