### PR TITLE
docs: align ::marker and anchor on the same line in firefox

### DIFF
--- a/docs/.vitepress/vitepress/styles/content/table-of-content.scss
+++ b/docs/.vitepress/vitepress/styles/content/table-of-content.scss
@@ -50,6 +50,7 @@
         color: inherit;
 
         .toc-link {
+          display: inline-block;
           position: relative;
           color: var(--text-color-lighter);
           transition: color var(--el-transition-duration);


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description
In firefox, marker and anchor are not aligned on the same line.
![image](https://github.com/element-plus/element-plus/assets/35426360/5d2db1c2-3b8e-4840-9ce9-7399f79659db)
After:
FF:
![image](https://github.com/element-plus/element-plus/assets/35426360/62325c64-5bfd-4aa4-b976-c7166b0cb4b1)
Chrome:
![image](https://github.com/element-plus/element-plus/assets/35426360/9275be52-af3b-4166-9cbe-ccbc8eeb99ef)



<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd4f7e4</samp>

Improve documentation layout and style. Add horizontal alignment for table of contents items in `table-of-content.scss`.

## Related Issue

no.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bd4f7e4</samp>

* Add `display: inline-block` property to table of contents items to align them horizontally ([link](https://github.com/element-plus/element-plus/pull/13752/files?diff=unified&w=0#diff-1fed6282b75d056e5a1f621d6cd3bdd6f71b2955215f1aed58995b1d93d5b9d2R53))
