### PR TITLE
fix(components): [date-picker] slot compatible with Vue3.3.x

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/basic-cell-render.tsx
+++ b/packages/components/date-picker/src/date-picker-com/basic-cell-render.tsx
@@ -14,7 +14,9 @@ export default defineComponent({
       if (slots.default) {
         const list = slots.default(cell).filter((item) => {
           return (
-            item.patchFlag !== -2 && item.type.toString() !== 'Symbol(Comment)'
+            item.patchFlag !== -2 &&
+            item.type.toString() !== 'Symbol(Comment)' &&
+            item.type.toString() !== 'Symbol(v-cmt)'
           )
         })
         if (list.length) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9592d64</samp>

Fix a bug with the date picker component when using `v-if` inside the cell slot. Filter out the virtual comment nodes from the cell render function in `basic-cell-render.tsx`.

## Related Issue

Fixes #14342 .

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9592d64</samp>

* Fix a bug with the date picker when using `v-if` inside the cell slot by filtering out the virtual comment nodes ([link](https://github.com/element-plus/element-plus/pull/14354/files?diff=unified&w=0#diff-2d0a60e1bf84549bcbd25d8fb941ede708d4314e22f06bf363938b53547f4760L17-R19))
