### PR TITLE
fix(theme-chalk): [form] remove default width of Input in inline form

### DIFF
--- a/docs/en-US/component/form.md
+++ b/docs/en-US/component/form.md
@@ -37,7 +37,7 @@ To prevent this behavior, you can add `@submit.prevent` on `<el-form>`.
 
 When the vertical space is limited and the form is relatively simple, you can put it in one line.
 
-:::demo Set the `inline` attribute to `true` and the form will be inline. After ^(2.3.6), the ElInput component will get a fixed width to avoid the width change caused by the clearable icon.
+:::demo Set the `inline` attribute to `true` and the form will be inline.
 
 form/inline-form
 
@@ -125,25 +125,24 @@ form/accessibility
 
 ### Form Attributes
 
-| Name                      | Description                                                                                                                                                                              | Type                                                          | Default |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------- |
-| model                     | Data of form component.                                                                                                                                                                  | ^[object]`Record<string, any>`                                | —       |
-| rules                     | Validation rules of form.                                                                                                                                                                | ^[object]`FormRules`                                          | —       |
-| inline                    | Whether the form is inline.                                                                                                                                                              | ^[boolean]                                                    | false   |
-| label-position            | Position of label. If set to `'left'` or `'right'`, `label-width` prop is also required.                                                                                                 | ^[enum]`'left' \| 'right' \| 'top'`                           | right   |
-| label-width               | Width of label, e.g. `'50px'`. All its direct child form items will inherit this value. `auto` is supported.                                                                             | ^[string] / ^[number]                                         | ''      |
-| label-suffix              | Suffix of the label.                                                                                                                                                                     | ^[string]                                                     | ''      |
-| hide-required-asterisk    | Whether to hide required fields should have a red asterisk (star) beside their labels.                                                                                                   | ^[boolean]                                                    | false   |
-| require-asterisk-position | Position of asterisk.                                                                                                                                                                    | ^[enum]`'left' \| 'right'`                                    | left    |
-| show-message              | Whether to show the error message.                                                                                                                                                       | ^[boolean]                                                    | true    |
-| inline-message            | Whether to display the error message inline with the form item.                                                                                                                          | ^[boolean]                                                    | false   |
-| status-icon               | Whether to display an icon indicating the validation result.                                                                                                                             | ^[boolean]                                                    | false   |
-| validate-on-rule-change   | Whether to trigger validation when the `rules` prop is changed.                                                                                                                          | ^[boolean]                                                    | true    |
-| size                      | Control the size of components in this form.                                                                                                                                             | ^[enum]`'' \| 'large' \| 'default' \| 'small'`                | —       |
-| disabled                  | Whether to disable all components in this form. If set to `true`, it will override the `disabled` prop of the inner component.                                                           | ^[boolean]                                                    | false   |
-| scroll-to-error           | When validation fails, scroll to the first error form entry.                                                                                                                             | ^[boolean]                                                    | false   |
-| scroll-into-view-options  | When validation fails, it scrolls to the first error item based on the scrollIntoView option. [scrollIntoView](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView). | ^[object]`Record<string, any>` / ^[boolean]                   | —       |
-
+| Name                      | Description                                                                                                                                                                              | Type                                           | Default |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ------- |
+| model                     | Data of form component.                                                                                                                                                                  | ^[object]`Record<string, any>`                 | —       |
+| rules                     | Validation rules of form.                                                                                                                                                                | ^[object]`FormRules`                           | —       |
+| inline                    | Whether the form is inline.                                                                                                                                                              | ^[boolean]                                     | false   |
+| label-position            | Position of label. If set to `'left'` or `'right'`, `label-width` prop is also required.                                                                                                 | ^[enum]`'left' \| 'right' \| 'top'`            | right   |
+| label-width               | Width of label, e.g. `'50px'`. All its direct child form items will inherit this value. `auto` is supported.                                                                             | ^[string] / ^[number]                          | ''      |
+| label-suffix              | Suffix of the label.                                                                                                                                                                     | ^[string]                                      | ''      |
+| hide-required-asterisk    | Whether to hide required fields should have a red asterisk (star) beside their labels.                                                                                                   | ^[boolean]                                     | false   |
+| require-asterisk-position | Position of asterisk.                                                                                                                                                                    | ^[enum]`'left' \| 'right'`                     | left    |
+| show-message              | Whether to show the error message.                                                                                                                                                       | ^[boolean]                                     | true    |
+| inline-message            | Whether to display the error message inline with the form item.                                                                                                                          | ^[boolean]                                     | false   |
+| status-icon               | Whether to display an icon indicating the validation result.                                                                                                                             | ^[boolean]                                     | false   |
+| validate-on-rule-change   | Whether to trigger validation when the `rules` prop is changed.                                                                                                                          | ^[boolean]                                     | true    |
+| size                      | Control the size of components in this form.                                                                                                                                             | ^[enum]`'' \| 'large' \| 'default' \| 'small'` | —       |
+| disabled                  | Whether to disable all components in this form. If set to `true`, it will override the `disabled` prop of the inner component.                                                           | ^[boolean]                                     | false   |
+| scroll-to-error           | When validation fails, scroll to the first error form entry.                                                                                                                             | ^[boolean]                                     | false   |
+| scroll-into-view-options  | When validation fails, it scrolls to the first error item based on the scrollIntoView option. [scrollIntoView](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView). | ^[object]`Record<string, any>` / ^[boolean]    | —       |
 
 ### Form Events
 
