### PR TITLE
fix(components): [select] fixed backspace can delete disabled tag

### DIFF
--- a/docs/examples/select/disabled-option.vue
+++ b/docs/examples/select/disabled-option.vue
@@ -1,19 +1,41 @@
 <template>
-  <el-select v-model="value" placeholder="Select">
-    <el-option
-      v-for="item in options"
-      :key="item.value"
-      :label="item.label"
-      :value="item.value"
-      :disabled="item.disabled"
-    />
-  </el-select>
+  <div class="m-4">
+    <p>single</p>
+    <el-select v-model="value" placeholder="Select">
+      <el-option
+        v-for="item in options"
+        :key="item.value"
+        :label="item.label"
+        :value="item.value"
+        :disabled="item.disabled"
+      />
+    </el-select>
+  </div>
+  <div class="m-4">
+    <p>multiple</p>
+    <el-select
+      v-model="value2"
+      multiple
+      clearable
+      filterable
+      placeholder="Select"
+    >
+      <el-option
+        v-for="item in options"
+        :key="item.value"
+        :label="item.label"
+        :value="item.value"
+        :disabled="item.disabled"
+      />
+    </el-select>
+  </div>
 </template>
 
 <script lang="ts" setup>
 import { ref } from 'vue'
 
 const value = ref('')
+const value2 = ref(['Option1', 'Option2', 'Option3'])
 const options = [
   {
     value: 'Option1',

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -621,9 +621,32 @@ export const useSelect = (props, states: States, ctx) => {
       emitChange(value)
     }
 
+    const option = states.selected[states.selected.length - 1]
+    if (option && option.isDisabled) {
+      // if last option is disabled, find the prev not disabled option to delete.
+      deletePrevAvailableTag()
+    }
+
     if (e.target.value.length === 1 && props.modelValue.length === 0) {
       states.currentPlaceholder = states.cachedPlaceHolder
     }
+  }
+
+  // delete prev not disabled option
+  const deletePrevAvailableTag = () => {
+    const option = states.selected.findLast((item) => !item.isDisabled)
+
+    if (!option) return
+    option.hitState = !option.hitState
+
+    if (option.hitState) return
+
+    const value = props.modelValue.slice()
+    const index = value.indexOf(option.value)
+    value.splice(index, 1)
+
+    ctx.emit(UPDATE_MODEL_EVENT, value)
+    emitChange(value)
   }
 
   const deleteTag = (event, tag) => {
@@ -757,7 +780,9 @@ export const useSelect = (props, states: States, ctx) => {
     if (!Array.isArray(states.selected)) return
     const option = states.selected[states.selected.length - 1]
     if (!option) return
-
+    if (option.isDisabled) {
+      return option.isDisabled
+    }
     if (hit === true || hit === false) {
       option.hitState = hit
       return hit


### PR DESCRIPTION
multiple select enables filtering, should can't use backspace to delete disabled tag

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

multiple select enables filtering, should can't use backspace to delete disabled tag

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

multiple select enables filtering, should can't use backspace to delete disabled tag, 
but can delete prev not disabled tag
