### PR TITLE
fix(style): [progress] linecap value of track is consistent with path

### DIFF
--- a/packages/components/progress/src/progress.vue
+++ b/packages/components/progress/src/progress.vue
@@ -49,6 +49,7 @@
           :class="ns.be('circle', 'track')"
           :d="trackPath"
           :stroke="`var(${ns.cssVarName('fill-color-light')}, #e5e9f2)`"
+          :stroke-linecap="strokeLinecap"
           :stroke-width="relativeStrokeWidth"
           fill="none"
           :style="trailPathStyle"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a73232</samp>

Added a new prop `strokeLinecap` to the `el-progress` component to enable customizing the end shape of the progress bar. Updated `packages/components/progress/src/progress.vue` to pass the prop to the SVG element.

## Related Issue

Fixes #13387.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a73232</samp>

* Add a prop `strokeLinecap` to `el-progress` component to customize the shape of the progress bar ends ([link](https://github.com/element-plus/element-plus/pull/13395/files?diff=unified&w=0#diff-33d9c9563d4d0a109e30a2a08fc82c1b7bced545fbd668c226c49511eaf68a78R52))
