### PR TITLE
fix(components): [select] gurad value type error

### DIFF
--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -914,11 +914,11 @@ export const useSelect = (props, states: States, ctx) => {
   )
 
   const showTagList = computed(() =>
-    states.selected.slice(0, props.maxCollapseTags)
+    props.multiple ? states.selected.slice(0, props.maxCollapseTags) : []
   )
 
   const collapseTagList = computed(() =>
-    states.selected.slice(props.maxCollapseTags)
+    props.multiple ? states.selected.slice(props.maxCollapseTags) : []
   )
 
   const navigateOptions = (direction) => {


### PR DESCRIPTION
select In the case of radio, the packaged code will report select. slice is not a function, because the radio selected is an object, and the object does not have the api of slice

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4655cc6</samp>

Fixed a bug that caused tags to appear in single mode select component. Modified `showTagList` and `collapseTagList` in `useSelect.ts` to respect the `multiple` prop.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4655cc6</samp>

* Fix tag display bug for select component in single mode ([link](https://github.com/element-plus/element-plus/pull/14074/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L917-R921))
