### PR TITLE
feat(components): [color-picker] add focus and blur event

### DIFF
--- a/docs/en-US/component/color-picker.md
+++ b/docs/en-US/component/color-picker.md
@@ -65,12 +65,12 @@ color-picker/sizes
 
 ### Events
 
-| Name            | Description                                    | Type                                     |
-| --------------- | ---------------------------------------------- | ---------------------------------------- |
-| change          | triggers when input value changes              | ^[Function]`(value: string) => void`     |
-| active-change   | triggers when the current active color changes | ^[Function]`(value: string) => void`     |
-| focus ^(2.3.13) | triggers when Component focuses                | ^[Function]`(event: FocusEvent) => void` |
-| blur ^(2.3.13)  | triggers when Component blurs                  | ^[Function]`(event: FocusEvent) => void` |
+| Name           | Description                                    | Type                                     |
+| -------------- | ---------------------------------------------- | ---------------------------------------- |
+| change         | triggers when input value changes              | ^[Function]`(value: string) => void`     |
+| active-change  | triggers when the current active color changes | ^[Function]`(value: string) => void`     |
+| focus ^(2.4.0) | triggers when Component focuses                | ^[Function]`(event: FocusEvent) => void` |
+| blur ^(2.4.0)  | triggers when Component blurs                  | ^[Function]`(event: FocusEvent) => void` |
 
 ### Exposes
 

--- a/docs/en-US/component/color-picker.md
+++ b/docs/en-US/component/color-picker.md
@@ -60,20 +60,24 @@ color-picker/sizes
 | predefine             | predefined color options                     | ^[object]`string[]`                                                                                              | —       |
 | validate-event        | whether to trigger form validation           | ^[boolean]                                                                                                       | true    |
 | tabindex              | ColorPicker tabindex                         | ^[string] / ^[number]                                                                                            | 0       |
-| label<A11yTag/>       | ColorPicker aria-label                       | ^[string]                                                                                                        | —       |
+| label ^(a11y)         | ColorPicker aria-label                       | ^[string]                                                                                                        | —       |
 | id                    | ColorPicker id                               | ^[string]                                                                                                        | —       |
 
 ### Events
 
-| Name          | Description                                    | Type                                 |
-| ------------- | ---------------------------------------------- | ------------------------------------ |
-| change        | triggers when input value changes              | ^[Function]`(value: string) => void` |
-| active-change | triggers when the current active color changes | ^[Function]`(value: string) => void` |
+| Name            | Description                                    | Type                                     |
+| --------------- | ---------------------------------------------- | ---------------------------------------- |
+| change          | triggers when input value changes              | ^[Function]`(value: string) => void`     |
+| active-change   | triggers when the current active color changes | ^[Function]`(value: string) => void`     |
+| focus ^(2.3.13) | triggers when Component focuses                | ^[Function]`(event: FocusEvent) => void` |
+| blur ^(2.3.13)  | triggers when Component blurs                  | ^[Function]`(event: FocusEvent) => void` |
 
 ### Exposes
 
-| Name          | Description               | Type                    |
-| ------------- | ------------------------- | ----------------------- |
-| color         | current color object      | ^[object]`Color`        |
-| show ^(2.3.3) | manually show ColorPicker | ^[Function]`() => void` |
-| hide ^(2.3.3) | manually hide ColorPicker | ^[Function]`() => void` |
+| Name            | Description               | Type                    |
+| --------------- | ------------------------- | ----------------------- |
+| color           | current color object      | ^[object]`Color`        |
+| show ^(2.3.3)   | manually show ColorPicker | ^[Function]`() => void` |
+| hide ^(2.3.3)   | manually hide ColorPicker | ^[Function]`() => void` |
+| focus ^(2.3.13) | focus the picker element  | ^[Function]`() => void` |
+| blur ^(2.3.13)  | blur the picker element   | ^[Function]`() => void` |

--- a/packages/components/color-picker/__tests__/color-picker.test.tsx
+++ b/packages/components/color-picker/__tests__/color-picker.test.tsx
@@ -453,4 +453,20 @@ describe('Color-picker', () => {
       expect(formItem.attributes().role).toBe('group')
     })
   })
+
+  it('it will target the focus & blur', async () => {
+    const focusHandler = vi.fn()
+    const blurHandler = vi.fn()
+    const wrapper = mount(() => (
+      <ColorPicker onFocus={focusHandler} onBlur={blurHandler} />
+    ))
+
+    await nextTick()
+    await wrapper.find('.el-color-picker').trigger('focus')
+    expect(focusHandler).toHaveBeenCalledTimes(1)
+
+    await wrapper.find('.el-color-picker').trigger('blur')
+    expect(blurHandler).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
 })

