### PR TITLE
docs: [table-v2] modify the type definition of the row slot

### DIFF
--- a/docs/en-US/component/table-v2.md
+++ b/docs/en-US/component/table-v2.md
@@ -524,9 +524,7 @@ type RowsRenderedParams = {
 }
 
 type RowSlotProps = {
-  cells: VNode[]
   columns: Column<any>[]
-  depth: number
   rowData: any
   columnIndex: number
   rowIndex: number

--- a/docs/en-US/component/table-v2.md
+++ b/docs/en-US/component/table-v2.md
@@ -524,11 +524,12 @@ type RowsRenderedParams = {
 }
 
 type RowSlotProps = {
-  columnIndex: number
-  rowIndex: number
-  data: any
-  key: number | string
+  cells: VNode[]
+  columns: Column<any>[]
+  depth: number
   isScrolling?: boolean | undefined
+  rowData: any
+  rowIndex: number
   style: CSSProperties
 }
 

--- a/docs/en-US/component/table-v2.md
+++ b/docs/en-US/component/table-v2.md
@@ -527,9 +527,12 @@ type RowSlotProps = {
   cells: VNode[]
   columns: Column<any>[]
   depth: number
-  isScrolling?: boolean | undefined
   rowData: any
+  columnIndex: number
   rowIndex: number
+  data: any
+  key: number | string
+  isScrolling?: boolean
   style: CSSProperties
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2c94d80</samp>

Updated the documentation for the `row` slot of the `el-table` component to reflect the new props and features. Removed some outdated or redundant props from the `RowSlotProps` type.

## Related Issue

Fixes #14233

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2c94d80</samp>

* Update the `row` slot props of `el-table` component to provide more information and flexibility for customizing the row rendering ([link](https://github.com/element-plus/element-plus/pull/14254/files?diff=unified&w=0#diff-fbf98dbc4f3a5f2ab656152a5d6a8099ab38202e225f262d51933b03d2f23339L527-R532))
