### PR TITLE
refactor(components): [checkbox] set the label default value to `undefined`

### DIFF
--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -21,6 +21,11 @@ describe('Checkbox', () => {
     expect(wrapper.classes('is-checked')).toBe(false)
   })
 
+  test('label set to number 0', async () => {
+    const wrapper = mount(() => <Checkbox label={0} />)
+    expect(wrapper.find('.el-checkbox__label').text()).toBe('0')
+  })
+
   describe('no v-model', () => {
     test('checkbox without label', async () => {
       const checked = ref(false)

--- a/packages/components/checkbox/src/checkbox.ts
+++ b/packages/components/checkbox/src/checkbox.ts
@@ -20,6 +20,7 @@ export const checkboxProps = {
    */
   label: {
     type: [String, Boolean, Number, Object],
+    default: undefined,
   },
   /**
    * @description Set indeterminate state, only responsible for style control

--- a/packages/components/checkbox/src/composables/use-checkbox-status.ts
+++ b/packages/components/checkbox/src/composables/use-checkbox-status.ts
@@ -1,5 +1,5 @@
 import { computed, inject, ref, toRaw } from 'vue'
-import { isEqual } from 'lodash-unified'
+import { isEqual, isNil } from 'lodash-unified'
 import { useFormSize } from '@element-plus/components/form'
 import { isArray, isBoolean, isObject } from '@element-plus/utils'
 import { checkboxGroupContextKey } from '../constants'
@@ -41,7 +41,7 @@ export const useCheckboxStatus = (
   const checkboxSize = useFormSize(computed(() => checkboxGroup?.size?.value))
 
   const hasOwnLabel = computed<boolean>(() => {
-    return !!(slots.default || props.label)
+    return !!(slots.default || !isNil(props.label))
   })
 
   return {

--- a/packages/components/checkbox/src/composables/use-checkbox-status.ts
+++ b/packages/components/checkbox/src/composables/use-checkbox-status.ts
@@ -41,7 +41,7 @@ export const useCheckboxStatus = (
   const checkboxSize = useFormSize(computed(() => checkboxGroup?.size?.value))
 
   const hasOwnLabel = computed<boolean>(() => {
-    return !!(slots.default || !isNil(props.label))
+    return !!slots.default || (!isNil(props.label) && props.label !== false)
   })
 
   return {

--- a/packages/components/checkbox/src/composables/use-checkbox-status.ts
+++ b/packages/components/checkbox/src/composables/use-checkbox-status.ts
@@ -41,7 +41,7 @@ export const useCheckboxStatus = (
   const checkboxSize = useFormSize(computed(() => checkboxGroup?.size?.value))
 
   const hasOwnLabel = computed<boolean>(() => {
-    return !!slots.default || (!isNil(props.label) && props.label !== false)
+    return !!slots.default || !isNil(props.label)
   })
 
   return {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description
**BREAKING CHANGE**

before:
When the label value is set to `false`, the label is not displayed.

after:
When the label value is set to `false`, the label will display the false string.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1531abe</samp>

Fix checkbox label bug and enhance null checking. Use `isNil` function from `lodash` to check for `null` or `undefined` values in `label` prop of `use-checkbox-status` composable.

## Related Issue

Fixes #14009.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1531abe</samp>

* Import `isNil` function from `lodash-unified` to check for null or undefined values ([link](https://github.com/element-plus/element-plus/pull/14011/files?diff=unified&w=0#diff-5433b2d3d78b06b76e58a73b076b27d4b48b291acfa41f478dc5a41a83081764L2-R2))
* Fix bug that prevented checkbox from having label of `0` or `false` by using `isNil` instead of `!!` in `hasOwnLabel` computed property ([link](https://github.com/element-plus/element-plus/pull/14011/files?diff=unified&w=0#diff-5433b2d3d78b06b76e58a73b076b27d4b48b291acfa41f478dc5a41a83081764L44-R44))