@@ -237,6 +236,6 @@ interface FormItemRule extends RuleItem {
   trigger?: Arrayable<string>
 }
 type FormRules = Partial<Record<string, Arrayable<FormItemRule>>>
-
 ```
+
 </details>

--- a/docs/en-US/component/input.md
+++ b/docs/en-US/component/input.md
@@ -183,3 +183,15 @@ input/length-limiting
 | select         | select the text in input element | ^[Function]`() => void`                                 |
 | textarea       | HTML textarea element            | ^[object]`Ref<HTMLTextAreaElement>`                     |
 | textareaStyle  | style of textarea                | ^[object]`Ref<StyleValue>`                              |
+
+## FAQ
+
+#### Why is the width of the ElInput component expanded by clearable?
+
+Typical issue: [#7287](https://github.com/element-plus/element-plus/issues/7287)
+
+PS: Since the ElInput component does not have a default width, when the clearable icon is displayed, the width of the component will be expanded, which can be solved by setting width.
+
+```vue
+<el-input v-model="input" clearable style="width: 200px" />
+```

--- a/docs/examples/form/inline-form.vue
+++ b/docs/examples/form/inline-form.vue
@@ -40,3 +40,9 @@ const onSubmit = () => {
   console.log('submit!')
 }
 </script>
+
+<style>
+.demo-form-inline .el-input {
+  --el-input-width: 220px;
+}
+</style>

--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -91,13 +91,6 @@ $form-item-label-top-margin-bottom: map.merge(
         display: block;
       }
     }
-
-    .#{$namespace}-input {
-      @include set-css-var-value(
-        'input-width',
-        getCssVar('form-inline-content-width')
-      );
-    }
   }
 
   @each $size in (large, default, small) {


### PR DESCRIPTION
Revert #12897

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f36216</samp>

This pull request enhances the documentation and code quality of the Form and Input components. It updates the type and comment of some Form props, adds a FAQ section to the Input documentation, shows how to use CSS variables to control the input width in the inline form example, and removes an unused style rule for the ElInput component.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9f36216</samp>

* Remove outdated comment about ElInput width issue in inline form documentation ([link](https://github.com/element-plus/element-plus/pull/13375/files?diff=unified&w=0#diff-938901c6b4a36faaf382938e98ca0757e24362185cecf77f8ad55c64390ac466L40-R40))
* Update type annotation of model and scroll-into-view-options props of Form component to use Record<string, any> instead of object ([link](https://github.com/element-plus/element-plus/pull/13375/files?diff=unified&w=0#diff-938901c6b4a36faaf382938e98ca0757e24362185cecf77f8ad55c64390ac466L128-R146))
* Fix typo in closing tag of details element in type declarations documentation ([link](https://github.com/element-plus/element-plus/pull/13375/files?diff=unified&w=0#diff-938901c6b4a36faaf382938e98ca0757e24362185cecf77f8ad55c64390ac466L240-R240))
* Add FAQ section to Input component documentation explaining how to fix width expansion when using clearable prop ([link](https://github.com/element-plus/element-plus/pull/13375/files?diff=unified&w=0#diff-f92e676fa2f29edcadd21a64fe82ddb99dbdbdc15e1c364e35a8630cb9ccf7f1R186-R197))
* Add style block to inline form example code demonstrating how to control ElInput width using CSS variables ([link](https://github.com/element-plus/element-plus/pull/13375/files?diff=unified&w=0#diff-1655af4684641006c2459653a6e0656524774a5865ac91bf3ac9ab4bde37e5a0R43-R48))
* Remove redundant style rule for ElInput width in `form.scss` ([link](https://github.com/element-plus/element-plus/pull/13375/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29L94-L100))
