### PR TITLE
chore(components): [autocomplete] fix the comment description error

### DIFF
--- a/packages/components/autocomplete/src/autocomplete.ts
+++ b/packages/components/autocomplete/src/autocomplete.ts
@@ -51,7 +51,7 @@ export const autocompleteProps = buildProps({
     default: 300,
   },
   /**
-   * @description the placeholder of Autocomplete
+   * @description placement of the popup menu
    */
   placement: {
     type: definePropType<Placement>(String),


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0288d3</samp>

Updated the comment for the `placement` prop of the Autocomplete component to avoid confusion with the placeholder. This change enhances the readability and accuracy of the code documentation in `packages/components/autocomplete/src/autocomplete.ts`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f0288d3</samp>

* Clarify the meaning of the `placement` prop for the Autocomplete component ([link](https://github.com/element-plus/element-plus/pull/13979/files?diff=unified&w=0#diff-34813a1f6dca1eac7ebb5133f1e7a9d839b9520b6e403355a5fc35492ee62cbfL54-R54))
