### PR TITLE
fix(components): [date-picker] fix attribute conflict

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -274,8 +274,13 @@ const checkDateWithinRange = (date: ConfigType) => {
     ? timeWithinRange(date, selectableRange.value, props.format || 'HH:mm:ss')
     : true
 }
-const formatEmit = (emitDayjs: Dayjs) => {
-  if (defaultTime && !visibleTime.value && !isChangeToNow.value) {
+const formatEmit = (emitDayjs: Dayjs, isShortcut = false) => {
+  if (
+    defaultTime &&
+    !visibleTime.value &&
+    !isChangeToNow.value &&
+    !isShortcut
+  ) {
     return defaultTimeD.value
       .year(emitDayjs.year())
       .month(emitDayjs.month())
@@ -284,14 +289,14 @@ const formatEmit = (emitDayjs: Dayjs) => {
   if (showTime.value) return emitDayjs.millisecond(0)
   return emitDayjs.startOf('day')
 }
-const emit = (value: Dayjs | Dayjs[], ...args: any[]) => {
+const emit = (value: Dayjs | Dayjs[], isShortcut = false, ...args: any[]) => {
   if (!value) {
     contextEmit('pick', value, ...args)
   } else if (isArray(value)) {
-    const dates = value.map(formatEmit)
+    const dates = value.map((date) => formatEmit(date))
     contextEmit('pick', dates, ...args)
   } else {
-    contextEmit('pick', formatEmit(value), ...args)
+    contextEmit('pick', formatEmit(value, isShortcut), ...args)
   }
   userInputDate.value = null
   userInputTime.value = null
@@ -366,7 +371,7 @@ const handleShortcutClick = (shortcut: Shortcut) => {
     ? shortcut.value()
     : shortcut.value
   if (shortcutValue) {
-    emit(dayjs(shortcutValue).locale(lang.value))
+    emit(dayjs(shortcutValue).locale(lang.value), true)
     return
   }
   if (shortcut.onClick) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9b18497</samp>

Add `isShortcut` parameter to `panel-date-pick.vue` to enable shortcut date emission without default time. This enhances the date picker component's usability and precision.

## Related Issue

Fixes #13483.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9b18497</samp>

* Add a new parameter `isShortcut` to the `formatEmit` function to avoid applying the default time value to the shortcut date ([link](https://github.com/element-plus/element-plus/pull/13503/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759L277-R283))
* Pass the `isShortcut` parameter to the `formatEmit` function in the `emit` function, which emits the selected date value to the parent component ([link](https://github.com/element-plus/element-plus/pull/13503/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759L287-R299))
* Pass the `isShortcut` parameter as `true` to the `emit` function in the shortcut handler function, which is triggered by the shortcut option click ([link](https://github.com/element-plus/element-plus/pull/13503/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759L369-R374))
