### PR TITLE
fix(components): [dialog] fix el-dialog z-index bug

### DIFF
--- a/packages/components/dialog/src/use-dialog.ts
+++ b/packages/components/dialog/src/use-dialog.ts
@@ -8,6 +8,7 @@ import {
 } from 'vue'
 import { useTimeoutFn } from '@vueuse/core'
 
+import { isUndefined } from 'lodash'
 import {
   defaultNamespace,
   useId,
@@ -161,7 +162,7 @@ export const useDialog = (
         closed.value = false
         open()
         rendered.value = true // enables lazy rendering
-        zIndex.value = isUndefined(props.zIndex) ? nextZIndex() :  zIndex.value++ 
+        zIndex.value = isUndefined(props.zIndex) ? nextZIndex() : zIndex.value++
         // this.$el.addEventListener('scroll', this.updatePopper)
         nextTick(() => {
           emit('open')

--- a/packages/components/dialog/src/use-dialog.ts
+++ b/packages/components/dialog/src/use-dialog.ts
@@ -35,7 +35,7 @@ export const useDialog = (
   const visible = ref(false)
   const closed = ref(false)
   const rendered = ref(false) // when desctroyOnClose is true, we initialize it as false vise versa
-  const zIndex = ref(props.zIndex || nextZIndex())
+  const zIndex = ref(props.zIndex ?? nextZIndex())
 
   let openTimer: (() => void) | undefined = undefined
   let closeTimer: (() => void) | undefined = undefined
@@ -161,7 +161,7 @@ export const useDialog = (
         closed.value = false
         open()
         rendered.value = true // enables lazy rendering
-        zIndex.value = props.zIndex ? zIndex.value++ : nextZIndex()
+        zIndex.value = props.zIndex || props.zIndex === 0 ? zIndex.value++ : nextZIndex()
         // this.$el.addEventListener('scroll', this.updatePopper)
         nextTick(() => {
           emit('open')

--- a/packages/components/dialog/src/use-dialog.ts
+++ b/packages/components/dialog/src/use-dialog.ts
@@ -161,7 +161,7 @@ export const useDialog = (
         closed.value = false
         open()
         rendered.value = true // enables lazy rendering
-        zIndex.value = props.zIndex || props.zIndex === 0 ? zIndex.value++ : nextZIndex()
+        zIndex.value = isUndefined(props.zIndex) ? nextZIndex() :  zIndex.value++ 
         // this.$el.addEventListener('scroll', this.updatePopper)
         nextTick(() => {
           emit('open')


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 104d38f</samp>

Fixed a bug in `use-dialog.ts` that caused incorrect `zIndex` for dialog components with `props.zIndex` set to 0. Improved the robustness of the `zIndex` assignment and update logic.

## Related Issue

Fixes #14369 

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 104d38f</samp>

*  Use nullish coalescing operator to assign `zIndex` ref from `props.zIndex` or `nextZIndex()` ([link](https://github.com/element-plus/element-plus/pull/14373/files?diff=unified&w=0#diff-99f04200ea4398c3bc7e40a15a806092a6511285f14a99a318d333a30fdade68L38-R38))
*  Update `zIndex` value only if `props.zIndex` is provided and not 0, otherwise call `nextZIndex()` ([link](https://github.com/element-plus/element-plus/pull/14373/files?diff=unified&w=0#diff-99f04200ea4398c3bc7e40a15a806092a6511285f14a99a318d333a30fdade68L164-R164))
