### PR TITLE
fix(components): [select-v2] blur event doesn't work

### DIFF
--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -500,6 +500,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
       }
       if (states.isSilentBlur) {
         states.isSilentBlur = false
+        emit('blur', event)
       } else {
         if (states.isComposing) {
           emit('blur', event)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 122c990</samp>

Emit 'blur' event from select component on focus loss. Update `useSelect.ts` to trigger the event in `handleBlur` function.

## Related Issue

Fixes #14118

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 122c990</samp>

*  Emit 'blur' event when select component loses focus ([link](https://github.com/element-plus/element-plus/pull/14119/files?diff=unified&w=0#diff-6018da2b9e35c71aca0d0a0f881a93c00ab1f1958a3a9c69e332fa8d0b2e9865R503))
