### PR TITLE
docs(components): [dialog] use new display tag

### DIFF
--- a/docs/en-US/component/dialog.md
+++ b/docs/en-US/component/dialog.md
@@ -111,30 +111,34 @@ When using `modal` = false, please make sure that `append-to-body` was set to **
 
 :::
 
-## Attributes
+## API
 
-| Name                       | Description                                                                                       | Type                                              | Accepted Values | Default |
-| -------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------- | --------------- | ------- |
-| model-value / v-model      | visibility of Dialog                                                                              | boolean                                           | —               | —       |
-| title                      | title of Dialog. Can also be passed with a named slot (see the following table)                   | string                                            | —               | —       |
-| width                      | width of Dialog                                                                                   | string / number                                   | —               | 50%     |
-| fullscreen                 | whether the Dialog takes up full screen                                                           | boolean                                           | —               | false   |
-| top                        | value for `margin-top` of Dialog CSS                                                              | string                                            | —               | 15vh    |
-| modal                      | whether a mask is displayed                                                                       | boolean                                           | —               | true    |
-| modal-class                | custom class names for mask                                                                       | string                                            | —               | —       |
-| append-to-body             | whether to append Dialog itself to body. A nested Dialog should have this attribute set to `true` | boolean                                           | —               | false   |
-| lock-scroll                | whether scroll of body is disabled while Dialog is displayed                                      | boolean                                           | —               | true    |
-| custom-class ^(deprecated) | custom class names for Dialog                                                                     | string                                            | —               | —       |
-| open-delay                 | Time(milliseconds) before open                                                                    | number                                            | —               | 0       |
-| close-delay                | Time(milliseconds) before close                                                                   | number                                            | —               | 0       |
-| close-on-click-modal       | whether the Dialog can be closed by clicking the mask                                             | boolean                                           | —               | true    |
-| close-on-press-escape      | whether the Dialog can be closed by pressing ESC                                                  | boolean                                           | —               | true    |
-| show-close                 | whether to show a close button                                                                    | boolean                                           | —               | true    |
-| before-close               | callback before Dialog closes, and it will prevent Dialog from closing                            | Function(done) (done is used to close the Dialog) | —               | —       |
-| draggable                  | enable dragging feature for Dialog                                                                | boolean                                           | —               | false   |
-| center                     | whether to align the header and footer in center                                                  | boolean                                           | —               | false   |
-| align-center               | whether to align the dialog both horizontally and vertically                                      | boolean                                           | —               | false   |
-| destroy-on-close           | Destroy elements in Dialog when closed                                                            | boolean                                           | —               | false   |
+### Attributes
+
+| Name                       | Description                                                                                          | Type                                | Default |
+| -------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------- | ------- |
+| model-value / v-model      | visibility of Dialog                                                                                 | ^[boolean]                          | —       |
+| title                      | title of Dialog. Can also be passed with a named slot (see the following table)                      | ^[string]                           | ''      |
+| width                      | width of Dialog, default is 50%                                                                      | ^[string] / ^[number]               | ''      |
+| fullscreen                 | whether the Dialog takes up full screen                                                              | ^[boolean]                          | false   |
+| top                        | value for `margin-top` of Dialog CSS, default is 15vh                                                | ^[string]                           | ''      |
+| modal                      | whether a mask is displayed                                                                          | ^[boolean]                          | true    |
+| modal-class                | custom class names for mask                                                                          | ^[string]                           | —       |
+| append-to-body             | whether to append Dialog itself to body. A nested Dialog should have this attribute set to `true`    | ^[boolean]                          | false   |
+| lock-scroll                | whether scroll of body is disabled while Dialog is displayed                                         | ^[boolean]                          | true    |
+| custom-class ^(deprecated) | custom class names for Dialog                                                                        | ^[string]                           | ''      |
+| open-delay                 | the Time(milliseconds) before open                                                                   | ^[number]                           | 0       |
+| close-delay                | the Time(milliseconds) before close                                                                  | ^[number]                           | 0       |
+| close-on-click-modal       | whether the Dialog can be closed by clicking the mask                                                | ^[boolean]                          | true    |
+| close-on-press-escape      | whether the Dialog can be closed by pressing ESC                                                     | ^[boolean]                          | true    |
+| show-close                 | whether to show a close button                                                                       | ^[boolean]                          | true    |
+| before-close               | callback before Dialog closes, and it will prevent Dialog from closing, use done to close the dialog | ^[Function]`(done: DoneFn) => void` | —       |
+| draggable                  | enable dragging feature for Dialog                                                                   | ^[boolean]                          | false   |
+| center                     | whether to align the header and footer in center                                                     | ^[boolean]                          | false   |
+| align-center               | whether to align the dialog both horizontally and vertically                                         | ^[boolean]                          | false   |
+| destroy-on-close           | destroy elements in Dialog when closed                                                               | ^[boolean]                          | false   |
+| close-icon                 | custom close icon, default is Close                                                                  | ^[string] / ^[Component]            | —       |
+| z-index                    | same as z-index in native CSS, z-order of dialog                                                     | ^[number]                           | —       |
 
 :::warning
 
