### PR TITLE
fix(theme-chalk): [tabs] fix padding error in border-card mode

### DIFF
--- a/packages/theme-chalk/src/tabs.scss
+++ b/packages/theme-chalk/src/tabs.scss
@@ -284,16 +284,6 @@
     }
   }
   @include m((top, bottom)) {
-    .#{$namespace}-tabs__item.is-top:nth-child(2),
-    .#{$namespace}-tabs__item.is-bottom:nth-child(2) {
-      padding-left: 0;
-    }
-    .#{$namespace}-tabs__item.is-top:last-child,
-    .#{$namespace}-tabs__item.is-bottom:last-child {
-      padding-right: 0;
-    }
-
-    &.#{$namespace}-tabs--border-card,
     &.#{$namespace}-tabs--card,
     .#{$namespace}-tabs--left,
     .#{$namespace}-tabs--right {


### PR DESCRIPTION
closed #13934

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa32eed</samp>

Removed redundant CSS code for tabs with border-card style. Fixed padding issue by adjusting item width in `tabs` component.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fa32eed</samp>

* Removed redundant padding for border-card tabs ([link](https://github.com/element-plus/element-plus/pull/13966/files?diff=unified&w=0#diff-b6ef28eb7d734a93f382677d5da10697969e317a60766947332248113dd8cc30L287-L296))
