### PR TITLE
fix(components): [color-picker] exposed show method wrong behavior

### DIFF
--- a/packages/components/color-picker/src/color-picker.vue
+++ b/packages/components/color-picker/src/color-picker.vue
@@ -215,7 +215,7 @@ function setShowPicker(value: boolean) {
   showPicker.value = value
 }
 
-const debounceSetShowPicker = debounce(setShowPicker, 100)
+const debounceSetShowPicker = debounce(setShowPicker, 100, { leading: true })
 
 function show() {
   if (colorDisabled.value) return


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9fda852</samp>

Improved the responsiveness of the color picker component by using the `leading` option of the `debounce` function in `color-picker.vue`. This change is part of a pull request that fixes various color picker issues.

## Related Issue

Fixes https://github.com/element-plus/element-plus/issues/14049_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9fda852</samp>

* Improve the user experience of the color picker component by making it show up faster on the first click ([link](https://github.com/element-plus/element-plus/pull/14064/files?diff=unified&w=0#diff-e6aa984eb701b03261840f9ebb2e298a98085c4fa8d435a64c62f257ef6f3c97L218-R218))
