### PR TITLE
fix(components): [table]tooltipOptions.showAfter is not effective

### DIFF
--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -364,8 +364,24 @@ export function createTablePopper(
     arrow.className = `${ns}-popper__arrow`
     return arrow
   }
+  function togglePopperShow(display: 'none' | 'block') {
+    return {
+      name: 'updateState',
+      enabled: true,
+      phase: 'beforeWrite',
+      fn: ({ state }) => {
+        state.styles.popper.display = display
+      },
+      requires: ['computeStyles'],
+    }
+  }
   function showPopper() {
-    popperInstance && popperInstance.update()
+    if (tooltipOptions.showAfter) {
+      popperInstance?.setOptions({
+        modifiers: [togglePopperShow('block')],
+      })
+    }
+    popperInstance?.update()
   }
   removePopper?.()
   removePopper = () => {
@@ -411,6 +427,9 @@ export function createTablePopper(
       },
     })
   }
+  if (tooltipOptions.showAfter) {
+    modifiers.push(togglePopperShow('none'))
+  }
   const popperOptions = tooltipOptions.popperOptions || {}
   popperInstance = createPopper(trigger, content, {
     placement: tooltipOptions.placement || 'top',
@@ -423,6 +442,7 @@ export function createTablePopper(
   trigger.addEventListener('mouseenter', onOpen)
   trigger.addEventListener('mouseleave', onClose)
   scrollContainer?.addEventListener('scroll', removePopper)
+  onOpen()
   return popperInstance
 }
 

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -364,7 +364,7 @@ export function createTablePopper(
     arrow.className = `${ns}-popper__arrow`
     return arrow
   }
-  function togglePopperShow(display: 'none' | 'block') {
+  function togglePopperVisible(display: 'none' | 'block') {
     return {
       name: 'updateState',
       enabled: true,
@@ -378,7 +378,7 @@ export function createTablePopper(
   function showPopper() {
     if (tooltipOptions.showAfter) {
       popperInstance?.setOptions({
-        modifiers: [togglePopperShow('block')],
+        modifiers: [togglePopperVisible('block')],
       })
     }
     popperInstance?.update()
@@ -395,19 +395,17 @@ export function createTablePopper(
     } catch {}
   }
   let popperInstance: Nullable<PopperInstance> = null
-  let onOpen = showPopper
-  let onClose = removePopper
-  if (tooltipOptions.enterable) {
-    ;({ onOpen, onClose } = useDelayedToggle({
-      showAfter: tooltipOptions.showAfter,
-      hideAfter: tooltipOptions.hideAfter,
-      open: showPopper,
-      close: removePopper,
-    }))
-  }
+  const { onOpen, onClose } = useDelayedToggle({
+    showAfter: tooltipOptions.showAfter,
+    hideAfter: tooltipOptions.hideAfter,
+    open: showPopper,
+    close: removePopper,
+  })
   const content = renderContent()
-  content.onmouseenter = onOpen
-  content.onmouseleave = onClose
+  if (tooltipOptions.enterable) {
+    content.onmouseenter = onOpen
+    content.onmouseleave = onClose
+  }
   const modifiers = []
   if (tooltipOptions.offset) {
     modifiers.push({
@@ -428,7 +426,7 @@ export function createTablePopper(
     })
   }
   if (tooltipOptions.showAfter) {
-    modifiers.push(togglePopperShow('none'))
+    modifiers.push(togglePopperVisible('none'))
   }
   const popperOptions = tooltipOptions.popperOptions || {}
   popperInstance = createPopper(trigger, content, {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7380576</samp>

Add popper delay feature and refactor table util code. The `util.ts` file is updated to use a new function `togglePopperVisible` that handles the popper visibility logic with a configurable delay, and to simplify and improve the event handlers and popper positioning for the table component.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7380576</samp>

*  Add a feature to allow setting a delay before showing or hiding the popper for table cells with overflow tooltips ([link](https://github.com/element-plus/element-plus/pull/13173/files?diff=unified&w=0#diff-e6d3319a7079fd77e391d7d2d10e68f50f7bc93bb031a254ab9f8170d58e2ac4L367-R384), [link](https://github.com/element-plus/element-plus/pull/13173/files?diff=unified&w=0#diff-e6d3319a7079fd77e391d7d2d10e68f50f7bc93bb031a254ab9f8170d58e2ac4L382-R408), [link](https://github.com/element-plus/element-plus/pull/13173/files?diff=unified&w=0#diff-e6d3319a7079fd77e391d7d2d10e68f50f7bc93bb031a254ab9f8170d58e2ac4R428-R430), [link](https://github.com/element-plus/element-plus/pull/13173/files?diff=unified&w=0#diff-e6d3319a7079fd77e391d7d2d10e68f50f7bc93bb031a254ab9f8170d58e2ac4R443))
  - Define a new function `togglePopperVisible` that modifies the popper display style according to a parameter in `util.ts` ([link](https://github.com/element-plus/element-plus/pull/13173/files?diff=unified&w=0#diff-e6d3319a7079fd77e391d7d2d10e68f50f7bc93bb031a254ab9f8170d58e2ac4L367-R384))
  - Simplify the assignment of `onOpen` and `onClose` handlers for the content element by using the `useDelayedToggle` hook in `use-tooltip.ts` ([link](https://github.com/element-plus/element-plus/pull/13173/files?diff=unified&w=0#diff-e6d3319a7079fd77e391d7d2d10e68f50f7bc93bb031a254ab9f8170d58e2ac4L382-R408))
  - Add a modifier to the popper instance that initially sets its display style to 'none' in `use-tooltip.ts` ([link](https://github.com/element-plus/element-plus/pull/13173/files?diff=unified&w=0#diff-e6d3319a7079fd77e391d7d2d10e68f50f7bc93bb031a254ab9f8170d58e2ac4R428-R430))
  - Call `onOpen` after creating the popper instance to trigger the popper update in `use-tooltip.ts` ([link](https://github.com/element-plus/element-plus/pull/13173/files?diff=unified&w=0#diff-e6d3319a7079fd77e391d7d2d10e68f50f7bc93bb031a254ab9f8170d58e2ac4R443))