@@ -142,25 +146,31 @@ When using `modal` = false, please make sure that `append-to-body` was set to **
 
 :::
 
-## Slots
+### Slots
 
 | Name                | Description                                                                                           |
 | ------------------- | ----------------------------------------------------------------------------------------------------- |
 | —                   | content of Dialog                                                                                     |
 | header              | content of the Dialog header; Replacing this removes the title, but does not remove the close button. |
-| title ^(deprecated) | Works the same as the header slot. Use that instead.                                                  |
+| title ^(deprecated) | works the same as the header slot. Use that instead.                                                  |
 | footer              | content of the Dialog footer                                                                          |
 
-## Events
+:::warning
 
-| Name             | Description                                      | Parameters |
-| ---------------- | ------------------------------------------------ | ---------- |
-| open             | triggers when the Dialog opens                   | —          |
-| opened           | triggers when the Dialog opening animation ends  | —          |
-| close            | triggers when the Dialog closes                  | —          |
-| closed           | triggers when the Dialog closing animation ends  | —          |
-| open-auto-focus  | triggers after Dialog opens and content focused  | —          |
-| close-auto-focus | triggers after Dialog closed and content focused | —          |
+`title` has been **deprecated**, and **will be** removed in ^(2.4.0), please use `header`.
+
+:::
+
+### Events
+
+| Name             | Description                                      | Type                    |
+| ---------------- | ------------------------------------------------ | ----------------------- |
+| open             | triggers when the Dialog opens                   | ^[Function]`() => void` |
+| opened           | triggers when the Dialog opening animation ends  | ^[Function]`() => void` |
+| close            | triggers when the Dialog closes                  | ^[Function]`() => void` |
+| closed           | triggers when the Dialog closing animation ends  | ^[Function]`() => void` |
+| open-auto-focus  | triggers after Dialog opens and content focused  | ^[Function]`() => void` |
+| close-auto-focus | triggers after Dialog closed and content focused | ^[Function]`() => void` |
 
 ## FAQ
 

