### PR TITLE
feat(components): [dropdown]

### DIFF
--- a/packages/components/dropdown/src/dropdown.ts
+++ b/packages/components/dropdown/src/dropdown.ts
@@ -88,6 +88,7 @@ export const dropdownProps = buildProps({
     type: definePropType<ButtonProps>(Object),
   },
   teleported: useTooltipContentProps.teleported,
+  transition: useTooltipContentProps.transition,
 } as const)
 
 export const dropdownItemProps = buildProps({

--- a/packages/components/dropdown/src/dropdown.vue
+++ b/packages/components/dropdown/src/dropdown.vue
@@ -20,7 +20,7 @@
       :virtual-ref="triggeringElementRef"
       :virtual-triggering="splitButton"
       :disabled="disabled"
-      :transition="`${ns.namespace.value}-zoom-in-top`"
+      :transition="transitionName"
       :teleported="teleported"
       pure
       persistent
@@ -161,6 +161,10 @@ export default defineComponent({
       return props.id || defaultTriggerId
     })
 
+    const transitionName = computed<string>(
+      () => props.transition ?? `${ns.namespace.value}-zoom-in-top`
+    )
+
     // The goal of this code is to focus on the tooltip triggering element when it is hovered.
     // This is a temporary fix for where closing the dropdown through pointerleave event focuses on a
     // completely different element. For a permanent solution, remove all calls to any "element.focus()"
@@ -292,6 +296,7 @@ export default defineComponent({
     return {
       t,
       ns,
+      transitionName,
       scrollbar,
       wrapStyle,
       dropdownTriggerKls,


### PR DESCRIPTION
增加prop：transition，增加下拉框交互效果

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 62163b3</samp>

This pull request adds a new `transitionName` prop to the `ElDropdown` component, which enables customizing the transition effect of the dropdown menu. It also makes the `ElDropdown` component inherit the transition effect from the `ElTooltip` component by using the `useTooltipContentProps` hook.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 62163b3</samp>

*  Add `transition` property to `dropdownProps` object to pass it to `ElPopper` component ([link](https://github.com/element-plus/element-plus/pull/14144/files?diff=unified&w=0#diff-4a9f5c4d864dded55a299dabe92d423feef49e116b603fc9aee5f3afa4454104R91))
*  Replace hard-coded `transition` prop value with dynamic `transitionName` prop value in `ElPopper` component in `dropdown.vue` ([link](https://github.com/element-plus/element-plus/pull/14144/files?diff=unified&w=0#diff-cfcfd827eb84ec394161fa290520daeb2054c0de555375ff066363c1e68670b3L23-R23))
*  Define `transitionName` computed property in `ElDropdown` component to return `transition` prop value or namespace-based value ([link](https://github.com/element-plus/element-plus/pull/14144/files?diff=unified&w=0#diff-cfcfd827eb84ec394161fa290520daeb2054c0de555375ff066363c1e68670b3R164-R167))
*  Add `transitionName` computed property to `setup` function return object in `ElDropdown` component ([link](https://github.com/element-plus/element-plus/pull/14144/files?diff=unified&w=0#diff-cfcfd827eb84ec394161fa290520daeb2054c0de555375ff066363c1e68670b3R299))
