### PR TITLE
fix(components): [select-v2] read properties of null

### DIFF
--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -755,7 +755,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
 
   // fix the problem that scrollTop is not reset in filterable mode
   watch(filteredOptions, () => {
-    return nextTick(menuRef.value.resetScrollTop)
+    return menuRef.value && nextTick(menuRef.value.resetScrollTop)
   })
 
   watch(


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b57357e</samp>

Add null check for `menuRef.value` in `useSelect.ts` to avoid error. This improves the stability of the select component in filterable mode.

## Related Issue

Fixes #14316 .

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b57357e</samp>

* Add a null check for `menuRef.value` before calling `nextTick` to prevent errors ([link](https://github.com/element-plus/element-plus/pull/14321/files?diff=unified&w=0#diff-6018da2b9e35c71aca0d0a0f881a93c00ab1f1958a3a9c69e332fa8d0b2e9865L758-R758))
