### PR TITLE
fix(components): [input-number] disable native step validation

### DIFF
--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -126,6 +126,13 @@ describe('InputNumber.vue', () => {
     expect(wrapper.find('input').element.value).toEqual('4')
   })
 
+  // fix: #11658
+  test('disable native step validation', async () => {
+    const num = ref(0.5)
+    const wrapper = mount(() => <InputNumber v-model={num.value} step={2} />)
+    expect(wrapper.find('input:invalid').exists()).toBe(false)
+  })
+
   test('value decimals miss prop precision', async () => {
     const num = ref(0.2)
     const wrapper = mount(() => (

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -39,7 +39,7 @@
       :id="id"
       ref="input"
       type="number"
-      :step="step"
+      step="any"
       :model-value="displayValue"
       :placeholder="placeholder"
       :readonly="readonly"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

Set the step attribute on the native input to "any" to disable the native validation.
This is done even if step-strictly is set to true because with `:min="1" :step="2"`, step-strictly will round the value to 2, 4, 6... while the native input expects 1, 3, 5...

## Related Issue

Fixes #11658.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8541f50</samp>

*  Disable native step validation for input-number component to fix issue #11658 ([link](https://github.com/element-plus/element-plus/pull/14477/files?diff=unified&w=0#diff-0ae90cff73c6316f25336e807f41c1ecaca3dfbe4210f80273a4310aa89ac5a8L42-R42))
*  Add test case to verify that input-number component does not trigger invalid message when value is not a multiple of step ([link](https://github.com/element-plus/element-plus/pull/14477/files?diff=unified&w=0#diff-72ec1db9873d845eb37943dfa7857b7fd8f4c8b156ac648e4bdb53b21efb3239R129-R135))
