### PR TITLE
fix(components): [menu] export MenuInstance

### DIFF
--- a/packages/components/menu/index.ts
+++ b/packages/components/menu/index.ts
@@ -14,12 +14,10 @@ export default ElMenu
 export const ElMenuItem = withNoopInstall(MenuItem)
 export const ElMenuItemGroup = withNoopInstall(MenuItemGroup)
 export const ElSubMenu = withNoopInstall(SubMenu)
-export type MenuItemInstance = InstanceType<typeof MenuItem>
-export type MenuItemGroupInstance = InstanceType<typeof MenuItemGroup>
-export type SubMenuInstance = InstanceType<typeof SubMenu>
 
 export * from './src/menu'
 export * from './src/menu-item'
 export * from './src/menu-item-group'
 export * from './src/sub-menu'
 export * from './src/types'
+export * from './src/instance'

--- a/packages/components/menu/index.ts
+++ b/packages/components/menu/index.ts
@@ -14,6 +14,9 @@ export default ElMenu
 export const ElMenuItem = withNoopInstall(MenuItem)
 export const ElMenuItemGroup = withNoopInstall(MenuItemGroup)
 export const ElSubMenu = withNoopInstall(SubMenu)
+export type MenuItemInstance = InstanceType<typeof MenuItem>
+export type MenuItemGroupInstance = InstanceType<typeof MenuItemGroup>
+export type SubMenuInstance = InstanceType<typeof SubMenu>
 
 export * from './src/menu'
 export * from './src/menu-item'

--- a/packages/components/menu/src/instance.ts
+++ b/packages/components/menu/src/instance.ts
@@ -1,0 +1,14 @@
+import type Menu from './menu'
+import type MenuItem from './menu-item.vue'
+import type MenuItemGroup from './menu-item-group.vue'
+import type SubMenu from './sub-menu'
+
+export type MenuInstance = InstanceType<typeof Menu> & {
+  open: (index: string) => void
+  close: (index: string) => void
+  handleResize: () => void
+}
+
+export type MenuItemInstance = InstanceType<typeof MenuItem>
+export type MenuItemGroupInstance = InstanceType<typeof MenuItemGroup>
+export type SubMenuInstance = InstanceType<typeof SubMenu>

--- a/packages/components/menu/src/menu.ts
+++ b/packages/components/menu/src/menu.ts
@@ -98,7 +98,7 @@ export const menuEmits = {
 }
 export type MenuEmits = typeof menuEmits
 
-const ElMenu = defineComponent({
+export default defineComponent({
   name: 'ElMenu',
 
   props: menuProps,
@@ -436,11 +436,3 @@ const ElMenu = defineComponent({
     }
   },
 })
-
-export type MenuInstance = InstanceType<typeof ElMenu> & {
-  open: (index: string) => void
-  close: (index: string) => void
-  handleResize: () => void
-}
-
-export default ElMenu

--- a/packages/components/menu/src/menu.ts
+++ b/packages/components/menu/src/menu.ts
@@ -98,7 +98,7 @@ export const menuEmits = {
 }
 export type MenuEmits = typeof menuEmits
 
-export default defineComponent({
+const ElMenu = defineComponent({
   name: 'ElMenu',
 
   props: menuProps,
@@ -436,3 +436,11 @@ export default defineComponent({
     }
   },
 })
+
+export type MenuInstance = InstanceType<typeof ElMenu> & {
+  open: (index: string) => void
+  close: (index: string) => void
+  handleResize: () => void
+}
+
+export default ElMenu


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
close #14251 
- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c784a4</samp>

This pull request refactors the menu component and its subcomponents to use a consistent naming convention and export their types. This makes the menu component easier to use and bundle with TypeScript.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c784a4</samp>

* Export menu component's subcomponent types as aliases ([link](https://github.com/element-plus/element-plus/pull/14284/files?diff=unified&w=0#diff-62b90812201c632ab65af54cd0647f0cb367b3ae52d6a20311d054f20f3faaf1R17-R19))
* Rename menu component's default export to `ElMenu` and export it as a named export ([link](https://github.com/element-plus/element-plus/pull/14284/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5L101-R101))
* Define and export a type alias for menu component's instance with additional methods ([link](https://github.com/element-plus/element-plus/pull/14284/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5R439-R446))
