### PR TITLE
fix(components): [select] abnormal focus when click tags

### DIFF
--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -7,7 +7,6 @@ import { ArrowDown, CaretTop, CircleClose } from '@element-plus/icons-vue'
 import { usePopperContainerId } from '@element-plus/hooks'
 import { hasClass } from '@element-plus/utils'
 import { ElFormItem } from '@element-plus/components/form'
-import sleep from '@element-plus/test-utils/sleep'
 import Select from '../src/select.vue'
 import Group from '../src/option-group.vue'
 import Option from '../src/option.vue'
@@ -1222,10 +1221,72 @@ describe('Select', () => {
 
     expect(input.exists()).toBe(true)
     await input.trigger('focus')
-    expect(handleFocus).toHaveBeenCalled()
+    expect(handleFocus).toHaveBeenCalledTimes(1)
     await input.trigger('blur')
-    await sleep(0)
-    expect(handleBlur).toHaveBeenCalled()
+    expect(handleBlur).toHaveBeenCalledTimes(1)
+
+    await input.trigger('focus')
+    expect(handleFocus).toHaveBeenCalledTimes(2)
+    await input.trigger('blur')
+    expect(handleBlur).toHaveBeenCalledTimes(2)
+  })
+
+  test('event:focus & blur for clearable & filterable', async () => {
+    const handleFocus = vi.fn()
+    const handleBlur = vi.fn()
+    wrapper = _mount(
+      `<el-select
+        v-model="value"
+        clearable
+        filterable
+        @focus="handleFocus"
+        @blur="handleBlur"
+      >
+        <el-option
+          v-for="item in options"
+          :label="item.label"
+          :key="item.value"
+          :value="item.value"
+        />
+      </el-select>`,
+      () => ({
+        options: [
+          {
+            value: '选项1',
+            label: '黄金糕',
+          },
+        ],
+        value: '选项1',
+        handleFocus,
+        handleBlur,
+      })
+    )
+
+    const select = wrapper.findComponent({ name: 'ElSelect' })
+    const vm = wrapper.vm as any
+    const selectVm = select.vm as any
+    selectVm.inputHovering = true
+    await selectVm.$nextTick()
+
+    const iconClear = wrapper.findComponent(CircleClose)
+    expect(iconClear.exists()).toBe(true)
+    await iconClear.trigger('click')
+    expect(vm.value).toBe('')
+    expect(handleFocus).toHaveBeenCalledTimes(1)
+    expect(handleBlur).not.toHaveBeenCalled()
+
+    const options = getOptions()
+    options[0].click()
+    await nextTick()
+    expect(vm.value).toBe('选项1')
+    selectVm.inputHovering = true
+    await iconClear.trigger('click')
+    expect(handleFocus).toHaveBeenCalledTimes(1)
+    expect(handleBlur).not.toHaveBeenCalled()
+
+    const input = select.find('input')
+    await input.trigger('blur')
+    expect(handleBlur).toHaveBeenCalledTimes(1)
   })
 
   test('event:focus & blur for multiple & filterable select', async () => {
@@ -1251,8 +1312,73 @@ describe('Select', () => {
     await input.trigger('focus')
     expect(handleFocus).toHaveBeenCalled()
     await input.trigger('blur')
-    await sleep(0)
     expect(handleBlur).toHaveBeenCalled()
+
+    await input.trigger('focus')
+    expect(handleFocus).toHaveBeenCalledTimes(2)
+    await input.trigger('blur')
+    expect(handleBlur).toHaveBeenCalledTimes(2)
+  })
+
+  test('event:focus & blur for multiple tag close', async () => {
+    const handleFocus = vi.fn()
+    const handleBlur = vi.fn()
+    wrapper = _mount(
+      `<el-select
+        v-model="value"
+        multiple
+        @focus="handleFocus"
+        @blur="handleBlur"
+      >
+        <el-option
+          v-for="item in options"
+          :label="item.label"
+          :key="item.value"
+          :value="item.value">
+          <p>{{item.label}} {{item.value}}</p>
+        </el-option>
+      </el-select>`,
+      () => ({
+        options: [
+          {
+            value: '选项1',
+            label: '黄金糕',
+          },
+          {
+            value: '选项2',
+            label: '双皮奶',
+          },
+          {
+            value: '选项3',
+            label: '蚵仔煎',
+          },
+          {
+            value: '选项4',
+            label: '龙须面',
+          },
+          {
+            value: '选项5',
+            label: '北京烤鸭',
+          },
+        ],
+        value: ['选项1', '选项2'],
+        handleFocus,
+        handleBlur,
+      })
+    )
+
+    const select = wrapper.findComponent({ name: 'ElSelect' })
+    const input = select.find('input')
+
+    await input.trigger('focus')
+    expect(handleFocus).toHaveBeenCalledTimes(1)
+    const tagCloseIcons = wrapper.findAll('.el-tag__close')
+    await tagCloseIcons[1].trigger('click')
+    await tagCloseIcons[0].trigger('click')
+    expect(handleFocus).toHaveBeenCalledTimes(1)
+    expect(handleBlur).not.toHaveBeenCalled()
+    await input.trigger('blur')
+    expect(handleBlur).toHaveBeenCalledTimes(1)
   })
 
   test('should not open popper when automatic-dropdown not set', async () => {

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -33,8 +33,11 @@
           <div
             v-if="multiple"
             ref="tags"
+            role="button"
+            tabindex="-1"
             :class="tagsKls"
             :style="selectTagsStyle"
+            @click="focus"
           >
             <transition
               v-if="collapseTags && selected.length"
@@ -279,7 +282,7 @@ import {
 import { useResizeObserver } from '@vueuse/core'
 import { placements } from '@popperjs/core'
 import { ClickOutside } from '@element-plus/directives'
-import { useFocus, useLocale, useNamespace } from '@element-plus/hooks'
+import { useLocale, useNamespace } from '@element-plus/hooks'
 import ElInput from '@element-plus/components/input'
 import ElTooltip, {
   useTooltipContentProps,
@@ -462,6 +465,7 @@ export default defineComponent({
       onOptionDestroy,
       handleMenuEnter,
       handleFocus,
+      focus,
       blur,
       handleBlur,
       handleClearClick,
@@ -489,8 +493,6 @@ export default defineComponent({
       showTagList,
       collapseTagList,
     } = useSelect(props, states, ctx)
-
-    const { focus } = useFocus(reference)
 
     const {
       inputWidth,
@@ -682,6 +684,7 @@ export default defineComponent({
       handleComposition,
       handleMenuEnter,
       handleFocus,
+      focus,
       blur,
       handleBlur,
       handleClearClick,
@@ -692,7 +695,6 @@ export default defineComponent({
       getValueKey,
       navigateOptions,
       dropMenuVisible,
-      focus,
 
       reference,
       input,

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -33,7 +33,6 @@
           <div
             v-if="multiple"
             ref="tags"
-            role="button"
             tabindex="-1"
             :class="tagsKls"
             :style="selectTagsStyle"

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -652,6 +652,7 @@ export const useSelect = (props, states: States, ctx) => {
     states.hoverIndex = -1
     states.visible = false
     ctx.emit('clear')
+    focus()
   }
 
   const handleOptionSelect = (option) => {
@@ -829,6 +830,7 @@ export const useSelect = (props, states: States, ctx) => {
   }
 
   const handleClearClick = (event: Event) => {
+    console.log('handleClearClick')
     deleteSelected(event)
   }
 

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -812,21 +812,19 @@ export const useSelect = (props, states: States, ctx) => {
   }
 
   const handleBlur = (event: FocusEvent) => {
-    setTimeout(() => {
-      // validate current focus event is inside el-tooltip-content or el-select
-      // if so, ignore the blur event.
-      if (
-        tooltipRef.value?.isFocusInsideContent() ||
-        tagTooltipRef.value?.isFocusInsideContent() ||
-        selectWrapper.value?.contains(event.relatedTarget)
-      ) {
-        return
-      }
+    // validate current focus event is inside el-tooltip-content or el-select
+    // if so, ignore the blur event.
+    if (
+      tooltipRef.value?.isFocusInsideContent(event) ||
+      tagTooltipRef.value?.isFocusInsideContent(event) ||
+      selectWrapper.value?.contains(event.relatedTarget)
+    ) {
+      return
+    }
 
-      states.visible && handleClose()
-      states.focused = false
-      ctx.emit('blur', event)
-    })
+    states.visible && handleClose()
+    states.focused = false
+    ctx.emit('blur', event)
   }
 
   const handleClearClick = (event: Event) => {

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -830,7 +830,6 @@ export const useSelect = (props, states: States, ctx) => {
   }
 
   const handleClearClick = (event: Event) => {
-    console.log('handleClearClick')
     deleteSelected(event)
   }
 

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -57,9 +57,9 @@ export function useSelectStates(props) {
     isOnComposition: false,
     prefixWidth: 11,
     mouseEnter: false,
+    focused: false,
   })
 }
-let ignoreFocusEvent = false
 
 type States = ReturnType<typeof useSelectStates>
 
@@ -270,7 +270,6 @@ export const useSelect = (props, states: States, ctx) => {
             props.remoteMethod('')
           }
         }
-        input.value && input.value.blur()
         states.query = ''
         states.previousQuery = null
         states.selectedLabel = ''
@@ -637,6 +636,7 @@ export const useSelect = (props, states: States, ctx) => {
       ctx.emit('remove-tag', tag.value)
     }
     event.stopPropagation()
+    focus()
   }
 
   const deleteSelected = (event) => {
@@ -784,16 +784,23 @@ export const useSelect = (props, states: States, ctx) => {
   }
 
   const handleFocus = (event: FocusEvent) => {
-    if (!ignoreFocusEvent) {
+    if (!states.focused) {
       if (props.automaticDropdown || props.filterable) {
         if (props.filterable && !states.visible) {
           states.menuVisibleOnFocus = true
         }
         states.visible = true
       }
+      states.focused = true
       ctx.emit('focus', event)
+    }
+  }
+
+  const focus = () => {
+    if (states.visible) {
+      ;(input.value || reference.value)?.focus()
     } else {
-      ignoreFocusEvent = false
+      reference.value?.focus()
     }
   }
 
@@ -806,15 +813,17 @@ export const useSelect = (props, states: States, ctx) => {
   const handleBlur = (event: FocusEvent) => {
     setTimeout(() => {
       // validate current focus event is inside el-tooltip-content or el-select
-      // if so, ignore the blur event and the next focus event
+      // if so, ignore the blur event.
       if (
         tooltipRef.value?.isFocusInsideContent() ||
+        tagTooltipRef.value?.isFocusInsideContent() ||
         selectWrapper.value?.contains(event.relatedTarget)
       ) {
-        ignoreFocusEvent = true
         return
       }
+
       states.visible && handleClose()
+      states.focused = false
       ctx.emit('blur', event)
     })
   }
@@ -847,9 +856,7 @@ export const useSelect = (props, states: States, ctx) => {
           states.visible = !states.visible
         }
       }
-      if (states.visible) {
-        ;(input.value || reference.value)?.focus()
-      }
+      focus()
     }
   }
 
@@ -954,6 +961,7 @@ export const useSelect = (props, states: States, ctx) => {
     onOptionDestroy,
     handleMenuEnter,
     handleFocus,
+    focus,
     blur,
     handleBlur,
     handleClearClick,

--- a/packages/components/tooltip/src/tooltip.vue
+++ b/packages/components/tooltip/src/tooltip.vue
@@ -154,10 +154,12 @@ watch(
   }
 )
 
-const isFocusInsideContent = () => {
+const isFocusInsideContent = (event?: FocusEvent) => {
   const popperContent: HTMLElement | undefined =
     contentRef.value?.contentRef?.popperContentRef
-  return popperContent && popperContent.contains(document.activeElement)
+  const activeElement = (event?.relatedTarget as Node) || document.activeElement
+
+  return popperContent && popperContent.contains(activeElement)
 }
 
 onDeactivated(() => open.value && hide())


### PR DESCRIPTION
closed #13665, close #13487, close #13750

[before](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6Ijx0ZW1wbGF0ZT5cbiAgPGRpdiBjbGFzcz1cIm0tNFwiPlxuICAgIDxwPm11bHRpcGxlPC9wPlxuICAgIDxlbC1zZWxlY3RcbiAgICAgIHYtbW9kZWw9XCJ2YWx1ZTFcIlxuICAgICAgbXVsdGlwbGVcbiAgICAgIHBsYWNlaG9sZGVyPVwiU2VsZWN0XCJcbiAgICAgIHN0eWxlPVwid2lkdGg6IDI0MHB4XCJcbiAgICAgIEBmb2N1cz1cImxvZygnZm9jdXMnKVwiXG4gICAgICBAYmx1cj1cImxvZygnYmx1cicpXCJcbiAgICA+XG4gICAgICA8ZWwtb3B0aW9uXG4gICAgICAgIHYtZm9yPVwiaXRlbSBpbiBvcHRpb25zXCJcbiAgICAgICAgOmtleT1cIml0ZW0udmFsdWVcIlxuICAgICAgICA6bGFiZWw9XCJpdGVtLmxhYmVsXCJcbiAgICAgICAgOnZhbHVlPVwiaXRlbS52YWx1ZVwiXG4gICAgICAvPlxuICAgIDwvZWwtc2VsZWN0PlxuICA8L2Rpdj5cbiAgPGRpdiBjbGFzcz1cIm0tNFwiPlxuICAgIDxwPm11bHRpcGxlICsgZmlsdGVyYWJsZTwvcD5cbiAgICA8ZWwtc2VsZWN0XG4gICAgICB2LW1vZGVsPVwidmFsdWUyXCJcbiAgICAgIG11bHRpcGxlXG4gICAgICBmaWx0ZXJhYmxlIFxuICAgICAgcGxhY2Vob2xkZXI9XCJTZWxlY3RcIlxuICAgICAgc3R5bGU9XCJ3aWR0aDogMjQwcHhcIlxuICAgICAgQGZvY3VzPVwibG9nKCdmb2N1cycpXCJcbiAgICAgIEBibHVyPVwibG9nKCdibHVyJylcIlxuICAgID5cbiAgICAgIDxlbC1vcHRpb25cbiAgICAgICAgdi1mb3I9XCJpdGVtIGluIG9wdGlvbnNcIlxuICAgICAgICA6a2V5PVwiaXRlbS52YWx1ZVwiXG4gICAgICAgIDpsYWJlbD1cIml0ZW0ubGFiZWxcIlxuICAgICAgICA6dmFsdWU9XCJpdGVtLnZhbHVlXCJcbiAgICAgIC8+XG4gICAgPC9lbC1zZWxlY3Q+XG4gIDwvZGl2PlxuICA8ZGl2IGNsYXNzPVwibS00XCI+XG4gICAgPHA+ZGVmYXVsdDwvcD5cbiAgICA8ZWwtc2VsZWN0XG4gICAgICB2LW1vZGVsPVwidmFsdWUzXCJcbiAgICAgIHBsYWNlaG9sZGVyPVwiU2VsZWN0XCJcbiAgICAgIHN0eWxlPVwid2lkdGg6IDI0MHB4XCJcbiAgICAgIEBmb2N1cz1cImxvZygnZm9jdXMnKVwiXG4gICAgICBAYmx1cj1cImxvZygnYmx1cicpXCJcbiAgICA+XG4gICAgICA8ZWwtb3B0aW9uXG4gICAgICAgIHYtZm9yPVwiaXRlbSBpbiBvcHRpb25zXCJcbiAgICAgICAgOmtleT1cIml0ZW0udmFsdWVcIlxuICAgICAgICA6bGFiZWw9XCJpdGVtLmxhYmVsXCJcbiAgICAgICAgOnZhbHVlPVwiaXRlbS52YWx1ZVwiXG4gICAgICAvPlxuICAgIDwvZWwtc2VsZWN0PlxuICA8L2Rpdj5cbiAgPGRpdiBjbGFzcz1cIm0tNFwiPlxuICAgIDxwPmZpbHRlcmFibGU8L3A+XG4gICAgPGVsLXNlbGVjdFxuICAgICAgdi1tb2RlbD1cInZhbHVlNFwiXG4gICAgICBmaWx0ZXJhYmxlXG4gICAgICBwbGFjZWhvbGRlcj1cIlNlbGVjdFwiXG4gICAgICBzdHlsZT1cIndpZHRoOiAyNDBweFwiXG4gICAgICBAZm9jdXM9XCJsb2coJ2ZvY3VzJylcIlxuICAgICAgQGJsdXI9XCJsb2coJ2JsdXInKVwiXG4gICAgPlxuICAgICAgPGVsLW9wdGlvblxuICAgICAgICB2LWZvcj1cIml0ZW0gaW4gb3B0aW9uc1wiXG4gICAgICAgIDprZXk9XCJpdGVtLnZhbHVlXCJcbiAgICAgICAgOmxhYmVsPVwiaXRlbS5sYWJlbFwiXG4gICAgICAgIDp2YWx1ZT1cIml0ZW0udmFsdWVcIlxuICAgICAgLz5cbiAgICA8L2VsLXNlbGVjdD5cbiAgPC9kaXY+XG48L3RlbXBsYXRlPlxuXG48c2NyaXB0IGxhbmc9XCJ0c1wiIHNldHVwPlxuaW1wb3J0IHsgcmVmIH0gZnJvbSAndnVlJ1xuXG5jb25zdCB2YWx1ZTEgPSByZWYoW10pXG5jb25zdCB2YWx1ZTIgPSByZWYoW10pXG5jb25zdCB2YWx1ZTMgPSByZWYoKVxuY29uc3QgdmFsdWU0ID0gcmVmKClcbmNvbnN0IG9wdGlvbnMgPSBbXG4gIHtcbiAgICB2YWx1ZTogJ09wdGlvbjEnLFxuICAgIGxhYmVsOiAnT3B0aW9uMScsXG4gIH0sXG4gIHtcbiAgICB2YWx1ZTogJ09wdGlvbjInLFxuICAgIGxhYmVsOiAnT3B0aW9uMicsXG4gIH0sXG4gIHtcbiAgICB2YWx1ZTogJ09wdGlvbjMnLFxuICAgIGxhYmVsOiAnT3B0aW9uMycsXG4gIH0sXG4gIHtcbiAgICB2YWx1ZTogJ09wdGlvbjQnLFxuICAgIGxhYmVsOiAnT3B0aW9uNCcsXG4gIH0sXG4gIHtcbiAgICB2YWx1ZTogJ09wdGlvbjUnLFxuICAgIGxhYmVsOiAnT3B0aW9uNScsXG4gIH0sXG5dXG5cbmNvbnN0IGxvZyA9IChzdHI6IHN0cmluZykgPT4ge1xuICBjb25zb2xlLmxvZygnLS0tLScsIHN0cilcbn1cbjwvc2NyaXB0PlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge31cbn0iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWUsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwiX28iOnt9fQ==)

[after](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6Ijx0ZW1wbGF0ZT5cbiAgPGRpdiBjbGFzcz1cIm0tNFwiPlxuICAgIDxwPm11bHRpcGxlPC9wPlxuICAgIDxlbC1zZWxlY3RcbiAgICAgIHYtbW9kZWw9XCJ2YWx1ZTFcIlxuICAgICAgbXVsdGlwbGVcbiAgICAgIGNsZWFyYWJsZVxuICAgICAgcGxhY2Vob2xkZXI9XCJTZWxlY3RcIlxuICAgICAgc3R5bGU9XCJ3aWR0aDogMjQwcHhcIlxuICAgICAgQGZvY3VzPVwibG9nKCdmb2N1cycpXCJcbiAgICAgIEBibHVyPVwibG9nKCdibHVyJylcIlxuICAgID5cbiAgICAgIDxlbC1vcHRpb25cbiAgICAgICAgdi1mb3I9XCJpdGVtIGluIG9wdGlvbnNcIlxuICAgICAgICA6a2V5PVwiaXRlbS52YWx1ZVwiXG4gICAgICAgIDpsYWJlbD1cIml0ZW0ubGFiZWxcIlxuICAgICAgICA6dmFsdWU9XCJpdGVtLnZhbHVlXCJcbiAgICAgIC8+XG4gICAgPC9lbC1zZWxlY3Q+XG4gIDwvZGl2PlxuICA8ZGl2IGNsYXNzPVwibS00XCI+XG4gICAgPHA+bXVsdGlwbGUgKyBmaWx0ZXJhYmxlPC9wPlxuICAgIDxlbC1zZWxlY3RcbiAgICAgIHYtbW9kZWw9XCJ2YWx1ZTJcIlxuICAgICAgbXVsdGlwbGVcbiAgICAgIGNsZWFyYWJsZVxuICAgICAgZmlsdGVyYWJsZSBcbiAgICAgIHBsYWNlaG9sZGVyPVwiU2VsZWN0XCJcbiAgICAgIHN0eWxlPVwid2lkdGg6IDI0MHB4XCJcbiAgICAgIEBmb2N1cz1cImxvZygnZm9jdXMnKVwiXG4gICAgICBAYmx1cj1cImxvZygnYmx1cicpXCJcbiAgICA+XG4gICAgICA8ZWwtb3B0aW9uXG4gICAgICAgIHYtZm9yPVwiaXRlbSBpbiBvcHRpb25zXCJcbiAgICAgICAgOmtleT1cIml0ZW0udmFsdWVcIlxuICAgICAgICA6bGFiZWw9XCJpdGVtLmxhYmVsXCJcbiAgICAgICAgOnZhbHVlPVwiaXRlbS52YWx1ZVwiXG4gICAgICAvPlxuICAgIDwvZWwtc2VsZWN0PlxuICA8L2Rpdj5cbiAgPGRpdiBjbGFzcz1cIm0tNFwiPlxuICAgIDxwPmRlZmF1bHQ8L3A+XG4gICAgPGVsLXNlbGVjdFxuICAgICAgdi1tb2RlbD1cInZhbHVlM1wiXG4gICAgICBjbGVhcmFibGVcbiAgICAgIHBsYWNlaG9sZGVyPVwiU2VsZWN0XCJcbiAgICAgIHN0eWxlPVwid2lkdGg6IDI0MHB4XCJcbiAgICAgIEBmb2N1cz1cImxvZygnZm9jdXMnKVwiXG4gICAgICBAYmx1cj1cImxvZygnYmx1cicpXCJcbiAgICA+XG4gICAgICA8ZWwtb3B0aW9uXG4gICAgICAgIHYtZm9yPVwiaXRlbSBpbiBvcHRpb25zXCJcbiAgICAgICAgOmtleT1cIml0ZW0udmFsdWVcIlxuICAgICAgICA6bGFiZWw9XCJpdGVtLmxhYmVsXCJcbiAgICAgICAgOnZhbHVlPVwiaXRlbS52YWx1ZVwiXG4gICAgICAvPlxuICAgIDwvZWwtc2VsZWN0PlxuICA8L2Rpdj5cbiAgPGRpdiBjbGFzcz1cIm0tNFwiPlxuICAgIDxwPmZpbHRlcmFibGU8L3A+XG4gICAgPGVsLXNlbGVjdFxuICAgICAgdi1tb2RlbD1cInZhbHVlNFwiXG4gICAgICBmaWx0ZXJhYmxlXG4gICAgICBjbGVhcmFibGVcbiAgICAgIHBsYWNlaG9sZGVyPVwiU2VsZWN0XCJcbiAgICAgIHN0eWxlPVwid2lkdGg6IDI0MHB4XCJcbiAgICAgIEBmb2N1cz1cImxvZygnZm9jdXMnKVwiXG4gICAgICBAYmx1cj1cImxvZygnYmx1cicpXCJcbiAgICA+XG4gICAgICA8ZWwtb3B0aW9uXG4gICAgICAgIHYtZm9yPVwiaXRlbSBpbiBvcHRpb25zXCJcbiAgICAgICAgOmtleT1cIml0ZW0udmFsdWVcIlxuICAgICAgICA6bGFiZWw9XCJpdGVtLmxhYmVsXCJcbiAgICAgICAgOnZhbHVlPVwiaXRlbS52YWx1ZVwiXG4gICAgICAvPlxuICAgIDwvZWwtc2VsZWN0PlxuICA8L2Rpdj5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgbGFuZz1cInRzXCIgc2V0dXA+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5cbmNvbnN0IHZhbHVlMSA9IHJlZihbXSlcbmNvbnN0IHZhbHVlMiA9IHJlZihbXSlcbmNvbnN0IHZhbHVlMyA9IHJlZigpXG5jb25zdCB2YWx1ZTQgPSByZWYoKVxuY29uc3Qgb3B0aW9ucyA9IFtcbiAge1xuICAgIHZhbHVlOiAnT3B0aW9uMScsXG4gICAgbGFiZWw6ICdPcHRpb24xJyxcbiAgfSxcbiAge1xuICAgIHZhbHVlOiAnT3B0aW9uMicsXG4gICAgbGFiZWw6ICdPcHRpb24yJyxcbiAgfSxcbiAge1xuICAgIHZhbHVlOiAnT3B0aW9uMycsXG4gICAgbGFiZWw6ICdPcHRpb24zJyxcbiAgfSxcbiAge1xuICAgIHZhbHVlOiAnT3B0aW9uNCcsXG4gICAgbGFiZWw6ICdPcHRpb240JyxcbiAgfSxcbiAge1xuICAgIHZhbHVlOiAnT3B0aW9uNScsXG4gICAgbGFiZWw6ICdPcHRpb241JyxcbiAgfSxcbl1cblxuY29uc3QgbG9nID0gKHN0cjogc3RyaW5nKSA9PiB7XG4gIGNvbnNvbGUubG9nKCctLS0tJywgc3RyKVxufVxuPC9zY3JpcHQ+XG4iLCJzcmMvUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9wcmV2aWV3LTEzNjk5LWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIlxuICB9XG59IiwidHNjb25maWcuanNvbiI6IntcbiAgXCJjb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVSZXNvbHV0aW9uXCI6IFwiQnVuZGxlclwiLFxuICAgIFwiYWxsb3dJbXBvcnRpbmdUc0V4dGVuc2lvbnNcIjogdHJ1ZSxcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXVxuICB9LFxuICBcInZ1ZUNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogMy4zXG4gIH1cbn1cbiIsInNyYy9lbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5pbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICBsaW5rLmhyZWYgPSAnaHR0cHM6Ly9wcmV2aWV3LTEzNjk5LWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguY3NzJ1xuICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdlcnJvcicsIHJlamVjdClcbiAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICB9KVxufSIsIl9vIjp7InNob3dIaWRkZW4iOnRydWUsInN0eWxlU291cmNlIjoiaHR0cHM6Ly9wcmV2aWV3LTEzNjk5LWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguY3NzIn19)

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9e3e21f</samp>

This pull request enhances the accessibility and keyboard interaction of the select component and its multiple variant. It adds or modifies some attributes and methods related to focus and role in `select.vue` and `useSelect.ts`. It also fixes some bugs and refactors some code in these files.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9e3e21f</samp>

*  Improve the accessibility and keyboard interaction of the multiple select component by adding `role`, `tabindex`, and `click` attributes and handler to the `tags` element ([link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540L36-R40))
*  Remove the unused import of `useFocus` from `select.vue` ([link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540L282-R285))
*  Add the `focus` method to the `methods` object and the `expose` function of the `select.vue` component, which is a proxy for the `focus` method defined in `useSelect.ts` ([link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540R468), [link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540R687))
*  Remove the redundant or unnecessary `focus` methods from the `setup` function and the `expose` function of the `select.vue` component ([link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540L493-L494), [link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-9bfd95a8f0051f829d273a71e6ae89d2f5b583a6bdb2d808dd5b2e22709b2540L695))
*  Add the `focused` state to the `useSelectStates` function in `useSelect.ts`, which indicates whether the select component is focused or not ([link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L60-R62))
*  Remove the line that blurs the input element in the `resetInputState` function in `useSelect.ts`, which causes the select component to lose focus when cleared or closed ([link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L273))
*  Add the call to the `focus` method in the `handleClear` function in `useSelect.ts`, which ensures that the select component remains focused after clearing ([link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368R639))
*  Replace the `ignoreFocusEvent` variable with the `focused` state in the `handleFocus` function in `useSelect.ts`, which is a more robust way to track the focus status and avoid unnecessary events ([link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L787-R787))
*  Set the `focused` state to `true` in the `handleFocus` function in `useSelect.ts`, which updates the state accordingly when the select component is focused ([link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L794-R803))
*  Modify the `handleBlur` function in `useSelect.ts` to check for the `tagTooltipRef` value and set the `focused` state to `false`, which improves the focus management and accessibility and prevents the `blur` event from being emitted when the user focuses on the tooltip content or the select component itself ([link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L809-R826))
*  Simplify the call to the `focus` method in the `handleComposition` function in `useSelect.ts`, which makes the code more concise and consistent ([link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L850-R859))
*  Add the `focus` method to the return value of the `useSelect` function in `useSelect.ts`, which exposes the method to the `select.vue` component ([link](https://github.com/element-plus/element-plus/pull/13699/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368R964))
