### PR TITLE
refactor(components): [form-label-wrap] use getStyle method

### DIFF
--- a/packages/components/form/src/form-label-wrap.tsx
+++ b/packages/components/form/src/form-label-wrap.tsx
@@ -11,7 +11,7 @@ import {
   watch,
 } from 'vue'
 import { useResizeObserver } from '@vueuse/core'
-import { throwError } from '@element-plus/utils'
+import { getStyle, throwError } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { formContextKey, formItemContextKey } from './constants'
 
@@ -41,8 +41,11 @@ export default defineComponent({
 
     const getLabelWidth = () => {
       if (el.value?.firstElementChild) {
-        const width = window.getComputedStyle(el.value.firstElementChild).width
-        return Math.ceil(Number.parseFloat(width))
+        const width = getStyle(
+          el.value.firstElementChild as HTMLElement,
+          'width'
+        )
+        return Math.ceil(Number.parseFloat(width)) || 0
       } else {
         return 0
       }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b59e861</samp>

Improved form label component by using `getStyle` utility and adding fallback width. This fixes some cross-browser issues and makes the component more robust.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b59e861</samp>

* Import and use `getStyle` function from `@element-plus/utils` to get the style of an element in a cross-browser compatible way ([link](https://github.com/element-plus/element-plus/pull/13913/files?diff=unified&w=0#diff-a6bb223ed8a3146beae02e7c03358277c781a12022cb8bfdbf99cc1126634b19L14-R14), [link](https://github.com/element-plus/element-plus/pull/13913/files?diff=unified&w=0#diff-a6bb223ed8a3146beae02e7c03358277c781a12022cb8bfdbf99cc1126634b19L44-R48))
* Add fallback value of 0 for label width in case of NaN ([link](https://github.com/element-plus/element-plus/pull/13913/files?diff=unified&w=0#diff-a6bb223ed8a3146beae02e7c03358277c781a12022cb8bfdbf99cc1126634b19L44-R48))
