### PR TITLE
feat(components): [color-picker] alpha-slider a11y

### DIFF
--- a/packages/components/color-picker/__tests__/color-picker.test.tsx
+++ b/packages/components/color-picker/__tests__/color-picker.test.tsx
@@ -2,6 +2,7 @@ import { nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { ElFormItem } from '@element-plus/components/form'
+import { EVENT_CODE } from '@element-plus/constants'
 import ColorPicker from '../src/color-picker.vue'
 import type { ComponentPublicInstance } from 'vue'
 
@@ -68,6 +69,34 @@ describe('Color-picker', () => {
       '.el-color-dropdown__value input'
     )
     expect(input!.value.trim().toUpperCase()).toEqual('#20A0FFEE')
+    wrapper.unmount()
+  })
+  it('control alpha changes through keyboard', async () => {
+    const color = ref('rgba(19, 206, 102, 0.18)')
+    const wrapper = mount(() => (
+      <ColorPicker v-model={color.value} show-alpha />
+    ))
+
+    await wrapper.find('.el-color-picker__trigger').trigger('click')
+    const alphaSlider = wrapper.findComponent('.el-color-alpha-slider')
+    await alphaSlider.find('.el-color-alpha-slider__thumb').trigger('keydown', {
+      key: EVENT_CODE.down,
+      code: EVENT_CODE.down,
+    })
+    await alphaSlider.find('.el-color-alpha-slider__thumb').trigger('keydown', {
+      key: EVENT_CODE.left,
+      code: EVENT_CODE.left,
+    })
+    const input = document.querySelector<HTMLInputElement>(
+      '.el-color-dropdown__value input'
+    )
+    expect(input!.value).toEqual('rgba(19, 206, 102, 0.16)')
+
+    await alphaSlider.find('.el-color-alpha-slider__thumb').trigger('keydown', {
+      key: EVENT_CODE.up,
+      code: EVENT_CODE.up,
+    })
+    expect(input!.value).toEqual('rgba(19, 206, 102, 0.17)')
     wrapper.unmount()
   })
   it('should pick a color when confirm button click', async () => {

--- a/packages/components/color-picker/src/components/alpha-slider.vue
+++ b/packages/components/color-picker/src/components/alpha-slider.vue
@@ -1,7 +1,19 @@
 <template>
   <div :class="rootKls">
     <div ref="bar" :class="barKls" :style="barStyle" @click="handleClick" />
-    <div ref="thumb" :class="thumbKls" :style="thumbStyle" />
+    <div
+      ref="thumb"
+      :class="thumbKls"
+      :style="thumbStyle"
+      :aria-label="alphaLabel"
+      :aria-valuenow="alpha"
+      :aria-orientation="vertical ? 'vertical' : 'horizontal'"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      role="slider"
+      tabindex="0"
+      @keydown="handleKeydown"
+    />
   </div>
 </template>
 
@@ -20,7 +32,15 @@ defineOptions({
 
 const props = defineProps(alphaSliderProps)
 
-const { bar, thumb, handleDrag, handleClick } = useAlphaSlider(props)
+const {
+  alpha,
+  alphaLabel,
+  bar,
+  thumb,
+  handleDrag,
+  handleClick,
+  handleKeydown,
+} = useAlphaSlider(props)
 
 const { rootKls, barKls, barStyle, thumbKls, thumbStyle, update } =
   useAlphaSliderDOM(props, {

--- a/packages/components/color-picker/src/composables/use-alpha-slider.ts
+++ b/packages/components/color-picker/src/composables/use-alpha-slider.ts
@@ -68,8 +68,10 @@ export const useAlphaSlider = (props: AlphaSliderProps) => {
   }
 
   function handleKeydown(event: KeyboardEvent) {
-    const step = 1
-    switch (event.code) {
+    const { code, shiftKey } = event
+    const step = shiftKey ? 10 : 1
+
+    switch (code) {
       case EVENT_CODE.left:
       case EVENT_CODE.down:
         event.preventDefault()

--- a/packages/components/color-picker/src/composables/use-alpha-slider.ts
+++ b/packages/components/color-picker/src/composables/use-alpha-slider.ts
@@ -7,16 +7,21 @@ import {
   watch,
 } from 'vue'
 import { addUnit, getClientXY } from '@element-plus/utils'
-import { useNamespace } from '@element-plus/hooks'
+import { useLocale, useNamespace } from '@element-plus/hooks'
+import { EVENT_CODE } from '@element-plus/constants'
 import { draggable } from '../utils/draggable'
 
 import type { AlphaSliderProps } from '../props/alpha-slider'
 
 export const useAlphaSlider = (props: AlphaSliderProps) => {
   const instance = getCurrentInstance()!
+  const { t } = useLocale()
 
   const thumb = shallowRef<HTMLElement>()
   const bar = shallowRef<HTMLElement>()
+
+  const alpha = computed(() => props.color.get('alpha'))
+  const alphaLabel = computed(() => t('el.colorpicker.alphaLabel'))
 
   function handleClick(event: MouseEvent | TouchEvent) {
     const target = event.target
@@ -62,11 +67,38 @@ export const useAlphaSlider = (props: AlphaSliderProps) => {
     }
   }
 
+  function handleKeydown(event: KeyboardEvent) {
+    const step = 1
+    switch (event.code) {
+      case EVENT_CODE.left:
+      case EVENT_CODE.down:
+        event.preventDefault()
+        event.stopPropagation()
+        incrementPosition(-step)
+        break
+      case EVENT_CODE.right:
+      case EVENT_CODE.up:
+        event.preventDefault()
+        event.stopPropagation()
+        incrementPosition(step)
+        break
+    }
+  }
+
+  function incrementPosition(step: number) {
+    let next = alpha.value + step
+    next = next < 0 ? 0 : next > 100 ? 100 : next
+    props.color.set('alpha', next)
+  }
+
   return {
     thumb,
     bar,
+    alpha,
+    alphaLabel,
     handleDrag,
     handleClick,
+    handleKeydown,
   }
 }
 

--- a/packages/components/color-picker/src/composables/use-alpha-slider.ts
+++ b/packages/components/color-picker/src/composables/use-alpha-slider.ts
@@ -29,6 +29,7 @@ export const useAlphaSlider = (props: AlphaSliderProps) => {
     if (target !== thumb.value) {
       handleDrag(event)
     }
+    thumb.value?.focus()
   }
 
   function handleDrag(event: MouseEvent | TouchEvent) {

--- a/packages/locale/lang/en.ts
+++ b/packages/locale/lang/en.ts
@@ -7,6 +7,7 @@ export default {
       defaultLabel: 'color picker',
       description:
         'current color is {color}. press enter to select a new color.',
+      alphaLabel: 'pick alpha value',
     },
     datepicker: {
       now: 'Now',

--- a/packages/locale/lang/zh-cn.ts
+++ b/packages/locale/lang/zh-cn.ts
@@ -4,6 +4,9 @@ export default {
     colorpicker: {
       confirm: '确定',
       clear: '清空',
+      defaultLabel: '颜色选择器',
+      description: '当前颜色 {color}，按 Enter 键选择新颜色',
+      alphaLabel: '选择透明度的值',
     },
     datepicker: {
       now: '此刻',

--- a/packages/theme-chalk/src/color-picker.scss
+++ b/packages/theme-chalk/src/color-picker.scss
@@ -19,6 +19,11 @@ $color-picker-size: map.merge($common-component-size, $color-picker-size);
   border: 1px solid getCssVar('border-color', 'lighter');
   box-shadow: 0 0 2px rgba(0, 0, 0, 0.6);
   z-index: 1;
+
+  &:focus-visible {
+    outline: 2px solid getCssVar('color-primary');
+    outline-offset: 1px;
+  }
 }
 
 @mixin bar-background($side: right) {


### PR DESCRIPTION
support for adjusting alpha through keyboard

[after](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6IjxzY3JpcHQgc2V0dXAgbGFuZz1cInRzXCI+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5cbmNvbnN0IGNvbG9yID0gcmVmKCcjMjBBMEZGRUUnKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPHA+c2VsZWN0IGNvbG9yLXBpY2tlcjwvcD5cbiAgPHA+Y2xpY2sgdGhlIElucHV0IGNvbXBvbmVudDwvcD5cbiAgPHA+cHJlc3MgU2hpZnQgKyBUYWIga2V5PC9wPlxuICA8cD5wcmVzcyBBcnJvd1VwIEFycm93RG93biBBcnJvd0xlZnQgQXJyb3dSaWdodDwvcD5cbiAgPGVsLWNvbG9yLXBpY2tlciB2LW1vZGVsPVwiY29sb3JcIiBzaG93LWFscGhhIC8+XG48L3RlbXBsYXRlPlxuIiwic3JjL1BsYXlncm91bmRNYWluLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgQXBwIGZyb20gJy4vQXBwLnZ1ZSdcbmltcG9ydCB7IHNldHVwRWxlbWVudFBsdXMgfSBmcm9tICcuL2VsZW1lbnQtcGx1cy5qcydcbnNldHVwRWxlbWVudFBsdXMoKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPEFwcCAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vcHJldmlldy0xNDI0NS1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcInVuc3VwcG9ydGVkXCJcbiAgfVxufSIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcImFsbG93SnNcIjogdHJ1ZSxcbiAgICBcImNoZWNrSnNcIjogdHJ1ZSxcbiAgICBcImpzeFwiOiBcInByZXNlcnZlXCIsXG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJ0eXBlc1wiOiBbXCJlbGVtZW50LXBsdXMvZ2xvYmFsLmQudHNcIl1cbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJzcmMvZWxlbWVudC1wbHVzLmpzIjoiaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuaW1wb3J0IEVsZW1lbnRQbHVzIGZyb20gJ2VsZW1lbnQtcGx1cydcblxubGV0IGluc3RhbGxlZCA9IGZhbHNlXG5hd2FpdCBsb2FkU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gc2V0dXBFbGVtZW50UGx1cygpIHtcbiAgaWYgKGluc3RhbGxlZCkgcmV0dXJuXG4gIGNvbnN0IGluc3RhbmNlID0gZ2V0Q3VycmVudEluc3RhbmNlKClcbiAgaW5zdGFuY2UuYXBwQ29udGV4dC5hcHAudXNlKEVsZW1lbnRQbHVzKVxuICBpbnN0YWxsZWQgPSB0cnVlXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkU3R5bGUoKSB7XG4gIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgbGluay5ocmVmID0gJ2h0dHBzOi8vcHJldmlldy0xNDI0NS1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcydcbiAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2xvYWQnLCByZXNvbHZlKVxuICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgfSlcbn0iLCJfbyI6eyJzaG93SGlkZGVuIjp0cnVlLCJzdHlsZVNvdXJjZSI6Imh0dHBzOi8vcHJldmlldy0xNDI0NS1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcyJ9fQ==)

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf49c1a</samp>

This pull request improves the accessibility and localization of the color picker component, especially the alpha slider. It adds keyboard support, focus styles, and localized labels to the slider, and updates the test and locale files accordingly. It also refactors some code to use constants and composables.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf49c1a</samp>

*  Add keyboard interaction and accessibility attributes to the alpha slider component of the color picker ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-b562b3d6fcba17d799a44798b76ad3162b04ca518d7cf4cabf93d677145db860L4-R16), [link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-b562b3d6fcba17d799a44798b76ad3162b04ca518d7cf4cabf93d677145db860L23-R43), [link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-6dc63e24412803da59a5b0c5eddc975c0c343cf9634428d746ff903c847aff67L10-R11), [link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-6dc63e24412803da59a5b0c5eddc975c0c343cf9634428d746ff903c847aff67L17-R25), [link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-6dc63e24412803da59a5b0c5eddc975c0c343cf9634428d746ff903c847aff67L65-R101), [link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-2b67c528d0e02e7bfc677ba0517450d8015eae18c79ce8e9066b5f5b7aabf984R22-R26))
  - Import `useLocale` hook and `EVENT_CODE` constant in `use-alpha-slider.ts` ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-6dc63e24412803da59a5b0c5eddc975c0c343cf9634428d746ff903c847aff67L10-R11))
  - Define `alpha` and `alphaLabel` computed values in `useAlphaSlider` composable to get the alpha value and the localized label of the slider ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-6dc63e24412803da59a5b0c5eddc975c0c343cf9634428d746ff903c847aff67L17-R25))
  - Define `handleKeydown` and `incrementPosition` functions in `useAlphaSlider` composable to handle keydown events on the thumb element and update the alpha value of the color prop ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-6dc63e24412803da59a5b0c5eddc975c0c343cf9634428d746ff903c847aff67L65-R101))
  - Add `aria-label`, `aria-valuenow`, `aria-orientation`, `role`, and `tabindex` attributes to the thumb element in `alpha-slider.vue` ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-b562b3d6fcba17d799a44798b76ad3162b04ca518d7cf4cabf93d677145db860L4-R16))
  - Add `@keydown` event listener to the thumb element in `alpha-slider.vue` and call `handleKeydown` method from `useAlphaSlider` composable ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-b562b3d6fcba17d799a44798b76ad3162b04ca518d7cf4cabf93d677145db860L4-R16))
  - Add `alpha`, `alphaLabel`, and `handleKeydown` properties to the return object of `useAlphaSlider` composable and use them in `alpha-slider.vue` template ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-b562b3d6fcba17d799a44798b76ad3162b04ca518d7cf4cabf93d677145db860L23-R43))
  - Add `:focus-visible` pseudo-class selector to the thumb element in `color-picker.scss` and apply a blue outline and offset to indicate focus state ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-2b67c528d0e02e7bfc677ba0517450d8015eae18c79ce8e9066b5f5b7aabf984R22-R26))
