### PR TITLE
fix(components): [date-picker] The panel month will display the same month

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -548,7 +548,6 @@ const handleDateInput = (value: string | null, type: ChangeType) => {
       return
     }
     if (type === 'min') {
-      leftDate.value = parsedValueD
       minDate.value = (minDate.value || leftDate.value)
         .year(parsedValueD.year())
         .month(parsedValueD.month())
@@ -561,7 +560,6 @@ const handleDateInput = (value: string | null, type: ChangeType) => {
         maxDate.value = minDate.value.add(1, 'month')
       }
     } else {
-      rightDate.value = parsedValueD
       maxDate.value = (maxDate.value || rightDate.value)
         .year(parsedValueD.year())
         .month(parsedValueD.month())
@@ -601,7 +599,6 @@ const handleTimeInput = (value: string | null, type: ChangeType) => {
         .hour(parsedValueD.hour())
         .minute(parsedValueD.minute())
         .second(parsedValueD.second())
-      rightDate.value = maxDate.value
       if (maxDate.value && maxDate.value.isBefore(minDate.value)) {
         minDate.value = maxDate.value
       }
@@ -612,10 +609,8 @@ const handleTimeInput = (value: string | null, type: ChangeType) => {
 const handleTimeChange = (value: string | null, type: ChangeType) => {
   timeUserInput.value[type] = null
   if (type === 'min') {
-    leftDate.value = minDate.value!
     minTimePickerVisible.value = false
   } else {
-    rightDate.value = maxDate.value!
     maxTimePickerVisible.value = false
   }
 }
@@ -636,7 +631,6 @@ const handleMinTimePick = (value: Dayjs, visible: boolean, first: boolean) => {
 
   if (!maxDate.value || maxDate.value.isBefore(minDate.value)) {
     maxDate.value = minDate.value
-    rightDate.value = value
   }
 }
 


### PR DESCRIPTION
The panel month will display the same month

BREAKING CHANGE :
The panel month will display the same month

closed #4904

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c689ed</samp>

Refactored and cleaned up some code in `panel-date-range.vue` to improve readability and avoid potential bugs.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c689ed</samp>

* Remove redundant code that sets `leftDate` and `rightDate` values in `panel-date-range.vue` ([link](https://github.com/element-plus/element-plus/pull/14499/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L551), [link](https://github.com/element-plus/element-plus/pull/14499/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L564))
* Remove unnecessary code that limits `rightDate` value by `maxDate` in `panel-date-range.vue` ([link](https://github.com/element-plus/element-plus/pull/14499/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L604))
* Simplify code that handles date change in `panel-date-range.vue` by removing unused assignments to `leftDate` and `rightDate` ([link](https://github.com/element-plus/element-plus/pull/14499/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L615-R613))
* Fix incorrect code that updates `rightDate` value by `handleDateChange` method in `panel-date-range.vue` ([link](https://github.com/element-plus/element-plus/pull/14499/files?diff=unified&w=0#diff-c6cfc3c5d64d776c7962e059460dc01995f9f692faab74c6d2e3175eed0d80d6L639))
