### PR TITLE
fix(components): [tabs] Fix some events accidentally firing

### DIFF
--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -99,20 +99,18 @@ export default defineComponent({
       props.modelValue ?? props.activeName ?? '0'
     )
 
-    const changeCurrentName = (value: TabPaneName) => {
-      currentName.value = value
-      emit(UPDATE_MODEL_EVENT, value)
-      emit('tabChange', value)
-    }
-
-    const setCurrentName = async (value?: TabPaneName) => {
+    const setCurrentName = async (value?: TabPaneName, trigger = false) => {
       // should do nothing.
       if (currentName.value === value || isUndefined(value)) return
 
       try {
         const canLeave = await props.beforeLeave?.(value, currentName.value)
         if (canLeave !== false) {
-          changeCurrentName(value)
+          currentName.value = value
+          if (trigger) {
+            emit(UPDATE_MODEL_EVENT, value)
+            emit('tabChange', value)
+          }
 
           // call exposed function, Vue doesn't support expose in typescript yet.
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -128,7 +126,7 @@ export default defineComponent({
       event: Event
     ) => {
       if (tab.props.disabled) return
-      setCurrentName(tabName)
+      setCurrentName(tabName, true)
       emit('tabClick', tab, event)
     }
 


### PR DESCRIPTION
Fixes #14222 

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5fdc290</samp>

Refactored `setCurrentName` function in `tabs.tsx` to simplify logic and fix event emission bug.

## Related Issue

Fixes #14222 

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5fdc290</samp>

*  Simplify and fix event emission logic for current name changes ([link](https://github.com/element-plus/element-plus/pull/14224/files?diff=unified&w=0#diff-50e3b1682badc3cce7c21a7fe3eca91302c86aefaf2592c1d743cd249a5333e5L102-R102), [link](https://github.com/element-plus/element-plus/pull/14224/files?diff=unified&w=0#diff-50e3b1682badc3cce7c21a7fe3eca91302c86aefaf2592c1d743cd249a5333e5L115-R113), [link](https://github.com/element-plus/element-plus/pull/14224/files?diff=unified&w=0#diff-50e3b1682badc3cce7c21a7fe3eca91302c86aefaf2592c1d743cd249a5333e5L131-R129))
  - Remove `changeCurrentName` function and move its logic to `setCurrentName` ([link](https://github.com/element-plus/element-plus/pull/14224/files?diff=unified&w=0#diff-50e3b1682badc3cce7c21a7fe3eca91302c86aefaf2592c1d743cd249a5333e5L102-R102))
  - Add `trigger` parameter to `setCurrentName` to control whether to emit events ([link](https://github.com/element-plus/element-plus/pull/14224/files?diff=unified&w=0#diff-50e3b1682badc3cce7c21a7fe3eca91302c86aefaf2592c1d743cd249a5333e5L115-R113), [link](https://github.com/element-plus/element-plus/pull/14224/files?diff=unified&w=0#diff-50e3b1682badc3cce7c21a7fe3eca91302c86aefaf2592c1d743cd249a5333e5L131-R129))
  - Use `trigger` parameter to allow `beforeLeave` hook to prevent events if it returns false ([link](https://github.com/element-plus/element-plus/pull/14224/files?diff=unified&w=0#diff-50e3b1682badc3cce7c21a7fe3eca91302c86aefaf2592c1d743cd249a5333e5L115-R113))
  - Pass `true` as `trigger` parameter when user clicks on a tab in `handleTabClick` ([link](https://github.com/element-plus/element-plus/pull/14224/files?diff=unified&w=0#diff-50e3b1682badc3cce7c21a7fe3eca91302c86aefaf2592c1d743cd249a5333e5L131-R129))
