### PR TITLE
fix(components): [date-picker]日期时间选择器面板月份会显示同一月份

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -636,7 +636,11 @@ const handleMinTimePick = (value: Dayjs, visible: boolean, first: boolean) => {
 
   if (!maxDate.value || maxDate.value.isBefore(minDate.value)) {
     maxDate.value = minDate.value
-    rightDate.value = value
+    rightDate.value =
+      minDate.value?.year() === maxDate.value?.year() &&
+      minDate.value?.month() === maxDate.value?.month()
+        ? value.add(1, unit)
+        : value
   }
 }
 


### PR DESCRIPTION
日期时间选择器选择同年同月同日时间开始大于结束时，面板月份会显示同一月份

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a0c0d3</samp>

Fix right date panel bug in `panel-date-range.vue`. Ensure that the right date panel always shows a different month or year than the left one when min and max dates are in the same month and year.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a0c0d3</samp>

* Fix a bug where the right date panel would not update correctly when the min and max dates are in the same month and year ([link](https://github.com/element-plus/element-plus/pull/13714/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L639-R643))
