### PR TITLE
fix(components): [DatePicker] change the format prop to reactive

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -246,6 +246,7 @@ const pickerBase = inject('EP_PICKER_BASE') as any
 const popper = inject(TOOLTIP_INJECTION_KEY)
 const { shortcuts, disabledDate, cellClassName, defaultTime } = pickerBase.props
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
+const format = toRef(pickerBase.props, 'format')
 
 const currentViewRef = ref<{ focus: () => void }>()
 
@@ -273,7 +274,7 @@ const userInputTime = ref<string | null>(null)
 // todo update to disableHour
 const checkDateWithinRange = (date: ConfigType) => {
   return selectableRange.value.length > 0
-    ? timeWithinRange(date, selectableRange.value, props.format || 'HH:mm:ss')
+    ? timeWithinRange(date, selectableRange.value, format.value || 'HH:mm:ss')
     : true
 }
 const formatEmit = (emitDayjs: Dayjs) => {
@@ -493,11 +494,11 @@ const changeToNow = () => {
 }
 
 const timeFormat = computed(() => {
-  return extractTimeFormat(props.format)
+  return extractTimeFormat(format.value)
 })
 
 const dateFormat = computed(() => {
-  return extractDateFormat(props.format)
+  return extractDateFormat(format.value)
 })
 
 const visibleTime = computed(() => {
@@ -581,13 +582,13 @@ const isValidValue = (date: unknown) => {
 
 const formatToString = (value: Dayjs | Dayjs[]) => {
   if (selectionMode.value === 'dates') {
-    return (value as Dayjs[]).map((_) => _.format(props.format))
+    return (value as Dayjs[]).map((_) => _.format(format.value))
   }
-  return (value as Dayjs).format(props.format)
+  return (value as Dayjs).format(format.value)
 }
 
 const parseUserInput = (value: Dayjs) => {
-  return dayjs(value, props.format).locale(lang.value)
+  return dayjs(value, format.value).locale(lang.value)
 }
 
 const getDefaultValue = () => {

--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -285,10 +285,10 @@ const emit = defineEmits([
 const unit = 'month'
 // FIXME: fix the type for ep picker
 const pickerBase = inject('EP_PICKER_BASE') as any
-const { disabledDate, cellClassName, format, defaultTime, clearable } =
-  pickerBase.props
+const { disabledDate, cellClassName, defaultTime, clearable } = pickerBase.props
 const shortcuts = toRef(pickerBase.props, 'shortcuts')
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
+const format = toRef(pickerBase.props, 'format')
 const { lang } = useLocale()
 const leftDate = ref<Dayjs>(dayjs().locale(lang.value))
 const rightDate = ref<Dayjs>(dayjs().locale(lang.value).add(1, unit))
@@ -380,11 +380,11 @@ const maxVisibleTime = computed(() => {
 })
 
 const timeFormat = computed(() => {
-  return extractTimeFormat(format)
+  return extractTimeFormat(format.value)
 })
 
 const dateFormat = computed(() => {
-  return extractDateFormat(format)
+  return extractDateFormat(format.value)
 })
 
 const leftPrevYear = () => {
@@ -667,14 +667,14 @@ const handleClear = () => {
 
 const formatToString = (value: Dayjs | Dayjs[]) => {
   return isArray(value)
-    ? value.map((_) => _.format(format))
-    : value.format(format)
+    ? value.map((_) => _.format(format.value))
+    : value.format(format.value)
 }
 
 const parseUserInput = (value: Dayjs | Dayjs[]) => {
   return isArray(value)
-    ? value.map((_) => dayjs(_, format).locale(lang.value))
-    : dayjs(value, format).locale(lang.value)
+    ? value.map((_) => dayjs(_, format.value).locale(lang.value))
+    : dayjs(value, format.value).locale(lang.value)
 }
 
 function onParsedValueChanged(

--- a/packages/components/date-picker/src/date-picker-com/panel-month-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-month-range.vue
@@ -124,7 +124,8 @@ const unit = 'year'
 
 const { lang } = useLocale()
 const pickerBase = inject('EP_PICKER_BASE') as any
-const { shortcuts, disabledDate, format } = pickerBase.props
+const { shortcuts, disabledDate } = pickerBase.props
+const format = toRef(pickerBase.props, 'format')
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 const leftDate = ref(dayjs().locale(lang.value))
 const rightDate = ref(dayjs().locale(lang.value).add(1, unit))
@@ -192,7 +193,7 @@ const handleRangePick = (val: RangePickValue, close = true) => {
 }
 
 const formatToString = (days: Dayjs[]) => {
-  return days.map((day) => day.format(format))
+  return days.map((day) => day.format(format.value))
 }
 
 function onParsedValueChanged(

--- a/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, ref } from 'vue'
+import { computed, inject, ref, toRef } from 'vue'
 import dayjs from 'dayjs'
 import { EVENT_CODE } from '@element-plus/constants'
 import { useLocale, useNamespace } from '@element-plus/hooks'
@@ -65,6 +65,7 @@ const {
   disabledSeconds,
   defaultValue,
 } = pickerBase.props
+const format = toRef(pickerBase.props, 'format')
 const { getAvailableHours, getAvailableMinutes, getAvailableSeconds } =
   buildAvailableTimeSlotGetter(disabledHours, disabledMinutes, disabledSeconds)
 
@@ -80,11 +81,11 @@ const transitionName = computed(() => {
     : ''
 })
 const showSeconds = computed(() => {
-  return props.format.includes('ss')
+  return format.value.includes('ss')
 })
 const amPmMode = computed(() => {
-  if (props.format.includes('A')) return 'A'
-  if (props.format.includes('a')) return 'a'
+  if (format.value.includes('A')) return 'A'
+  if (format.value.includes('a')) return 'a'
   return ''
 })
 // method
@@ -156,12 +157,12 @@ const getRangeAvailableTime = (date: Dayjs) => {
 
 const parseUserInput = (value: Dayjs) => {
   if (!value) return null
-  return dayjs(value, props.format).locale(lang.value)
+  return dayjs(value, format.value).locale(lang.value)
 }
 
 const formatToString = (value: Dayjs) => {
   if (!value) return null
-  return value.format(props.format)
+  return value.format(format.value)
 }
 
 const getDefaultValue = () => {

--- a/packages/components/time-picker/src/time-picker-com/panel-time-range.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-range.vue
@@ -68,7 +68,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, ref, unref } from 'vue'
+import { computed, inject, ref, toRef, unref } from 'vue'
 import dayjs from 'dayjs'
 import { union } from 'lodash-unified'
 import { useLocale, useNamespace } from '@element-plus/hooks'
@@ -106,6 +106,7 @@ const {
   disabledSeconds,
   defaultValue,
 } = pickerBase.props
+const format = toRef(pickerBase.props, 'format')
 
 const startContainerKls = computed(() => [
   nsTime.be('range-picker', 'body'),
@@ -127,11 +128,11 @@ const handleCancel = () => {
   emit('pick', oldValue.value, false)
 }
 const showSeconds = computed(() => {
-  return props.format.includes('ss')
+  return format.value.includes('ss')
 })
 const amPmMode = computed(() => {
-  if (props.format.includes('A')) return 'A'
-  if (props.format.includes('a')) return 'a'
+  if (format.value.includes('A')) return 'A'
+  if (format.value.includes('a')) return 'a'
   return ''
 })
 
@@ -284,17 +285,17 @@ const {
 const parseUserInput = (days: Dayjs[] | Dayjs) => {
   if (!days) return null
   if (isArray(days)) {
-    return days.map((d) => dayjs(d, props.format).locale(lang.value))
+    return days.map((d) => dayjs(d, format.value).locale(lang.value))
   }
-  return dayjs(days, props.format).locale(lang.value)
+  return dayjs(days, format.value).locale(lang.value)
 }
 
 const formatToString = (days: Dayjs[] | Dayjs) => {
   if (!days) return null
   if (isArray(days)) {
-    return days.map((d) => d.format(props.format))
+    return days.map((d) => d.format(format.value))
   }
-  return days.format(props.format)
+  return days.format(format.value)
 }
 
 const getDefaultValue = () => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
#13980 
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d387ecc</samp>

This pull request refactors and simplifies the `format` logic in several date and time picker components. It uses constants and the `toRef` function to access the `format` prop from the `pickerBase` component, and removes redundant or unnecessary variables. This improves the readability, consistency, and maintainability of the code.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d387ecc</samp>

*  Define a new constant `format` that references the `format` prop from the `pickerBase` component in all the panel files (`panel-date-pick.vue`, `panel-date-range.vue`, `panel-month-range.vue`, `panel-time-pick.vue`, `panel-time-range.vue`) to simplify the code and avoid repeating the `pickerBase.props.format` expression ([link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759R249), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-60b8d640aee096b38e04f0f59a87c5d8c5ddc9e877a4bcbe50a86058b59b3ceaR68), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-893f4fcade0e0077fbd58008fb0d3f6ae67311c285509aba7c361a69c143161dR109))
* Replace the `props.format` expression with the `format.value` expression, using the new constant, in all the places where the format value is used in the panel files, to be consistent and concise ([link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759L276-R277), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759L496-R501), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759L584-R591), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L383-R387), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L670-R677), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-aae21490a51f2812af5785511e78e38b1160b12da90559b82c3a6a1b9a07e308L195-R196), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-60b8d640aee096b38e04f0f59a87c5d8c5ddc9e877a4bcbe50a86058b59b3ceaL83-R88), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-60b8d640aee096b38e04f0f59a87c5d8c5ddc9e877a4bcbe50a86058b59b3ceaL159-R165), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-893f4fcade0e0077fbd58008fb0d3f6ae67311c285509aba7c361a69c143161dL130-R135), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-893f4fcade0e0077fbd58008fb0d3f6ae67311c285509aba7c361a69c143161dL287-R290), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-893f4fcade0e0077fbd58008fb0d3f6ae67311c285509aba7c361a69c143161dL295-R298))
* Remove the `format` variable from the destructuring assignment of the `pickerBase.props` object in the `panel-date-range.vue` and `panel-month-range.vue` files, since it is no longer needed after defining the `format` constant ([link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L288-R291), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-aae21490a51f2812af5785511e78e38b1160b12da90559b82c3a6a1b9a07e308L127-R128))
* Add the `toRef` function to the import statement from the `vue` module in the `panel-time-pick.vue` and `panel-time-range.vue` files, since it is used to define the `format` constant ([link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-60b8d640aee096b38e04f0f59a87c5d8c5ddc9e877a4bcbe50a86058b59b3ceaL41-R41), [link](https://github.com/element-plus/element-plus/pull/13989/files?diff=unified&w=0#diff-893f4fcade0e0077fbd58008fb0d3f6ae67311c285509aba7c361a69c143161dL71-R71))
