### PR TITLE
fix(components): [select-v2] filter-method doesn't work #13873

### DIFF
--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -138,6 +138,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
   })
 
   const filteredOptions = computed(() => {
+    if (props.filterable && isFunction(props.filterMethod)) return props.options
     const isValidOption = (o: Option): boolean => {
       // fill the conditions here.
       const query = states.inputValue


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

fix `select-v2` component, `filter-method` attribute doesn't work as expection
## Related Issue

Fixes #13873 

## Explanation of Changes
if `select-v2` component received `options` props,then return the `options` in `filteredOptions`
