### PR TITLE
fix(play): apply esbuild plugin to tsx component

### DIFF
--- a/play/vite.config.ts
+++ b/play/vite.config.ts
@@ -22,7 +22,6 @@ import './vite.init'
 const esbuildPlugin = (): Plugin => ({
   ...esbuild({
     target: 'chrome64',
-    include: /\.vue$/,
     loaders: {
       '.vue': 'js',
     },


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description
If `include` is configured, the default configuration will be overwritten, and the `ts` or `tsx` component will be ignored.
https://github.com/egoist/rollup-plugin-esbuild/blob/3822de9c58896d946631003d5507b285f5dfa417/src/index.ts#L77-L80
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cebb7d3</samp>

Remove `include` option from `esbuildPlugin` in `play/vite.config.ts` to fix import resolution bug. This option is redundant and may cause conflicts with vite's default handling of vue files.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cebb7d3</samp>

* Remove `include` option from `esbuildPlugin` function to fix import resolution bug ([link](https://github.com/element-plus/element-plus/pull/14480/files?diff=unified&w=0#diff-a0798f44a1182dac9e0fa3bb7d7be78412481f89668f3955ee80ae12ce5cbdfbL25))
