### PR TITLE
docs(form): add that `prop` supports dot notation string

### DIFF
--- a/docs/en-US/component/form.md
+++ b/docs/en-US/component/form.md
@@ -172,7 +172,7 @@ form/accessibility
 
 | Name            | Description                                                                                                                                                     | Type                                                | Default |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ------- |
-| prop            | A key of `model`. It could be an array of property paths (e.g `['a', 'b', '0']`). In the use of `validate` and `resetFields` method, the attribute is required. | ^[string] / ^[string&#91;&#93;]                     | —       |
+| prop            | A key of `model`. It could be a path of the property (e.g `a.b.0` or `['a', 'b', '0']`). In the use of `validate` and `resetFields` method, the attribute is required. | ^[string] / ^[string&#91;&#93;]                     | —       |
 | label           | Label text.                                                                                                                                                     | ^[string]                                           | —       |
 | label-width     | Width of label, e.g. `'50px'`. `'auto'` is supported.                                                                                                           | ^[string] / ^[number]                               | ''      |
 | required        | Whether the field is required or not, will be determined by validation rules if omitted.                                                                        | ^[boolean]                                          | —       |


### PR DESCRIPTION
Related to [[Component] [form] form表单单独验证路径数组失败 #14309](https://github.com/element-plus/element-plus/issues/14309)