### PR TITLE
fix(components): [date-picker] fix the logic of checking the date range

### DIFF
--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -365,6 +365,32 @@ describe('DatePicker', () => {
     expect(document.querySelector('.disabled')).not.toBeNull()
   })
 
+  it('should work when using disabledDate prop and daterange type', async () => {
+    const wrapper = _mount(
+      `<el-date-picker
+        v-model="value"
+        type="daterange"
+        :disabledDate="disabledDate"
+    />`,
+      () => ({
+        value: ['2000-10-01', '2002-10-01'],
+        disabledDate(time) {
+          return time.getTime() > new Date(2002, 11)
+        },
+      })
+    )
+    const input = wrapper.findAll('input')[1]
+    input.element.value = '2001-10-01'
+    await input.trigger('input')
+    await input.trigger('change')
+    expect(dayjs(wrapper.vm.value[1]).toDate()).toEqual(new Date(2001, 9))
+
+    input.element.value = '2003-10-01'
+    await input.trigger('input')
+    await input.trigger('change')
+    expect(dayjs(wrapper.vm.value[1]).toDate()).toEqual(new Date(2001, 9))
+  })
+
   it('ref focus', async () => {
     _mount(
       `<el-date-picker

--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -395,6 +395,15 @@ const dateFormat = computed(() => {
   return extractDateFormat(format)
 })
 
+const isValidValue = (date: [Dayjs, Dayjs]) => {
+  return (
+    isValidRange(date) &&
+    (disabledDate
+      ? !disabledDate(date[0].toDate()) && !disabledDate(date[1].toDate())
+      : true)
+  )
+}
+
 const leftPrevYear = () => {
   leftDate.value = leftDate.value.subtract(1, 'year')
   if (!props.unlinkPanels) {
@@ -709,7 +718,7 @@ function onParsedValueChanged(
   }
 }
 
-emit('set-picker-option', ['isValidValue', isValidRange])
+emit('set-picker-option', ['isValidValue', isValidValue])
 emit('set-picker-option', ['parseUserInput', parseUserInput])
 emit('set-picker-option', ['formatToString', formatToString])
 emit('set-picker-option', ['handleClear', handleClear])


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b724a20</samp>

This pull request enhances the `date-picker` component with better validation of date ranges based on the `disabledDate` prop. It also adds a test case to verify the new functionality in `date-picker.test.ts`.

## Related Issue

Fixes #13373

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b724a20</samp>

* Add a new function `isValidValue` to the panel-date-range component that checks the validity of the selected date range with respect to the `disabledDate` prop ([link](https://github.com/element-plus/element-plus/pull/13377/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6R398-R406))
* Use the new `isValidValue` function to emit the correct validation result to the parent date-picker component ([link](https://github.com/element-plus/element-plus/pull/13377/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L712-R721))
* Add a test case for the date-picker component with the type of daterange and the `disabledDate` prop, verifying that the input value is updated and validated correctly ([link](https://github.com/element-plus/element-plus/pull/13377/files?diff=unified&w=0#diff-341b6dbc39d522f565c4cf2cca59cbdcd62f2d8a770aa838b6097219a27c05d0R368-R393))
