### PR TITLE
fix(components): [date-picker] correct onCalendarChange param type

### DIFF
--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -725,7 +725,7 @@ const onSetPickerOption = <T extends keyof PickerOptions>(
   pickerOptions.value.panelReady = true
 }
 
-const onCalendarChange = (e: [Date, false | Date]) => {
+const onCalendarChange = (e: [Date, null | Date]) => {
   emit('calendar-change', e)
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [✔] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [✔ ] Make sure you are merging your commits to `dev` branch.
- [✔ ] Add some descriptions and refer to relative issues for your PR.

## Description

**中文:**
下面这里似乎是唯一调用`calendar-change`方法的地方
https://github.com/element-plus/element-plus/blob/dev/packages/components/date-picker/src/date-picker-com/panel-date-range.vue#L516
```typescript
emit('calendar-change', [min_.toDate(), max_ && max_.toDate()])
```
既然 `max_` 的类型是 `dayjs.Dayjs | null` , 那么 `max_ && max_.toDate()` 的类型也就应该是 `Date | null ` , 所以 `picker.vue` 的对应方法也应该把参数类型由 `[Date, false | Date]` 改为 `[Date, null | Date]`

**English:**
This seems to be the only place that will emit 'calendar-change'.
https://github.com/element-plus/element-plus/blob/dev/packages/components/date-picker/src/date-picker-com/panel-date-range.vue#L516
```typescript
emit('calendar-change', [min_.toDate(), max_ && max_.toDate()])
```
Since `max_` 's type is `dayjs.Dayjs | null` , `max_ && max_.toDate()` should be `Date | null ` , so `picker.vue` should also change the param type from `[Date, false | Date]` to `[Date, null | Date]`

## Related Issue

Fixes null.
