### PR TITLE
Update table-v2.md

### DIFF
--- a/docs/en-US/component/table-v2.md
+++ b/docs/en-US/component/table-v2.md
@@ -499,12 +499,13 @@ type HeaderCellSlotProps = {
 }
 
 type RowSlotProps = {
-  columnIndex: number
-  rowIndex: number
-  data: any
-  key: number | string
-  isScrolling?: boolean | undefined
+  cells: VNode[]
   style: CSSProperties
+  columns: Column<any>[]
+  depth: number
+  rowData: any
+  rowIndex: number
+  isScrolling?: boolean | undefined
 }
 
 type Data = {


### PR DESCRIPTION
fix(docs): CellSlotProps type error

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a4718f</samp>

Updated the `row` slot interface of the `el-table` component and its documentation. The new interface provides more row information and customization options.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a4718f</samp>

*  Update the type of the `row` slot in the `el-table` component to provide more information and flexibility for customizing the row rendering ([link](https://github.com/element-plus/element-plus/pull/13583/files?diff=unified&w=0#diff-fbf98dbc4f3a5f2ab656152a5d6a8099ab38202e225f262d51933b03d2f23339L502-R508))
