### PR TITLE
fix(components): [popper] invalid when props z-index is zero

### DIFF
--- a/packages/components/popper/src/composables/use-content-dom.ts
+++ b/packages/components/popper/src/composables/use-content-dom.ts
@@ -1,6 +1,7 @@
 import { computed, ref, unref } from 'vue'
 import { useNamespace, useZIndex } from '@element-plus/hooks'
 
+import { isNumber } from '@element-plus/utils'
 import type { CSSProperties, StyleValue } from 'vue'
 import type { UsePopperReturn } from '@element-plus/hooks'
 import type { UsePopperContentReturn } from './use-content'
@@ -19,7 +20,9 @@ export const usePopperContentDOM = (
   const ns = useNamespace('popper')
 
   const contentAttrs = computed(() => unref(attributes).popper)
-  const contentZIndex = ref<number>(props.zIndex || nextZIndex())
+  const contentZIndex = ref<number>(
+    isNumber(props.zIndex) ? props.zIndex : nextZIndex()
+  )
   const contentClass = computed(() => [
     ns.b(),
     ns.is('pure', props.pure),
@@ -41,7 +44,7 @@ export const usePopperContentDOM = (
   )
 
   const updateZIndex = () => {
-    contentZIndex.value = props.zIndex || nextZIndex()
+    contentZIndex.value = isNumber(props.zIndex) ? props.zIndex : nextZIndex()
   }
 
   return {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

[popper] invalid when props z-index is zero

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

[popper] invalid when props z-index is zero
