### PR TITLE
fix(components): [input-number] display value don't match actual value

### DIFF
--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -284,7 +284,7 @@ watch(
   (value) => {
     const userInput = verifyValue(data.userInput)
     const newValue = verifyValue(value, true)
-    if (isNumber(userInput) === false || userInput !== newValue) {
+    if (!isNumber(userInput) || userInput !== newValue) {
       data.currentValue = newValue
       data.userInput = null
     }

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -284,7 +284,7 @@ watch(
   (value) => {
     const userInput = verifyValue(data.userInput)
     const newValue = verifyValue(value, true)
-    if (!isNumber(userInput) && (!userInput || userInput !== newValue)) {
+    if (isNumber(userInput) === false || userInput !== newValue) {
       data.currentValue = newValue
       data.userInput = null
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc71d85</samp>

Simplify and optimize the code for input-number component. Remove redundant logic and improve accessibility by updating `currentValue`, `userInput`, and `aria-valuenow` consistently.

## Related Issue

Fixes #14438

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc71d85</samp>

*  Simplify the condition for updating `currentValue` and `userInput` data properties ([link](https://github.com/element-plus/element-plus/pull/14439/files?diff=unified&w=0#diff-0ae90cff73c6316f25336e807f41c1ecaca3dfbe4210f80273a4310aa89ac5a8L287-R287))
*  Remove unnecessary ternary and nullish coalescing operators for setting `aria-valuenow` attribute of the inner input element ([link](https://github.com/element-plus/element-plus/pull/14439/files?diff=unified&w=0#diff-0ae90cff73c6316f25336e807f41c1ecaca3dfbe4210f80273a4310aa89ac5a8L308-R308), [link](https://github.com/element-plus/element-plus/pull/14439/files?diff=unified&w=0#diff-0ae90cff73c6316f25336e807f41c1ecaca3dfbe4210f80273a4310aa89ac5a8L325-R320))
