### PR TITLE
refactor(components): [menu] adjust default value of fallbackPlacements

### DIFF
--- a/packages/components/menu/src/sub-menu.ts
+++ b/packages/components/menu/src/sub-menu.ts
@@ -159,6 +159,8 @@ export default defineComponent({
           ]
         : [
             'right-start',
+            'right',
+            'right-end',
             'left-start',
             'bottom-start',
             'bottom-end',


### PR DESCRIPTION
closed #13682

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c51ea35</samp>

Add `right` and `right-end` options for `placement` prop of `sub-menu` component. This allows sub-menus to be positioned more flexibly relative to their parent menus.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c51ea35</samp>

* Add two new options for the `placement` prop of the `sub-menu` component: `right` and `right-end` ([link](https://github.com/element-plus/element-plus/pull/13696/files?diff=unified&w=0#diff-e88a538d21977473a9cbf0151395e8ca2c30b47937addaab50089612fd907b95R162-R163))
