### PR TITLE
fix(components): [select] don't trigger remoteMethod when dropdown hides

### DIFF
--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -262,14 +262,6 @@ export const useSelect = (props, states: States, ctx) => {
     () => states.visible,
     (val) => {
       if (!val) {
-        if (props.filterable) {
-          if (isFunction(props.filterMethod)) {
-            props.filterMethod('')
-          }
-          if (isFunction(props.remoteMethod)) {
-            props.remoteMethod('')
-          }
-        }
         states.query = ''
         states.previousQuery = null
         states.selectedLabel = ''


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

The filterMethod or remoteMethod should not be triggered when the dropdown menu is hidden.

## Related Issue

Fixes #13847
Related to Issue #9539, #10283, #11614, and PR #9587, #10218

## Explanation of Changes

Regarding #9539, I think that when the select is clicked again, it should display the list of search results from the previous search.  Additionally, triggering the filterMethod or remoteMethod again when the change event or blur event is triggered could have some negative impacts.  I have reviewed other UI component libraries, such as [Ant Design](https://ant.design/components/select#select-demo-search-box) and [Semi Design](https://semi.design/zh-CN/input/select#%E8%BF%9C%E7%A8%8B%E6%90%9C%E7%B4%A2), and it is indeed the case.
