### PR TITLE
fix(components): inline style doesn't use the custom sass setting value

### DIFF
--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -409,9 +409,8 @@ export const useSelect = (props, states: States, ctx) => {
       const _tags = tags.value
       const cssVarOfSelectSize =
         getComputedStyle(input).getPropertyValue('--el-input-height')
-      const gotSize = cssVarOfSelectSize
-        ? cssVarOfSelectSize
-       const gotSize = cssVarOfSelectSize || getComponentSize(selectSize.value || form?.size)
+      const gotSize =
+        cssVarOfSelectSize || getComponentSize(selectSize.value || form?.size)
 
       const sizeInMap =
         selectSize.value ||

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -411,7 +411,7 @@ export const useSelect = (props, states: States, ctx) => {
         getComputedStyle(input).getPropertyValue('--el-input-height')
       const gotSize = cssVarOfSelectSize
         ? cssVarOfSelectSize
-        : getComponentSize(selectSize.value || form?.size)
+       const gotSize = cssVarOfSelectSize || getComponentSize(selectSize.value || form?.size)
 
       const sizeInMap =
         selectSize.value ||

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -407,7 +407,11 @@ export const useSelect = (props, states: States, ctx) => {
         originClientHeight ||
         (input.clientHeight > 0 ? input.clientHeight + 2 : 0)
       const _tags = tags.value
-      const gotSize = getComponentSize(selectSize.value || form?.size)
+      const cssVarOfSelectSize =
+        getComputedStyle(input).getPropertyValue('--el-input-height')
+      const gotSize = cssVarOfSelectSize
+        ? cssVarOfSelectSize
+        : getComponentSize(selectSize.value || form?.size)
 
       const sizeInMap =
         selectSize.value ||

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -407,8 +407,9 @@ export const useSelect = (props, states: States, ctx) => {
         originClientHeight ||
         (input.clientHeight > 0 ? input.clientHeight + 2 : 0)
       const _tags = tags.value
-      const cssVarOfSelectSize =
-        getComputedStyle(input).getPropertyValue('--el-input-height')
+      const cssVarOfSelectSize = getComputedStyle(input).getPropertyValue(
+        ns.cssVarName('input-height')
+      )
       const gotSize =
         cssVarOfSelectSize || getComponentSize(selectSize.value || form?.size)
 


### PR DESCRIPTION
closed #14038

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db75662</samp>

Improve select component's size adaptation by using CSS variable `--el-input-height` as a fallback. Update `useSelect.ts` to implement this logic.

## Related Issue

Fixes #14038.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at db75662</samp>

* Add fallback logic to get select size from CSS variable ([link](https://github.com/element-plus/element-plus/pull/14117/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L410-R414))
