### PR TITLE
Update panel-date-pick.vue

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -766,4 +766,5 @@ contextEmit('set-picker-option', ['isValidValue', isValidValue])
 contextEmit('set-picker-option', ['formatToString', formatToString])
 contextEmit('set-picker-option', ['parseUserInput', parseUserInput])
 contextEmit('set-picker-option', ['handleFocusPicker', handleFocusPicker])
+contextEmit("set-picker-option", ["getDefaultValue", getDefaultValue])
 </script>


### PR DESCRIPTION
当有配置 disabledDate 和 defaultValue 时，默认情况下确定按钮被disabled，这种情况应该是可保存确定

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a3edec7</samp>

Emit `set-picker-option` event from `panel-date-pick.vue` to expose `getDefaultValue` function. This enables setting the default value of the date picker dynamically based on the picker type and value.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a3edec7</samp>

*  Emit `set-picker-option` event to expose `getDefaultValue` function to parent component ([link](https://github.com/element-plus/element-plus/pull/14259/files?diff=unified&w=0#diff-ce64860e98ab8af028e85764b0975f255abd40120c8544de36e9105b18966759R769))
