### PR TITLE
fix(components): refDebounced imported from wrong package

### DIFF
--- a/packages/components/form/src/form-item.vue
+++ b/packages/components/form/src/form-item.vue
@@ -52,7 +52,7 @@ import {
 } from 'vue'
 import AsyncValidator from 'async-validator'
 import { clone } from 'lodash-unified'
-import { refDebounced } from '@vueuse/core'
+import { refDebounced } from '@vueuse/shared'
 import {
   addUnit,
   ensureArray,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a5d9054</samp>

Changed the import source of `refDebounced` in `form-item.vue` to a smaller package. This improves the performance and code quality of the `form` component.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a5d9054</samp>

* Change the import source of `refDebounced` from `@vueuse/core` to `@vueuse/shared` to reduce bundle size and avoid unnecessary dependencies ([link](https://github.com/element-plus/element-plus/pull/13598/files?diff=unified&w=0#diff-ec639edfd5d7463de4e60beb64943914663f64e5e4fc14ca2d93166e1ef2bad3L55-R55))