--- a/packages/components/dialog/src/dialog-content.ts
+++ b/packages/components/dialog/src/dialog-content.ts
@@ -1,14 +1,17 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 
 export const dialogContentProps = buildProps({
-  center: {
-    type: Boolean,
-    default: false,
-  },
-  alignCenter: {
-    type: Boolean,
-    default: false,
-  },
+  /**
+   * @description whether to align the header and footer in center
+   */
+  center: Boolean,
+  /**
+   * @description whether to align the dialog both horizontally and vertically
+   */
+  alignCenter: Boolean,
+  /**
+   * @description custom close icon, default is Close
+   */
   closeIcon: {
     type: iconPropType,
   },
@@ -19,18 +22,24 @@ export const dialogContentProps = buildProps({
     type: String,
     default: '',
   },
-  draggable: {
-    type: Boolean,
-    default: false,
-  },
-  fullscreen: {
-    type: Boolean,
-    default: false,
-  },
+  /**
+   * @description enable dragging feature for Dialog
+   */
+  draggable: Boolean,
+  /**
+   * @description whether the Dialog takes up full screen
+   */
+  fullscreen: Boolean,
+  /**
+   * @description whether to show a close button
+   */
   showClose: {
     type: Boolean,
     default: true,
   },
+  /**
+   * @description title of Dialog. Can also be passed with a named slot (see the following table)
+   */
   title: {
     type: String,
     default: '',

--- a/packages/components/dialog/src/dialog-content.vue
+++ b/packages/components/dialog/src/dialog-content.vue
@@ -1,17 +1,5 @@
 <template>
-  <div
-    :ref="composedDialogRef"
-    :class="[
-      ns.b(),
-      ns.is('fullscreen', fullscreen),
-      ns.is('draggable', draggable),
-      ns.is('align-center', alignCenter),
-      { [ns.m('center')]: center },
-      customClass,
-    ]"
-    :style="style"
-    tabindex="-1"
-  >
+  <div :ref="composedDialogRef" :class="dialogKls" :style="style" tabindex="-1">
     <header ref="headerRef" :class="ns.e('header')">
       <slot name="header">
         <span role="heading" :class="ns.e('title')">
@@ -57,6 +45,15 @@ defineEmits(dialogContentEmits)
 
 const { dialogRef, headerRef, bodyId, ns, style } = inject(dialogInjectionKey)!
 const { focusTrapRef } = inject(FOCUS_TRAP_INJECTION_KEY)!
+
+const dialogKls = computed(() => [
+  ns.b(),
+  ns.is('fullscreen', props.fullscreen),
+  ns.is('draggable', props.draggable),
+  ns.is('align-center', props.alignCenter),
+  { [ns.m('center')]: props.center },
+  props.customClass,
+])
 
 const composedDialogRef = composeRefs(focusTrapRef, dialogRef)
 

--- a/packages/components/dialog/src/dialog.ts
+++ b/packages/components/dialog/src/dialog.ts
@@ -9,55 +9,91 @@ export type DialogBeforeCloseFn = (done: DoneFn) => void
 
 export const dialogProps = buildProps({
   ...dialogContentProps,
-  appendToBody: {
-    type: Boolean,
-    default: false,
-  },
+  /**
+   * @description whether to append Dialog itself to body. A nested Dialog should have this attribute set to `true`
+   */
+  appendToBody: Boolean,
+  /**
+   * @description callback before Dialog closes, and it will prevent Dialog from closing, use done to close the dialog
+   */
   beforeClose: {
     type: definePropType<DialogBeforeCloseFn>(Function),
   },
-  destroyOnClose: {
-    type: Boolean,
-    default: false,
-  },
+  /**
+   * @description destroy elements in Dialog when closed
+   */
+  destroyOnClose: Boolean,
+  /**
+   * @description whether the Dialog can be closed by clicking the mask
+   */
   closeOnClickModal: {
     type: Boolean,
     default: true,
   },
+  /**
+   * @description whether the Dialog can be closed by pressing ESC
+   */
   closeOnPressEscape: {
     type: Boolean,
     default: true,
   },
+  /**
+   * @description whether scroll of body is disabled while Dialog is displayed
+   */
   lockScroll: {
     type: Boolean,
     default: true,
   },
+  /**
+   * @description whether a mask is displayed
+   */
   modal: {
     type: Boolean,
     default: true,
   },
+  /**
+   * @description the Time(milliseconds) before open
+   */
   openDelay: {
     type: Number,
     default: 0,
   },
+  /**
+   * @description the Time(milliseconds) before close
+   */
   closeDelay: {
     type: Number,
     default: 0,
   },
+  /**
+   * @description value for `margin-top` of Dialog CSS, default is 15vh
+   */
   top: {
     type: String,
   },
-  modelValue: {
-    type: Boolean,
-    default: false,
-  },
+  /**
+   * @description visibility of Dialog
+   */
+  modelValue: Boolean,
+  /**
+   * @description custom class names for mask
+   */
   modalClass: String,
+  /**
+   * @description width of Dialog, default is 50%
+   */
   width: {
     type: [String, Number],
   },
+  /**
+   * @description same as z-index in native CSS, z-order of dialog
+   */
   zIndex: {
     type: Number,
   },
+  /**
+   * @deprecated will be removed in version 2.4.0
+   */
   trapFocus: {
     type: Boolean,
     default: false,

--- a/packages/components/dialog/src/dialog.ts
+++ b/packages/components/dialog/src/dialog.ts
@@ -91,9 +91,6 @@ export const dialogProps = buildProps({
   zIndex: {
     type: Number,
   },
-  /**
-   * @deprecated will be removed in version 2.4.0
-   */
   trapFocus: {
     type: Boolean,
     default: false,


### PR DESCRIPTION
Related: #10754 

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0ecc00</samp>

This pull request updates the `Draggable Dialog` component and its documentation to use the new prop annotation format and improve readability. It also marks some deprecated features with a warning message and refactors some template and script code. The affected files are `docs/en-US/component/dialog.md`, `packages/components/dialog/src/dialog-content.ts`, `packages/components/dialog/src/dialog-content.vue`, and `packages/components/dialog/src/dialog.ts`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0ecc00</samp>

*  Update the `Attributes`, `Slots`, and `Events` sections of the `Draggable Dialog` documentation in `docs/en-US/component/dialog.md` to match the new API format and reflect the latest changes in the component code ([link](https://github.com/element-plus/element-plus/pull/13499/files?diff=unified&w=0#diff-abbb3d078da77db6d9ad1eed9a9356891f9119733d8e8bb4fc8771e3429dc626L114-R142), [link](https://github.com/element-plus/element-plus/pull/13499/files?diff=unified&w=0#diff-abbb3d078da77db6d9ad1eed9a9356891f9119733d8e8bb4fc8771e3429dc626L145-R149), [link](https://github.com/element-plus/element-plus/pull/13499/files?diff=unified&w=0#diff-abbb3d078da77db6d9ad1eed9a9356891f9119733d8e8bb4fc8771e3429dc626L151-R174))
*  Update the prop annotation format and description of the `dialogProps` and `dialogContentProps` objects in `dialog.ts` and `dialog-content.ts` files, and mark the `trapFocus` prop as deprecated ([link](https://github.com/element-plus/element-plus/pull/13499/files?diff=unified&w=0#diff-b1abdb1afe933b28864280eb5eab6d5d9edc5174b3a04d819515ee9f015b3befL4-R14), [link](https://github.com/element-plus/element-plus/pull/13499/files?diff=unified&w=0#diff-b1abdb1afe933b28864280eb5eab6d5d9edc5174b3a04d819515ee9f015b3befL22-R42), [link](https://github.com/element-plus/element-plus/pull/13499/files?diff=unified&w=0#diff-8e4884ffc45253766cb46796a84d2aeb1fb07f95966b3a4e2440f264948807b6L12-R96))
*  Add the `dialogKls` computed property to the `dialog-content.vue` file to generate the class names for the dialog element, and use it in the template instead of the inline expression ([link](https://github.com/element-plus/element-plus/pull/13499/files?diff=unified&w=0#diff-bb6d76682592cb7b9dce997ae9cce0aaad06c8c422fda86008ab31c3d34f0756L2-R2), [link](https://github.com/element-plus/element-plus/pull/13499/files?diff=unified&w=0#diff-bb6d76682592cb7b9dce997ae9cce0aaad06c8c422fda86008ab31c3d34f0756R49-R57))
