### PR TITLE
feat: [Menu] add active-bg-color props

### DIFF
--- a/docs/en-US/component/menu.md
+++ b/docs/en-US/component/menu.md
@@ -17,7 +17,7 @@ This component requires the `<client-only></client-only>` wrap when used in SSR 
 
 Top bar Menu can be used in a variety of scenarios.
 
-:::demo By default Menu is vertical, but you can change it to horizontal by setting the mode prop to 'horizontal'. In addition, you can use the sub-menu component to create a second level menu. Menu provides `background-color`, `text-color` and `active-text-color` to customize the colors.
+:::demo By default Menu is vertical, but you can change it to horizontal by setting the mode prop to 'horizontal'. In addition, you can use the sub-menu component to create a second level menu. Menu provides `background-color`, `text-color`, `active-text-color` and `active-bg-color` to customize the colors.
 
 menu/basic
 
@@ -59,6 +59,7 @@ menu/collapse
 | collapse                | whether the menu is collapsed (available only in vertical mode)                                                                                                       | boolean | —                     | false    |
 | ellipsis                | whether the menu is ellipsis (available only in horizontal mode)                                                                                                      | boolean | —                     | true     |
 | background-color        | background color of Menu (hex format) (deprecated, use `--bg-color` instead)                                                                                          | string  | —                     | #ffffff  |
+| active-bg-color         | background color of currently active menu item (hex format) (deprecated, use `--active-bg-color` instead)                                                             | string  | —                     | —        |
 | text-color              | text color of Menu (hex format) (deprecated, use `--text-color` instead)                                                                                              | string  | —                     | #303133  |
 | active-text-color       | text color of currently active menu item (hex format) (deprecated, use `--active-color` instead)                                                                      | string  | —                     | #409EFF  |
 | default-active          | index of active menu on page load                                                                                                                                     | string  | —                     | —        |

--- a/docs/examples/menu/vertical.vue
+++ b/docs/examples/menu/vertical.vue
@@ -43,6 +43,7 @@
       <h5 class="mb-2">Custom colors</h5>
       <el-menu
         active-text-color="#ffd04b"
+        active-bg-color="#434a50"
         background-color="#545c64"
         class="el-menu-vertical-demo"
         default-active="2"

