### PR TITLE
fix(components): [upload] upload fail when data array value not has blob

### DIFF
--- a/packages/components/upload/src/ajax.ts
+++ b/packages/components/upload/src/ajax.ts
@@ -1,5 +1,5 @@
 import { isNil } from 'lodash-unified'
-import { isArray, throwError } from '@element-plus/utils'
+import { isArray, isBlob, throwError } from '@element-plus/utils'
 import type {
   UploadProgressEvent,
   UploadRequestHandler,
@@ -52,6 +52,10 @@ function getBody(xhr: XMLHttpRequest): XMLHttpRequestResponseType {
   }
 }
 
+function isFormBlobValue(value: unknown): value is [Blob] | [Blob, string] {
+  return isArray(value) && value.length < 2 && isBlob(value[0])
+}
+
 export const ajaxUpload: UploadRequestHandler = (option) => {
   if (typeof XMLHttpRequest === 'undefined')
     throwError(SCOPE, 'XMLHttpRequest is undefined')
@@ -70,7 +74,7 @@ export const ajaxUpload: UploadRequestHandler = (option) => {
   const formData = new FormData()
   if (option.data) {
     for (const [key, value] of Object.entries(option.data)) {
-      if (isArray(value) && value.length) formData.append(key, ...value)
+      if (isFormBlobValue(value)) formData.append(key, ...value)
       else formData.append(key, value)
     }
   }

--- a/packages/components/upload/src/upload-content.vue
+++ b/packages/components/upload/src/upload-content.vue
@@ -31,7 +31,7 @@ import { shallowRef } from 'vue'
 import { isPlainObject } from '@vue/shared'
 import { cloneDeep, isEqual } from 'lodash-unified'
 import { useNamespace } from '@element-plus/hooks'
-import { entriesOf, isFunction } from '@element-plus/utils'
+import { entriesOf, isBlob, isFile, isFunction } from '@element-plus/utils'
 import { useFormDisabled } from '@element-plus/components/form'
 import UploadDragger from './upload-dragger.vue'
 import { uploadContentProps } from './upload-content'
@@ -110,8 +110,8 @@ const upload = async (rawFile: UploadRawFile): Promise<void> => {
   }
 
   let file: File = rawFile
-  if (hookResult instanceof Blob) {
-    if (hookResult instanceof File) {
+  if (isBlob(hookResult)) {
+    if (isFile(hookResult)) {
       file = hookResult
     } else {
       file = new File([hookResult], rawFile.name, {

--- a/packages/components/upload/src/upload.ts
+++ b/packages/components/upload/src/upload.ts
@@ -20,7 +20,7 @@ export interface UploadProgressEvent extends ProgressEvent {
 export interface UploadRequestOptions {
   action: string
   method: string
-  data: Record<string, string | Blob | [string | Blob, string]>
+  data: Record<string, string | Blob | [Blob, string]>
   filename: string
   file: UploadRawFile
   headers: Headers | Record<string, string | number | null | undefined>

--- a/packages/components/upload/src/use-handlers.ts
+++ b/packages/components/upload/src/use-handlers.ts
@@ -1,7 +1,7 @@
 import { watch } from 'vue'
 import { isNil } from 'lodash-unified'
 import { useVModel } from '@vueuse/core'
-import { debugWarn, throwError } from '@element-plus/utils'
+import { debugWarn, isFile, throwError } from '@element-plus/utils'
 import { genFileId } from './upload'
 import type { ShallowRef } from 'vue'
 import type {
@@ -109,7 +109,7 @@ export const useHandlers = (
   const handleRemove: UploadContentProps['onRemove'] = async (
     file
   ): Promise<void> => {
-    const uploadFile = file instanceof File ? getFile(file) : file
+    const uploadFile = isFile(file) ? getFile(file) : file
     if (!uploadFile) throwError(SCOPE, 'file to be removed not found')
 
     const doRemove = (file: UploadFile) => {

--- a/packages/utils/types.ts
+++ b/packages/utils/types.ts
@@ -36,3 +36,11 @@ export const isStringNumber = (val: string): boolean => {
   }
   return !Number.isNaN(Number(val))
 }
+
+export const isBlob = (val: unknown): val is Blob => {
+  return val instanceof Blob
+}
+
+export const isFile = (val: unknown): val is File => {
+  return val instanceof File
+}


### PR DESCRIPTION
1. fix upload fail when data value is array, and it's length is bigger than 1, but the first item of it is not a blob.

2. refactor: use isBlob and isFile to replace instanceof

closed #14226

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 145ac2e</samp>

Improved the upload component's compatibility and handling of Blob and File values in the data option of the upload request. Added utility functions `isBlob` and `isFile` to `packages/utils/types.ts` to check for these types.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 145ac2e</samp>

*  Import and use `isBlob` and `isFile` functions from `@element-plus/utils` to check for Blob and File objects in upload components and hooks ([link](https://github.com/element-plus/element-plus/pull/14249/files?diff=unified&w=0#diff-abe5073fc7604d817b28680ac58a38a7c08c017d604bb8b0ea621a5d4cbd18bbL2-R2), [link](https://github.com/element-plus/element-plus/pull/14249/files?diff=unified&w=0#diff-848fa2c711dee63acb2665d4ec3ba52674c4644d2e2657bb123d2f0d613a053eL34-R34), [link](https://github.com/element-plus/element-plus/pull/14249/files?diff=unified&w=0#diff-d8dd88d8e9e426a8d86a1eac087c95671d764ebd9772f869a91256a4464c09cdL4-R4), [link](https://github.com/element-plus/element-plus/pull/14249/files?diff=unified&w=0#diff-848fa2c711dee63acb2665d4ec3ba52674c4644d2e2657bb123d2f0d613a053eL113-R114), [link](https://github.com/element-plus/element-plus/pull/14249/files?diff=unified&w=0#diff-d8dd88d8e9e426a8d86a1eac087c95671d764ebd9772f869a91256a4464c09cdL112-R112))
* Add `isFormBlobValue` function to `ajax.ts` to check for Blob values with filenames in the data option of the upload request ([link](https://github.com/element-plus/element-plus/pull/14249/files?diff=unified&w=0#diff-abe5073fc7604d817b28680ac58a38a7c08c017d604bb8b0ea621a5d4cbd18bbR55-R58), [link](https://github.com/element-plus/element-plus/pull/14249/files?diff=unified&w=0#diff-abe5073fc7604d817b28680ac58a38a7c08c017d604bb8b0ea621a5d4cbd18bbL73-R77))
* Change the type of the `data` property in the `UploadRequestOptions` interface to reflect the correct format of Blob values with filenames ([link](https://github.com/element-plus/element-plus/pull/14249/files?diff=unified&w=0#diff-054875df38de531805c46c402c7943693d4e049f56c732f0be36133b4c01065cL23-R23))
* Add `isBlob` and `isFile` functions to `packages/utils/types.ts` to provide type guards for Blob and File objects ([link](https://github.com/element-plus/element-plus/pull/14249/files?diff=unified&w=0#diff-5af022c3b407dea1efbe46be68f4682039e16178e65b25004ec76e7c5065f911R39-R46))
