### PR TITLE
fix(components): [date-picker] Custom Content not working for month type

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/basic-month-cell-render.tsx
+++ b/packages/components/date-picker/src/date-picker-com/basic-month-cell-render.tsx
@@ -1,0 +1,31 @@
+import { defineComponent, inject } from 'vue'
+import { useNamespace } from '@element-plus/hooks'
+import { ROOT_PICKER_INJECTION_KEY } from '../constants'
+import { basicCellProps } from '../props/basic-month-cell'
+
+export default defineComponent({
+  name: 'ElMonthPickerCell',
+  props: basicCellProps,
+  setup(props) {
+    const { slots } = inject(ROOT_PICKER_INJECTION_KEY)!
+    return () => {
+      const { cell } = props
+      if (slots.default) {
+        const list = slots.default(cell).filter((item) => {
+          return (
+            item.patchFlag !== -2 && item.type.toString() !== 'Symbol(Comment)'
+          )
+        })
+        if (list.length) {
+          return list
+        }
+      }
+
+      return (
+        <div>
+          <span class="cell">{cell?.text}</span>
+        </div>
+      )
+    }
+  },
+})

--- a/packages/components/date-picker/src/date-picker.type.ts
+++ b/packages/components/date-picker/src/date-picker.type.ts
@@ -29,3 +29,19 @@ export interface DateCell {
   dayjs?: Dayjs
   type?: DateCellType
 }
+
+export interface MonthCell {
+  column: number
+  row: number
+  disabled: boolean
+  start: boolean
+  end: boolean
+  text: string
+  index: number
+  type: 'normal' | 'today'
+  inRange: boolean
+  dayjs: Dayjs
+  date: Date
+  isCurrent: boolean
+  timestamp: number
+}

--- a/packages/components/date-picker/src/props/basic-month-cell.ts
+++ b/packages/components/date-picker/src/props/basic-month-cell.ts
@@ -1,0 +1,12 @@
+import { buildProps, definePropType } from '@element-plus/utils'
+
+import type { ExtractPropTypes } from 'vue'
+import type { MonthCell } from '../date-picker.type'
+
+export const basicCellProps = buildProps({
+  cell: {
+    type: definePropType<MonthCell>(Object),
+  },
+} as const)
+
+export type BasicCellProps = ExtractPropTypes<typeof basicCellProps>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

For date type where we are able to use slot to show custom content, for month calender also, make the date-picker able to use slot to show custom content.

## Related Issue

Fixes #13535.

## Explanation of Changes

* add basic-cell-render component to show the slot content
* refactor the MonthCell type to expose more attributes for users to use
