### PR TITLE
fix(components): [tag] fix bug #13229

### DIFF
--- a/packages/components/tag/src/tag.vue
+++ b/packages/components/tag/src/tag.vue
@@ -2,7 +2,7 @@
   <span
     v-if="disableTransitions"
     :class="containerKls"
-    :style="{ backgroundColor: color }"
+    :style="{ backgroundColor: color, verticalAlign: 'middle' }"
     @click="handleClick"
   >
     <span :class="ns.e('content')">
@@ -15,7 +15,7 @@
   <transition v-else :name="`${ns.namespace.value}-zoom-in-center`" appear>
     <span
       :class="containerKls"
-      :style="{ backgroundColor: color }"
+      :style="{ backgroundColor: color, verticalAlign: 'middle' }"
       @click="handleClick"
     >
       <span :class="ns.e('content')">


### PR DESCRIPTION
fix bug [#13229](https://github.com/element-plus/element-plus/issues/13229)

空span和有内容的span不对齐，通过 vertical-align: middle; 使之对齐