### PR TITLE
fix: types in exports

### DIFF
--- a/packages/element-plus/package.json
+++ b/packages/element-plus/package.json
@@ -27,7 +27,10 @@
     "./es": "./es/index.mjs",
     "./lib": "./lib/index.js",
     "./es/*.mjs": "./es/*.mjs",
-    "./es/*": "./es/*.mjs",
+    "./es/*": {
+      "types": "./es/*/index.d.ts",
+      "import": "./es/*.mjs"
+    },
     "./lib/*.js": "./lib/*.js",
     "./lib/*": "./lib/*.js",
     "./*": "./*"


### PR DESCRIPTION
closed #11818

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description
[TypeScript] Fix TypeScript compilation error caused by import {ElButton} from 'element-plus'
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da01901</samp>

Add types field to es modules export map in `package.json`. This improves TypeScript support and compatibility for element-plus library.

## Related Issue

Fixes #11818.

## Explanation of Changes
I encountered a TypeScript compilation error when the 'moduleResolution' option in tsconfig.json was set to 'bundler'. The specific error message I received was "TypeScript error TS2614: Module 'element-plus' has no exported member 'ElButton'".

After investigating the issue, I discovered that the error was due to the module resolution strategy specified in the tsconfig.json file. When 'moduleResolution' is set to 'bundler', TypeScript expects the bundled module files to be provided, which may not be the case for the 'element-plus' library.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at da01901</samp>

* Add types field to export map for es modules, enabling TypeScript users to import them with type checking and intellisense ([link](https://github.com/element-plus/element-plus/pull/13443/files?diff=unified&w=0#diff-923d7d6b10313ed59d132ecf0395ac640320ed228a7172bccce53a8e7b859e01L30-R33))
