### PR TITLE
fix(components): [date-picker]日期时间选择器选择同年同月同日时，面板月份可能会显示同一月份

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -561,7 +561,11 @@ const handleDateInput = (value: string | null, type: ChangeType) => {
         maxDate.value = minDate.value.add(1, 'month')
       }
     } else {
-      rightDate.value = parsedValueD
+      rightDate.value =
+        minDate.value?.year() === maxDate.value?.year() &&
+        minDate.value?.month() === maxDate.value?.month()
+          ? parsedValueD?.add(1, unit)
+          : parsedValueD
       maxDate.value = (maxDate.value || rightDate.value)
         .year(parsedValueD.year())
         .month(parsedValueD.month())
@@ -601,7 +605,11 @@ const handleTimeInput = (value: string | null, type: ChangeType) => {
         .hour(parsedValueD.hour())
         .minute(parsedValueD.minute())
         .second(parsedValueD.second())
-      rightDate.value = maxDate.value
+      rightDate.value =
+        minDate.value?.year() === maxDate.value?.year() &&
+        minDate.value?.month() === maxDate.value?.month()
+          ? maxDate.value?.add(1, unit)
+          : maxDate.value
       if (maxDate.value && maxDate.value.isBefore(minDate.value)) {
         minDate.value = maxDate.value
       }
@@ -615,7 +623,11 @@ const handleTimeChange = (value: string | null, type: ChangeType) => {
     leftDate.value = minDate.value!
     minTimePickerVisible.value = false
   } else {
-    rightDate.value = maxDate.value!
+    rightDate.value =
+      minDate.value?.year() === maxDate.value?.year() &&
+      minDate.value?.month() === maxDate.value?.month()
+        ? maxDate.value?.add(1, unit)
+        : maxDate.value
     maxTimePickerVisible.value = false
   }
 }
@@ -636,7 +648,11 @@ const handleMinTimePick = (value: Dayjs, visible: boolean, first: boolean) => {
 
   if (!maxDate.value || maxDate.value.isBefore(minDate.value)) {
     maxDate.value = minDate.value
-    rightDate.value = value
+    rightDate.value =
+      minDate.value?.year() === maxDate.value?.year() &&
+      minDate.value?.month() === maxDate.value?.month()
+        ? value.add(1, unit)
+        : value
   }
 }
 


### PR DESCRIPTION
日期时间选择器选择同年同月同日时，面板月份可能会显示同一月份

closed #4904

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description
![image](https://github.com/element-plus/element-plus/assets/26105165/42ec4155-02a0-42e7-8d3f-f692060c230c)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d46b86f</samp>

Fix date range picker bug and improve its logic. Adjust the right date picker value in `panel-date-range.vue` to avoid invalid or overlapping ranges.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d46b86f</samp>

* Fix a bug where the right date picker would not update correctly when the min or max date is changed and the left date picker is in the same month and year as the min or max date ([link](https://github.com/element-plus/element-plus/pull/13722/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L564-R568), [link](https://github.com/element-plus/element-plus/pull/13722/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L604-R612), [link](https://github.com/element-plus/element-plus/pull/13722/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L618-R630), [link](https://github.com/element-plus/element-plus/pull/13722/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L639-R655)) in `panel-date-range.vue`
