### PR TITLE
refactor(components)!: [select-v2] value-key is used for object select

### DIFF
--- a/docs/examples/select-v2/use-valueKey.vue
+++ b/docs/examples/select-v2/use-valueKey.vue
@@ -3,7 +3,7 @@
     v-model="value"
     :options="options"
     placeholder="Please select"
-    value-key="value.name"
+    value-key="name"
   />
 </template>
 
@@ -11,7 +11,7 @@
 import { ref } from 'vue'
 const initials = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
 
-const value = ref()
+const value = ref({ name: 'Option 1', test: 'test 0' })
 const options = Array.from({ length: 1000 }).map((_, idx) => ({
   value: {
     name: `Option ${idx + 1}`,

--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -272,22 +272,19 @@ describe('Select', () => {
   it('default value is Object', async () => {
     const wrapper = createSelect({
       data: () => ({
-        valueKey: 'value',
-        value: {
-          value: '1',
-          label: 'option_a',
-        },
+        valueKey: 'id',
+        value: { id: 1 },
         options: [
           {
-            value: '1',
+            value: { id: 1 },
             label: 'option_a',
           },
           {
-            value: '2',
+            value: { id: 2 },
             label: 'option_b',
           },
           {
-            value: '3',
+            value: { id: 3 },
             label: 'option_c',
           },
         ],
@@ -298,9 +295,7 @@ describe('Select', () => {
     expect(wrapper.find(`.${PLACEHOLDER_CLASS_NAME}`).text()).toBe(
       vm.options[0].label
     )
-    expect(wrapper.find(`.${PLACEHOLDER_CLASS_NAME}`).text()).toBe(
-      vm.value.label
-    )
+    expect(vm.value).toEqual(vm.options[0].value)
   })
 
   it('sync set value and options', async () => {
@@ -352,22 +347,19 @@ describe('Select', () => {
         return {
           options: [
             {
-              id: 'id 1',
-              value: 'value 1',
+              value: { id: 1 },
               label: 'option 1',
             },
             {
-              id: 'id 2',
-              value: 'value 2',
+              value: { id: 2 },
               label: 'option 2',
             },
             {
-              id: 'id 3',
-              value: 'value 3',
+              value: { id: 3 },
               label: 'option 3',
             },
           ],
-          value: '',
+          value: undefined,
           valueKey: 'id',
         }
       },
@@ -378,12 +370,11 @@ describe('Select', () => {
     const options = getOptions()
     options[1].click()
     await nextTick()
-    expect(vm.value).toBe(vm.options[1].id)
-    vm.valueKey = 'value'
-    await nextTick()
+    expect(vm.value).toEqual(vm.options[1].value)
+
     options[2].click()
     await nextTick()
-    expect(vm.value).toBe(vm.options[2].value)
+    expect(vm.value).toEqual(vm.options[2].value)
   })
 
   it('disabled option', async () => {
@@ -616,18 +607,15 @@ describe('Select', () => {
           return {
             options: [
               {
-                id: 'id 1',
-                value: 'value 1',
+                value: { id: 1, value: 'a' },
                 label: 'option 1',
               },
               {
-                id: 'id 2',
-                value: 'value 2',
+                value: { id: 2, value: 'b' },
                 label: 'option 2',
               },
               {
-                id: 'id 3',
-                value: 'value 3',
+                value: { id: 3, value: 'c' },
                 label: 'option 3',
               },
             ],
@@ -644,13 +632,24 @@ describe('Select', () => {
       options[1].click()
       await nextTick()
       expect(vm.value.length).toBe(1)
-      expect(vm.value[0]).toBe(vm.options[1].id)
-      vm.valueKey = 'value'
-      await nextTick()
+      expect(vm.value).toContainEqual(vm.options[1].value)
       options[2].click()
       await nextTick()
       expect(vm.value.length).toBe(2)
-      expect(vm.value[1]).toBe(vm.options[2].value)
+      expect(vm.value).toContainEqual(vm.options[2].value)
+      options[2].click()
+      await nextTick()
+      expect(vm.value.length).toBe(1)
+      expect(vm.value).not.toContainEqual(vm.options[2].value)
+
+      vm.valueKey = 'value'
+      await nextTick()
+      expect(vm.value.length).toBe(1)
+      expect(vm.value).toContainEqual(vm.options[1].value)
+      options[0].click()
+      await nextTick()
+      expect(vm.value.length).toBe(2)
+      expect(vm.value).toContainEqual(vm.options[0].value)
     })
   })
 

--- a/packages/components/select-v2/src/select-dropdown.tsx
+++ b/packages/components/select-v2/src/select-dropdown.tsx
@@ -1,4 +1,12 @@
-import { computed, defineComponent, inject, ref, unref, watch } from 'vue'
+import {
+  computed,
+  defineComponent,
+  inject,
+  ref,
+  toRaw,
+  unref,
+  watch,
+} from 'vue'
 import { get } from 'lodash-unified'
 import { isObject, isUndefined } from '@element-plus/utils'
 import {
@@ -69,7 +77,7 @@ export default defineComponent({
       return (
         arr &&
         arr.some((item) => {
-          return get(item, valueKey) === get(target, valueKey)
+          return toRaw(get(item, valueKey)) === get(target, valueKey)
         })
       )
     }
@@ -83,11 +91,10 @@ export default defineComponent({
     }
 
     const isItemSelected = (modelValue: any[] | any, target: Option) => {
-      const { valueKey } = select.props
       if (select.props.multiple) {
-        return contains(modelValue, get(target, valueKey))
+        return contains(modelValue, target.value)
       }
-      return isEqual(modelValue, get(target, valueKey))
+      return isEqual(modelValue, target.value)
     }
 
     const isItemDisabled = (modelValue: any[] | any, selected: boolean) => {

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -176,7 +176,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
     const valueMap = new Map()
 
     filteredOptions.value.forEach((option, index) => {
-      valueMap.set(getValueKey(option), { option, index })
+      valueMap.set(getValueKey(option.value), { option, index })
     })
     return valueMap
   })
@@ -409,7 +409,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
     if (props.multiple) {
       let selectedOptions = (props.modelValue as any[]).slice()
 
-      const index = getValueIndex(selectedOptions, getValueKey(option))
+      const index = getValueIndex(selectedOptions, option.value)
       if (index > -1) {
         selectedOptions = [
           ...selectedOptions.slice(0, index),
@@ -421,7 +421,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
         props.multipleLimit <= 0 ||
         selectedOptions.length < props.multipleLimit
       ) {
-        selectedOptions = [...selectedOptions, getValueKey(option)]
+        selectedOptions = [...selectedOptions, option.value]
         states.cachedOptions.push(option)
         selectNewOption(option)
         updateHoveringIndex(idx)
@@ -445,7 +445,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
     } else {
       selectedIndex.value = idx
       states.selectedLabel = option.label
-      update(getValueKey(option))
+      update(option.value)
       expanded.value = false
       states.isComposing = false
       states.isSilentBlur = byClick
@@ -457,20 +457,21 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
     }
   }
 
-  const deleteTag = (event: MouseEvent, tag: Option) => {
-    const { valueKey } = props
-    const index = (props.modelValue as Array<any>).indexOf(get(tag, valueKey))
+  const deleteTag = (event: MouseEvent, option: Option) => {
+    let selectedOptions = (props.modelValue as any[]).slice()
+
+    const index = getValueIndex(selectedOptions, option.value)
 
     if (index > -1 && !selectDisabled.value) {
-      const value = [
+      selectedOptions = [
         ...(props.modelValue as Array<unknown>).slice(0, index),
         ...(props.modelValue as Array<unknown>).slice(index + 1),
       ]
       states.cachedOptions.splice(index, 1)
-      update(value)
-      emit('remove-tag', get(tag, valueKey))
+      update(selectedOptions)
+      emit('remove-tag', option.value)
       states.softFocus = true
-      removeNewOption(tag)
+      removeNewOption(option)
       return nextTick(focusAndUpdatePopup)
     }
     event.stopPropagation()
@@ -673,8 +674,12 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
         states.previousValue = props.modelValue.toString()
 
         for (const value of props.modelValue) {
-          if (filteredOptionsValueMap.value.has(value)) {
-            const { index, option } = filteredOptionsValueMap.value.get(value)
+          const selectValue = getValueKey(value)
+
+          if (filteredOptionsValueMap.value.has(selectValue)) {
+            const { index, option } =
+              filteredOptionsValueMap.value.get(selectValue)
+
             states.cachedOptions.push(option)
             if (!initHovering) {
               updateHoveringIndex(index)
@@ -691,7 +696,8 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
         states.previousValue = props.modelValue
         const options = filteredOptions.value
         const selectedItemIndex = options.findIndex(
-          (option) => getValueKey(option) === getValueKey(props.modelValue)
+          (option) =>
+            getValueKey(option.value) === getValueKey(props.modelValue)
         )
         if (~selectedItemIndex) {
           states.selectedLabel = options[selectedItemIndex].label


### PR DESCRIPTION
This is a replica of #9638.

Currently the `value-key` is used to select both value in `options` ​​and value in `modelValue`. But they are always preceded by a difference `value`, leading to inability to select objects or various other errors.

```
const options = [
  {
    value: {
      id: '1',
      name: 'x',
    },
    label: 'x',
  }
]
const modelValue = {  id: '1',  name: 'x'  }
```

value-key should be consistent with the Select component, only used to select objects.

### TODO

Added attribute(`props: { label: 'label', value: 'value', options: 'options' }`) to configure aliases for data in `options`

Please make sure these boxes are checked before submitting your PR, thank you!

[before](https://element-plus.run/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3Qgc2VsZWN0ZWQgPSByZWYoe1xuICBpZDogJzInLFxuICBuYW1lOiAneScsXG59KVxuY29uc3QgbXVsdGlwbGUgPSByZWYoW1xuICB7XG4gICAgaWQ6ICcyJyxcbiAgICBuYW1lOiAneScsXG4gIH0sXG5dKVxuXG5jb25zdCBvcHRpb25zID0gW1xuICB7XG4gICAgdmFsdWU6IHtcbiAgICAgIGlkOiAnMScsXG4gICAgICBuYW1lOiAneCcsXG4gICAgfSxcbiAgICBsYWJlbDogJ3gnLFxuICB9LFxuICB7XG4gICAgdmFsdWU6IHtcbiAgICAgIGlkOiAnMicsXG4gICAgICBuYW1lOiAneScsXG4gICAgfSxcbiAgICBsYWJlbDogJ3knLFxuICB9LFxuICB7XG4gICAgdmFsdWU6IHtcbiAgICAgIGlkOiAnMycsXG4gICAgICBuYW1lOiAneicsXG4gICAgfSxcbiAgICBsYWJlbDogJ3onLFxuICB9LFxuXVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGgxPlVuYWJsZSB0byBzZWxlY3Qgb2JqZWN0PC9oMT5cbiAgPGgyPm11bHRpcGxlOiBmYWxzZTwvaDI+XG4gIDxwPnt7IHNlbGVjdGVkIH19PC9wPlxuICA8ZGl2PlxuICAgIDxzcGFuIGNsYXNzPVwibGFiZWxcIj5zZWxlY3QtdjI8L3NwYW4+XG4gICAgPGVsLXNlbGVjdC12MlxuICAgICAgdi1tb2RlbD1cInNlbGVjdGVkXCJcbiAgICAgIDpvcHRpb25zPVwib3B0aW9uc1wiXG4gICAgICB2YWx1ZS1rZXk9XCJpZFwiXG4gICAgICBjbGVhcmFibGVcbiAgICAvPlxuICA8L2Rpdj5cbiAgPGRpdj5cbiAgICA8c3BhbiBjbGFzcz1cImxhYmVsXCI+c2VsZWN0PC9zcGFuPlxuICAgIDxlbC1zZWxlY3Qgdi1tb2RlbD1cInNlbGVjdGVkXCIgdmFsdWUta2V5PVwiaWRcIiBkaXNhYmxlZD5cbiAgICAgIDxlbC1vcHRpb25cbiAgICAgICAgdi1mb3I9XCJpdGVtIGluIG9wdGlvbnNcIlxuICAgICAgICA6a2V5PVwiaXRlbS5sYWJlbFwiXG4gICAgICAgIDpsYWJlbD1cIml0ZW0ubGFiZWxcIlxuICAgICAgICA6dmFsdWU9XCJpdGVtLnZhbHVlXCJcbiAgICAgIC8+XG4gICAgPC9lbC1zZWxlY3Q+XG4gIDwvZGl2PlxuICA8aDI+bXVsdGlwbGU6IHRydWU8L2gyPlxuICA8cD57eyBtdWx0aXBsZSB9fTwvcD5cbiAgPGRpdj5cbiAgICA8c3BhbiBjbGFzcz1cImxhYmVsXCI+c2VsZWN0LXYyPC9zcGFuPlxuICAgIDxlbC1zZWxlY3QtdjJcbiAgICAgIHYtbW9kZWw9XCJtdWx0aXBsZVwiXG4gICAgICA6b3B0aW9ucz1cIm9wdGlvbnNcIlxuICAgICAgbXVsdGlwbGVcbiAgICAgIHZhbHVlLWtleT1cImlkXCJcbiAgICAgIGNsZWFyYWJsZVxuICAgICAgc3R5bGU9XCJ3aWR0aDogMjAwcHhcIlxuICAgIC8+XG4gIDwvZGl2PlxuICA8ZGl2PlxuICAgIDxzcGFuIGNsYXNzPVwibGFiZWxcIj5zZWxlY3Q8L3NwYW4+XG4gICAgPGVsLXNlbGVjdCB2LW1vZGVsPVwibXVsdGlwbGVcIiB2YWx1ZS1rZXk9XCJpZFwiIG11bHRpcGxlIGRpc2FibGVkPlxuICAgICAgPGVsLW9wdGlvblxuICAgICAgICB2LWZvcj1cIml0ZW0gaW4gb3B0aW9uc1wiXG4gICAgICAgIDprZXk9XCJpdGVtLmxhYmVsXCJcbiAgICAgICAgOmxhYmVsPVwiaXRlbS5sYWJlbFwiXG4gICAgICAgIDp2YWx1ZT1cIml0ZW0udmFsdWVcIlxuICAgICAgLz5cbiAgICA8L2VsLXNlbGVjdD5cbiAgPC9kaXY+XG48L3RlbXBsYXRlPlxuXG48c3R5bGU+XG4ubGFiZWwge1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIG1hcmdpbi1yaWdodDogMTZweDtcbiAgd2lkdGg6IDEwMHB4O1xuICB0ZXh0LWFsaWduOiByaWdodDtcbn1cbjwvc3R5bGU+XG4iLCJpbXBvcnRfbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7fVxufSIsIl9vIjp7fX0=)

[after](https://element-plus.run/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3Qgc2VsZWN0ZWQgPSByZWYoe1xuICBpZDogJzInLFxuICBuYW1lOiAneScsXG59KVxuY29uc3QgbXVsdGlwbGUgPSByZWYoW1xuICB7XG4gICAgaWQ6ICcyJyxcbiAgICBuYW1lOiAneScsXG4gIH0sXG5dKVxuXG5jb25zdCBvcHRpb25zID0gW1xuICB7XG4gICAgdmFsdWU6IHtcbiAgICAgIGlkOiAnMScsXG4gICAgICBuYW1lOiAneCcsXG4gICAgfSxcbiAgICBsYWJlbDogJ3gnLFxuICB9LFxuICB7XG4gICAgdmFsdWU6IHtcbiAgICAgIGlkOiAnMicsXG4gICAgICBuYW1lOiAneScsXG4gICAgfSxcbiAgICBsYWJlbDogJ3knLFxuICB9LFxuICB7XG4gICAgdmFsdWU6IHtcbiAgICAgIGlkOiAnMycsXG4gICAgICBuYW1lOiAneicsXG4gICAgfSxcbiAgICBsYWJlbDogJ3onLFxuICB9LFxuXVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGgxPlVuYWJsZSB0byBzZWxlY3Qgb2JqZWN0PC9oMT5cbiAgPGgyPm11bHRpcGxlOiBmYWxzZTwvaDI+XG4gIDxwPnt7IHNlbGVjdGVkIH19PC9wPlxuICA8ZGl2PlxuICAgIDxzcGFuIGNsYXNzPVwibGFiZWxcIj5zZWxlY3QtdjI8L3NwYW4+XG4gICAgPGVsLXNlbGVjdC12MlxuICAgICAgdi1tb2RlbD1cInNlbGVjdGVkXCJcbiAgICAgIDpvcHRpb25zPVwib3B0aW9uc1wiXG4gICAgICB2YWx1ZS1rZXk9XCJpZFwiXG4gICAgICBjbGVhcmFibGVcbiAgICAvPlxuICA8L2Rpdj5cbiAgPGRpdj5cbiAgICA8c3BhbiBjbGFzcz1cImxhYmVsXCI+c2VsZWN0PC9zcGFuPlxuICAgIDxlbC1zZWxlY3Qgdi1tb2RlbD1cInNlbGVjdGVkXCIgdmFsdWUta2V5PVwiaWRcIiBkaXNhYmxlZD5cbiAgICAgIDxlbC1vcHRpb25cbiAgICAgICAgdi1mb3I9XCJpdGVtIGluIG9wdGlvbnNcIlxuICAgICAgICA6a2V5PVwiaXRlbS5sYWJlbFwiXG4gICAgICAgIDpsYWJlbD1cIml0ZW0ubGFiZWxcIlxuICAgICAgICA6dmFsdWU9XCJpdGVtLnZhbHVlXCJcbiAgICAgIC8+XG4gICAgPC9lbC1zZWxlY3Q+XG4gIDwvZGl2PlxuICA8aDI+bXVsdGlwbGU6IHRydWU8L2gyPlxuICA8cD57eyBtdWx0aXBsZSB9fTwvcD5cbiAgPGRpdj5cbiAgICA8c3BhbiBjbGFzcz1cImxhYmVsXCI+c2VsZWN0LXYyPC9zcGFuPlxuICAgIDxlbC1zZWxlY3QtdjJcbiAgICAgIHYtbW9kZWw9XCJtdWx0aXBsZVwiXG4gICAgICA6b3B0aW9ucz1cIm9wdGlvbnNcIlxuICAgICAgbXVsdGlwbGVcbiAgICAgIHZhbHVlLWtleT1cImlkXCJcbiAgICAgIGNsZWFyYWJsZVxuICAgICAgc3R5bGU9XCJ3aWR0aDogMjAwcHhcIlxuICAgIC8+XG4gIDwvZGl2PlxuICA8ZGl2PlxuICAgIDxzcGFuIGNsYXNzPVwibGFiZWxcIj5zZWxlY3Q8L3NwYW4+XG4gICAgPGVsLXNlbGVjdCB2LW1vZGVsPVwibXVsdGlwbGVcIiB2YWx1ZS1rZXk9XCJpZFwiIG11bHRpcGxlIGRpc2FibGVkPlxuICAgICAgPGVsLW9wdGlvblxuICAgICAgICB2LWZvcj1cIml0ZW0gaW4gb3B0aW9uc1wiXG4gICAgICAgIDprZXk9XCJpdGVtLmxhYmVsXCJcbiAgICAgICAgOmxhYmVsPVwiaXRlbS5sYWJlbFwiXG4gICAgICAgIDp2YWx1ZT1cIml0ZW0udmFsdWVcIlxuICAgICAgLz5cbiAgICA8L2VsLXNlbGVjdD5cbiAgPC9kaXY+XG48L3RlbXBsYXRlPlxuXG48c3R5bGU+XG4ubGFiZWwge1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIG1hcmdpbi1yaWdodDogMTZweDtcbiAgd2lkdGg6IDEwMHB4O1xuICB0ZXh0LWFsaWduOiByaWdodDtcbn1cbjwvc3R5bGU+XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnRfbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL3ByZXZpZXctMTMyNjMtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5mdWxsLm1pbi5tanNcIixcbiAgICBcImVsZW1lbnQtcGx1cy9cIjogXCJ1bnN1cHBvcnRlZFwiXG4gIH1cbn0iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3VucGtnLmNvbS9AdnVlL3J1bnRpbWUtZG9tQGxhdGVzdC9kaXN0L3J1bnRpbWUtZG9tLmVzbS1icm93c2VyLmpzXCIsXG4gICAgXCJAdnVlL3NoYXJlZFwiOiBcImh0dHBzOi8vdW5wa2cuY29tL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9wcmV2aWV3LTEzMjYzLWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly91bnBrZy5jb20vQGVsZW1lbnQtcGx1cy9pY29ucy12dWVAMi9kaXN0L2luZGV4Lm1pbi5qc1wiXG4gIH0sXG4gIFwic2NvcGVzXCI6IHt9XG59IiwiZWxlbWVudC1wbHVzLmpzIjoiaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuaW1wb3J0IEVsZW1lbnRQbHVzIGZyb20gJ2VsZW1lbnQtcGx1cydcblxubGV0IGluc3RhbGxlZCA9IGZhbHNlXG5hd2FpdCBsb2FkU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gc2V0dXBFbGVtZW50UGx1cygpIHtcbiAgaWYgKGluc3RhbGxlZCkgcmV0dXJuXG4gIGNvbnN0IGluc3RhbmNlID0gZ2V0Q3VycmVudEluc3RhbmNlKClcbiAgaW5zdGFuY2UuYXBwQ29udGV4dC5hcHAudXNlKEVsZW1lbnRQbHVzKVxuICBpbnN0YWxsZWQgPSB0cnVlXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkU3R5bGUoKSB7XG4gIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgbGluay5ocmVmID0gJ2h0dHBzOi8vcHJldmlldy0xMzI2My1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcydcbiAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2xvYWQnLCByZXNvbHZlKVxuICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgfSlcbn0iLCJfbyI6eyJzaG93SGlkZGVuIjp0cnVlLCJzdHlsZVNvdXJjZSI6Imh0dHBzOi8vcHJldmlldy0xMzI2My1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcyJ9fQ==)

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 62fdd71</samp>

The pull request enhances the `select-v2` component and its documentation by fixing the usage of the `value-key` prop, refactoring the test cases, and improving the performance and readability of the code. It affects the files `use-valueKey.vue`, `select.test.ts`, `select-dropdown.tsx`, and `useSelect.ts`.

## Related Issue

close #9628, close #8369, close #7140, close #6502, close #8374, close #13259

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 62fdd71</samp>

*  Simplify the usage of the `value-key` prop for the `ElSelectV2` component by always using `value` as the value key ([link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-c14b0015adeae222af02a054650188c2462f7d1c042668e16ac8317974e38d69L86-R97), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-6018da2b9e35c71aca0d0a0f881a93c00ab1f1958a3a9c69e332fa8d0b2e9865L179-R179), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-6018da2b9e35c71aca0d0a0f881a93c00ab1f1958a3a9c69e332fa8d0b2e9865L412-R412), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-6018da2b9e35c71aca0d0a0f881a93c00ab1f1958a3a9c69e332fa8d0b2e9865L424-R424), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-6018da2b9e35c71aca0d0a0f881a93c00ab1f1958a3a9c69e332fa8d0b2e9865L448-R448), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-6018da2b9e35c71aca0d0a0f881a93c00ab1f1958a3a9c69e332fa8d0b2e9865L460-R474), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-6018da2b9e35c71aca0d0a0f881a93c00ab1f1958a3a9c69e332fa8d0b2e9865L676-R682), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-6018da2b9e35c71aca0d0a0f881a93c00ab1f1958a3a9c69e332fa8d0b2e9865L694-R700))
*  Update the `contains` function in `select-dropdown.tsx` to unwrap the reactive values before comparing them with plain objects ([link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-c14b0015adeae222af02a054650188c2462f7d1c042668e16ac8317974e38d69L1-R9), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-c14b0015adeae222af02a054650188c2462f7d1c042668e16ac8317974e38d69L72-R80))
*  Update the `use-valueKey.vue` example to match the new structure of the `options` prop and the `value` ref, which are arrays and objects with `value` and `label` properties ([link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-5a9acf7c76a9dfdd4abbe1608769971137b37d2206c8dd1533b4109a172fcf11L6-R6), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-5a9acf7c76a9dfdd4abbe1608769971137b37d2206c8dd1533b4109a172fcf11L14-R14))
*  Update the test cases in `select.test.ts` to use objects with `value` and `label` properties as options, and to check the equality of the `value` prop with the selected option's value ([link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-fcb6e88a28a001059cca0b18d5425f18d2fc4de1a608031374b155a74e67e46aL275-R287), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-fcb6e88a28a001059cca0b18d5425f18d2fc4de1a608031374b155a74e67e46aL301-R298), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-fcb6e88a28a001059cca0b18d5425f18d2fc4de1a608031374b155a74e67e46aL355-R362), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-fcb6e88a28a001059cca0b18d5425f18d2fc4de1a608031374b155a74e67e46aL381-R377), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-fcb6e88a28a001059cca0b18d5425f18d2fc4de1a608031374b155a74e67e46aL619-R618), [link](https://github.com/element-plus/element-plus/pull/13263/files?diff=unified&w=0#diff-fcb6e88a28a001059cca0b18d5425f18d2fc4de1a608031374b155a74e67e46aL647-R652))
