### PR TITLE
fix(components): [table] add table selection checkbox aria-labels

### DIFF
--- a/packages/components/table/src/config.ts
+++ b/packages/components/table/src/config.ts
@@ -46,7 +46,7 @@ export const getDefaultClassName = (type) => {
 // 这些选项不应该被覆盖
 export const cellForced = {
   selection: {
-    renderHeader<T>({ store }: { store: Store<T> }) {
+    renderHeader<T>({ store, column }: { store: Store<T> }) {
       function isDisabled() {
         return store.states.data.value && store.states.data.value.length === 0
       }
@@ -58,6 +58,7 @@ export const cellForced = {
           !store.states.isAllSelected.value,
         'onUpdate:modelValue': store.toggleAllSelection,
         modelValue: store.states.isAllSelected.value,
+        ariaLabel: column.label,
       })
     },
     renderCell<T>({
@@ -81,6 +82,7 @@ export const cellForced = {
         },
         onClick: (event: Event) => event.stopPropagation(),
         modelValue: store.isSelected(row),
+        ariaLabel: column.label,
       })
     },
     sortable: false,


### PR DESCRIPTION
When checkboxes have no label, it causes accessibility issues. This commit adds aria-labels to table's selection checkboxes

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b2bae3</samp>

Improved accessibility of `selection` column in `table` component. Added `ariaLabel` attributes to checkbox elements using column label as value.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6b2bae3</samp>

*  Add `ariaLabel` attribute to header and body checkbox elements in `selection` column for accessibility ([link](https://github.com/element-plus/element-plus/pull/13908/files?diff=unified&w=0#diff-0207e2f7962917c808d1a150c2ec789d141a552de7a18b20d60854dc9d57ab17L49-R49), [link](https://github.com/element-plus/element-plus/pull/13908/files?diff=unified&w=0#diff-0207e2f7962917c808d1a150c2ec789d141a552de7a18b20d60854dc9d57ab17R61), [link](https://github.com/element-plus/element-plus/pull/13908/files?diff=unified&w=0#diff-0207e2f7962917c808d1a150c2ec789d141a552de7a18b20d60854dc9d57ab17R85))
*  Modify `renderHeader` function of `selection` column to accept `column` parameter with column information ([link](https://github.com/element-plus/element-plus/pull/13908/files?diff=unified&w=0#diff-0207e2f7962917c808d1a150c2ec789d141a552de7a18b20d60854dc9d57ab17L49-R49))
