### PR TITLE
fix(components): fix the attribute conflict

### DIFF
--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1560,4 +1560,34 @@ describe('MonthRange', () => {
     await nextTick()
     expect(pickHandler).toHaveBeenCalledTimes(1)
   })
+
+  it('prop defaultTime should not confilt with prop shortcuts', async () => {
+    const wrapper = _mount(
+      `<el-date-picker
+          v-model="value"
+          type="datetime"
+          :shortcuts="[
+                { text: '12:00', value: new Date(2023, 0, 1, 12) }
+              , { text: '13:00', value: new Date(2023, 0, 1, 13) }
+              , { text: '14:00', value: new Date(2023, 0, 1, 14) }
+            ]"
+          :defaultTime="new Date(2023, 0, 1, 19, 0, 0)"
+        />`,
+      () => ({ value: '' })
+    )
+    const input = wrapper.find('input')
+    input.trigger('blur')
+    input.trigger('focus')
+    await nextTick()
+    document
+      .querySelector('.el-picker-panel__sidebar .el-picker-panel__shortcut')
+      .click()
+    await nextTick()
+    const vm = wrapper.vm as any
+    expect(vm.value).toBeDefined()
+    expect(vm.value.getFullYear()).toBe(2023)
+    expect(vm.value.getMonth()).toBe(0)
+    expect(vm.value.getDate()).toBe(1)
+    expect(vm.value.getHours()).toBe(12)
+  })
 })

--- a/packages/components/date-picker/__tests__/date-time-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-time-picker.test.tsx
@@ -760,4 +760,34 @@ describe('Datetimerange', () => {
     expect(startInput.element.value).toBe('')
     expect(endInput.element.value).toBe('')
   })
+
+  it('prop defaultTime should not confilt with prop shortcuts', async () => {
+    const value = ref('')
+    const wrapper = _mount(() => (
+      <DatePicker
+        v-model={value.value}
+        type="datetime"
+        shortcuts={[
+          { text: '12:00', value: new Date(2023, 0, 1, 12) },
+          { text: '13:00', value: new Date(2023, 0, 1, 13) },
+          { text: '14:00', value: new Date(2023, 0, 1, 14) },
+        ]}
+        default-time={new Date(2023, 0, 1, 19, 0, 0)}
+      />
+    ))
+    const input = wrapper.find('input')
+    input.trigger('blur')
+    input.trigger('focus')
+    await nextTick()
+    ;(
+      document.querySelector(
+        '.el-picker-panel__sidebar .el-picker-panel__shortcut'
+      ) as HTMLElement
+    ).click()
+    await nextTick()
+    expect(value.value).toBeDefined()
+    expect(dayjs(value.value).format('YYYY-MM-DD HH:mm:ss')).toStrictEqual(
+      '2023-01-01 12:00:00'
+    )
+  })
 })

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -319,11 +319,11 @@ const handleDatePick = (value: DateTableEmits, keepOpen?: boolean) => {
         .date(value.date())
     }
     innerDate.value = newDate
-    emit(newDate, showTime.value || keepOpen)
+    emit(newDate, false, showTime.value || keepOpen)
   } else if (selectionMode.value === 'week') {
     emit((value as WeekPickerEmits).date)
   } else if (selectionMode.value === 'dates') {
-    emit(value as DatesPickerEmits, true) // set true to keep panel open
+    emit(value as DatesPickerEmits, false, true) // set true to keep panel open
   }
 }
 
