### PR TITLE
fix(components): [date-picker] el-date-picker cannot display date

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/basic-cell-render.tsx
+++ b/packages/components/date-picker/src/date-picker-com/basic-cell-render.tsx
@@ -14,7 +14,10 @@ export default defineComponent({
       if (slots.default) {
         const list = slots.default(cell).filter((item) => {
           return (
-            item.patchFlag !== -2 && item.type.toString() !== 'Symbol(Comment)'
+            item.patchFlag !== -2 &&
+            item.type.toString() !== 'Symbol(Comment)' &&
+            item.type.toString() !== 'Symbol(v-cmt)' &&
+            item.type.toString() !== 'template'
           )
         })
         if (list.length) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a173d6</samp>

Updated the filter condition for the cell slot in `basic-cell-render.tsx` to avoid rendering unwanted elements in the date picker. This fixed a bug where some cells showed a dot and improved the component's compatibility and performance.

## Related Issue

Fixes #14342.

## Explanation of Changes

When there is an annotation node in the slot and a template without a default slot, the date display will be blank.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a173d6</samp>

* Fix a bug where some empty cells would show a dot in the date picker component by updating the filter condition for the cell slot children elements to exclude v-cmt and template ([link](https://github.com/element-plus/element-plus/pull/14358/files?diff=unified&w=0#diff-2d0a60e1bf84549bcbd25d8fb941ede708d4314e22f06bf363938b53547f4760L17-R20) in `basic-cell-render.tsx`)
