### PR TITLE
refactor(components): [upload] reuse revkoeObjectURL function

### DIFF
--- a/packages/components/upload/src/upload.vue
+++ b/packages/components/upload/src/upload.vue
@@ -78,6 +78,7 @@ const {
   handleRemove,
   handleSuccess,
   handleProgress,
+  revokeFileObjectURL,
 } = useHandlers(props, uploadRef)
 
 const isPictureCard = computed(() => props.listType === 'picture-card')
@@ -93,9 +94,7 @@ const uploadContentProps = computed<UploadContentProps>(() => ({
 }))
 
 onBeforeUnmount(() => {
-  uploadFiles.value.forEach(({ url }) => {
-    if (url?.startsWith('blob:')) URL.revokeObjectURL(url)
-  })
+  uploadFiles.value.forEach(revokeFileObjectURL)
 })
 
 provide(uploadContextKey, {

--- a/packages/components/upload/src/use-handlers.ts
+++ b/packages/components/upload/src/use-handlers.ts
@@ -18,7 +18,7 @@ import type {
 
 const SCOPE = 'ElUpload'
 
-const revokeObjectURL = (file: UploadFile) => {
+const revokeFileObjectURL = (file: UploadFile) => {
   if (file.url?.startsWith('blob:')) {
     URL.revokeObjectURL(file.url)
   }
@@ -117,7 +117,7 @@ export const useHandlers = (
       const fileList = uploadFiles.value
       fileList.splice(fileList.indexOf(file), 1)
       props.onRemove(file, fileList)
-      revokeObjectURL(file)
+      revokeFileObjectURL(file)
     }
 
     if (props.beforeRemove) {
@@ -177,5 +177,6 @@ export const useHandlers = (
     handleSuccess,
     handleRemove,
     submit,
+    revokeFileObjectURL,
   }
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46249c1</samp>

Refactored `upload.vue` component to use a shared function for revoking blob URLs of uploaded files. Moved and renamed the function from `use-handlers.ts` to `upload.vue` for better readability and reusability.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46249c1</samp>

*  Rename and relocate `revokeObjectURL` function to `revokeFileObjectURL` in `upload.vue` to avoid confusion and improve consistency ([link](https://github.com/element-plus/element-plus/pull/14126/files?diff=unified&w=0#diff-d8dd88d8e9e426a8d86a1eac087c95671d764ebd9772f869a91256a4464c09cdL21-R21), [link](https://github.com/element-plus/element-plus/pull/14126/files?diff=unified&w=0#diff-d8dd88d8e9e426a8d86a1eac087c95671d764ebd9772f869a91256a4464c09cdR180), [link](https://github.com/element-plus/element-plus/pull/14126/files?diff=unified&w=0#diff-ca5e00783f688f94bf2bf6808671d3f836054f7253a8fd3b4b1fb9a57bc9bf31R81))
*  Simplify `onBeforeUnmount` hook in `upload.vue` to use `revokeFileObjectURL` function instead of repeating logic ([link](https://github.com/element-plus/element-plus/pull/14126/files?diff=unified&w=0#diff-ca5e00783f688f94bf2bf6808671d3f836054f7253a8fd3b4b1fb9a57bc9bf31L96-R97))
*  Replace `revokeObjectURL` function with `revokeFileObjectURL` function in `handleRemove` method in `use-handlers.ts` to reflect renaming and relocation ([link](https://github.com/element-plus/element-plus/pull/14126/files?diff=unified&w=0#diff-d8dd88d8e9e426a8d86a1eac087c95671d764ebd9772f869a91256a4464c09cdL120-R120))
