### PR TITLE
fix(components): [collapse] fix triggering form action when inside it

### DIFF
--- a/packages/components/collapse/src/collapse-item.vue
+++ b/packages/components/collapse/src/collapse-item.vue
@@ -7,6 +7,7 @@
       :aria-controls="scopedContentId"
       :aria-describedby="scopedContentId"
       :tabindex="disabled ? -1 : 0"
+      type="button"
       @click="handleHeaderClick"
       @keydown.space.enter.stop.prevent="handleEnterClick"
       @focus="handleFocus"


### PR DESCRIPTION
When el-collapse with el-collapse-item is placed inside a form and the collapse trigger btn is pressed, form's action as triggered. This fixes it

closed #14304

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 211e315</samp>

Added `type` attribute to `el-button` in `collapse-item` component to prevent form submission. This fixes a bug reported in issue #14304.

## Related Issue

Fixes #14304.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 211e315</samp>

* Add `type` attribute to `el-button` component to prevent form submission on click ([link](https://github.com/element-plus/element-plus/pull/14308/files?diff=unified&w=0#diff-c6f05c610009ff1fb4cee40b878ec64e16be5dd7f4eedc0ef32769abc43dc63eR10))
