### PR TITLE
fix(components): [select] fix for confusing click behaviour (#13642)

### DIFF
--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -805,9 +805,12 @@ export const useSelect = (props, states: States, ctx) => {
 
   const handleBlur = (event: FocusEvent) => {
     setTimeout(() => {
-      // validate current focus event is inside el-tooltip-content
+      // validate current focus event is inside el-tooltip-content or el-select
       // if so, ignore the blur event and the next focus event
-      if (tooltipRef.value?.isFocusInsideContent()) {
+      if (
+        tooltipRef.value?.isFocusInsideContent() ||
+        selectWrapper.value?.contains(event.relatedTarget)
+      ) {
         ignoreFocusEvent = true
         return
       }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c030957</samp>

Fixed a bug in `select` component where the dropdown would not close when clicking on another `select`. Added a check for `el-tooltip-content` in `handleBlur` function in `useSelect.ts`.

## Related Issue

Fixes #13642.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c030957</samp>

* Fix select dropdown not closing when clicking on another select component by checking focus event target in `handleBlur` function ([link](https://github.com/element-plus/element-plus/pull/13652/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L808-R813))
