### PR TITLE
fix(components): [table] fix level err in load-generated rows

### DIFF
--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -25,13 +25,14 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     const res = {}
     if (!keys.length) return res
     keys.forEach((key) => {
-      if (lazyTreeNodeMap.value[key].length) {
-        const item = { children: [] }
-        lazyTreeNodeMap.value[key].forEach((row) => {
+      const { children, level } = lazyTreeNodeMap.value[key]
+      if (children.length) {
+        const item = { children: [], level }
+        children.forEach((row) => {
           const currentRowKey = getRowIdentity(row, rowKey)
           item.children.push(currentRowKey)
           if (row[lazyColumnIdentifier.value] && !res[currentRowKey]) {
-            res[currentRowKey] = { children: [] }
+            res[currentRowKey] = { children: [], level: level + 1 }
           }
         })
         res[key] = item
@@ -110,7 +111,8 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
       if (lazy.value && lazyKeys.length && rootLazyRowKeys.length) {
         lazyKeys.forEach((key) => {
           const oldValue = oldTreeData[key]
-          const lazyNodeChildren = normalizedLazyNode_[key].children
+          const { children: lazyNodeChildren, level = '' } =
+            normalizedLazyNode_[key]
           if (rootLazyRowKeys.includes(key)) {
             // 懒加载的 root 节点，更新一下原有的数据，原来的 children 一定是空数组
             if (newTreeData[key].children.length !== 0) {
@@ -125,7 +127,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
               loading: !!loading,
               expanded: getExpanded(oldValue, key),
               children: lazyNodeChildren,
-              level: '',
+              level,
             }
           }
         })
@@ -201,7 +203,10 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
         treeData.value[key].loaded = true
         treeData.value[key].expanded = true
         if (data.length) {
-          lazyTreeNodeMap.value[key] = data
+          lazyTreeNodeMap.value[key] = {
+            children: data,
+            level: treeData.value[key].level,
+          }
         }
         instance.emit('expand-change', row, true)
       })

--- a/packages/components/table/src/table-body/render-helper.ts
+++ b/packages/components/table/src/table-body/render-helper.ts
@@ -249,7 +249,7 @@ function useRender<T>(props: Partial<TableBodyProps<T>>) {
             tmp.push(rowRender(node, $index + i, innerTreeRowData))
             if (cur) {
               const nodes =
-                lazyTreeNodeMap.value[childKey] ||
+                lazyTreeNodeMap.value[childKey]?.children ||
                 node[childrenColumnName.value]
               traverse(nodes, cur)
             }
@@ -258,7 +258,7 @@ function useRender<T>(props: Partial<TableBodyProps<T>>) {
         // 对于 root 节点，display 一定为 true
         cur.display = true
         const nodes =
-          lazyTreeNodeMap.value[key] || row[childrenColumnName.value]
+          lazyTreeNodeMap.value[key]?.children || row[childrenColumnName.value]
         traverse(nodes, cur)
       }
       return tmp


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

The level field of the tree node parameter of the lazy load method becomes an empty string when the level exceeds 1
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c3f8cd6</samp>

This pull request enhances the tree table component by fixing a bug with indentation for lazy-loaded nodes and adding error handling for accessing their children. It modifies the `tree.ts` and `render-helper.ts` files in the `table` component.

## Related Issue

Fixes #13619.

## Explanation of Changes

Add the level attribute in lazyTreeNodeMap value and use it to maintain the level in TreeData.
The pre method to maintain the level in DOM Node is travelling up the TreeData.Here can also travel up the treeData to maintain the level value,but I think it better to maintain the level value in lazyTreeNodeMap 
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c3f8cd6</samp>

*  Add and assign `level` property to tree nodes to fix indentation bug for lazy-loaded nodes ([link](https://github.com/element-plus/element-plus/pull/13671/files?diff=unified&w=0#diff-3d07efb93ef7ab28c5c66bda71423ad68670d4c5aae44218574d651b792d2fd8L28-R35), [link](https://github.com/element-plus/element-plus/pull/13671/files?diff=unified&w=0#diff-3d07efb93ef7ab28c5c66bda71423ad68670d4c5aae44218574d651b792d2fd8L113-R115), [link](https://github.com/element-plus/element-plus/pull/13671/files?diff=unified&w=0#diff-3d07efb93ef7ab28c5c66bda71423ad68670d4c5aae44218574d651b792d2fd8L128-R130), [link](https://github.com/element-plus/element-plus/pull/13671/files?diff=unified&w=0#diff-3d07efb93ef7ab28c5c66bda71423ad68670d4c5aae44218574d651b792d2fd8L204-R209))
*  Use optional chaining operator to prevent errors when accessing `children` property of undefined or null objects in `tree.ts` and `render-helper.ts` (  [link](https://github.com/element-plus/element-plus/pull/13671/files?diff=unified&w=0#diff-3f6ca57f264afd56fa303c14b84100c6a9b567f00a6fe8da67edf85671b97157L252-R252), [link](https://github.com/element-plus/element-plus/pull/13671/files?diff=unified&w=0#diff-3f6ca57f264afd56fa303c14b84100c6a9b567f00a6fe8da67edf85671b97157L261-R261))
