### PR TITLE
fix(components): [virtual-list] Resetting the vertical scrollbar state

### DIFF
--- a/packages/components/virtual-list/src/builders/build-grid.ts
+++ b/packages/components/virtual-list/src/builders/build-grid.ts
@@ -339,7 +339,7 @@ const createGrid = ({
         },
         (x: number, y: number) => {
           hScrollbar.value?.onMouseUp?.()
-          hScrollbar.value?.onMouseUp?.()
+          vScrollbar.value?.onMouseUp?.()
           const width = unref(parsedWidth)
           const height = unref(parsedHeight)
           scrollTo({


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description
The code lacks the reset of the vertical scroll bar state when executing the wheel event, it seems to be because 'hScrollbar' is written twice.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46be56e</samp>

Fix vertical scrollbar bug and enhance virtual-list component. Modify `createGrid` function in `build-grid.ts` to update both scrollbars on mouse up.
hScrollbar => vScrollbar
## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46be56e</samp>

* Fix vertical scrollbar bug after resizing grid by calling `onMouseUp` handler of both `vScrollbar` and `hScrollbar` in `createGrid` function ([link](https://github.com/element-plus/element-plus/pull/13319/files?diff=unified&w=0#diff-de24661a1254de92dac7cd4457472d58ffbdea8a9b5ae6e59c73b711fbfdc861L342-R342))
