### PR TITLE
fix(components): [row] align='top' is not working properly

### DIFF
--- a/packages/components/row/src/row.vue
+++ b/packages/components/row/src/row.vue
@@ -37,6 +37,6 @@ const style = computed(() => {
 const rowKls = computed(() => [
   ns.b(),
   ns.is(`justify-${props.justify}`, props.justify !== 'start'),
-  ns.is(`align-${props.align}`, props.align !== 'top'),
+  ns.is(`align-${props.align}`),
 ])
 </script>

--- a/packages/theme-chalk/src/row.scss
+++ b/packages/theme-chalk/src/row.scss
@@ -23,6 +23,9 @@
   @include when(justify-space-evenly) {
     justify-content: space-evenly;
   }
+  @include when(align-top) {
+    align-items: flex-start;
+  }
   @include when(align-middle) {
     align-items: center;
   }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4576170</samp>

Removed redundant condition for `align` class in `row.vue` and added `align-top` style rule in `row.scss` to support vertical alignment of row elements.

## Related Issue

Fixes #13538

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4576170</samp>

*  Simplify `align` class logic in `row.vue` component ([link](https://github.com/element-plus/element-plus/pull/13546/files?diff=unified&w=0#diff-de374d84834ffecf1ffb0b35f667dc7b9a2d004d8d8ee77d145c6f8da4c8b3adL40-R40))
*  Add style rule for `align-top` modifier class in `row.scss` file ([link](https://github.com/element-plus/element-plus/pull/13546/files?diff=unified&w=0#diff-144484ad2dd884e906df21614908a374a45fbf192983c660c368bae7df54df27R26-R28))
