### PR TITLE
feat: add menu horizontal height for img center

### DIFF
--- a/docs/examples/menu/left-and-right.vue
+++ b/docs/examples/menu/left-and-right.vue
@@ -6,7 +6,13 @@
     :ellipsis="false"
     @select="handleSelect"
   >
-    <el-menu-item index="0">LOGO</el-menu-item>
+    <el-menu-item index="0">
+      <img
+        style="width: 100px"
+        src="/images/element-plus-logo.svg"
+        alt="Element logo"
+      />
+    </el-menu-item>
     <div class="flex-grow" />
     <el-menu-item index="1">Processing Center</el-menu-item>
     <el-sub-menu index="2">

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -1037,6 +1037,7 @@ $menu: map.merge(
     'hover-bg-color': getCssVar('color-primary-light-9'),
     'item-height': 56px,
     'sub-item-height': calc(#{getCssVar('menu-item-height')} - 6px),
+    'horizontal-height': 60px,
     'horizontal-sub-item-height': 36px,
     'item-font-size': getCssVar('font-size-base'),
     'item-hover-fill': getCssVar('color-primary-light-9'),

--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -78,6 +78,8 @@
     flex-wrap: nowrap;
     border-right: none;
 
+    height: getCssVar('menu-horizontal-height');
+
     &.#{$namespace}-menu {
       border-bottom: solid 1px getCssVar('menu-border-color');
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

- add menu horizontal height for img center
- add img logo demo

Before:
![image](https://github.com/element-plus/element-plus/assets/25154432/c5bebec8-9070-4410-8ea4-0b3a5ee839ec)

After:
![image](https://github.com/element-plus/element-plus/assets/25154432/1fcb07e6-43c5-4971-8cee-c963c73e5e3f)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8362f5b</samp>

This pull request enhances the menu component by adding an Element logo to the left menu item and a custom height variable for the horizontal mode. The variable is defined in `var.scss` and used in `menu.scss`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8362f5b</samp>

* Add a new variable `menu-horizontal-height` to the common variables file `packages/theme-chalk/src/common/var.scss` to define the height of the horizontal menu component ([link](https://github.com/element-plus/element-plus/pull/14307/files?diff=unified&w=0#diff-eb85fc73444e26f19f950007c73a7d86028b1453c33efc86d2b5478ea027c01aR1040))
* Use the new variable `menu-horizontal-height` to set the height of the `el-menu` selector when it has the `el-menu--horizontal` class in the menu style file `packages/theme-chalk/src/menu.scss` ([link](https://github.com/element-plus/element-plus/pull/14307/files?diff=unified&w=0#diff-451ad66686a31c13be1b990962362c2ef9421c307729380fde9251ec87ea91baR81-R82))
* Replace the text LOGO with an image of the Element logo in the first `el-menu-item` of the menu example file `docs/examples/menu/left-and-right.vue` to improve the appearance and branding of the menu component ([link](https://github.com/element-plus/element-plus/pull/14307/files?diff=unified&w=0#diff-52b461bdaa8cfcfa0635e7478358740edadf5a009cb83341bd407d4023ec9e52L9-R15))
