### PR TITLE
fix(components): [tree] fix expand-icon.is-leaf prevent click event

### DIFF
--- a/packages/theme-chalk/src/tree.scss
+++ b/packages/theme-chalk/src/tree.scss
@@ -104,6 +104,7 @@
     &.is-leaf {
       color: transparent;
       cursor: default;
+      visibility: hidden;
     }
     &.is-hidden {
       visibility: hidden;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

-[x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

unfold icon on leaf-node has wrong cursor although it is hidden.what's more,it covers the leaf-node and make it unable to trigger click event

## Related Issue

Fixes #13613.

## Explanation of Changes

add visibility:hidden to unfold icon in leaf-node