### PR TITLE
docs: tooltip set max-width

### DIFF
--- a/docs/.vitepress/vitepress/components/globals/vp-api-typing.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-api-typing.vue
@@ -28,7 +28,7 @@ const detail = computed(() => apiTypingLocale[lang.value].detail)
         />
         <template #content>
           <slot>
-            <div class="m-1">
+            <div class="m-1" style="max-width: 600px">
               <code
                 style="
                   color: var(--code-tooltip-color);


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

before

![image](https://github.com/element-plus/element-plus/assets/24516654/ca76a839-bacb-41d7-95ad-2faf5d2beeb1)

after

![image](https://github.com/element-plus/element-plus/assets/24516654/1e1d111e-6e04-49c8-b15b-4af152599383)


## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 798b41b</samp>

Fixed code block overflow in documentation by setting `max-width` for `div` wrapper. This improves the readability and responsiveness of the `vp-api-typing.vue` component.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 798b41b</samp>

* Set `max-width` style for code block wrapper to prevent overflow ([link](https://github.com/element-plus/element-plus/pull/13462/files?diff=unified&w=0#diff-291615ff79e03460713002647d2a024c7382b86e3434e915f2bf4b9a1ad53689L31-R31))
