### PR TITLE
feat(components): [switch] add custom action icon prop

### DIFF
--- a/docs/en-US/component/switch.md
+++ b/docs/en-US/component/switch.md
@@ -79,6 +79,14 @@ switch/prevent-switching
 
 :::
 
+## custom action icon
+
+:::demo You can add `active-action-icon` and `inactive-active-icon` attribute to show icons.
+
+switch/custom-action-icon
+
+:::
+
 ## API
 
 ### Attributes
@@ -93,6 +101,8 @@ switch/prevent-switching
 | inline-prompt                | whether icon or text is displayed inside dot, only the first character will be rendered for text                                                | ^[boolean]                                       | false   |
 | active-icon                  | component of the icon displayed when in `on` state, overrides `active-text`                                                                     | ^[string] / ^[Component]                         | —       |
 | inactive-icon                | component of the icon displayed when in `off` state, overrides `inactive-text`                                                                  | ^[string] / ^[Component]                         | —       |
+| active-action-icon           | component of the icon displayed in action when in `on` state                                                                                    | ^[string] / ^[Component]                         | —       |
+| inactive-action-icon         | component of the icon displayed in action when in `off` state                                                                                   | ^[string] / ^[Component]                         | —       |
 | active-text                  | text displayed when in `on` state                                                                                                               | ^[string]                                        | ''      |
 | inactive-text                | text displayed when in `off` state                                                                                                              | ^[string]                                        | ''      |
 | active-value                 | switch value when in `on` state                                                                                                                 | ^[boolean] / ^[string] / ^[number]               | true    |

--- a/docs/examples/switch/custom-action-icon.vue
+++ b/docs/examples/switch/custom-action-icon.vue
@@ -1,0 +1,13 @@
+<template>
+  <el-switch
+    v-model="value1"
+    :active-action-icon="View"
+    :inactive-action-icon="Hide"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Hide, View } from '@element-plus/icons-vue'
+const value1 = ref(true)
+</script>

--- a/packages/components/switch/__tests__/switch.test.tsx
+++ b/packages/components/switch/__tests__/switch.test.tsx
@@ -2,7 +2,7 @@ import { markRaw, nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { debugWarn } from '@element-plus/utils'
-import { Checked, CircleClose } from '@element-plus/icons-vue'
+import { Checked, CircleClose, Hide, View } from '@element-plus/icons-vue'
 import { ElFormItem } from '@element-plus/components/form'
 import Switch from '../src/switch.vue'
 import type { VueWrapper } from '@vue/test-utils'
@@ -310,6 +310,32 @@ describe('Switch.vue', () => {
     expect(value.value).toEqual(true)
   })
 
+  test('custom action icon', async () => {
+    const value = ref(true)
+    const wrapper = mount(() => (
+      <div>
+        <Switch
+          v-model={value.value}
+          activeActionIcon={View}
+          inactiveActionIcon={Hide}
+        />
+      </div>
+    ))
+
+    const coreWrapper = wrapper.find('.el-switch__core')
+    const switchWrapper = wrapper.findComponent(Switch)
+    const switchVm = switchWrapper.vm
+    const inputEl = switchVm.$el.querySelector('input')
+
+    expect(switchWrapper.classes('is-checked')).toEqual(true)
+    expect(inputEl.checked).toEqual(true)
+    expect(wrapper.findComponent(View).exists()).toBe(true)
+
+    await coreWrapper.trigger('click')
+    expect(switchWrapper.classes('is-checked')).toEqual(false)
+    expect(inputEl.checked).toEqual(false)
+    expect(wrapper.findComponent(Hide).exists()).toBe(true)
+  })
   describe('form item accessibility integration', () => {
     test('automatic id attachment', async () => {
       const wrapper = mount(() => (

--- a/packages/components/switch/src/switch.ts
+++ b/packages/components/switch/src/switch.ts
@@ -60,6 +60,18 @@ export const switchProps = buildProps({
     default: false,
   },
   /**
+   * @description component of the icon displayed in action when in `on` state
+   */
+  inactiveActionIcon: {
+    type: iconPropType,
+  },
+  /**
+   * @description component of the icon displayed in action when in `off` state
+   */
+  activeActionIcon: {
+    type: iconPropType,
+  },
+  /**
    * @description component of the icon displayed when in `on` state, overrides `active-text`
    */
   activeIcon: {

--- a/packages/components/switch/src/switch.vue
+++ b/packages/components/switch/src/switch.vue
@@ -44,6 +44,12 @@
         <el-icon v-if="loading" :class="ns.is('loading')">
           <loading />
         </el-icon>
+        <el-icon v-else-if="activeActionIcon && checked">
+          <component :is="activeActionIcon" />
+        </el-icon>
+        <el-icon v-else-if="inactiveActionIcon && !checked">
+          <component :is="inactiveActionIcon" />
+        </el-icon>
       </div>
     </span>
     <span


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ac4f1c</samp>

This pull request adds the ability to customize the switch component with different icons for the active and inactive states. It modifies the `switch` component script, template, documentation, and test files, and adds a new example file using the `@element-plus/icons-vue` package.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ac4f1c</samp>

*  Add custom action icon feature to switch component ([link](https://github.com/element-plus/element-plus/pull/13746/files?diff=unified&w=0#diff-5fded0baca14bc85d6b3a235e24790419a6113d1861afd9bb388b3f5f2aba80cR82-R89), [link](https://github.com/element-plus/element-plus/pull/13746/files?diff=unified&w=0#diff-5fded0baca14bc85d6b3a235e24790419a6113d1861afd9bb388b3f5f2aba80cR104-R105), [link](https://github.com/element-plus/element-plus/pull/13746/files?diff=unified&w=0#diff-0a338a3f7ffaabbc6be24288bcab27a3e3b4ce0094619f7e6f469b0a5bb565c0R1-R13), [link](https://github.com/element-plus/element-plus/pull/13746/files?diff=unified&w=0#diff-0011e1301b9387de7c8b9559e7ae56cd4889751959ae82bd499dfa9a91322e75L5-R5), [link](https://github.com/element-plus/element-plus/pull/13746/files?diff=unified&w=0#diff-0011e1301b9387de7c8b9559e7ae56cd4889751959ae82bd499dfa9a91322e75R313-R338), [link](https://github.com/element-plus/element-plus/pull/13746/files?diff=unified&w=0#diff-944d71227061db7997220d97c8f510e37c916a5ba3db7063735bf87dfc871da6R63-R74), [link](https://github.com/element-plus/element-plus/pull/13746/files?diff=unified&w=0#diff-a8d9aaca9c72c0998e021fe3e607217cbf71f0fe04eca2dbb0760b66e4755d76R47-R52))
