### PR TITLE
docs(components): [dialog] docs description abnormal

### DIFF
--- a/docs/en-US/component/dialog.md
+++ b/docs/en-US/component/dialog.md
@@ -111,7 +111,7 @@ When using `modal` = false, please make sure that `append-to-body` was set to **
 
 :::
 
-## Attributes
+## API
 
 ### Attributes
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 09325ba</samp>

This pull request fixes a documentation issue in `docs/en-US/component/dialog.md` by removing a redundant heading.

## Related Issue

Fixes #14491

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 09325ba</samp>

* Remove redundant `Attributes` heading from `Draggable Dialog` section ([link](https://github.com/element-plus/element-plus/pull/14496/files?diff=unified&w=0#diff-abbb3d078da77db6d9ad1eed9a9356891f9119733d8e8bb4fc8771e3429dc626L114-L115))
