### PR TITLE
fix(components): [select] get current instance in the watch for option-group

### DIFF
--- a/packages/components/select/src/option-group.vue
+++ b/packages/components/select/src/option-group.vue
@@ -75,7 +75,9 @@ export default defineComponent({
       groupQueryChange,
       () => {
         children.value = flattedChildren(instance.subTree)
-        visible.value = children.value.some((option) => option.visible === true) || !children.value.length
+        visible.value =
+          children.value.some((option) => option.visible === true) ||
+          children.value.length === 0
       },
       { flush: 'post' }
     )

--- a/packages/components/select/src/option-group.vue
+++ b/packages/components/select/src/option-group.vue
@@ -77,7 +77,7 @@ export default defineComponent({
         children.value = flattedChildren(instance.subTree)
         visible.value =
           children.value.some((option) => option.visible === true) ||
-          children.value.length === 0
+          !children.value.length
       },
       { flush: 'post' }
     )

--- a/packages/components/select/src/option-group.vue
+++ b/packages/components/select/src/option-group.vue
@@ -15,7 +15,6 @@ import {
   defineComponent,
   getCurrentInstance,
   inject,
-  onMounted,
   provide,
   reactive,
   ref,
@@ -51,11 +50,7 @@ export default defineComponent({
     )
 
     const select = inject(selectKey)
-
-    onMounted(() => {
-      children.value = flattedChildren(instance.subTree)
-    })
-
+    
     // get all instances of options
     const flattedChildren = (node) => {
       const children = []
@@ -80,6 +75,7 @@ export default defineComponent({
     watch(
       groupQueryChange,
       () => {
+        children.value = flattedChildren(instance.subTree)
         visible.value = children.value.some((option) => option.visible === true)
       },
       { flush: 'post' }

--- a/packages/components/select/src/option-group.vue
+++ b/packages/components/select/src/option-group.vue
@@ -75,7 +75,7 @@ export default defineComponent({
       groupQueryChange,
       () => {
         children.value = flattedChildren(instance.subTree)
-        visible.value = children.value.some((option) => option.visible === true)
+        visible.value = children.value.some((option) => option.visible === true) || !children.value.length
       },
       { flush: 'post' }
     )

--- a/packages/components/select/src/option-group.vue
+++ b/packages/components/select/src/option-group.vue
@@ -50,7 +50,6 @@ export default defineComponent({
     )
 
     const select = inject(selectKey)
-    
     // get all instances of options
     const flattedChildren = (node) => {
       const children = []


### PR DESCRIPTION

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

optionGroup组件在onMounted中获取组件实例时，无法获取到异步的数据，导致获取到的实例数据（children.value）为空，建议在watch中获取实例

<img width="377" alt="image" src="https://github.com/element-plus/element-plus/assets/75007029/61972f58-946c-429d-b3f7-27c04750f321">


![image](https://github.com/element-plus/element-plus/assets/75007029/65f7da58-3614-43be-9e05-f68cddbb5af1)



## Related Issue

Fixes #13999

