### PR TITLE
fix(components): [time-picker] time format in 'MMM DD, YYYY HH:mm'

### DIFF
--- a/packages/components/time-picker/src/utils.ts
+++ b/packages/components/time-picker/src/utils.ts
@@ -24,7 +24,7 @@ export const extractDateFormat = (format: string) => {
 
 export const extractTimeFormat = (format: string) => {
   return format
-    .replace(/\W?D{1,2}|\W?Do|\W?d{1,4}|\W?M{1,4}|\W?Y{2,4}/g, '')
+    .replace(/\W?D{1,2}|\W?Do|\W?d{1,4}|\W?M{1,4}|\W?Y{2,4}|\W[^\w]/g, '')
     .trim()
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

When formatting the English time format, the extra comma in the time selection box is not removed
<img width="324" alt="image" src="https://github.com/element-plus/element-plus/assets/29764938/e10e245a-bfd0-4d74-83ac-94a55d87a0fc">



