### PR TITLE
fix(components):  [button] Buttons are misleading after being clicked and in disabled mode fix #13736

### DIFF
--- a/packages/components/button/src/button.ts
+++ b/packages/components/button/src/button.ts
@@ -111,6 +111,11 @@ export const buttonProps = buildProps({
     type: definePropType<string | Component>([String, Object]),
     default: 'button',
   },
+  /**
+    * @description PreventFocus  prevent the button from being focused after being clicked
+    */
+  PreventFocus: Boolean,
+
 } as const)
 export const buttonEmits = {
   click: (evt: MouseEvent) => evt instanceof MouseEvent,

--- a/packages/components/button/src/button.ts
+++ b/packages/components/button/src/button.ts
@@ -112,9 +112,9 @@ export const buttonProps = buildProps({
     default: 'button',
   },
   /**
-    * @description PreventFocus  prevent the button from being focused after being clicked
+    * @description preventFocus  prevent the button from being focused after being clicked
     */
-  PreventFocus: Boolean,
+  preventFocus: Boolean,
 
 } as const)
 export const buttonEmits = {

--- a/packages/components/button/src/button.vue
+++ b/packages/components/button/src/button.vue
@@ -18,6 +18,7 @@
     ]"
     :style="buttonStyle"
     @click="handleClick"
+    @mousedown="mouseDown"
   >
     <template v-if="loading">
       <slot v-if="$slots.loading" name="loading" />
@@ -54,7 +55,7 @@ const emit = defineEmits(buttonEmits)
 
 const buttonStyle = useButtonCustomStyle(props)
 const ns = useNamespace('button')
-const { _ref, _size, _type, _disabled, _props, shouldAddSpace, handleClick } =
+const { _ref, _size, _type, _disabled, _props, shouldAddSpace, handleClick,mouseDown } =
   useButton(props, emit)
 
 defineExpose({

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -71,7 +71,7 @@ export const useButton = (
     emit('click', evt)
   }
   const mouseDown = (evt: MouseEvent) => {
-    if (props.PreventFocus) {
+    if (props.preventFocus) {
       evt.preventDefault()
     }
     emit('mousedown', evt)

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -70,6 +70,12 @@ export const useButton = (
     }
     emit('click', evt)
   }
+  const mouseDown = (evt: MouseEvent) => {
+    if (props.PreventFocus) {
+      evt.preventDefault()
+    }
+    emit('mousedown', evt)
+  }
 
   return {
     _disabled,
@@ -79,5 +85,6 @@ export const useButton = (
     _props,
     shouldAddSpace,
     handleClick,
+    mouseDown
   }
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 76be2c5</samp>

This pull request adds a new feature to the `button` component that enables the user to prevent the button from being focused after being clicked. It introduces a new prop `PreventFocus` and a custom `mousedown` event to achieve this behavior.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 76be2c5</samp>

*  Add a new prop `PreventFocus` to the `buttonProps` interface, which allows the user to control whether the button should be focused after being clicked ([link](https://github.com/element-plus/element-plus/pull/14258/files?diff=unified&w=0#diff-043025f7e5f7add14be78f47786cc3980c374f9e6d7ba5f02fc9b901b2d5d1cfR114-R118))
* Implement the logic of preventing the default focus behavior and emitting the `mousedown` event to the parent component in the `mouseDown` function, which is defined in the `useButton` hook and exposed to the button component ([link](https://github.com/element-plus/element-plus/pull/14258/files?diff=unified&w=0#diff-fe680d96593e2581cc3fa44aa7f27dff3e9f02e4b400b128614c06293c9badfaR73-R78), [link](https://github.com/element-plus/element-plus/pull/14258/files?diff=unified&w=0#diff-fe680d96593e2581cc3fa44aa7f27dff3e9f02e4b400b128614c06293c9badfaR88), [link](https://github.com/element-plus/element-plus/pull/14258/files?diff=unified&w=0#diff-1c64d60120c5ede235d1dcb98efa20a889756b54269c59b065eb7f27f5bf79d0L57-R58))
* Add a `@mousedown` event listener to the button component template, which invokes the `mouseDown` function ([link](https://github.com/element-plus/element-plus/pull/14258/files?diff=unified&w=0#diff-1c64d60120c5ede235d1dcb98efa20a889756b54269c59b065eb7f27f5bf79d0R21))
