### PR TITLE
fix(hooks): [useDraggable] Fixed when overflow transformed incorrectly

### DIFF
--- a/packages/hooks/use-draggable/index.ts
+++ b/packages/hooks/use-draggable/index.ts
@@ -26,10 +26,17 @@ export const useDraggable = (
     const clientWidth = document.documentElement.clientWidth
     const clientHeight = document.documentElement.clientHeight
 
+    const hasXOverflow = targetWidth > clientWidth
+    const hasYOverflow = targetHeight > clientHeight
+
     const minLeft = -targetLeft + offsetX
     const minTop = -targetTop + offsetY
-    const maxLeft = clientWidth - targetLeft - targetWidth + offsetX
-    const maxTop = clientHeight - targetTop - targetHeight + offsetY
+    const maxLeft = hasXOverflow
+      ? 0
+      : clientWidth - targetLeft - targetWidth + offsetX
+    const maxTop = hasYOverflow
+      ? clientHeight + targetTop
+      : clientHeight - targetTop - targetHeight + offsetY
 
     const onMousemove = (e: MouseEvent) => {
       const moveX = Math.min(
@@ -40,14 +47,13 @@ export const useDraggable = (
         Math.max(offsetY + e.clientY - downY, minTop),
         maxTop
       )
-
       transform = {
         offsetX: moveX,
         offsetY: moveY,
       }
-      targetRef.value!.style.transform = `translate(${addUnit(
-        moveX
-      )}, ${addUnit(moveY)})`
+      targetRef.value!.style.transform = `translate(${
+        moveX ? addUnit(moveX) : '0px'
+      }, ${addUnit(moveY)})`
     }
 
     const onMouseup = () => {


### PR DESCRIPTION
1. fix overflow transform value incorrctly

2. handle when maxLeft is zero addUnit get empty string cause transform syntax error

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa4f0e6</samp>

Fix dialog dragging bug and refactor `transform` style code in `use-draggable` hook.

## Related Issue

Fixes #13724

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fa4f0e6</samp>

* Fix bug where draggable dialog could not be dragged back to window when resized larger than window (#3080) ([link](https://github.com/element-plus/element-plus/pull/13735/files?diff=unified&w=0#diff-133f52e896f588bae299f717797165cb0735f359c5ee4b69ce7f201fc044dde3L29-R39))
* Optimize and improve readability of transform style assignment ([link](https://github.com/element-plus/element-plus/pull/13735/files?diff=unified&w=0#diff-133f52e896f588bae299f717797165cb0735f359c5ee4b69ce7f201fc044dde3L43-R56))