* Add a test case for the alpha slider component in `color-picker.test.tsx` ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-9f7664ebf5f470e2924136e8569cc55c7d95eab6f6bb8138012957b75b2d8bd4R74-R101))
  - Import `EVENT_CODE` constant in `color-picker.test.tsx` ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-9f7664ebf5f470e2924136e8569cc55c7d95eab6f6bb8138012957b75b2d8bd4R5))
  - Use `mount` function from `@vue/test-utils` to render the color picker component with `show-alpha` prop and a reactive color value ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-9f7664ebf5f470e2924136e8569cc55c7d95eab6f6bb8138012957b75b2d8bd4R74-R101))
  - Simulate clicking on the trigger, finding the alpha slider component, and triggering keydown events on the thumb element ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-9f7664ebf5f470e2924136e8569cc55c7d95eab6f6bb8138012957b75b2d8bd4R74-R101))
  - Assert that the input value in the color dropdown reflects the expected alpha value after each keydown event ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-9f7664ebf5f470e2924136e8569cc55c7d95eab6f6bb8138012957b75b2d8bd4R74-R101))
* Add localized labels for the color picker and the alpha slider to the English and Simplified Chinese locale files ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-62f4e441a5e940d91aa6a2487030103a7196e1993bd9d949d2f2cc36280c79e3R10), [link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-07619f75d6e66771808991225f984999f3398a9b6a59737f2085b0aa6eb28de3R7-R9))
  - Add `alphaLabel` key and value to `en.ts` and `zh-cn.ts` files ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-62f4e441a5e940d91aa6a2487030103a7196e1993bd9d949d2f2cc36280c79e3R10), [link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-07619f75d6e66771808991225f984999f3398a9b6a59737f2085b0aa6eb28de3R7-R9))
  - Add `defaultLabel`, `description` keys and values to `zh-cn.ts` file ([link](https://github.com/element-plus/element-plus/pull/14245/files?diff=unified&w=0#diff-07619f75d6e66771808991225f984999f3398a9b6a59737f2085b0aa6eb28de3R7-R9))
