### PR TITLE
fix: tree content checkbox height larger than item height, close #13396

### DIFF
--- a/packages/theme-chalk/src/checkbox.scss
+++ b/packages/theme-chalk/src/checkbox.scss
@@ -49,7 +49,10 @@ $checkbox-bordered-input-width: map.merge(
   white-space: nowrap;
   user-select: none;
   margin-right: 30px;
-  height: map.get($checkbox-height, 'default');
+  height: getCssVarWithDefault(
+    'checkbox-height',
+    map.get($checkbox-height, 'default')
+  );
 
   @include when(disabled) {
     cursor: not-allowed;

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -950,6 +950,7 @@ $text-font-size: map.merge(
 $tree: () !default;
 $tree: map.merge(
   (
+    'node-content-height': 26px,
     'node-hover-bg-color': getCssVar('fill-color', 'light'),
     'text-color': getCssVar('text-color-regular'),
     'expand-icon-color': getCssVar('text-color-placeholder'),

--- a/packages/theme-chalk/src/tree.scss
+++ b/packages/theme-chalk/src/tree.scss
@@ -58,9 +58,11 @@
   }
 
   @include e(content) {
+    @include css-var-from-global('checkbox-height', 'tree-node-content-height');
+
     display: flex;
     align-items: center;
-    height: 26px;
+    height: getCssVar('tree-node-content-height');
     cursor: pointer;
 
     & > .#{$namespace}-tree-node__expand-icon {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6220438</samp>

This pull request introduces a custom CSS variable `--el-checkbox-height` that allows the user to adjust the height of the checkbox and tree components. The variable is defined in `common/var.scss` and used in `checkbox.scss` and `tree.scss`.

## Related Issue

Fixes #13396.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6220438</samp>

*  Add `node-content-height` variable to common variables file ([link](https://github.com/element-plus/element-plus/pull/13446/files?diff=unified&w=0#diff-eb85fc73444e26f19f950007c73a7d86028b1453c33efc86d2b5478ea027c01aR953))
*  Use custom CSS variable for checkbox and tree node content height ([link](https://github.com/element-plus/element-plus/pull/13446/files?diff=unified&w=0#diff-6b713f13028c431d017a143554ea7c4bbca90a9180858d1597bfb24718d615e2L52-R55), [link](https://github.com/element-plus/element-plus/pull/13446/files?diff=unified&w=0#diff-fb1d791e79d774edff5aadd2e705874b5d7ae0010c8beb5fef20215972df39eeL61-R65))
