### PR TITLE
docs(locale): import language path

### DIFF
--- a/docs/en-US/guide/i18n.md
+++ b/docs/en-US/guide/i18n.md
@@ -14,7 +14,7 @@ Element Plus provides global configurations
 
 ```typescript
 import ElementPlus from 'element-plus'
-import zhCn from 'element-plus/dist/locale/zh-cn.mjs'
+import zhCn from 'element-plus/lib/locale/lang/zh-cn'
 
 app.use(ElementPlus, {
   locale: zhCn,
@@ -37,7 +37,7 @@ for globally configuring locale and other settings.
   import { defineComponent } from 'vue'
   import { ElConfigProvider } from 'element-plus'
 
-  import zhCn from 'element-plus/dist/locale/zh-cn.mjs'
+  import zhCn from 'element-plus/lib/locale/lang/zh-cn'
 
   export default defineComponent({
     components: {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

The current document uses: `import zhCn from 'element-plus/dist/locale/zh-cn.mjs';` Prompt that the type declaration file for the module cannot be found Change to: `import zhCn from 'element-plus/lib/locale/lang/zh-cn';`
  will solve the problem

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b74aadf</samp>

Fixed import paths of locale files in the i18n guide. This improves the documentation accuracy and avoids potential i18n errors.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b74aadf</samp>

* Updated the import paths of the Chinese locale file to match the new directory structure of the element-plus package ([link](https://github.com/element-plus/element-plus/pull/13508/files?diff=unified&w=0#diff-5ac3e68d4785d7645cd3e748941017f0670dc5f937c38155863202c89c00207dL17-R17), [link](https://github.com/element-plus/element-plus/pull/13508/files?diff=unified&w=0#diff-5ac3e68d4785d7645cd3e748941017f0670dc5f937c38155863202c89c00207dL40-R40))
