### PR TITLE
fix(style): [select] tooltip positioning is incorrect

### DIFF
--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -64,6 +64,7 @@
                 >
                   <el-tooltip
                     v-if="collapseTagsTooltip"
+                    ref="tagTooltipRef"
                     :disabled="dropMenuVisible"
                     :fallback-placements="['bottom', 'top', 'right', 'left']"
                     :effect="effect"
@@ -90,7 +91,7 @@
                             :type="tagType"
                             disable-transitions
                             :style="{ margin: '2px' }"
-                            @close="deleteTag($event, item)"
+                            @close="handleDeleteTooltipTag($event, item)"
                           >
                             <span
                               :class="nsSelect.e('tags-text')"
@@ -470,12 +471,14 @@ export default defineComponent({
       selectOption,
       getValueKey,
       navigateOptions,
+      handleDeleteTooltipTag,
       dropMenuVisible,
 
       reference,
       input,
       iOSInput,
       tooltipRef,
+      tagTooltipRef,
       tags,
       selectWrapper,
       scrollbar,
@@ -649,6 +652,7 @@ export default defineComponent({
       debouncedQueryChange,
       deletePrevTag,
       deleteTag,
+      handleDeleteTooltipTag,
       deleteSelected,
       handleOptionSelect,
       scrollToOption,
@@ -713,6 +717,7 @@ export default defineComponent({
       handleMouseLeave,
       showTagList,
       collapseTagList,
+      tagTooltipRef,
     }
   },
 })

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -87,6 +87,7 @@ export const useSelect = (props, states: States, ctx) => {
   const input = ref<HTMLInputElement | null>(null)
   const iOSInput = ref<HTMLInputElement | null>(null)
   const tooltipRef = ref<InstanceType<typeof ElTooltip> | null>(null)
+  const tagTooltipRef = ref<InstanceType<typeof ElTooltip> | null>(null)
   const tags = ref<HTMLElement | null>(null)
   const selectWrapper = ref<HTMLElement | null>(null)
   const scrollbar = ref<{
@@ -916,7 +917,10 @@ export const useSelect = (props, states: States, ctx) => {
   const handleMouseLeave = () => {
     states.mouseEnter = false
   }
-
+  const handleDeleteTooltipTag = (event, tag) => {
+    deleteTag(event, tag)
+    tagTooltipRef.value?.updatePopper?.()
+  }
   return {
     optionList,
     optionsArray,
@@ -956,6 +960,7 @@ export const useSelect = (props, states: States, ctx) => {
     selectOption,
     getValueKey,
     navigateOptions,
+    handleDeleteTooltipTag,
     dropMenuVisible,
     queryChange,
     groupQueryChange,
@@ -967,6 +972,7 @@ export const useSelect = (props, states: States, ctx) => {
     input,
     iOSInput,
     tooltipRef,
+    tagTooltipRef,
     tags,
     selectWrapper,
     scrollbar,


### PR DESCRIPTION
closed #13251
closed #13422

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

When el-select is configured with collapse-tags-tooltip, after the selected tag is displayed in a floating state, the small triangle is positioned incorrectly (not centered) after the tag is deleted

## Related Issue

#13251 #13422

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 82c59d5</samp>

*  Add a ref attribute to the ElTag component inside the ElTooltip component in the select.vue template and expose a function to update the ElTooltip position when a tag is deleted ([link](https://github.com/element-plus/element-plus/pull/13424/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540R67), [link](https://github.com/element-plus/element-plus/pull/13424/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540L93-R94), [link](https://github.com/element-plus/element-plus/pull/13424/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540R655))
* Define and export a ref to store the ElTooltip instance and a function to delete a tag and update the ElTooltip position in the useSelect.ts file ([link](https://github.com/element-plus/element-plus/pull/13424/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368R90), [link](https://github.com/element-plus/element-plus/pull/13424/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L919-R923), [link](https://github.com/element-plus/element-plus/pull/13424/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368R963), [link](https://github.com/element-plus/element-plus/pull/13424/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368R975))
* Import and use the ref and the function in the setup function of the select.vue script ([link](https://github.com/element-plus/element-plus/pull/13424/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540R474), [link](https://github.com/element-plus/element-plus/pull/13424/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540R481))
