### PR TITLE
fix(components): [input] fix resize not working

### DIFF
--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -339,7 +339,7 @@ useResizeObserver(textarea, (entries) => {
   const { width } = entry.contentRect
   countStyle.value = {
     /** right: 100% - width + padding(22) - right(10) */
-    right: `calc(100% - ${width + 12}px)`,
+    right: `calc(100% - ${width + 22 - 10}px)`,
   }
 })
 

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -338,8 +338,8 @@ useResizeObserver(textarea, (entries) => {
   const entry = entries[0]
   const { width } = entry.contentRect
   countStyle.value = {
-    /** right: 100% - width + padding(15) + right(6) */
-    right: `calc(100% - ${width + 15 + 6}px)`,
+    /** right: 100% - width + padding(22) - right(10) */
+    right: `calc(100% - ${width + 12}px)`,
   }
 })
 

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -330,7 +330,11 @@ const [recordCursor, setCursor] = useCursor(input)
 
 useResizeObserver(textarea, (entries) => {
   onceInitSizeTextarea()
-  if (!isWordLimitVisible.value || props.resize !== 'both') return
+  if (
+    !isWordLimitVisible.value ||
+    (props.resize !== 'both' && props.resize !== 'horizontal')
+  )
+    return
   const entry = entries[0]
   const { width } = entry.contentRect
   countStyle.value = {


### PR DESCRIPTION
When the resize value is set to ‘horizontal’, resizing the input size does not reposition the ‘show-word-limit’.

BREAKING CHANGE :
N

closed #13769

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

Fix the issue where the “show-word-limit” feature does not correctly position when resizing to horizontal.
[link](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6Ijx0ZW1wbGF0ZT5cbiAgXG4gIDxlbC1pbnB1dFxuICAgIHN0eWxlPVwid2lkdGg6NjAlXCJcbiAgICB2LW1vZGVsPVwidGV4dGFyZWFcIlxuICAgIG1heGxlbmd0aD1cIjEwMFwiXG4gICAgcGxhY2Vob2xkZXI9XCJQbGVhc2UgaW5wdXRcIlxuICAgIHNob3ctd29yZC1saW1pdFxuICAgIHR5cGU9XCJ0ZXh0YXJlYVwiXG4gICAgcmVzaXplPVwiaG9yaXpvbnRhbFwiXG4gIC8+XG4gIFxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD4gIFxuaW1wb3J0IHsgcmVmIH0gZnJvbSAndnVlJ1xuY29uc3QgdGV4dGFyZWEgPSByZWYoJ1doZW4gSSBjaGFuZ2UgdGhlIGlucHV0IHNpemUsIHRoZSAgcmVzaXplIGFwaSBiZWNvbWVzIGluZWZmZWN0aXZlLicpXG48L3NjcmlwdD5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHt9XG59IiwidHNjb25maWcuanNvbiI6IntcbiAgXCJjb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVSZXNvbHV0aW9uXCI6IFwiQnVuZGxlclwiLFxuICAgIFwiYWxsb3dJbXBvcnRpbmdUc0V4dGVuc2lvbnNcIjogdHJ1ZSxcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXVxuICB9LFxuICBcInZ1ZUNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogMy4zXG4gIH1cbn1cbiIsIl9vIjp7fX0=)

## Related Issue

Fixes #13769

## Explanation of Changes

Fix the conditional logic of the “useResizeObserver” function in input.vue. 
