### PR TITLE
test: [table] add show-overflow-tooltip to table and table-column

### DIFF
--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -1632,4 +1632,31 @@ describe('Table.vue', () => {
     // 5 rows and 2 columns should be 10
     expect(findTooltipEl).toEqual(10)
   })
+
+  it('add show-overflow-tooltip to table and table-column', async () => {
+    const wrapper = mount({
+      components: {
+        ElTable,
+        ElTableColumn,
+      },
+
+      template: `
+      <el-table :data="testData" show-overflow-tooltip>
+        <el-table-column prop="name" label="name" :show-overflow-tooltip="false" />
+        <el-table-column prop="release" label="release" />
+      </el-table>
+    `,
+
+      data() {
+        const testData = getTestData() as any
+        return {
+          testData,
+        }
+      },
+    })
+
+    await doubleWait()
+    const findTooltipEl = wrapper.findAll('.el-tooltip').length
+    expect(findTooltipEl).toEqual(5)
+  })
 })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description
supplement #13282 
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 24e85bb</samp>

Add a test case for `show-overflow-tooltip` prop in table component. The test case verifies that the prop can be applied and overridden at different levels of the table hierarchy.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 24e85bb</samp>

* Add a test case for `show-overflow-tooltip` prop on table and table-column components ([link](https://github.com/element-plus/element-plus/pull/13323/files?diff=unified&w=0#diff-7459dbb43e3646d48d84cc2005f10d661d6ef683fcfbb0e7d3780f8faa43111dR1635-R1661))
