### PR TITLE
fix(components): [date-picker] extractDateFormat and extractTimeFormat

### DIFF
--- a/packages/components/date-picker/__tests__/date-time-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-time-picker.test.tsx
@@ -48,6 +48,16 @@ describe('Datetime Picker', () => {
     expect(dateInput.value).toBe('2018/03/05')
     expect(timeInput.value).toBe('10:15 AM')
 
+    format.value = 'YYYY年MM月DD日 HH时mm分ss秒'
+    await nextTick()
+    expect(dateInput.value).toBe('2018年03月05日')
+    expect(timeInput.value).toBe('10时15分24秒')
+
+    format.value = 'HH:mm:ss YYYY_MM_DD '
+    await nextTick()
+    expect(dateInput.value).toBe('2018_03_05')
+    expect(timeInput.value).toBe('10:15:24')
+
     format.value = 'MM-DD-YYYY HH a'
     await nextTick()
     expect(dateInput.value).toBe('03-05-2018')

--- a/packages/components/time-picker/src/utils.ts
+++ b/packages/components/time-picker/src/utils.ts
@@ -16,16 +16,41 @@ export const rangeArr = (n: number) =>
   Array.from(Array.from({ length: n }).keys())
 
 export const extractDateFormat = (format: string) => {
-  return format
-    .replace(/\W?m{1,2}|\W?ZZ/g, '')
-    .replace(/\W?h{1,2}|\W?s{1,3}|\W?a/gi, '')
-    .trim()
+  const list = [
+    'h{1,2}',
+    'H{1,2}',
+    'm{1,2}',
+    's{1,2}',
+    'SSS',
+    'Z{1,2}',
+    '(a|A)',
+    '(k|K)',
+    '(x|X)',
+  ]
+  const reg = new RegExp(
+    list.map((item) => `[^A-Za-z ]*${item}[^A-Za-z ]*`).join('|'),
+    'g'
+  )
+  return format.replace(reg, '').trim()
 }
 
 export const extractTimeFormat = (format: string) => {
-  return format
-    .replace(/\W?D{1,2}|\W?Do|\W?d{1,4}|\W?M{1,4}|\W?Y{2,4}/g, '')
-    .trim()
+  const list = [
+    'Do',
+    'D{1,2}',
+    'd{1,4}',
+    'M{1,4}',
+    'Y{2,4}',
+    'Q',
+    'wo',
+    'w{1,2}',
+    'gggg',
+  ]
+  const reg = new RegExp(
+    list.map((item) => `[^A-Za-z ]*${item}[^A-Za-z ]*`).join('|'),
+    'g'
+  )
+  return format.replace(reg, '').trim()
 }
 
 export const dateEquals = function (a: Date | unknown, b: Date | unknown) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7293b94</samp>

This pull request enhances the `format` prop handling for the `DateTimePicker` component. It adds more test cases for different formats, and fixes some bugs and limitations in the format extraction functions in `utils.ts`.

## Related Issue

Fixes #14411 .

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7293b94</samp>

* Improve the format extraction for `DateTimePicker` by using regular expressions and handling more tokens ([link](https://github.com/element-plus/element-plus/pull/14470/files?diff=unified&w=0#diff-71fc4e3b92b74590b4a4fc23ce2d39c111afd8ff6756fee676c3c03982c95512L19-R53))
* Add tests for different formats with Chinese characters and underscores for `DateTimePicker` in `date-time-picker.test.tsx` ([link](https://github.com/element-plus/element-plus/pull/14470/files?diff=unified&w=0#diff-2c8d0d7dfac33a9842c6dc1eab5796b572648bdea47508e73c5332c670259a93R51-R60))