--- a/packages/components/menu/__tests__/menu.test.ts
+++ b/packages/components/menu/__tests__/menu.test.ts
@@ -71,6 +71,7 @@ describe('menu', () => {
     // expect(item1.vm.$el.style.backgroundColor).toEqual(backgroundColor)
     // expect(item1.vm.$el.style.color).toEqual(textColor)
     // expect(item2.vm.$el.style.color).toEqual(activeTextColor)
+    // expect(item2.vm.$el.style.backgroundColor).toEqual(activeBgColor)
     await item1.trigger('mouseenter')
     await nextTick()
     // expect(item1.vm.$el.style.backgroundColor).toEqual('rgb(204, 0, 0)')

--- a/packages/components/menu/__tests__/menu.test.ts
+++ b/packages/components/menu/__tests__/menu.test.ts
@@ -46,10 +46,12 @@ describe('menu', () => {
     const backgroundColor = '#f00'
     const textColor = '#000'
     const activeTextColor = '#0f0'
+    const activeBgColor = '#00f'
 
     const wrapper = _mount(
       `<el-menu default-active="2"
         background-color="${backgroundColor}"
+        active-bg-color="${activeBgColor}"
         text-color="${textColor}"
         active-text-color="${activeTextColor}">
         <el-menu-item index="1" ref="item1">处理中心</el-menu-item>

--- a/packages/components/menu/src/menu.ts
+++ b/packages/components/menu/src/menu.ts
@@ -57,6 +57,7 @@ export const menuProps = buildProps({
   },
   collapse: Boolean,
   backgroundColor: String,
+  activeBgColor: String,
   textColor: String,
   activeTextColor: String,
   collapseTransition: {

--- a/packages/components/menu/src/sub-menu.ts
+++ b/packages/components/menu/src/sub-menu.ts
@@ -189,6 +189,9 @@ export default defineComponent({
 
     const backgroundColor = computed(() => rootMenu.props.backgroundColor || '')
     const activeTextColor = computed(() => rootMenu.props.activeTextColor || '')
+    const activeBgColor = computed(
+      () => rootMenu.props.activeBgColor || backgroundColor.value
+    )
     const textColor = computed(() => rootMenu.props.textColor || '')
     const mode = computed(() => rootMenu.props.mode)
     const item = reactive({
@@ -414,7 +417,11 @@ export default defineComponent({
                     class: nsSubMenu.e('title'),
                     style: [
                       titleStyle.value,
-                      { backgroundColor: backgroundColor.value },
+                      {
+                        backgroundColor: active.value
+                          ? activeBgColor.value
+                          : backgroundColor.value,
+                      },
                     ],
                     onClick: handleClick,
                   },
@@ -429,7 +436,11 @@ export default defineComponent({
                 class: nsSubMenu.e('title'),
                 style: [
                   titleStyle.value,
-                  { backgroundColor: backgroundColor.value },
+                  {
+                    backgroundColor: active.value
+                      ? activeBgColor.value
+                      : backgroundColor.value,
+                  },
                 ],
                 ref: verticalTitleRef,
                 onClick: handleClick,

--- a/packages/components/menu/src/use-menu-css-var.ts
+++ b/packages/components/menu/src/use-menu-css-var.ts
@@ -13,6 +13,7 @@ export const useMenuCssVar = (props: MenuProps, level: number) => {
       'bg-color': props.backgroundColor || '',
       'hover-bg-color': useMenuColor(props).value || '',
       'active-color': props.activeTextColor || '',
+      'active-bg-color': props.activeBgColor || props.backgroundColor || '',
       level: `${level}`,
     })
   })

--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -115,6 +115,7 @@
         .#{$namespace}-sub-menu__title {
           border-bottom: 2px solid getCssVar('menu-active-color');
           color: getCssVar('menu-active-color');
+          background-color: getCssVar('menu-active-bg-color');
         }
       }
 
@@ -147,6 +148,7 @@
       & .#{$namespace}-menu-item.is-active,
       & .#{$namespace}-sub-menu.is-active > .#{$namespace}-sub-menu__title {
         color: getCssVar('menu-active-color');
+        background-color: getCssVar('menu-active-bg-color');
       }
     }
     & .#{$namespace}-menu-item:not(.is-disabled):hover,
@@ -158,6 +160,7 @@
     & > .#{$namespace}-menu-item.is-active {
       border-bottom: 2px solid getCssVar('menu-active-color');
       color: getCssVar('menu-active-color') !important;
+      background-color: getCssVar('menu-active-bg-color') !important;
     }
   }
   @include m(collapse) {
@@ -226,6 +229,7 @@
   }
   @include when(active) {
     color: getCssVar('menu-active-color');
+    background-color: getCssVar('menu-active-bg-color');
     i {
       color: inherit;
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

Add `active-bg-color` props for `Menu` component.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b70a9e</samp>

Added a new prop `activeBgColor` to the menu component, which allows users to customize the background color of active menu items and sub-menus. Deprecated the old prop `active-bg-color` in the top bar menu component and suggested using the CSS variable `--menu-active-bg-color` instead. Updated the documentation, tests, and examples to reflect the changes.

## Related Issue

null.

## Explanation of Changes

1. Added `active-bg-color` props for the `Menu` component;
2. Added relevant docs
3. Added the attribute in unit test files (but currently it seems like there are no actual tests related to bg-color according to [this line](https://github.com/evanryuu/element-plus/blob/feat/menu-active-bg-color/packages/components/menu/__tests__/menu.test.ts#L69))

The final effect looks like below:
<img width="547" alt="image" src="https://github.com/element-plus/element-plus/assets/55378595/f903abf8-73bf-48eb-9281-fa3eb0df8901">

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b70a9e</samp>

*  Add `active-bg-color` prop to menu component to customize active menu item background color ([link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-68f9957a7840b355dcdda10667dc726edd89eefcade651c450066137e7c5e3a8L20-R20), [link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-68f9957a7840b355dcdda10667dc726edd89eefcade651c450066137e7c5e3a8R62), [link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5R60), [link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-9e99e464b0de00288a1e622c2d9a718112032674e9ebfc9018b55c6dee3f10b6R16))
*  Apply `active-bg-color` prop to sub-menu component and use it for sub-menu title style ([link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-e88a538d21977473a9cbf0151395e8ca2c30b47937addaab50089612fd907b95R192-R194), [link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-e88a538d21977473a9cbf0151395e8ca2c30b47937addaab50089612fd907b95L417-R424), [link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-e88a538d21977473a9cbf0151395e8ca2c30b47937addaab50089612fd907b95L432-R443))
*  Use CSS variable `menu-active-bg-color` to set `background-color` for active menu item and sub-menu item in `menu.scss` ([link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-451ad66686a31c13be1b990962362c2ef9421c307729380fde9251ec87ea91baR118), [link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-451ad66686a31c13be1b990962362c2ef9421c307729380fde9251ec87ea91baR151), [link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-451ad66686a31c13be1b990962362c2ef9421c307729380fde9251ec87ea91baR163), [link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-451ad66686a31c13be1b990962362c2ef9421c307729380fde9251ec87ea91baR232))
*  Add `active-bg-color` prop to menu examples in `vertical.vue` and `menu.test.ts` ([link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-5d1be6df5bd53447a661889dfe4c95e450e5d68fc270c8a1fdd0b91a56bfe8d1R46), [link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-8e308651f34c2210b75274b51eb06c7d1f80754bbca787d848449f6fff0d2121L49-R54))
*  Comment out irrelevant assertion for active menu item background color in `menu.test.ts` ([link](https://github.com/element-plus/element-plus/pull/14323/files?diff=unified&w=0#diff-8e308651f34c2210b75274b51eb06c7d1f80754bbca787d848449f6fff0d2121R74))
