### PR TITLE
fix(components): [date-picker] month range should emit `calendar-change`

### DIFF
--- a/docs/en-US/component/date-picker.md
+++ b/docs/en-US/component/date-picker.md
@@ -177,14 +177,14 @@ Note, date time locale (month name, first day of the week ...) are also configur
 
 ## Events
 
-| Name            | Description                                                               | Parameters                    |
-| --------------- | ------------------------------------------------------------------------- | ----------------------------- |
-| change          | triggers when user confirms the value                                     | `(val: typeof v-model)`       |
-| blur            | triggers when Input blurs                                                 | `(e: FocusEvent)`             |
-| focus           | triggers when Input focuses                                               | `(e: FocusEvent)`             |
-| calendar-change | triggers when the calendar selected date is changed. Only for `daterange` | `(val: [Date, null \| Date])` |
-| panel-change    | triggers when the navigation button click.                                | `(date, mode, view)`          |
-| visible-change  | triggers when the DatePicker's dropdown appears/disappears                | `(visibility: boolean)`       |
+| Name            | Description                                                | Parameters                    |
+| --------------- | ---------------------------------------------------------- | ----------------------------- |
+| change          | triggers when user confirms the value                      | `(val: typeof v-model)`       |
+| blur            | triggers when Input blurs                                  | `(e: FocusEvent)`             |
+| focus           | triggers when Input focuses                                | `(e: FocusEvent)`             |
+| calendar-change | triggers when the calendar selected date is changed.       | `(val: [Date, null \| Date])` |
+| panel-change    | triggers when the navigation button click.                 | `(date, mode, view)`          |
+| visible-change  | triggers when the DatePicker's dropdown appears/disappears | `(visibility: boolean)`       |
 
 ## Methods
 

--- a/packages/components/date-picker/src/date-picker-com/panel-month-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-month-range.vue
@@ -184,6 +184,7 @@ const handleRangePick = (val: RangePickValue, close = true) => {
   if (maxDate.value === maxDate_ && minDate.value === minDate_) {
     return
   }
+  emit('calendar-change', [minDate_.toDate(), maxDate_ && maxDate_.toDate()])
   maxDate.value = maxDate_
   minDate.value = minDate_
 

--- a/packages/components/date-picker/src/props/panel-month-range.ts
+++ b/packages/components/date-picker/src/props/panel-month-range.ts
@@ -7,6 +7,10 @@ export const panelMonthRangeProps = buildProps({
   ...panelRangeSharedProps,
 } as const)
 
-export const panelMonthRangeEmits = ['pick', 'set-picker-option']
+export const panelMonthRangeEmits = [
+  'pick',
+  'set-picker-option',
+  'calendar-change',
+]
 
 export type PanelMonthRangeProps = ExtractPropTypes<typeof panelMonthRangeProps>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

This PR is a complement to #13880 (which is blocked at the moment). 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b7d25b</samp>

Added `calendar-change` event to `panel-month-range.vue` component and updated the documentation. This event allows users to get the selected min and max dates when they change the calendar view in the `monthrange` and `yearrange` panels.

## Related Issue

Fixes #13835.

Related Discussions:

* https://github.com/element-plus/element-plus/discussions/10175
* https://github.com/element-plus/element-plus/discussions/11864

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b7d25b</samp>

* Add `calendar-change` event to `panel-month-range.vue` component to emit selected min and max dates as an array when calendar view changes ([link](https://github.com/element-plus/element-plus/pull/14262/files?diff=unified&w=0#diff-aae21490a51f2812af5785511e78e38b1160b12da90559b82c3a6a1b9a07e308R187), [link](https://github.com/element-plus/element-plus/pull/14262/files?diff=unified&w=0#diff-dc286407796475103c5f0aa16361fd385f1e0445ff6ffc192e2c831030a95ff9L10-R14))
* Update description of `calendar-change` event in `date-picker.md` documentation to reflect that it is also emitted by `monthrange` and `yearrange` panels ([link](https://github.com/element-plus/element-plus/pull/14262/files?diff=unified&w=0#diff-936f76a60feba4602e81cd280e37ac122e009f3326ea42c660e69272e806a483L180-R187))
