### PR TITLE
feat(components): [date-picker] add prop for custom now date

### DIFF
--- a/docs/en-US/component/datetime-picker.md
+++ b/docs/en-US/component/datetime-picker.md
@@ -92,6 +92,7 @@ datetime-picker/default-time
 | shortcuts             | an object array to set shortcut options                                                               | object[{ text: string, value: date / function }] | —                                                             | —                   |
 | disabled-date         | a function determining if a date is disabled with that date as its parameter. Should return a Boolean | function(Date)                                   | —                                                             | —                   |
 | cell-class-name       | set custom className                                                                                  | Function(Date)                                   | —                                                             | —                   |
+| now-value             | set custom date for now button                                                                        | ^[Function]`() => Date`                          | —                                                             | —                   |
 | teleported            | whether datetime-picker dropdown is teleported to the body                                            | boolean                                          | true / false                                                  | true                |
 
 ## Events

--- a/packages/components/date-picker/__tests__/date-time-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-time-picker.test.tsx
@@ -113,6 +113,23 @@ describe('Datetime Picker', () => {
     expect(dayjs(value.value).diff(dayjs()) < 10).toBeTruthy()
   })
 
+  it('custom now date', async () => {
+    const now = new Date('2018-04-04T16:10:00.000Z')
+    const value = ref('')
+    const wrapper = _mount(() => (
+      <DatePicker v-model={value.value} type="datetime" nowValue={() => now} />
+    ))
+    const input = wrapper.find('input')
+    input.trigger('blur')
+    input.trigger('focus')
+    await nextTick()
+    ;(
+      document.querySelector('.el-picker-panel__link-btn') as HTMLElement
+    )?.click()
+    await nextTick()
+    expect(value.value).toEqual(now)
+  })
+
   it('time-picker select && input time && input date', async () => {
     const value = ref('')
     const wrapper = _mount(() => (

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -243,8 +243,14 @@ const slots = useSlots()
 const { t, lang } = useLocale()
 const pickerBase = inject('EP_PICKER_BASE') as any
 const popper = inject(TOOLTIP_INJECTION_KEY)
-const { shortcuts, disabledDate, cellClassName, defaultTime, arrowControl } =
-  pickerBase.props
+const {
+  shortcuts,
+  disabledDate,
+  cellClassName,
+  defaultTime,
+  arrowControl,
+  nowValue,
+} = pickerBase.props
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 
 const currentViewRef = ref<{ focus: () => void }>()
@@ -459,14 +465,15 @@ const onConfirm = () => {
 const changeToNow = () => {
   // NOTE: not a permanent solution
   //       consider disable "now" button in the future
-  const now = dayjs().locale(lang.value)
+  const customNow = nowValue?.()
+  const now = dayjs(customNow).locale(lang.value)
   const nowDate = now.toDate()
   isChangeToNow.value = true
   if (
     (!disabledDate || !disabledDate(nowDate)) &&
     checkDateWithinRange(nowDate)
   ) {
-    innerDate.value = dayjs().locale(lang.value)
+    innerDate.value = dayjs(customNow).locale(lang.value)
     emit(innerDate.value)
   }
 }

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -465,15 +465,15 @@ const onConfirm = () => {
 const changeToNow = () => {
   // NOTE: not a permanent solution
   //       consider disable "now" button in the future
-  const customNow = nowValue?.()
-  const now = dayjs(customNow).locale(lang.value)
+  const nowRaw = isFunction(nowValue) ? nowValue() : new Date()
+  const now = dayjs(nowRaw).locale(lang.value)
   const nowDate = now.toDate()
   isChangeToNow.value = true
   if (
     (!disabledDate || !disabledDate(nowDate)) &&
     checkDateWithinRange(nowDate)
   ) {
-    innerDate.value = dayjs(customNow).locale(lang.value)
+    innerDate.value = dayjs(nowRaw).locale(lang.value)
     emit(innerDate.value)
   }
 }

--- a/packages/components/time-picker/src/common/props.ts
+++ b/packages/components/time-picker/src/common/props.ts
@@ -215,6 +215,10 @@ export const timePickerDefaultProps = buildProps({
    * @description unlink two date-panels in range-picker
    */
   unlinkPanels: Boolean,
+  /**
+   * @description set custom now date
+   */
+  nowValue: Function,
 } as const)
 
 export type TimePickerDefaultProps = ExtractPropTypes<


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

With the changes it is possible to pass a custom 'now' date to the date picker, that will be applied after clicking the now button. 

## Related Issue

--

## Explanation of Changes

Added a new prop `now-value` to date picker component (which accepts a function that returns the custom now date) and set this custom now date in click handler of now button if exist (changeToNow function).
