### PR TITLE
docs(descriptions): fix the `customed style` example

### DIFF
--- a/docs/examples/descriptions/customized-style.vue
+++ b/docs/examples/descriptions/customized-style.vue
@@ -25,10 +25,10 @@
   </el-descriptions>
 </template>
 <style scoped>
-.my-label {
-  background: var(--el-color-success-light-9);
+:deep(.my-label) {
+  background: var(--el-color-success-light-9) !important;
 }
-.my-content {
+:deep(.my-content) {
   background: var(--el-color-danger-light-9);
 }
 </style>


### PR DESCRIPTION
before:
![image](https://github.com/element-plus/element-plus/assets/93767616/59013e38-f6c9-4ab6-890d-df6a98876ded)

after:
![image](https://github.com/element-plus/element-plus/assets/93767616/21b82551-56e1-4632-bb69-e6556d37129c)