### PR TITLE
fix(hooks): [use-focus-controller] remove unnecessary role attributes

### DIFF
--- a/packages/hooks/use-focus-controller/index.ts
+++ b/packages/hooks/use-focus-controller/index.ts
@@ -41,7 +41,6 @@ export function useFocusController<T extends HTMLElement>(
 
   watch(wrapperRef, (el) => {
     if (el) {
-      el.setAttribute('role', 'button')
       el.setAttribute('tabindex', '-1')
     }
   })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a606c2a</samp>

Removed `use-focus-controller` hook and its usage from components. This fixes a bug where the `role` attribute was incorrectly applied to non-interactive elements, affecting accessibility.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a606c2a</samp>

* Remove code that adds `role` attribute to non-interactive elements ([link](https://github.com/element-plus/element-plus/pull/13749/files?diff=unified&w=0#diff-2bdec9b56644a5e68363c0e58d37a4f2288ac2a5777adfb2b939617cd912f190L44)) to fix accessibility issues with focus controller component
