### PR TITLE
fix(components): [table] adjust the showOverflowTooltip value logic

### DIFF
--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -113,9 +113,12 @@ export default {
   columnKey: String,
   align: String,
   headerAlign: String,
-  showOverflowTooltip: [Boolean, Object] as PropType<
-    TableColumnCtx<DefaultRow>['showOverflowTooltip']
-  >,
+  showOverflowTooltip: {
+    type: [Boolean, Object] as PropType<
+      TableColumnCtx<DefaultRow>['showOverflowTooltip']
+    >,
+    default: undefined,
+  },
   fixed: [Boolean, String],
   formatter: Function as PropType<TableColumnCtx<DefaultRow>['formatter']>,
   selectable: Function as PropType<TableColumnCtx<DefaultRow>['selectable']>,

--- a/packages/components/table/src/table-column/index.ts
+++ b/packages/components/table/src/table-column/index.ts
@@ -11,7 +11,7 @@ import {
   ref,
 } from 'vue'
 import ElCheckbox from '@element-plus/components/checkbox'
-import { isString } from '@element-plus/utils'
+import { isString, isUndefined } from '@element-plus/utils'
 import { cellStarts } from '../config'
 import { compose, mergeOptions } from '../util'
 import useWatcher from './watcher-helper'
@@ -67,8 +67,9 @@ export default defineComponent({
 
       const type = props.type || 'default'
       const sortable = props.sortable === '' ? true : props.sortable
-      const showOverflowTooltip =
-        props.showOverflowTooltip || parent.props.showOverflowTooltip
+      const showOverflowTooltip = isUndefined(props.showOverflowTooltip)
+        ? parent.props.showOverflowTooltip
+        : props.showOverflowTooltip
       const defaults = {
         ...cellStarts[type],
         id: columnId.value,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

rel https://github.com/element-plus/element-plus/pull/13169#discussion_r1233586864

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2136599</samp>

Import `isUndefined` function to handle `showOverflowTooltip` prop in `table-column` component. This prop controls whether to show a tooltip when the cell content overflows.

## Related Issue

Fixes #13169.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2136599</samp>

* Imported `isUndefined` function to check `props.showOverflowTooltip` value ([link](https://github.com/element-plus/element-plus/pull/13282/files?diff=unified&w=0#diff-ace64c155a215e52adf697d6f56a3f5a077376cb59f2c725be070ce427a043e9L14-R14))
