### PR TITLE
test(components): [teleport] Fixed spelling error ElTelport to ElTelepot

### DIFF
--- a/packages/components/teleport/__tests__/teleport.test.ts
+++ b/packages/components/teleport/__tests__/teleport.test.ts
@@ -6,7 +6,7 @@ import type { TeleportInstance } from '../src/teleport'
 
 const AXIOM = 'rem is the best girl'
 
-describe('ElTelport', () => {
+describe('ElTeleport', () => {
   let wrapper: VueWrapper<TeleportInstance>
 
   beforeEach(() => {


### PR DESCRIPTION
In the teleport test file, changed "describe('ElTelport'" to "describe('ElTeleport'".

I hope ElementPlus will be perfect everywhere.

closed only spelling error

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55a8221</samp>

Fixed a typo in the `ElTeleport` test file. This change improves the readability and consistency of the test code.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55a8221</samp>

* Fix typo `ElTelport` to `ElTeleport` in test description ([link](https://github.com/element-plus/element-plus/pull/14337/files?diff=unified&w=0#diff-a3f1372948d55f56b5d29554299d60af08e7616b75fc11534e0c8153dbae0fe8L9-R9))
