### PR TITLE
fix(components): [color-picker] first click should be trigger

### DIFF
--- a/packages/components/color-picker/src/color-picker.vue
+++ b/packages/components/color-picker/src/color-picker.vue
@@ -84,7 +84,7 @@
                 <arrow-down />
               </el-icon>
               <el-icon
-                v-if="!modelValue && !showPanelColor"
+                v-show="!modelValue && !showPanelColor"
                 :class="[ns.be('picker', 'empty'), ns.is('icon-close')]"
               >
                 <close />


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b1462e</samp>

Refactor and optimize color picker component. Use `v-show` instead of `v-if` for empty icon in `color-picker.vue` to avoid unnecessary rendering.

## Related Issue

Fixes https://github.com/element-plus/element-plus/issues/14205.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b1462e</samp>

* Improve performance and user experience of color picker component by using `v-show` instead of `v-if` for empty icon ([link](https://github.com/element-plus/element-plus/pull/14209/files?diff=unified&w=0#diff-e6aa984eb701b03261840f9ebb2e298a98085c4fa8d435a64c62f257ef6f3c97L87-R87))
