### PR TITLE
style(theme-chalk): fix message-box icon size & rm dialog header margin

### DIFF
--- a/packages/theme-chalk/src/dialog.scss
+++ b/packages/theme-chalk/src/dialog.scss
@@ -54,7 +54,6 @@
   @include e(header) {
     padding: getCssVar('dialog', 'padding-primary');
     padding-bottom: 10px;
-    margin-right: 16px;
   }
 
   @include e(headerbtn) {

--- a/packages/theme-chalk/src/message-box.scss
+++ b/packages/theme-chalk/src/message-box.scss
@@ -195,7 +195,7 @@
     @include e(status) {
       position: relative;
       top: auto;
-      padding-right: 5px;
+      margin-right: 5px;
       text-align: center;
       transform: translateY(-1px);
     }


### PR DESCRIPTION
In case user reset box-sizing to border box caused icon space squeezed

closed #13237

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ab3355</samp>

Refactor the dialog and message-box components to use the same close button style and title alignment. Remove `margin-right` from `dialog.scss` and add `margin-right` to `message-box.scss`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5ab3355</samp>

* Refactor the close button style and alignment for dialog and message-box components ([link](https://github.com/element-plus/element-plus/pull/13238/files?diff=unified&w=0#diff-b2d490585a718d28da2126ce6f39b1f996d7bad85369c7de8105d2451a44a50dL57), [link](https://github.com/element-plus/element-plus/pull/13238/files?diff=unified&w=0#diff-337571374a4d460660de89796bc19bc953e3867e5849dd6ed0ab79503e480452L198-R198))
