### PR TITLE
fix(components): [time-picker]Add configuration for time picker

### DIFF
--- a/docs/en-US/component/time-picker.md
+++ b/docs/en-US/component/time-picker.md
@@ -70,6 +70,9 @@ time-picker/range
 | disabled-minutes      | To specify the array of minutes that cannot be selected  | Function(selectedHour)                 | —                                                             | —           |
 | disabled-seconds      | To specify the array of seconds that cannot be selected  | Function(selectedHour, selectedMinute) | —                                                             | —           |
 | teleported            | whether time-picker dropdown is teleported to the body   | boolean                                | true / false                                                  | true        |
+—                                                             | —           |
+| isImmediately         | Do you want to update now? Otherwise, update only after clicking OK | boolean           |
+true / false                                                  | true        |
 
 ## Events
 

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -195,6 +195,7 @@ import type {
   UserInput,
 } from './props'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
+import type { HideType } from '../props/shared'
 
 // Date object and string
 
@@ -228,6 +229,7 @@ const inputRef = ref<HTMLElement | ComponentPublicInstance>()
 const pickerVisible = ref(false)
 const pickerActualVisible = ref(false)
 const valueOnOpen = ref<TimePickerDefaultProps['modelValue'] | null>(null)
+const hideType = ref<HideType>('')
 
 let hasJustTabExitedInput = false
 let ignoreFocusEvent = false
@@ -235,10 +237,16 @@ let ignoreFocusEvent = false
 watch(pickerVisible, (val) => {
   if (!val) {
     userInput.value = null
+    if (!props.isImmediately && hideType.value !== 'confirm') {
+      const changValue =
+        valueOnOpen.value as TimePickerDefaultProps['modelValue']
+      return emitInput(changValue)
+    }
     nextTick(() => {
       emitChange(props.modelValue)
     })
   } else {
+    hideType.value = ''
     nextTick(() => {
       if (val) {
         valueOnOpen.value = props.modelValue
@@ -302,9 +310,10 @@ const focusOnInputBox = () => {
   })
 }
 
-const onPick = (date: any = '', visible = false) => {
+const onPick = (date: any = '', visible = false, type: HideType = '') => {
   if (!visible) {
     ignoreFocusEvent = true
+    hideType.value = type
   }
   pickerVisible.value = visible
   let result

--- a/packages/components/time-picker/src/common/props.ts
+++ b/packages/components/time-picker/src/common/props.ts
@@ -125,6 +125,10 @@ export const timePickerDefaultProps = buildProps({
     default: true,
   },
   unlinkPanels: Boolean,
+  isImmediately: {
+    type: Boolean,
+    default: true,
+  },
 } as const)
 
 export type TimePickerDefaultProps = ExtractPropTypes<

--- a/packages/components/time-picker/src/props/shared.ts
+++ b/packages/components/time-picker/src/props/shared.ts
@@ -45,3 +45,5 @@ export const timePanelSharedProps = buildProps({
 } as const)
 
 export type TimePanelSharedProps = ExtractPropTypes<typeof timePanelSharedProps>
+
+export type HideType = 'confirm' | '' | null

--- a/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
@@ -96,9 +96,9 @@ const isValidValue = (_date: Dayjs) => {
 const handleCancel = () => {
   emit('pick', oldValue.value, false)
 }
-const handleConfirm = (visible = false, first = false) => {
+const handleConfirm = (visible = false, first = false, type = 'confirm') => {
   if (first) return
-  emit('pick', props.parsedValue, visible)
+  emit('pick', props.parsedValue, visible, type)
 }
 const handleChange = (_date: Dayjs) => {
   // visible avoids edge cases, when use scrolls during panel closing animation

--- a/packages/components/time-picker/src/time-picker-com/panel-time-range.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-range.vue
@@ -136,8 +136,8 @@ const amPmMode = computed(() => {
   return ''
 })
 
-const handleConfirm = (visible = false) => {
-  emit('pick', [startTime.value, endTime.value], visible)
+const handleConfirm = (visible = false, type = 'confirm') => {
+  emit('pick', [startTime.value, endTime.value], visible, type)
 }
 
 const handleMinChange = (date: Dayjs) => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [√] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [√] Make sure you are merging your commits to `dev` branch.
- [√] Add some descriptions and refer to relative issues for your PR.

## Description
给el-time-picker增加了一个配置，用于控制是否只在点击确定时才对值进行修改，是对这个问题的修复https://github.com/element-plus/element-plus/issues/14279

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f78a5c</samp>

This pull request adds a new attribute `isImmediately` to the `time-picker` component, which allows users to control when the model value is updated. It also introduces a new type `HideType` to indicate the reason for hiding the picker panel, such as confirming or canceling. The changes affect the picker component, the panel components, the props files, and the documentation.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8f78a5c</samp>

*  Add a new attribute `isImmediately` to the time-picker component and document its usage ([link](https://github.com/element-plus/element-plus/pull/14331/files?diff=unified&w=0#diff-da5785b94fd7a09ee3a71aa32b18bd95bdf07e9e2fcae927a4100fb50f2b9ea4R73-R75), [link](https://github.com/element-plus/element-plus/pull/14331/files?diff=unified&w=0#diff-4d5804445bd2a26541567338da443fedac41179034d4ef377f967d6b1d66074cR128-R131))
* Define a new type `HideType` to indicate the reason for hiding the picker panel ([link](https://github.com/element-plus/element-plus/pull/14331/files?diff=unified&w=0#diff-8d94d4d480876abd0f946e292f26eff6ee2065751c7ce6f56ff2008eb496711eR48-R49))
* Import the `HideType` type in `picker.vue` and declare a reactive variable `hideType` to store its value ([link](https://github.com/element-plus/element-plus/pull/14331/files?diff=unified&w=0#diff-3d026a2d83f86f5dc2ce3aa7b95b77eff4a475e67c362841827e0e1bac7456abR198), [link](https://github.com/element-plus/element-plus/pull/14331/files?diff=unified&w=0#diff-3d026a2d83f86f5dc2ce3aa7b95b77eff4a475e67c362841827e0e1bac7456abR232))
* Modify the `handleInput` function in `picker.vue` to emit the input event conditionally based on the `isImmediately` prop and the `hideType` value ([link](https://github.com/element-plus/element-plus/pull/14331/files?diff=unified&w=0#diff-3d026a2d83f86f5dc2ce3aa7b95b77eff4a475e67c362841827e0e1bac7456abL238-R249))
* Modify the `onPick` function in `picker.vue` to assign the `hideType` value when the picker is not visible ([link](https://github.com/element-plus/element-plus/pull/14331/files?diff=unified&w=0#diff-3d026a2d83f86f5dc2ce3aa7b95b77eff4a475e67c362841827e0e1bac7456abL305-R316))
* Modify the `handleConfirm` and `emit` functions in `panel-time-pick.vue` and `panel-time-range.vue` to pass the `hideType` value to the parent component when confirming the picker value ([link](https://github.com/element-plus/element-plus/pull/14331/files?diff=unified&w=0#diff-60b8d640aee096b38e04f0f59a87c5d8c5ddc9e877a4bcbe50a86058b59b3ceaL99-R101), [link](https://github.com/element-plus/element-plus/pull/14331/files?diff=unified&w=0#diff-893f4fcade0e0077fbd58008fb0d3f6ae67311c285509aba7c361a69c143161dL139-R140))
