### PR TITLE
refactor(components): extract format to picker and lazy render panel

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -579,13 +579,6 @@ const isValidValue = (date: unknown) => {
   )
 }
 
-const formatToString = (value: Dayjs | Dayjs[]) => {
-  if (selectionMode.value === 'dates') {
-    return (value as Dayjs[]).map((_) => _.format(props.format))
-  }
-  return (value as Dayjs).format(props.format)
-}
-
 const parseUserInput = (value: Dayjs) => {
   return dayjs(value, props.format).locale(lang.value)
 }
@@ -763,7 +756,6 @@ watch(
 )
 
 contextEmit('set-picker-option', ['isValidValue', isValidValue])
-contextEmit('set-picker-option', ['formatToString', formatToString])
 contextEmit('set-picker-option', ['parseUserInput', parseUserInput])
 contextEmit('set-picker-option', ['handleFocusPicker', handleFocusPicker])
 </script>

--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -674,12 +674,6 @@ const handleClear = () => {
   emit('pick', null)
 }
 
-const formatToString = (value: Dayjs | Dayjs[]) => {
-  return isArray(value)
-    ? value.map((_) => _.format(format))
-    : value.format(format)
-}
-
 const parseUserInput = (value: Dayjs | Dayjs[]) => {
   return isArray(value)
     ? value.map((_) => dayjs(_, format).locale(lang.value))
@@ -712,6 +706,5 @@ function onParsedValueChanged(
 
 emit('set-picker-option', ['isValidValue', isValidValue])
 emit('set-picker-option', ['parseUserInput', parseUserInput])
-emit('set-picker-option', ['formatToString', formatToString])
 emit('set-picker-option', ['handleClear', handleClear])
 </script>

--- a/packages/components/date-picker/src/date-picker-com/panel-month-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-month-range.vue
@@ -104,10 +104,7 @@ import dayjs from 'dayjs'
 import ElIcon from '@element-plus/components/icon'
 import { useLocale } from '@element-plus/hooks'
 import { DArrowLeft, DArrowRight } from '@element-plus/icons-vue'
-import {
-  panelMonthRangeEmits,
-  panelMonthRangeProps,
-} from '../props/panel-month-range'
+import { panelMonthRangeProps } from '../props/panel-month-range'
 import { useMonthRangeHeader } from '../composables/use-month-range-header'
 import { useRangePicker } from '../composables/use-range-picker'
 import MonthTable from './basic-month-table.vue'
@@ -119,12 +116,11 @@ defineOptions({
 })
 
 const props = defineProps(panelMonthRangeProps)
-const emit = defineEmits(panelMonthRangeEmits)
 const unit = 'year'
 
 const { lang } = useLocale()
 const pickerBase = inject('EP_PICKER_BASE') as any
-const { shortcuts, disabledDate, format } = pickerBase.props
+const { shortcuts, disabledDate } = pickerBase.props
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 const leftDate = ref(dayjs().locale(lang.value))
 const rightDate = ref(dayjs().locale(lang.value).add(1, unit))
@@ -191,10 +187,6 @@ const handleRangePick = (val: RangePickValue, close = true) => {
   handleRangeConfirm()
 }
 
-const formatToString = (days: Dayjs[]) => {
-  return days.map((day) => day.format(format))
-}
-
 function onParsedValueChanged(
   minDate: Dayjs | undefined,
   maxDate: Dayjs | undefined
@@ -208,6 +200,4 @@ function onParsedValueChanged(
     rightDate.value = leftDate.value.add(1, unit)
   }
 }
-
-emit('set-picker-option', ['formatToString', formatToString])
 </script>

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -15,7 +15,6 @@
     :gpu-acceleration="false"
     :stop-popper-mouse-event="false"
     :hide-after="0"
-    persistent
     @before-show="onBeforeShow"
     @show="onShow"
     @hide="onHide"
@@ -455,7 +454,6 @@ const parsedValue = computed(() => {
 })
 
 const displayValue = computed<UserInput>(() => {
-  if (!pickerOptions.value.panelReady) return ''
   const formattedValue = formatDayjsToString(parsedValue.value)
   if (isArray(userInput.value)) {
     return [
@@ -593,7 +591,12 @@ const parseUserInputToDayjs = (value: UserInput) => {
 
 const formatDayjsToString = (value: DayOrDays) => {
   if (!value) return null
-  return pickerOptions.value.formatToString!(value)
+
+  if (Array.isArray(value)) {
+    return value.map((_) => _.format(props.format)) as UserInput
+  }
+
+  return value.format(props.format)
 }
 
 const isValidValue = (value: DayOrDays) => {

--- a/packages/components/time-picker/src/common/props.ts
+++ b/packages/components/time-picker/src/common/props.ts
@@ -225,7 +225,6 @@ export interface PickerOptions {
   isValidValue: (date: DayOrDays) => boolean
   handleKeydownInput: (event: KeyboardEvent) => void
   parseUserInput: (value: UserInput) => DayOrDays
-  formatToString: (value: DayOrDays) => UserInput
   getRangeAvailableTime: (date: DayOrDays) => DayOrDays
   getDefaultValue: () => DayOrDays
   panelReady: boolean

--- a/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
@@ -159,17 +159,11 @@ const parseUserInput = (value: Dayjs) => {
   return dayjs(value, props.format).locale(lang.value)
 }
 
-const formatToString = (value: Dayjs) => {
-  if (!value) return null
-  return value.format(props.format)
-}
-
 const getDefaultValue = () => {
   return dayjs(defaultValue).locale(lang.value)
 }
 
 emit('set-picker-option', ['isValidValue', isValidValue])
-emit('set-picker-option', ['formatToString', formatToString])
 emit('set-picker-option', ['parseUserInput', parseUserInput])
 emit('set-picker-option', ['handleKeydownInput', handleKeydown])
 emit('set-picker-option', ['getRangeAvailableTime', getRangeAvailableTime])

--- a/packages/components/time-picker/src/time-picker-com/panel-time-range.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-range.vue
@@ -289,14 +289,6 @@ const parseUserInput = (days: Dayjs[] | Dayjs) => {
   return dayjs(days, props.format).locale(lang.value)
 }
 
-const formatToString = (days: Dayjs[] | Dayjs) => {
-  if (!days) return null
-  if (isArray(days)) {
-    return days.map((d) => d.format(props.format))
-  }
-  return days.format(props.format)
-}
-
 const getDefaultValue = () => {
   if (isArray(defaultValue)) {
     return defaultValue.map((d: Date) => dayjs(d).locale(lang.value))
@@ -305,7 +297,6 @@ const getDefaultValue = () => {
   return [defaultDay, defaultDay.add(60, 'm')]
 }
 
-emit('set-picker-option', ['formatToString', formatToString])
 emit('set-picker-option', ['parseUserInput', parseUserInput])
 emit('set-picker-option', ['isValidValue', isValidValue])
 emit('set-picker-option', ['handleKeydownInput', handleKeydown])


### PR DESCRIPTION
There is currently an issue where the datepicker component loads its corresponding DOM even when the panel is not displayed. This can lead to performance problems, especially on complex form pages that contain multiple datepickers. The disabledDate function of each datepicker is executed simultaneously. To optimize performance, we need to address this problem.

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d610a0f</samp>

The pull request refactors the date and time picker components to simplify and unify the value formatting logic in the `picker.vue` component. It removes redundant or unused code and functions from the child components and fixes some potential bugs. It also improves the code readability and consistency.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d610a0f</samp>

*  Remove `formatToString` functions from child components and move them to `picker.vue` component ([link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759L582-L588), [link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L677-L682), [link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-aae21490a51f2812af5785511e78e38b1160b12da90559b82c3a6a1b9a07e308L194-L197), [link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-60b8d640aee096b38e04f0f59a87c5d8c5ddc9e877a4bcbe50a86058b59b3ceaL162-L166), [link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-893f4fcade0e0077fbd58008fb0d3f6ae67311c285509aba7c361a69c143161dL292-L299))
  * The `picker.vue` component now handles different selection modes and formats using the `formatDayjsToString` function ([link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-3d026a2d83f86f5dc2ce3aa7b95b77eff4a475e67c362841827e0e1bac7456abL596-R599))
  * The `format` prop is passed from the parent component to the `picker.vue` component ([link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-4d5804445bd2a26541567338da443fedac41179034d4ef377f967d6b1d66074cL228))
* Remove `set-picker-option` events from child components and use the `formatDayjsToString` function from the `picker.vue` component ([link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759L766), [link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L715), [link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-aae21490a51f2812af5785511e78e38b1160b12da90559b82c3a6a1b9a07e308L211-L212), [link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-60b8d640aee096b38e04f0f59a87c5d8c5ddc9e877a4bcbe50a86058b59b3ceaL172), [link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-893f4fcade0e0077fbd58008fb0d3f6ae67311c285509aba7c361a69c143161dL308))
* Remove unused and unnecessary variables and imports from `panel-month-range.vue` and `picker.vue` components ([link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-aae21490a51f2812af5785511e78e38b1160b12da90559b82c3a6a1b9a07e308L107-R107), [link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-aae21490a51f2812af5785511e78e38b1160b12da90559b82c3a6a1b9a07e308L122-R123), [link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-aae21490a51f2812af5785511e78e38b1160b12da90559b82c3a6a1b9a07e308L211-L212), [link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-3d026a2d83f86f5dc2ce3aa7b95b77eff4a475e67c362841827e0e1bac7456abL18), [link](https://github.com/element-plus/element-plus/pull/14159/files?diff=unified&w=0#diff-3d026a2d83f86f5dc2ce3aa7b95b77eff4a475e67c362841827e0e1bac7456abL458))
