### PR TITLE
docs(docs): fixed sidebar on the right size not fully displayed

### DIFF
--- a/docs/.vitepress/vitepress/styles/content/table-of-content.scss
+++ b/docs/.vitepress/vitepress/styles/content/table-of-content.scss
@@ -39,7 +39,8 @@
       padding: 0;
       margin: 12px 0 0;
       line-height: 1.2;
-
+      max-height: calc(100vh - 450px);
+      overflow: auto;
       .toc-item {
         margin-top: 10px;
         font-size: 11px;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1dde9fb</samp>

Add `max-height` and `overflow` to `.toc` class in `table-of-content.scss` to limit the size of the table of contents in the documentation. This improves the documentation layout and style.

fixed sidebar on the right size not fully displayed.For example, in the documentation, the form component and table component have many configurable options. On a regular laptop, these options cannot be displayed completely in the sidebar on the right side

before

![before](https://github.com/element-plus/element-plus/assets/59329360/64fda914-5760-4e50-befd-28918e85378d)



after

![after](https://github.com/element-plus/element-plus/assets/59329360/9570df8e-f0a5-4d82-846b-8a5cf4675868)




## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1dde9fb</samp>

* Add `max-height` and `overflow` properties to the `.toc` class to prevent table of contents from overflowing the viewport ([link](https://github.com/element-plus/element-plus/pull/14075/files?diff=unified&w=0#diff-1fed6282b75d056e5a1f621d6cd3bdd6f71b2955215f1aed58995b1d93d5b9d2L42-R43))
