### PR TITLE
fix(docs): [form] `label-position` type error

### DIFF
--- a/docs/examples/form/alignment.vue
+++ b/docs/examples/form/alignment.vue
@@ -25,8 +25,9 @@
 
 <script lang="ts" setup>
 import { reactive, ref } from 'vue'
+import type { FormProps } from 'element-plus'
 
-const labelPosition = ref('right')
+const labelPosition = ref<FormProps['labelPosition']>('right')
 
 const formLabelAlign = reactive({
   name: '',


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8cfabef</samp>

Added type annotation for `labelPosition` ref in form alignment example. This improves type safety and developer experience when using the `ElForm` component.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8cfabef</samp>

* Annotate `labelPosition` ref with `FormProps['labelPosition']` type for better type checking and code completion ([link](https://github.com/element-plus/element-plus/pull/14312/files?diff=unified&w=0#diff-80f55bdc38b953ba2cce8629fed4139519851e97270adcefd0190b5e29a879e5L28-R30))
