### PR TITLE
fix(theme-chalk): tabel tr bg in dark mode

### DIFF
--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -772,7 +772,7 @@ $table: map.merge(
     'header-bg-color': getCssVar('bg-color'),
     'fixed-box-shadow': getCssVar('box-shadow', 'light'),
     'bg-color': getCssVar('fill-color', 'blank'),
-    'tr-bg-color': getCssVar('fill-color', 'blank'),
+    'tr-bg-color': getCssVar('bg-color'),
     'expanded-cell-bg-color': getCssVar('fill-color', 'blank'),
     'fixed-left-column': inset 10px 0 10px -10px rgb(0 0 0 / 15%),
     'fixed-right-column': inset -10px 0 10px -10px rgb(0 0 0 / 15%),


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

- fix #14225 table tr bg in dark mode

> CC @StephenKe Review

Before:
![image](https://github.com/element-plus/element-plus/assets/25154432/98d5f8b5-b713-432c-816c-8214e9916ada)

After:
![image](https://github.com/element-plus/element-plus/assets/25154432/76350a1b-7368-4e56-b8be-2a6c868c0d82)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e0782e</samp>

Fixed table row background color bug with CSS variables by changing `tr-bg-color` to match `bg-color` in `var.scss`. This improved the table component's compatibility and usability with custom themes.

## Related Issue

Fixes #14225.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1e0782e</samp>

* Fix table row background color inconsistency with table background color when using custom CSS variables ([link](https://github.com/element-plus/element-plus/pull/14443/files?diff=unified&w=0#diff-eb85fc73444e26f19f950007c73a7d86028b1453c33efc86d2b5478ea027c01aL775-R775))