--- a/packages/components/color-picker/src/color-picker.ts
+++ b/packages/components/color-picker/src/color-picker.ts
@@ -70,6 +70,8 @@ export const colorPickerEmits = {
   [UPDATE_MODEL_EVENT]: (val: string | null) => isString(val) || isNil(val),
   [CHANGE_EVENT]: (val: string | null) => isString(val) || isNil(val),
   activeChange: (val: string | null) => isString(val) || isNil(val),
+  focus: (event: FocusEvent) => event instanceof FocusEvent,
+  blur: (event: FocusEvent) => event instanceof FocusEvent,
 }
 
 export type ColorPickerProps = ExtractPropTypes<typeof colorPickerProps>

--- a/packages/hooks/__tests__/use-focus-controller.test.tsx
+++ b/packages/hooks/__tests__/use-focus-controller.test.tsx
@@ -8,6 +8,92 @@ describe('useFocusController', () => {
     vi.restoreAllMocks()
   })
 
+  it('it will trigger focus & blur without wrapperRef', async () => {
+    const focusHandler = vi.fn()
+    const blurHandler = vi.fn()
+    const wrapper = mount({
+      emits: ['focus', 'blur'],
+      setup() {
+        const targetRef = ref()
+        const { isFocused, handleFocus, handleBlur } = useFocusController(
+          targetRef,
+          {
+            afterFocus: focusHandler,
+            afterBlur: blurHandler,
+          }
+        )
+
+        return () => (
+          <div>
+            <input ref={targetRef} onFocus={handleFocus} onBlur={handleBlur} />
+            <span>{String(isFocused.value)}</span>
+          </div>
+        )
+      },
+    })
+
+    await nextTick()
+    expect(wrapper.find('span').text()).toBe('false')
+    expect(focusHandler).toHaveBeenCalledTimes(0)
+    expect(blurHandler).toHaveBeenCalledTimes(0)
+
+    await wrapper.find('input').trigger('focus')
+    expect(wrapper.emitted()).toHaveProperty('focus')
+    expect(wrapper.find('span').text()).toBe('true')
+    expect(focusHandler).toHaveBeenCalledTimes(1)
+    expect(blurHandler).toHaveBeenCalledTimes(0)
+
+    await wrapper.find('input').trigger('blur')
+    expect(wrapper.emitted()).toHaveProperty('blur')
+    expect(wrapper.find('span').text()).toBe('false')
+    expect(blurHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('it will trigger focus & blur with tabindex', async () => {
+    const focusHandler = vi.fn()
+    const blurHandler = vi.fn()
+    const wrapper = mount({
+      emits: ['focus', 'blur'],
+      setup() {
+        const targetRef = ref()
+        const { isFocused, handleFocus, handleBlur } = useFocusController(
+          targetRef,
+          {
+            afterFocus: focusHandler,
+            afterBlur: blurHandler,
+          }
+        )
+
+        return () => (
+          <div
+            ref={targetRef}
+            tabindex="0"
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+          >
+            <span>{String(isFocused.value)}</span>
+          </div>
+        )
+      },
+    })
+
+    await nextTick()
+    expect(wrapper.find('span').text()).toBe('false')
+    expect(focusHandler).toHaveBeenCalledTimes(0)
+    expect(blurHandler).toHaveBeenCalledTimes(0)
+
+    await wrapper.find('div').trigger('focus')
+    expect(wrapper.emitted()).toHaveProperty('focus')
+    expect(wrapper.find('span').text()).toBe('true')
+    expect(focusHandler).toHaveBeenCalledTimes(1)
+    expect(blurHandler).toHaveBeenCalledTimes(0)
+
+    await wrapper.find('div').trigger('blur')
+    expect(wrapper.emitted()).toHaveProperty('blur')
+    expect(wrapper.find('span').text()).toBe('false')
+    expect(blurHandler).toHaveBeenCalledTimes(1)
+  })
+
   it('it will avoid trigger unnecessary blur event', async () => {
     const focusHandler = vi.fn()
     const blurHandler = vi.fn()
@@ -51,5 +137,48 @@ describe('useFocusController', () => {
     expect(wrapper.emitted()).toHaveProperty('blur')
     expect(wrapper.find('span').text()).toBe('false')
     expect(blurHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('it will avoid trigger unnecessary blur event by beforeBlur', async () => {
+    const beforeBlur = vi.fn()
+    const wrapper = mount({
+      emits: ['focus', 'blur'],
+      setup() {
+        const targetRef = ref()
+        const { wrapperRef, isFocused, handleFocus, handleBlur } =
+          useFocusController(targetRef, {
+            afterBlur: () => {
+              beforeBlur()
+              return true
+            },
+          })
+
+        return () => (
+          <>
+            <div ref={wrapperRef}>
+              <input
+                ref={targetRef}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+              />
+            </div>
+            <span>{String(isFocused.value)}</span>
+          </>
+        )
+      },
+    })
+
+    await nextTick()
+    expect(wrapper.find('span').text()).toBe('false')
+    expect(beforeBlur).toHaveBeenCalledTimes(0)
+
+    await wrapper.find('input').trigger('focus')
+    expect(wrapper.emitted()).toHaveProperty('focus')
+    expect(wrapper.find('span').text()).toBe('true')
+    expect(beforeBlur).toHaveBeenCalledTimes(0)
+
+    await wrapper.find('span').trigger('click')
+    expect(wrapper.emitted()).not.toHaveProperty('blur')
+    expect(beforeBlur).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/hooks/use-focus-controller/index.ts
+++ b/packages/hooks/use-focus-controller/index.ts
@@ -1,15 +1,21 @@
 import { getCurrentInstance, ref, shallowRef, watch } from 'vue'
 import { useEventListener } from '@vueuse/core'
+import { isFunction } from '@element-plus/utils'
 import type { ShallowRef } from 'vue'
 
 interface UseFocusControllerOptions {
   afterFocus?: () => void
+  /**
+   * return true to cancel blur
+   * @param event FocusEvent
+   */
+  beforeBlur?: (event: FocusEvent) => boolean | undefined
   afterBlur?: () => void
 }
 
 export function useFocusController<T extends HTMLElement>(
   target: ShallowRef<T | undefined>,
-  { afterFocus, afterBlur }: UseFocusControllerOptions = {}
+  { afterFocus, beforeBlur, afterBlur }: UseFocusControllerOptions = {}
 ) {
   const instance = getCurrentInstance()!
   const { emit } = instance
@@ -24,9 +30,11 @@ export function useFocusController<T extends HTMLElement>(
   }
 
   const handleBlur = (event: FocusEvent) => {
+    const cancelBlur = isFunction(beforeBlur) ? beforeBlur(event) : false
     if (
-      event.relatedTarget &&
-      wrapperRef.value?.contains(event.relatedTarget as Node)
+      cancelBlur ||
+      (event.relatedTarget &&
+        wrapperRef.value?.contains(event.relatedTarget as Node))
     )
       return
 

--- a/packages/theme-chalk/src/color-picker.scss
+++ b/packages/theme-chalk/src/color-picker.scss
@@ -246,9 +246,9 @@ $color-picker-size: map.merge($common-component-size, $color-picker-size);
   line-height: normal;
   outline: none;
 
-  &:hover:not(.is-disabled) {
+  &:hover:not(.is-disabled, .is-focused) {
     .#{$namespace}-color-picker__trigger {
-      border: 1px solid getCssVar('border-color-hover');
+      border-color: getCssVar('border-color-hover');
     }
   }
 
@@ -256,6 +256,12 @@ $color-picker-size: map.merge($common-component-size, $color-picker-size);
     .#{$namespace}-color-picker__trigger {
       outline: 2px solid getCssVar('color-primary');
       outline-offset: 1px;
+    }
+  }
+
+  @include when(focused) {
+    .#{$namespace}-color-picker__trigger {
+      border-color: getCssVar('color-primary');
     }
   }
 


### PR DESCRIPTION
- add focus and blur event
- a11y enhancement, support opening and closing dropdown through keyboard

[after](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6IjxzY3JpcHQgc2V0dXAgbGFuZz1cInRzXCI+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5cbmNvbnN0IGNvbG9yMSA9IHJlZignIzIwQTBGRkVFJylcbmNvbnN0IGNvbG9yMiA9IHJlZigpXG5cbmNvbnN0IGxvZyA9ICh0eXBlOiB1bmtub3duKSA9PiB7XG4gIGNvbnNvbGUubG9nKHR5cGUpXG59XG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8cD5FbnRlci9TcGFjZTogb3BlbiBkcm9wZG93bjwvcD5cbiAgPHA+RXNjOiBjbG9zZSBkcm9wZG93bjwvcD5cbiAgPGVsLWJ1dHRvbj5DbGljayBtZTwvZWwtYnV0dG9uPlxuICA8ZWwtY29sb3ItcGlja2VyIHYtbW9kZWw9XCJjb2xvcjFcIiBzaG93QWxwaGEgQGZvY3VzPVwibG9nKCdmb2N1cycpXCIgQGJsdXI9XCJsb2coJ2JsdXInKVwiIC8+XG4gIDxlbC1jb2xvci1waWNrZXIgdi1tb2RlbD1cImNvbG9yMlwiIGRpc2FibGVkIEBmb2N1cz1cImxvZygnZm9jdXMnKVwiIEBibHVyPVwibG9nKCdibHVyJylcIiAvPlxuPC90ZW1wbGF0ZT5cbiIsInNyYy9QbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL3ByZXZpZXctMTQyNDQtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5mdWxsLm1pbi5tanNcIixcbiAgICBcImVsZW1lbnQtcGx1cy9cIjogXCJ1bnN1cHBvcnRlZFwiXG4gIH1cbn0iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWUsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwic3JjL2VsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcbmltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgIGxpbmsuaHJlZiA9ICdodHRwczovL3ByZXZpZXctMTQyNDQtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5jc3MnXG4gICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gIH0pXG59IiwiX28iOnsic2hvd0hpZGRlbiI6dHJ1ZSwic3R5bGVTb3VyY2UiOiJodHRwczovL3ByZXZpZXctMTQyNDQtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5jc3MifX0=)

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b551f3b</samp>

The pull request improves the accessibility, usability, and testability of the `ColorPicker` component. It adds focus and blur logic and events, keyboard and mouse interactions, and accessibility attributes to the component. It also fixes a bug that prevented the component from closing properly. It updates the documentation, the styles, and the unit tests accordingly. It also introduces a new `useFocusController` hook with a `beforeBlur` option to control the blur event.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b551f3b</samp>

*  Fix a bug that prevented the ColorPicker from closing when clicking outside or pressing the escape key ([link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-e6aa984eb701b03261840f9ebb2e298a98085c4fa8d435a64c62f257ef6f3c97L15-R18), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-e6aa984eb701b03261840f9ebb2e298a98085c4fa8d435a64c62f257ef6f3c97R315-R354))
* Add focus and blur events and methods to the ColorPicker component to improve accessibility and usability ([link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-9f7664ebf5f470e2924136e8569cc55c7d95eab6f6bb8138012957b75b2d8bd4R456-R471), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-0d93db927a2880b6cfc38b9612a57b678b0ae1d4c9a44ea167c89d0886964f33R73-R74), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-e6aa984eb701b03261840f9ebb2e298a98085c4fa8d435a64c62f257ef6f3c97R33), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-e6aa984eb701b03261840f9ebb2e298a98085c4fa8d435a64c62f257ef6f3c97R63), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-e6aa984eb701b03261840f9ebb2e298a98085c4fa8d435a64c62f257ef6f3c97L68-R75), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-e6aa984eb701b03261840f9ebb2e298a98085c4fa8d435a64c62f257ef6f3c97L122-R133), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-e6aa984eb701b03261840f9ebb2e298a98085c4fa8d435a64c62f257ef6f3c97L158-R189), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-e6aa984eb701b03261840f9ebb2e298a98085c4fa8d435a64c62f257ef6f3c97R231), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-e6aa984eb701b03261840f9ebb2e298a98085c4fa8d435a64c62f257ef6f3c97R419-R426), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-5211bf9449eae978ee3bbaa79f074698b22b7e1fb33a919193b25f868a34cf51R11-R96), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-5211bf9449eae978ee3bbaa79f074698b22b7e1fb33a919193b25f868a34cf51R141-R183), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-2bdec9b56644a5e68363c0e58d37a4f2288ac2a5777adfb2b939617cd912f190L3-R12), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-2bdec9b56644a5e68363c0e58d37a4f2288ac2a5777adfb2b939617cd912f190L12-R18), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-2bdec9b56644a5e68363c0e58d37a4f2288ac2a5777adfb2b939617cd912f190L27-R37), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-2b67c528d0e02e7bfc677ba0517450d8015eae18c79ce8e9066b5f5b7aabf984L249-R251), [link](https://github.com/element-plus/element-plus/pull/14244/files?diff=unified&w=0#diff-2b67c528d0e02e7bfc677ba0517450d8015eae18c79ce8e9066b5f5b7aabf984R262-R267))
