### PR TITLE
fix(theme-chalk): [menu] the popup menu has 2px border at the bottom

### DIFF
--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -76,8 +76,11 @@
   @include m(horizontal) {
     display: flex;
     flex-wrap: nowrap;
-    border-bottom: solid 1px getCssVar('menu-border-color');
     border-right: none;
+
+    &.#{$namespace}-menu {
+      border-bottom: solid 1px getCssVar('menu-border-color');
+    }
 
     & > .#{$namespace}-menu-item {
       display: inline-flex;
@@ -92,11 +95,6 @@
       a,
       a:hover {
         color: inherit;
-      }
-
-      &:not(.is-disabled):hover,
-      &:not(.is-disabled):focus {
-        background-color: #fff;
       }
     }
     & > .#{$namespace}-sub-menu {


### PR DESCRIPTION
![2023-07-22 10.47.26.png](https://img1.imgtp.com/2023/07/22/58yQ0W9i.png)

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14f7d15</samp>

Improved menu component styling in `menu.scss`. Fixed a border-bottom bug and removed unnecessary hover and focus effects for horizontal menu items.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 14f7d15</samp>

* Fix border-bottom bug on horizontal submenus by moving style to more specific selector ([link](https://github.com/element-plus/element-plus/pull/13695/files?diff=unified&w=0#diff-451ad66686a31c13be1b990962362c2ef9421c307729380fde9251ec87ea91baL79-R84))
* Remove hover and focus styles from menu items to match design spec and avoid overlap with active style ([link](https://github.com/element-plus/element-plus/pull/13695/files?diff=unified&w=0#diff-451ad66686a31c13be1b990962362c2ef9421c307729380fde9251ec87ea91baL96-L100))
