### PR TITLE
fix(components): [tree] improve types

### DIFF
--- a/docs/examples/tree/checking-tree.vue
+++ b/docs/examples/tree/checking-tree.vue
@@ -20,7 +20,7 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-import { ElTree } from 'element-plus'
+import { ElTree, type TreeInstance } from 'element-plus'
 import type Node from 'element-plus/es/components/tree/src/model/node'
 
 interface Tree {
@@ -29,7 +29,7 @@ interface Tree {
   children?: Tree[]
 }
 
-const treeRef = ref<InstanceType<typeof ElTree>>()
+const treeRef = ref<TreeInstance>()
 
 const getCheckedNodes = () => {
   console.log(treeRef.value!.getCheckedNodes(false, false))

--- a/docs/examples/tree/filtering.vue
+++ b/docs/examples/tree/filtering.vue
@@ -13,14 +13,14 @@
 
 <script lang="ts" setup>
 import { ref, watch } from 'vue'
-import { ElTree } from 'element-plus'
+import { ElTree, type TreeInstance } from 'element-plus'
 
 interface Tree {
   [key: string]: any
 }
 
 const filterText = ref('')
-const treeRef = ref<InstanceType<typeof ElTree>>()
+const treeRef = ref<TreeInstance>()
 
 const defaultProps = {
   children: 'children',

--- a/packages/components/tree-select/__tests__/tree-select.test.tsx
+++ b/packages/components/tree-select/__tests__/tree-select.test.tsx
@@ -6,7 +6,7 @@ import TreeSelect from '../src/tree-select.vue'
 import type { RenderFunction } from 'vue'
 import type { VueWrapper } from '@vue/test-utils'
 import type ElSelect from '@element-plus/components/select'
-import type ElTree from '@element-plus/components/tree'
+import type { TreeInstance } from '@element-plus/components/tree'
 
 const createComponent = ({
   slots = {},
@@ -71,9 +71,7 @@ const createComponent = ({
     select: wrapper.findComponent({ name: 'ElSelect' }) as VueWrapper<
       InstanceType<typeof ElSelect>
     >,
-    tree: wrapper.findComponent({ name: 'ElTree' }) as VueWrapper<
-      InstanceType<typeof ElTree>
-    >,
+    tree: wrapper.findComponent({ name: 'ElTree' }) as VueWrapper<TreeInstance>,
   }
 }
 

--- a/packages/components/tree-select/src/select.ts
+++ b/packages/components/tree-select/src/select.ts
@@ -4,7 +4,7 @@ import { pick } from 'lodash-unified'
 import ElSelect from '@element-plus/components/select'
 import { useNamespace } from '@element-plus/hooks'
 import type { Ref } from 'vue'
-import type ElTree from '@element-plus/components/tree'
+import type { TreeInstance } from '@element-plus/components/tree'
 
 export const useSelect = (
   props,
@@ -14,7 +14,7 @@ export const useSelect = (
     key,
   }: {
     select: Ref<InstanceType<typeof ElSelect> | undefined>
-    tree: Ref<InstanceType<typeof ElTree> | undefined>
+    tree: Ref<TreeInstance | undefined>
     key: Ref<string>
   }
 ) => {

--- a/packages/components/tree-select/src/tree-select.vue
+++ b/packages/components/tree-select/src/tree-select.vue
@@ -3,10 +3,10 @@
 import { computed, defineComponent, h, onMounted, reactive, ref } from 'vue'
 import { pick } from 'lodash-unified'
 import ElSelect from '@element-plus/components/select'
-import ElTree from '@element-plus/components/tree'
 import { useSelect } from './select'
 import { useTree } from './tree'
 import CacheOptions from './cache-options'
+import type { TreeInstance } from '@element-plus/components/tree'
 
 export default defineComponent({
   name: 'ElTreeSelect',
@@ -27,7 +27,7 @@ export default defineComponent({
     const { slots, expose } = context
 
     const select = ref<InstanceType<typeof ElSelect>>()
-    const tree = ref<InstanceType<typeof ElTree>>()
+    const tree = ref<TreeInstance>()
 
     const key = computed(() => props.nodeKey || props.valueKey || 'value')
 

--- a/packages/components/tree-select/src/tree.ts
+++ b/packages/components/tree-select/src/tree.ts
@@ -12,6 +12,7 @@ import {
   treeEach,
   treeFind,
 } from './utils'
+import type { TreeInstance } from '@element-plus/components/tree'
 import type { CacheOption } from './cache-options'
 import type { Ref } from 'vue'
 import type ElSelect from '@element-plus/components/select'
@@ -27,7 +28,7 @@ export const useTree = (
     key,
   }: {
     select: Ref<InstanceType<typeof ElSelect> | undefined>
-    tree: Ref<InstanceType<typeof ElTree> | undefined>
+    tree: Ref<TreeInstance | undefined>
     key: Ref<string>
   }
 ) => {
@@ -210,7 +211,7 @@ export const useTree = (
         if (props.multiple) {
           emit(
             UPDATE_MODEL_EVENT,
-            (tree.value as InstanceType<typeof ElTree>).getCheckedKeys(true)
+            (tree.value as TreeInstance).getCheckedKeys(true)
           )
         } else {
           // select first leaf node when check parent

--- a/packages/components/tree/index.ts
+++ b/packages/components/tree/index.ts
@@ -1,13 +1,8 @@
+import { withInstall } from '@element-plus/utils'
+
 import Tree from './src/tree.vue'
 
-import type { App } from 'vue'
-import type { SFCWithInstall } from '@element-plus/utils'
+export const ElTree = withInstall(Tree)
+export default ElTree
 
-Tree.install = (app: App): void => {
-  app.component(Tree.name, Tree)
-}
-
-const _Tree = Tree as SFCWithInstall<typeof Tree>
-
-export default _Tree
-export const ElTree = _Tree
+export type { TreeInstance } from './src/instance'

--- a/packages/components/tree/src/instance.ts
+++ b/packages/components/tree/src/instance.ts
@@ -1,0 +1,3 @@
+import type Tree from './tree.vue'
+
+export type TreeInstance = InstanceType<typeof Tree>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

This PR improves tree types.

Previously, we have to write types to use tree ref to avoid any.

```ts
const treeRef = ref() // any

import { ElTree } from 'element-plus'
const treeRef = ref<InstanceType<typeof ElTree>>() // not any
```

After this, we can directly import and use the type.

```ts
const treeRef = ref() // any

import type { TreeInstance } from 'element-plus'
const treeRef = ref<TreeInstance>() // not any
```

Also, I updated some other files to use the new type.

Please note: `packages/components/tree/index.ts` is updated. If I introduced some breaking changes, please tell me and I will revert. 🙏

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc070e1</samp>

The pull request improved the type annotations and imports of the `TreeInstance` type in various files related to the `tree` and `tree-select` components. This type represents the instance of the `ElTree` component, which was also refactored to use the `withInstall` helper function. These changes made the code more consistent, readable, and reusable.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc070e1</samp>

*  Refactored the export of the `ElTree` component and the default export to use the `withInstall` helper function in `index.ts` ([link](https://github.com/element-plus/element-plus/pull/13217/files?diff=unified&w=0#diff-930f47df607049ce6a1a34e2ba3a2226049e4466e58d46e6a44dc90ce49e78b6L1-R8))
* Defined and exported the `TreeInstance` type as an alias for the `InstanceType<typeof Tree>` in `instance.ts` ([link](https://github.com/element-plus/element-plus/pull/13217/files?diff=unified&w=0#diff-3a3e0d271b646f456f8229731282b4e8c4106a90d9107d2b759d740edbe4dc23R1-R3))
* Imported the `TreeInstance` type from `element-plus` and used it as a type annotation for the `tree` parameter or property in various files ([link](https://github.com/element-plus/element-plus/pull/13217/files?diff=unified&w=0#diff-38c0e66ee242d4981b4f2cd98f7a9fee72c2a789424872de31570565d475726dL9-R9), [link](https://github.com/element-plus/element-plus/pull/13217/files?diff=unified&w=0#diff-d895cf8665299f6e338ee3fcd1259cbb2de31a2278a4bb30f691fe86fb497df7L7-R7), [link](https://github.com/element-plus/element-plus/pull/13217/files?diff=unified&w=0#diff-7edaee57f8bbaf143fa72bcdd51ef82eef9273119a3c89278eddfda4d62b9804R15))
* Imported the `TreeInstance` type from `element-plus` and used it as a type annotation for the `treeRef` ref in the `checking-tree.vue` and `filtering.vue` examples ([link](https://github.com/element-plus/element-plus/pull/13217/files?diff=unified&w=0#diff-09461af18bec4f4a58e8c893a0c2b9e95d89d8101852a67dfe9aa05918dc7a2fL23-R23), [link](https://github.com/element-plus/element-plus/pull/13217/files?diff=unified&w=0#diff-4b44b7465d2f8ead898742c5a155dbcb10feb70ffa9742b0102cbcf710b918c1L16-R16))
* Changed the type annotation of the `tree` ref in `tree-select.vue` from `InstanceType<typeof ElTree>` to `TreeInstance` ([link](https://github.com/element-plus/element-plus/pull/13217/files?diff=unified&w=0#diff-67135d1b4076705063e642a0f94a2d845e2ccdeb6cc9a24744804864b471d5e0L30-R30))
* Changed the type annotation of the `treeRef` ref in `checking-tree.vue` and `filtering.vue` from `InstanceType<typeof ElTree>` to `TreeInstance` ([link](https://github.com/element-plus/element-plus/pull/13217/files?diff=unified&w=0#diff-09461af18bec4f4a58e8c893a0c2b9e95d89d8101852a67dfe9aa05918dc7a2fL32-R32), [link](https://github.com/element-plus/element-plus/pull/13217/files?diff=unified&w=0#diff-4b44b7465d2f8ead898742c5a155dbcb10feb70ffa9742b0102cbcf710b918c1L23-R23))
* Changed the type assertion of the `tree.value` in `tree.ts` from `InstanceType<typeof ElTree>` to `TreeInstance` ([link](https://github.com/element-plus/element-plus/pull/13217/files?diff=unified&w=0#diff-7edaee57f8bbaf143fa72bcdd51ef82eef9273119a3c89278eddfda4d62b9804L213-R214))
* Removed the unused import of `ElTree` from `tree-select.vue` ([link](https://github.com/element-plus/element-plus/pull/13217/files?diff=unified&w=0#diff-67135d1b4076705063e642a0f94a2d845e2ccdeb6cc9a24744804864b471d5e0L6-R9))
