### PR TITLE
fix(components): cascader panel, checked status is not sync with UI

### DIFF
--- a/packages/components/cascader-panel/src/store.ts
+++ b/packages/components/cascader-panel/src/store.ts
@@ -1,3 +1,4 @@
+import { reactive } from 'vue'
 import { isEqual } from 'lodash-unified'
 import Node from './node'
 
@@ -27,8 +28,8 @@ export default class Store {
   readonly leafNodes: Node[]
 
   constructor(data: CascaderOption[], readonly config: CascaderConfig) {
-    const nodes = (data || []).map(
-      (nodeData) => new Node(nodeData, this.config)
+    const nodes = (data || []).map((nodeData) =>
+      reactive(new Node(nodeData, this.config))
     )
     this.nodes = nodes
     this.allNodes = flatNodes(nodes, false)


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4126c4</samp>

The pull request improves the reactivity of the cascader panel component and the compatibility of the element-plus installer. It uses the `reactive` function from `vue` to create reactive `Node` objects in `store.ts`.

fix cascader panel, checked status is not sync with UI

## Related Issue

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a4126c4</samp>

* Make the cascader panel nodes reactive to enable dynamic updates ([link](https://github.com/element-plus/element-plus/pull/13734/files?diff=unified&w=0#diff-6ca8bec8f218071c13b487edabe4a63e55df6b304cd429d1998cecf1a35405c9R2), [link](https://github.com/element-plus/element-plus/pull/13734/files?diff=unified&w=0#diff-6ca8bec8f218071c13b487edabe4a63e55df6b304cd429d1998cecf1a35405c9L31-R32))
  * Import the `reactive` function from `vue` in `store.ts` ([link](https://github.com/element-plus/element-plus/pull/13734/files?diff=unified&w=0#diff-6ca8bec8f218071c13b487edabe4a63e55df6b304cd429d1998cecf1a35405c9R2))
  * Wrap the `Node` instances created from the `data` array with the `reactive` function in `store.ts` ([link](https://github.com/element-plus/element-plus/pull/13734/files?diff=unified&w=0#diff-6ca8bec8f218071c13b487edabe4a63e55df6b304cd429d1998cecf1a35405c9L31-R32))