@@ -400,11 +400,11 @@ const hasShortcuts = computed(() => !!shortcuts.length)
 const handleMonthPick = async (month: number) => {
   innerDate.value = innerDate.value.startOf('month').month(month)
   if (selectionMode.value === 'month') {
-    emit(innerDate.value, false)
+    emit(innerDate.value, false, false)
   } else {
     currentView.value = 'date'
     if (['month', 'year', 'date', 'week'].includes(selectionMode.value)) {
-      emit(innerDate.value, true)
+      emit(innerDate.value, false, true)
       await nextTick()
       handleFocusPicker()
     }
@@ -415,12 +415,12 @@ const handleMonthPick = async (month: number) => {
 const handleYearPick = async (year: number) => {
   if (selectionMode.value === 'year') {
     innerDate.value = innerDate.value.startOf('year').year(year)
-    emit(innerDate.value, false)
+    emit(innerDate.value, false, false)
   } else {
     innerDate.value = innerDate.value.year(year)
     currentView.value = 'month'
     if (['month', 'year', 'date', 'week'].includes(selectionMode.value)) {
-      emit(innerDate.value, true)
+      emit(innerDate.value, false, true)
       await nextTick()
       handleFocusPicker()
     }
@@ -525,7 +525,7 @@ const handleTimePick = (value: Dayjs, visible: boolean, first: boolean) => {
     ? (props.parsedValue as Dayjs).hour(hour).minute(minute).second(second)
     : value
   innerDate.value = newDate
-  emit(innerDate.value, true)
+  emit(innerDate.value, false, true)
   if (!first) {
     timePickerVisible.value = visible
   }
@@ -538,7 +538,7 @@ const handleVisibleTimeChange = (value: string) => {
     innerDate.value = newDate.year(year).month(month).date(date)
     userInputTime.value = null
     timePickerVisible.value = false
-    emit(innerDate.value, true)
+    emit(innerDate.value, false, true)
   }
 }
 
@@ -551,7 +551,7 @@ const handleVisibleDateChange = (value: string) => {
     const { hour, minute, second } = getUnits(innerDate.value)
     innerDate.value = newDate.hour(hour).minute(minute).second(second)
     userInputDate.value = null
-    emit(innerDate.value, true)
+    emit(innerDate.value, false, true)
   }
 }
 
@@ -621,7 +621,7 @@ const handleKeydownTable = (event: KeyboardEvent) => {
     userInputTime.value === null
   ) {
     event.preventDefault()
-    emit(innerDate.value, false)
+    emit(innerDate.value, false, false)
   }
 }
 

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -274,8 +274,13 @@ const checkDateWithinRange = (date: ConfigType) => {
     ? timeWithinRange(date, selectableRange.value, props.format || 'HH:mm:ss')
     : true
 }
-const formatEmit = (emitDayjs: Dayjs) => {
-  if (defaultTime && !visibleTime.value && !isChangeToNow.value) {
+const formatEmit = (emitDayjs: Dayjs, isShortcut = false) => {
+  if (
+    defaultTime &&
+    !visibleTime.value &&
+    !isChangeToNow.value &&
+    !isShortcut
+  ) {
     return defaultTimeD.value
       .year(emitDayjs.year())
       .month(emitDayjs.month())
@@ -284,14 +289,14 @@ const formatEmit = (emitDayjs: Dayjs) => {
   if (showTime.value) return emitDayjs.millisecond(0)
   return emitDayjs.startOf('day')
 }
-const emit = (value: Dayjs | Dayjs[], ...args: any[]) => {
+const emit = (value: Dayjs | Dayjs[], isShortcut = false, ...args: any[]) => {
   if (!value) {
     contextEmit('pick', value, ...args)
   } else if (isArray(value)) {
-    const dates = value.map(formatEmit)
+    const dates = value.map((date) => formatEmit(date))
     contextEmit('pick', dates, ...args)
   } else {
-    contextEmit('pick', formatEmit(value), ...args)
+    contextEmit('pick', formatEmit(value, isShortcut), ...args)
   }
   userInputDate.value = null
   userInputTime.value = null
@@ -366,7 +371,7 @@ const handleShortcutClick = (shortcut: Shortcut) => {
     ? shortcut.value()
     : shortcut.value
   if (shortcutValue) {
-    emit(dayjs(shortcutValue).locale(lang.value))
+    emit(dayjs(shortcutValue).locale(lang.value), true)
     return
   }
   if (shortcut.onClick) {

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -253,7 +253,7 @@ const innerDate = ref(dayjs().locale(lang.value))
 
 const isChangeToNow = ref(false)
 
-const isShortcut = ref(false)
+let isShortcut = false
 
 const defaultTimeD = computed(() => {
   return dayjs(defaultTime).locale(lang.value)
@@ -281,7 +281,7 @@ const formatEmit = (emitDayjs: Dayjs) => {
     defaultTime &&
     !visibleTime.value &&
     !isChangeToNow.value &&
-    !isShortcut.value
+    !isShortcut
   ) {
     return defaultTimeD.value
       .year(emitDayjs.year())
@@ -303,7 +303,7 @@ const emit = (value: Dayjs | Dayjs[], ...args: any[]) => {
   userInputDate.value = null
   userInputTime.value = null
   isChangeToNow.value = false
-  isShortcut.value = false
+  isShortcut = false
 }
 const handleDatePick = (value: DateTableEmits, keepOpen?: boolean) => {
   if (selectionMode.value === 'date') {
@@ -374,7 +374,7 @@ const handleShortcutClick = (shortcut: Shortcut) => {
     ? shortcut.value()
     : shortcut.value
   if (shortcutValue) {
-    isShortcut.value = true
+    isShortcut = true
     emit(dayjs(shortcutValue).locale(lang.value))
     return
   }


### PR DESCRIPTION
When value is input by shortcut, it's value will not be changed by defaultTime anymore

closed #13483

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 146b1df</samp>

This change improves the date picker component by allowing shortcut options to emit date values without default time values. It introduces a new parameter `isShortcut` to the `formatEmit` and `emit` functions in `panel-date-pick.vue`.

## Related Issue

Fixes #13483.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 146b1df</samp>

* Add `isShortcut` parameter to `formatEmit` and `emit` functions to indicate shortcut date selection ([link](https://github.com/element-plus/element-plus/pull/13504/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759L277-R283), [link](https://github.com/element-plus/element-plus/pull/13504/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759L287-R299), [link](https://github.com/element-plus/element-plus/pull/13504/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759L369-R374))
