### PR TITLE
fix(components): [avatar] set img tag's width attribute

### DIFF
--- a/packages/theme-chalk/src/avatar.scss
+++ b/packages/theme-chalk/src/avatar.scss
@@ -27,6 +27,7 @@
 
   > img {
     display: block;
+    width: 100%;
     height: 100%;
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

The `object-fit` property requires the element to have explicit width and height in order to perform fitting operations based on its dimensions. 
Due to the `max-width: 100%` property set on the `img` element in [docs/.vitepress/vitepress/styles/base.scss](https://github.com/element-plus/element-plus/blob/dev/docs/.vitepress/vitepress/styles/base.scss#L184), the fit attribute is effective. However, since the avatar component does not have a width set, it will cause issues

## Related Issue

Fixes #13827

