### PR TITLE
feat(components): [Message] Add message iconMap configurations

### DIFF
--- a/docs/examples/config-provider/message.vue
+++ b/docs/examples/config-provider/message.vue
@@ -9,10 +9,16 @@
 <script lang="ts" setup>
 import { reactive } from 'vue'
 import { ElMessage } from 'element-plus'
+
+import { Coffee } from '@element-plus/icons-vue'
+
 const config = reactive({
   max: 3,
+  iconMap: {
+    info: Coffee,
+  },
 })
 const open = () => {
-  ElMessage('This is a message.')
+  ElMessage('You cannot order more than 3 cups of coffee.')
 }
 </script>

--- a/packages/components/message/src/message.ts
+++ b/packages/components/message/src/message.ts
@@ -5,16 +5,19 @@ import {
   isClient,
   mutable,
 } from '@element-plus/utils'
-import type { AppContext, ExtractPropTypes, VNode } from 'vue'
+import type { AppContext, Component, ExtractPropTypes, VNode } from 'vue'
 import type { Mutable } from '@element-plus/utils'
 import type MessageConstructor from './message.vue'
 
 export const messageTypes = ['success', 'info', 'warning', 'error'] as const
 
-export type messageType = typeof messageTypes[number]
+export type messageType = (typeof messageTypes)[number]
+
+export type IconMapType = { [key in messageType]?: string | Component }
 
 export interface MessageConfigContext {
   max?: number
+  iconMap?: IconMapType
 }
 
 export const messageDefaults = mutable({

--- a/packages/components/message/src/message.vue
+++ b/packages/components/message/src/message.vue
@@ -49,7 +49,10 @@ import { useEventListener, useResizeObserver, useTimeoutFn } from '@vueuse/core'
 import { TypeComponents, TypeComponentsMap } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import ElBadge from '@element-plus/components/badge'
-import { useGlobalComponentSettings } from '@element-plus/components/config-provider'
+import {
+  messageConfig,
+  useGlobalComponentSettings,
+} from '@element-plus/components/config-provider'
 import { ElIcon } from '@element-plus/components/icon'
 import { messageEmits, messageProps } from './message'
 import { getLastOffset, getOffsetOrSpace } from './instance'
@@ -82,7 +85,11 @@ const typeClass = computed(() => {
   return { [ns.bm('icon', type)]: type && TypeComponentsMap[type] }
 })
 const iconComponent = computed(
-  () => props.icon || TypeComponentsMap[props.type] || ''
+  () =>
+    props.icon ||
+    messageConfig.iconMap?.[props.type] ||
+    TypeComponentsMap[props.type] ||
+    ''
 )
 
 const lastOffset = computed(() => getLastOffset(props.id))


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3fdaa66</samp>

This pull request adds a new feature to the message component, which allows users to customize the icons for different message types. It modifies the `message.ts`, `message.vue`, and `config-provider` components, and updates the docs example in `message.vue`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3fdaa66</samp>

*  Add `iconMap` option to message component to allow customizing icons for each message type ([link](https://github.com/element-plus/element-plus/pull/14386/files?diff=unified&w=0#diff-52db55884ae2724ac41d0a9818d45942c4f44b08bb5d8ae2e9abcb0e12a449d5L14-R20), [link](https://github.com/element-plus/element-plus/pull/14386/files?diff=unified&w=0#diff-621e5adef28d5ef3199822a80828cb2904e1ba2473f57f586662964d9c3bd131L52-R55), [link](https://github.com/element-plus/element-plus/pull/14386/files?diff=unified&w=0#diff-621e5adef28d5ef3199822a80828cb2904e1ba2473f57f586662964d9c3bd131L85-R92))
*  Import `Component` type from `vue` to support component values for `iconMap` option ([link](https://github.com/element-plus/element-plus/pull/14386/files?diff=unified&w=0#diff-52db55884ae2724ac41d0a9818d45942c4f44b08bb5d8ae2e9abcb0e12a449d5L8-R8))
*  Update example code in `docs/examples/config-provider/message.vue` to demonstrate `iconMap` usage and import `Coffee` icon component ([link](https://github.com/element-plus/element-plus/pull/14386/files?diff=unified&w=0#diff-e8653f80f4add9159213a864701fdf96199319ca8713e6fadfe15b5c01dfe572L12-R22))
