### PR TITLE
fix(components): [date-picker] disable button if now is disabled

### DIFF
--- a/packages/components/date-picker/__tests__/date-time-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-time-picker.test.tsx
@@ -162,7 +162,7 @@ describe('Datetime Picker', () => {
   })
 
   it('now button: can not choose disabled date', async () => {
-    let isDisable = true
+    const isDisable = true
     const value = ref('')
     const disabledDate = () => isDisable
     const wrapper = _mount(() => (
@@ -185,11 +185,6 @@ describe('Datetime Picker', () => {
     await nextTick()
 
     expect(value.value).toBe('')
-    isDisable = false
-    await nextTick()
-    btn.click()
-    await nextTick()
-    expect(value.value).not.toBe('')
   })
 
   it('confirm button honors picked date', async () => {

--- a/packages/components/date-picker/__tests__/date-time-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-time-picker.test.tsx
@@ -187,6 +187,24 @@ describe('Datetime Picker', () => {
     expect(value.value).toBe('')
   })
 
+  it('now button: should be disabled when current date is disabled', async () => {
+    const isDisable = true
+    const disabledDate = () => isDisable
+    const wrapper = _mount(() => (
+      <DatePicker type="datetime" disabledDate={disabledDate} />
+    ))
+
+    const input = wrapper.find('input')
+    input.trigger('blur')
+    input.trigger('focus')
+    await nextTick()
+    // now button is disabled
+    const btn: HTMLElement = document.querySelector(
+      '.el-picker-panel__footer .is-text'
+    )!
+    expect(btn.getAttribute('disabled')).not.toBeUndefined()
+  })
+
   it('confirm button honors picked date', async () => {
     const value = ref(new Date(2000, 9, 1, 12, 0, 0))
     const wrapper = _mount(() => (

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -168,6 +168,7 @@
         text
         size="small"
         :class="ppNs.e('link-btn')"
+        :disabled="disabledNow"
         @click="changeToNow"
       >
         {{ t('el.datepicker.now') }}
@@ -176,6 +177,7 @@
         plain
         size="small"
         :class="ppNs.e('link-btn')"
+        :disabled="disabledConfirm"
         @click="onConfirm"
       >
         {{ t('el.datepicker.confirm') }}
@@ -437,6 +439,11 @@ const footerVisible = computed(() => {
   return showTime.value || selectionMode.value === 'dates'
 })
 
+const disabledConfirm = computed(() => {
+  if (!disabledDate) return false
+  if (!props.parsedValue) return true
+  return disabledDate(props.parsedValue)
+})
 const onConfirm = () => {
   if (selectionMode.value === 'dates') {
     emit(props.parsedValue as Dayjs[])
@@ -456,6 +463,10 @@ const onConfirm = () => {
   }
 }
 
+const disabledNow = computed(() => {
+  if (!disabledDate) return false
+  return disabledDate(dayjs().locale(lang.value).toDate())
+})
 const changeToNow = () => {
   // NOTE: not a permanent solution
   //       consider disable "now" button in the future

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -442,7 +442,10 @@ const footerVisible = computed(() => {
 const disabledConfirm = computed(() => {
   if (!disabledDate) return false
   if (!props.parsedValue) return true
-  return disabledDate(props.parsedValue)
+  if (isArray(props.parsedValue)) {
+    return disabledDate(props.parsedValue[0].toDate())
+  }
+  return disabledDate(props.parsedValue.toDate())
 })
 const onConfirm = () => {
   if (selectionMode.value === 'dates') {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6375356</samp>

Add `disabled` props to date picker panel buttons. This allows users to see when the "Now" and "Confirm" buttons are not available based on the `disabledDate` and `parsedValue` props of the date picker component.

## Related Issue

Fixes #13643.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6375356</samp>

*  Add `disabled` props to "Now" and "Confirm" buttons in date picker panel ([link](https://github.com/element-plus/element-plus/pull/13655/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759R171), [link](https://github.com/element-plus/element-plus/pull/13655/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759R180))
*  Define `disabledConfirm` and `disabledNow` computed properties to check if selected or current date is disabled by `disabledDate` prop ([link](https://github.com/element-plus/element-plus/pull/13655/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759R442-R446), [link](https://github.com/element-plus/element-plus/pull/13655/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759R466-R469))
*  Use `dayjs` library to get current date and set locale according to `lang` prop in `panel-date-pick.vue` ([link](https://github.com/element-plus/element-plus/pull/13655/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759R466-R469))
