### PR TITLE
fix: add more exports types

### DIFF
--- a/packages/element-plus/package.json
+++ b/packages/element-plus/package.json
@@ -24,15 +24,36 @@
       "import": "./es/index.mjs",
       "require": "./lib/index.js"
     },
-    "./es": "./es/index.mjs",
-    "./lib": "./lib/index.js",
-    "./es/*.mjs": "./es/*.mjs",
-    "./es/*": {
-      "types": "./es/*/index.d.ts",
+    "./es": {
+      "types": "./es/index.d.ts",
+      "import": "./es/index.mjs"
+    },
+    "./lib": {
+      "types": "./lib/index.d.ts",
+      "require": "./lib/index.js"
+    },
+    "./es/*.mjs": {
+      "types": "./es/*.d.ts",
       "import": "./es/*.mjs"
     },
-    "./lib/*.js": "./lib/*.js",
-    "./lib/*": "./lib/*.js",
+    "./es/*": {
+      "types": [
+        "./es/*.d.ts",
+        "./es/*/index.d.ts"
+      ],
+      "import": "./es/*.mjs"
+    },
+    "./lib/*.js": {
+      "types": "./lib/*.d.ts",
+      "require": "./lib/*.js"
+    },
+    "./lib/*": {
+      "types": [
+        "./lib/*.d.ts",
+        "./lib/*/index.d.ts"
+      ],
+      "require": "./lib/*.js"
+    },
     "./*": "./*"
   },
   "unpkg": "dist/index.full.js",


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a1ef96</samp>

Updated the `exports` field in `packages/element-plus/package.json` to specify the TypeScript declaration files and the ESM and CommonJS versions for each subpath. This improves the TypeScript support and compatibility of the element-plus library.

## Related Issue

Fixes #12821

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a1ef96</samp>

*  Add TypeScript declaration files for each subpath module in the `exports` field of `package.json` ([link](https://github.com/element-plus/element-plus/pull/13498/files?diff=unified&w=0#diff-923d7d6b10313ed59d132ecf0395ac640320ed228a7172bccce53a8e7b859e01L27-R56))
*  Specify ESM and CommonJS versions of the modules using `import` and `require` properties in the `exports` field ([link](https://github.com/element-plus/element-plus/pull/13498/files?diff=unified&w=0#diff-923d7d6b10313ed59d132ecf0395ac640320ed228a7172bccce53a8e7b859e01L27-R56))
