### PR TITLE
fix(components):color-picker can not show popover 

### DIFF
--- a/packages/components/color-picker/src/color-picker.vue
+++ b/packages/components/color-picker/src/color-picker.vue
@@ -223,6 +223,9 @@ function show() {
 }
 
 function hide() {
+  if(!showPicker.value){
+    return
+  }
   debounceSetShowPicker(false)
   resetColor()
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec36232</samp>

Fix a bug in `ColorPicker` component that caused unwanted `change` event. Add a visibility check to `handleClickOutside` method in `color-picker.vue`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec36232</samp>

*  Prevent `handleClickOutside` method from executing when color picker is hidden ([link](https://github.com/element-plus/element-plus/pull/14231/files?diff=unified&w=0#diff-e6aa984eb701b03261840f9ebb2e298a98085c4fa8d435a64c62f257ef6f3c97R226-R228))
