### PR TITLE
feat(docs): theme switch use startViewTransition api

### DIFF
--- a/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
+++ b/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
@@ -14,11 +14,11 @@ watch(
 )
 
 let resolveFn: (value: boolean | PromiseLike<boolean>) => void
-const isAppearanceTransition =
-  // @ts-expect-error
-  document.startViewTransition &&
-  !window.matchMedia('(prefers-reduced-motion: reduce)').matches
 const switchTheme = (event: MouseEvent) => {
+  const isAppearanceTransition =
+    // @ts-expect-error
+    document.startViewTransition &&
+    !window.matchMedia('(prefers-reduced-motion: reduce)').matches
   if (!isAppearanceTransition || !event) {
     resolveFn(true)
     return

--- a/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
+++ b/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
@@ -14,8 +14,8 @@ watch(
 )
 
 let resolveFn: (value: boolean | PromiseLike<boolean>) => void
-// @ts-expect-error
 const isAppearanceTransition =
+  // @ts-expect-error
   document.startViewTransition &&
   !window.matchMedia('(prefers-reduced-motion: reduce)').matches
 const switchTheme = (event: MouseEvent) => {

--- a/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
+++ b/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 import { isDark, toggleDark } from '../../composables/dark'
 import DarkIcon from '../icons/dark.vue'
 import LightIcon from '../icons/light.vue'
@@ -12,13 +12,60 @@ watch(
     toggleDark()
   }
 )
+
+let resolveFn: (value: boolean | PromiseLike<boolean>) => void
+// @ts-expect-error
+const isAppearanceTransition =
+  document.startViewTransition &&
+  !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+const switchTheme = (event: MouseEvent) => {
+  if (!isAppearanceTransition || !event) {
+    resolveFn(true)
+    return
+  }
+  const x = event.clientX
+  const y = event.clientY
+  const endRadius = Math.hypot(
+    Math.max(x, innerWidth - x),
+    Math.max(y, innerHeight - y)
+  )
+  // @ts-expect-error: Transition API
+  const transition = document.startViewTransition(async () => {
+    resolveFn(true)
+    await nextTick()
+  })
+  transition.ready.then(() => {
+    const clipPath = [
+      `circle(0px at ${x}px ${y}px)`,
+      `circle(${endRadius}px at ${x}px ${y}px)`,
+    ]
+    document.documentElement.animate(
+      {
+        clipPath: isDark.value ? [...clipPath].reverse() : clipPath,
+      },
+      {
+        duration: 400,
+        easing: 'ease-in',
+        pseudoElement: isDark.value
+          ? '::view-transition-old(root)'
+          : '::view-transition-new(root)',
+      }
+    )
+  })
+}
+const beforeChange = (): Promise<boolean> => {
+  return new Promise((resolve) => {
+    resolveFn = resolve
+  })
+}
 </script>
 
 <template>
-  <div>
+  <div @click.stop="switchTheme">
     <ClientOnly>
       <el-switch
         v-model="darkMode"
+        :before-change="beforeChange"
         :active-action-icon="DarkIcon"
         :inactive-action-icon="LightIcon"
       />

--- a/docs/.vitepress/vitepress/styles/base.scss
+++ b/docs/.vitepress/vitepress/styles/base.scss
@@ -49,6 +49,7 @@ h6 {
 }
 
 .doc-content {
+
   h1,
   h2,
   h3,
@@ -114,7 +115,7 @@ h2 {
   /* overflow-x: auto; */
 }
 
-h2 + h3 {
+h2+h3 {
   margin-top: 1.5rem;
 }
 
@@ -171,6 +172,7 @@ a.header-anchor {
   padding-right: 0.23em;
   font-size: 0.85em;
   opacity: 0;
+
   &:hover,
   :focus {
     text-decoration: none;
@@ -190,17 +192,18 @@ ol {
   padding-left: 1.25em;
 }
 
-li > ul,
-li > ol {
+li>ul,
+li>ol {
   margin: 0;
 }
 
-.doc-content > div .vp-table {
+.doc-content>div .vp-table {
   width: 100%;
   overflow-y: hidden;
   overflow-x: auto;
   margin-bottom: 45px;
-  & > table {
+
+  &>table {
     border-collapse: collapse;
     width: 100%;
     background-color: var(--bg-color);
@@ -242,7 +245,7 @@ blockquote {
   color: var(--text-color-lighter);
 }
 
-blockquote > p {
+blockquote>p {
   margin: 0;
 }
 
@@ -271,6 +274,7 @@ details {
   p:not(.custom-block-title) {
     font-size: 0.9rem;
   }
+
   &.tip {
     padding: 8px 16px;
     background-color: var(--block-tip-bg-color);
@@ -296,4 +300,26 @@ details {
   position: absolute;
   white-space: nowrap;
   width: 1px;
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+::view-transition-old(root) {
+  z-index: 1;
+}
+
+::view-transition-new(root) {
+  z-index: 2147483646;
+}
+
+.dark::view-transition-old(root) {
+  z-index: 2147483646;
+}
+
+.dark::view-transition-new(root) {
+  z-index: 1;
 }

--- a/docs/.vitepress/vitepress/styles/base.scss
+++ b/docs/.vitepress/vitepress/styles/base.scss
@@ -49,7 +49,6 @@ h6 {
 }
 
 .doc-content {
-
   h1,
   h2,
   h3,
@@ -115,7 +114,7 @@ h2 {
   /* overflow-x: auto; */
 }
 
-h2+h3 {
+h2 + h3 {
   margin-top: 1.5rem;
 }
 
@@ -192,18 +191,18 @@ ol {
   padding-left: 1.25em;
 }
 
-li>ul,
-li>ol {
+li > ul,
+li > ol {
   margin: 0;
 }
 
-.doc-content>div .vp-table {
+.doc-content > div .vp-table {
   width: 100%;
   overflow-y: hidden;
   overflow-x: auto;
   margin-bottom: 45px;
 
-  &>table {
+  & > table {
     border-collapse: collapse;
     width: 100%;
     background-color: var(--bg-color);
@@ -245,7 +244,7 @@ blockquote {
   color: var(--text-color-lighter);
 }
 
-blockquote>p {
+blockquote > p {
   margin: 0;
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description
![view](https://github.com/element-plus/element-plus/assets/24516654/e09548cf-7a3e-400b-8ea4-e3e322d1f8b2)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2287219</samp>

This pull request enhances the theme toggling feature of the documentation website by adding a smooth animation effect for the `vp-theme-toggler` component. It also improves the code style and readability of the `base.scss` file. It mainly modifies the files `vp-theme-toggler.vue` and `base.scss` using the Transition API.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2287219</samp>

*  Import `nextTick` function from `vue` and add `switchTheme` and `beforeChange` functions to handle theme transition animation using Transition API in `vp-theme-toggler.vue` ([link](https://github.com/element-plus/element-plus/pull/14489/files?diff=unified&w=0#diff-8ed6a0fd1d431640071a33ae0e403a87286fbd2e35965a7f7daa1e16686320b1L2-R2), [link](https://github.com/element-plus/element-plus/pull/14489/files?diff=unified&w=0#diff-8ed6a0fd1d431640071a33ae0e403a87286fbd2e35965a7f7daa1e16686320b1L15-R68))
* Add CSS rules for pseudo-elements `::view-transition-old(root)` and `::view-transition-new(root)` to create theme transition effect depending on dark or light mode in `base.scss` ([link](https://github.com/element-plus/element-plus/pull/14489/files?diff=unified&w=0#diff-6708822bf0593d401113d17494fc00ae554b6bf349f6b7dc2d0eb9ccdb156d9fL300-R324))
* Adjust spacing between selectors in some CSS rules for better readability in `base.scss` ([link](https://github.com/element-plus/element-plus/pull/14489/files?diff=unified&w=0#diff-6708822bf0593d401113d17494fc00ae554b6bf349f6b7dc2d0eb9ccdb156d9fL117-R118), [link](https://github.com/element-plus/element-plus/pull/14489/files?diff=unified&w=0#diff-6708822bf0593d401113d17494fc00ae554b6bf349f6b7dc2d0eb9ccdb156d9fL193-R206), [link](https://github.com/element-plus/element-plus/pull/14489/files?diff=unified&w=0#diff-6708822bf0593d401113d17494fc00ae554b6bf349f6b7dc2d0eb9ccdb156d9fL245-R248))
* Add empty lines for formatting purposes in `base.scss` ([link](https://github.com/element-plus/element-plus/pull/14489/files?diff=unified&w=0#diff-6708822bf0593d401113d17494fc00ae554b6bf349f6b7dc2d0eb9ccdb156d9fR52), [link](https://github.com/element-plus/element-plus/pull/14489/files?diff=unified&w=0#diff-6708822bf0593d401113d17494fc00ae554b6bf349f6b7dc2d0eb9ccdb156d9fR175), [link](https://github.com/element-plus/element-plus/pull/14489/files?diff=unified&w=0#diff-6708822bf0593d401113d17494fc00ae554b6bf349f6b7dc2d0eb9ccdb156d9fR277))
