### PR TITLE
fix(components): [table]fix lazy loading (#13817)

### DIFF
--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -200,9 +200,8 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
         treeData.value[key].loading = false
         treeData.value[key].loaded = true
         treeData.value[key].expanded = true
-        if (data.length) {
-          lazyTreeNodeMap.value[key] = data
-        }
+        lazyTreeNodeMap.value[key] = data
+
         instance.emit('expand-change', row, true)
       })
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67d6919</samp>

Fix tree table rendering bug for lazy-loaded nodes with empty data. Remove unnecessary condition in `tree.ts` that prevented assigning empty data to `lazyTreeNodeMap`.

## Related Issue

Fixes #13817.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67d6919</samp>

* Fix a bug where tree table would not render children of lazy-loaded node if data array was empty ([link](https://github.com/element-plus/element-plus/pull/13970/files?diff=unified&w=0#diff-3d07efb93ef7ab28c5c66bda71423ad68670d4c5aae44218574d651b792d2fd8L203-R204))
