### PR TITLE
feat(components): [switch] add label attribute for accessibility

### DIFF
--- a/docs/en-US/component/switch.md
+++ b/docs/en-US/component/switch.md
@@ -115,6 +115,7 @@ switch/custom-action-icon
 | before-change                 | before-change hook before the switch state changes. If `false` is returned or a `Promise` is returned and then is rejected, will stop switching | ^[boolean] / ^[Function]`() => Promise<boolean>` | —       |
 | id                            | id for input                                                                                                                                    | ^[string]                                        | —       |
 | tabindex                      | tabindex for input                                                                                                                              | ^[string] / ^[number]                            | —       |
+| label ^(a11y)                 | same as `aria-label` in native input                                                                                                            | ^[string]                                        | Switch  |
 
 ### Events
 

--- a/docs/en-US/component/switch.md
+++ b/docs/en-US/component/switch.md
@@ -115,7 +115,7 @@ switch/custom-action-icon
 | before-change                 | before-change hook before the switch state changes. If `false` is returned or a `Promise` is returned and then is rejected, will stop switching | ^[boolean] / ^[Function]`() => Promise<boolean>` | —       |
 | id                            | id for input                                                                                                                                    | ^[string]                                        | —       |
 | tabindex                      | tabindex for input                                                                                                                              | ^[string] / ^[number]                            | —       |
-| label ^(2.4.0) ^(a11y)        | same as `aria-label` in native input                                                                                                            | ^[string]                                        | —       |
+| label ^(2.4.1) ^(a11y)        | same as `aria-label` in native input                                                                                                            | ^[string]                                        | —       |
 
 ### Events
 

--- a/docs/en-US/component/switch.md
+++ b/docs/en-US/component/switch.md
@@ -115,7 +115,7 @@ switch/custom-action-icon
 | before-change                 | before-change hook before the switch state changes. If `false` is returned or a `Promise` is returned and then is rejected, will stop switching | ^[boolean] / ^[Function]`() => Promise<boolean>` | —       |
 | id                            | id for input                                                                                                                                    | ^[string]                                        | —       |
 | tabindex                      | tabindex for input                                                                                                                              | ^[string] / ^[number]                            | —       |
-| label ^(a11y)                 | same as `aria-label` in native input                                                                                                            | ^[string]                                        | Switch  |
+| label ^(2.4.0) ^(a11y)        | same as `aria-label` in native input                                                                                                            | ^[string]                                        | —       |
 
 ### Events
 

--- a/packages/components/switch/src/switch.ts
+++ b/packages/components/switch/src/switch.ts
@@ -169,6 +169,13 @@ export const switchProps = buildProps({
     type: [Boolean, String, Number],
     default: false,
   },
+  /**
+   * @description native input aria-label
+   */
+  label: {
+    type: String,
+    default: 'Switch',
+  },
 } as const)
 
 export type SwitchProps = ExtractPropTypes<typeof switchProps>

--- a/packages/components/switch/src/switch.ts
+++ b/packages/components/switch/src/switch.ts
@@ -174,7 +174,7 @@ export const switchProps = buildProps({
    */
   label: {
     type: String,
-    default: 'Switch',
+    default: undefined,
   },
 } as const)
 

--- a/packages/components/switch/src/switch.vue
+++ b/packages/components/switch/src/switch.vue
@@ -8,6 +8,7 @@
       role="switch"
       :aria-checked="checked"
       :aria-disabled="switchDisabled"
+      :aria-label="label"
       :name="name"
       :true-value="activeValue"
       :false-value="inactiveValue"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3e9cf80</samp>

This pull request adds a new `label` prop to the `Switch` component, which allows users to specify an accessible name for the native input element. The prop is documented in `docs/en-US/component/switch.md` and implemented in `packages/components/switch/src/switch.ts` and `packages/components/switch/src/switch.vue`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3e9cf80</samp>

*  Add `label` prop to `Switch` component to provide accessible name for native input element ([link](https://github.com/element-plus/element-plus/pull/14319/files?diff=unified&w=0#diff-944d71227061db7997220d97c8f510e37c916a5ba3db7063735bf87dfc871da6R172-R178), [link](https://github.com/element-plus/element-plus/pull/14319/files?diff=unified&w=0#diff-a8d9aaca9c72c0998e021fe3e607217cbf71f0fe04eca2dbb0760b66e4755d76R11))
*  Update documentation of `Switch` component to include `label` attribute and its usage ([link](https://github.com/element-plus/element-plus/pull/14319/files?diff=unified&w=0#diff-5fded0baca14bc85d6b3a235e24790419a6113d1861afd9bb388b3f5f2aba80cR118))
