### PR TITLE
fix(components): [checkbox] default after border color is transparent

### DIFF
--- a/packages/theme-chalk/src/checkbox.scss
+++ b/packages/theme-chalk/src/checkbox.scss
@@ -167,6 +167,7 @@ $checkbox-bordered-input-width: map.merge(
 
         &::after {
           transform: rotate(45deg) scaleY(1);
+          border-color: getCssVar('checkbox-checked-icon-color');
         }
       }
 
@@ -226,7 +227,7 @@ $checkbox-bordered-input-width: map.merge(
     &::after {
       box-sizing: content-box;
       content: '';
-      border: 1px solid getCssVar('checkbox-checked-icon-color');
+      border: 1px solid transparent;
       border-left: 0;
       border-top: 0;
       height: 7px;


### PR DESCRIPTION

![image](https://github.com/element-plus/element-plus/assets/23251408/5567f216-b784-4ddb-ac49-5c4cadab9f2a)

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10a98ca</samp>

Enhance checkbox component with customizable border color. Allow users to set the border color of the `checkbox` icon in `packages/theme-chalk/src/checkbox.scss` for different states.

## Related Issue

Fixes #13400.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 10a98ca</samp>

* Add a border color to the checked and indeterminate checkbox icon to improve appearance and accessibility ([link](https://github.com/element-plus/element-plus/pull/13402/files?diff=unified&w=0#diff-6b713f13028c431d017a143554ea7c4bbca90a9180858d1597bfb24718d615e2R170))
* Remove the border color from the unchecked and indeterminate checkbox icon to prevent overlapping with the background color ([link](https://github.com/element-plus/element-plus/pull/13402/files?diff=unified&w=0#diff-6b713f13028c431d017a143554ea7c4bbca90a9180858d1597bfb24718d615e2L229-R230))
