### PR TITLE
fix(docs): [date-picker] `calendar-change` event parameter type error

### DIFF
--- a/docs/en-US/component/date-picker.md
+++ b/docs/en-US/component/date-picker.md
@@ -177,14 +177,14 @@ Note, date time locale (month name, first day of the week ...) are also configur
 
 ## Events
 
-| Name            | Description                                                               | Parameters              |
-| --------------- | ------------------------------------------------------------------------- | ----------------------- |
-| change          | triggers when user confirms the value                                     | `(val: typeof v-model)` |
-| blur            | triggers when Input blurs                                                 | `(e: FocusEvent)`       |
-| focus           | triggers when Input focuses                                               | `(e: FocusEvent)`       |
-| calendar-change | triggers when the calendar selected date is changed. Only for `daterange` | `(val: [Date, Date])`   |
-| panel-change    | triggers when the navigation button click.                                | `(date, mode, view)`    |
-| visible-change  | triggers when the DatePicker's dropdown appears/disappears                | `(visibility: boolean)` |
+| Name            | Description                                                               | Parameters                    |
+| --------------- | ------------------------------------------------------------------------- | ----------------------------- |
+| change          | triggers when user confirms the value                                     | `(val: typeof v-model)`       |
+| blur            | triggers when Input blurs                                                 | `(e: FocusEvent)`             |
+| focus           | triggers when Input focuses                                               | `(e: FocusEvent)`             |
+| calendar-change | triggers when the calendar selected date is changed. Only for `daterange` | `(val: [Date, null \| Date])` |
+| panel-change    | triggers when the navigation button click.                                | `(date, mode, view)`          |
+| visible-change  | triggers when the DatePicker's dropdown appears/disappears                | `(visibility: boolean)`       |
 
 ## Methods
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description
Sync #13976
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91277ce</samp>

Updated the documentation of the `calendar-change` event for the `date-picker` component. Fixed the type of the `val` parameter to include null as a possible value.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91277ce</samp>

* Update the type of the `val` parameter for the `calendar-change` event to include null as a possible value for the end date of the range ([link](https://github.com/element-plus/element-plus/pull/14237/files?diff=unified&w=0#diff-936f76a60feba4602e81cd280e37ac122e009f3326ea42c660e69272e806a483L180-R187))
