### PR TITLE
docs: fix official migration reference link

### DIFF
--- a/docs/en-US/guide/migration.md
+++ b/docs/en-US/guide/migration.md
@@ -9,7 +9,7 @@ lang: en-US
 
 ## Vue 3 migration build
 
-You may encounter some issues when using Element Plus with Vue 3 migration build. Some of the components rely on Vue 3 internal API's. It's worth trying to adjust compatConfig mode to 3, either globally or [per component in your project](https://v3.vuejs.org/guide/migration/migration-build.html#per-component-config).
+You may encounter some issues when using Element Plus with Vue 3 migration build. Some of the components rely on Vue 3 internal API's. It's worth trying to adjust compatConfig mode to 3, either globally or [per component in your project](https://v3-migration.vuejs.org/migration-build.html).
 
 ## Migration Tool :hammer_and_wrench:
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

fix site doc about official migration link



## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eca55d2</samp>

* Updated the link to the Vue 3 migration build documentation ([link](https://github.com/element-plus/element-plus/pull/13911/files?diff=unified&w=0#diff-18583bfeb30f9db0d7cd26b885d9b941e3b5633f28a47d59e58cc7f4b5ef5cdbL12-R12)) to fix the broken URL and improve the user experience and the accuracy of the `migration.md` file.
