### PR TITLE
D2M

### DIFF
--- a/docs/en-US/component/card.md
+++ b/docs/en-US/component/card.md
@@ -55,7 +55,7 @@ card/shadow
 | ---------- | ------------------------------------------------------------- | --------------------------------- | ------- |
 | header     | title of the card. Also accepts a DOM passed by `slot#header` | ^[string]                         | —       |
 | body-style | CSS style of card body                                        | ^[object]`CSSProperties`          | —       |
-| body-class | custom class name of card body                                | ^[string]                         | —       |
+| body-class ^(2.3.10) | custom class name of card body                                | ^[string]                         | —       |
 | shadow     | when to show card shadows                                     | ^[enum]`always \| never \| hover` | always  |
 
 ### Slots

--- a/packages/components/form/src/form-label-wrap.tsx
+++ b/packages/components/form/src/form-label-wrap.tsx
@@ -11,7 +11,7 @@ import {
   watch,
 } from 'vue'
 import { useResizeObserver } from '@vueuse/core'
-import { getStyle, throwError } from '@element-plus/utils'
+import { throwError } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { formContextKey, formItemContextKey } from './constants'
 
@@ -41,11 +41,8 @@ export default defineComponent({
 
     const getLabelWidth = () => {
       if (el.value?.firstElementChild) {
-        const width = getStyle(
-          el.value.firstElementChild as HTMLElement,
-          'width'
-        )
-        return Math.ceil(Number.parseFloat(width)) || 0
+        const width = window.getComputedStyle(el.value.firstElementChild).width
+        return Math.ceil(Number.parseFloat(width))
       } else {
         return 0
       }

--- a/packages/components/message/__tests__/message.test.ts
+++ b/packages/components/message/__tests__/message.test.ts
@@ -54,7 +54,7 @@ describe('Message.vue', () => {
       const wrapper = _mount({
         props: {
           dangerouslyUseHTMLString: true,
-          message: `<string class="${tagClass}"'>${AXIOM}</strong>`,
+          message: `<strong class="${tagClass}"'>${AXIOM}</strong>`,
         },
       })
 
@@ -66,7 +66,7 @@ describe('Message.vue', () => {
       const wrapper = _mount({
         props: {
           dangerouslyUseHTMLString: false,
-          message: `<string class="${tagClass}"'>${AXIOM}</strong>`,
+          message: `<strong class="${tagClass}"'>${AXIOM}</strong>`,
         },
       })
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c81272</samp>

This pull request improves the code quality, fixes a bug, and updates the documentation of the `form`, `message`, and `card` components. It removes an unused import, replaces a custom function with a native one, fixes a typo, and adds a new attribute to the `card.md` file.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c81272</samp>

* Add `body-class` attribute to `card` component documentation ([link](https://github.com/element-plus/element-plus/pull/14114/files?diff=unified&w=0#diff-8c74950aac791fe4eecb5123466d0fd22b4a4c6e721ddc04e17a406bfe30bf6bL58-R58))
* Fix label width calculation by using `window.getComputedStyle` instead of `getStyle` ([link](https://github.com/element-plus/element-plus/pull/14114/files?diff=unified&w=0#diff-a6bb223ed8a3146beae02e7c03358277c781a12022cb8bfdbf99cc1126634b19L44-R45))
* Remove unused `getStyle` import from `form-label-wrap.tsx` ([link](https://github.com/element-plus/element-plus/pull/14114/files?diff=unified&w=0#diff-a6bb223ed8a3146beae02e7c03358277c781a12022cb8bfdbf99cc1126634b19L14-R14))
* Correct `<strong>` tag typo in `message` prop value for two test cases in `message.test.ts` ([link](https://github.com/element-plus/element-plus/pull/14114/files?diff=unified&w=0#diff-fab9ebe25724dd2f79435affdf0a6ef263cc172671076fda153538cdd8272921L57-R57), [link](https://github.com/element-plus/element-plus/pull/14114/files?diff=unified&w=0#diff-fab9ebe25724dd2f79435affdf0a6ef263cc172671076fda153538cdd8272921L69-R69))
