### PR TITLE
fix(components): [tag] element vertically centered

### DIFF
--- a/packages/theme-chalk/src/tag.scss
+++ b/packages/theme-chalk/src/tag.scss
@@ -92,7 +92,7 @@ $tag-icon-span-gap: map.merge(
   display: inline-flex;
   justify-content: center;
   align-items: center;
-
+  vertical-align: middle;
   height: map.get($tag-height, 'default');
   padding: 0 map.get($tag-padding, 'default') - $border-width;
 


### PR DESCRIPTION
fix bug [#13229](https://github.com/element-plus/element-plus/issues/13229)

空span和有内容的span不对齐，通过 vertical-align: middle; 使之对齐