### PR TITLE
chore(test): [message] wrong tag typo

### DIFF
--- a/packages/components/message/__tests__/message.test.ts
+++ b/packages/components/message/__tests__/message.test.ts
@@ -54,7 +54,7 @@ describe('Message.vue', () => {
       const wrapper = _mount({
         props: {
           dangerouslyUseHTMLString: true,
-          message: `<string class="${tagClass}"'>${AXIOM}</strong>`,
+          message: `<strong class="${tagClass}"'>${AXIOM}</strong>`,
         },
       })
 
@@ -66,7 +66,7 @@ describe('Message.vue', () => {
       const wrapper = _mount({
         props: {
           dangerouslyUseHTMLString: false,
-          message: `<string class="${tagClass}"'>${AXIOM}</strong>`,
+          message: `<strong class="${tagClass}"'>${AXIOM}</strong>`,
         },
       })
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

message test module, the label is wrong

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4c8b1b1</samp>

* Fix opening tag of message prop to use `<strong>` instead of `<string>` for correct HTML rendering ([link](https://github.com/element-plus/element-plus/pull/14099/files?diff=unified&w=0#diff-fab9ebe25724dd2f79435affdf0a6ef263cc172671076fda153538cdd8272921L57-R57), [link](https://github.com/element-plus/element-plus/pull/14099/files?diff=unified&w=0#diff-fab9ebe25724dd2f79435affdf0a6ef263cc172671076fda153538cdd8272921L69-R69))
* Update test cases in `message.test.ts` to match the fixed opening tag and verify the message prop output ([link](https://github.com/element-plus/element-plus/pull/14099/files?diff=unified&w=0#diff-fab9ebe25724dd2f79435affdf0a6ef263cc172671076fda153538cdd8272921L57-R57), [link](https://github.com/element-plus/element-plus/pull/14099/files?diff=unified&w=0#diff-fab9ebe25724dd2f79435affdf0a6ef263cc172671076fda153538cdd8272921L69-R69))
