### PR TITLE
fix(components): [formItem] fix props 'for' didn't work bug

### DIFF
--- a/packages/components/form/src/form-item.vue
+++ b/packages/components/form/src/form-item.vue
@@ -159,9 +159,9 @@ const hasLabel = computed<boolean>(() => {
 })
 
 const labelFor = computed<string | undefined>(() => {
-  return props.for || inputIds.value.length === 1
+  return props.for || (inputIds.value.length === 1
     ? inputIds.value[0]
-    : undefined
+    : undefined)
 })
 
 const isGroup = computed<boolean>(() => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcceb11</samp>

Fixed a bug in `form-item.vue` that caused wrong label association for multiple inputs. Enhanced the accessibility and usability of the `form-item` component.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bcceb11</samp>

* Fix bug where label for attribute would be incorrectly set to undefined when there were multiple input ids and no props.for was provided by adding parentheses around the ternary expression ([link](https://github.com/element-plus/element-plus/pull/14192/files?diff=unified&w=0#diff-ec639edfd5d7463de4e60beb64943914663f64e5e4fc14ca2d93166e1ef2bad3L162-R164))
