### PR TITLE
fix(components): [table] show-summary style error when table-layout=auto

### DIFF
--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -100,6 +100,7 @@
             />
             <table-footer
               v-if="showSummary && tableLayout === 'auto'"
+              :class="ns.e('body-footer')"
               :border="border"
               :default-sort="defaultSort"
               :store="store"

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -393,6 +393,11 @@
     }
   }
 
+  @include e((footer-wrapper)) {
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+
   @include e((header-wrapper, body-wrapper)) {
     .#{$namespace}-table-column--selection {
       > .cell {
@@ -558,10 +563,18 @@
     }
   }
 
-  @include e(body-header) {
-    position: sticky;
-    top: 0;
-    z-index: calc(getCssVar('table-index') + 2);
+  &.#{$namespace}-table--scrollable-y {
+    @include e(body-header) {
+      position: sticky;
+      top: 0;
+      z-index: calc(getCssVar('table-index') + 2);
+    }
+
+    @include e(body-footer) {
+      position: sticky;
+      bottom: 0;
+      z-index: calc(getCssVar('table-index') + 2);
+    }
   }
 
   @include e(column-resize-proxy) {


### PR DESCRIPTION
It is an enhancement for #14315, same like #11742.

- [after](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6Ijx0ZW1wbGF0ZT5cbiAgPGVsLXJhZGlvLWdyb3VwIHYtbW9kZWw9XCJ0YWJsZUxheW91dFwiPlxuICAgIDxlbC1yYWRpby1idXR0b24gbGFiZWw9XCJmaXhlZFwiIC8+XG4gICAgPGVsLXJhZGlvLWJ1dHRvbiBsYWJlbD1cImF1dG9cIiAvPlxuICA8L2VsLXJhZGlvLWdyb3VwPlxuICA8ZWwtdGFibGUgOmRhdGE9XCJ0YWJsZURhdGFcIiBzaG93LXN1bW1hcnkgc3R5bGU9XCJ3aWR0aDogMTAwJVwiIGhlaWdodD1cIjIwMFwiIDp0YWJsZS1sYXlvdXQ9XCJ0YWJsZUxheW91dFwiPlxuICAgIDxlbC10YWJsZS1jb2x1bW4gcHJvcD1cImlkXCIgbGFiZWw9XCJJRFwiIHdpZHRoPVwiMTgwXCIgLz5cbiAgICA8ZWwtdGFibGUtY29sdW1uIHByb3A9XCJuYW1lXCIgbGFiZWw9XCJOYW1lXCIgLz5cbiAgICA8ZWwtdGFibGUtY29sdW1uIHByb3A9XCJhbW91bnQxXCIgc29ydGFibGUgbGFiZWw9XCJBbW91bnQgMVwiIC8+XG4gICAgPGVsLXRhYmxlLWNvbHVtbiBwcm9wPVwiYW1vdW50MlwiIHNvcnRhYmxlIGxhYmVsPVwiQW1vdW50IDJcIiAvPlxuICAgIDxlbC10YWJsZS1jb2x1bW4gcHJvcD1cIm5hbWVcIiBsYWJlbD1cIk5hbWVcIiAvPlxuICAgIDxlbC10YWJsZS1jb2x1bW4gcHJvcD1cImFtb3VudDFcIiBzb3J0YWJsZSBsYWJlbD1cIkFtb3VudCAxXCIgLz5cbiAgICA8ZWwtdGFibGUtY29sdW1uIHByb3A9XCJhbW91bnQyXCIgc29ydGFibGUgbGFiZWw9XCJBbW91bnQgMlwiIC8+XG4gICAgPGVsLXRhYmxlLWNvbHVtbiBwcm9wPVwibmFtZVwiIGxhYmVsPVwiTmFtZVwiIC8+XG4gICAgPGVsLXRhYmxlLWNvbHVtbiBwcm9wPVwiYW1vdW50MVwiIHNvcnRhYmxlIGxhYmVsPVwiQW1vdW50IDFcIiAvPlxuICAgIDxlbC10YWJsZS1jb2x1bW4gcHJvcD1cImFtb3VudDJcIiBzb3J0YWJsZSBsYWJlbD1cIkFtb3VudCAyXCIgLz5cbiAgICA8ZWwtdGFibGUtY29sdW1uIHByb3A9XCJuYW1lXCIgbGFiZWw9XCJOYW1lXCIgLz5cbiAgICA8ZWwtdGFibGUtY29sdW1uIHByb3A9XCJhbW91bnQxXCIgc29ydGFibGUgbGFiZWw9XCJBbW91bnQgMVwiIC8+XG4gICAgPGVsLXRhYmxlLWNvbHVtbiBwcm9wPVwiYW1vdW50MlwiIHNvcnRhYmxlIGxhYmVsPVwiQW1vdW50IDJcIiAvPlxuICAgIDxlbC10YWJsZS1jb2x1bW4gcHJvcD1cImFtb3VudDNcIiBzb3J0YWJsZSBsYWJlbD1cIkFtb3VudCAzXCIgLz5cbiAgPC9lbC10YWJsZT5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgbGFuZz1cInRzXCIgc2V0dXA+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5cbmludGVyZmFjZSBQcm9kdWN0IHtcbiAgaWQ6IHN0cmluZ1xuICBuYW1lOiBzdHJpbmdcbiAgYW1vdW50MTogc3RyaW5nXG4gIGFtb3VudDI6IHN0cmluZ1xuICBhbW91bnQzOiBudW1iZXJcbn1cblxuY29uc3QgdGFibGVMYXlvdXQgPSByZWYoJ2F1dG8nIGFzIGNvbnN0KVxuXG5jb25zdCB0YWJsZURhdGE6IFByb2R1Y3RbXSA9IFtcbiAge1xuICAgIGlkOiAnMTI5ODcxMjInLFxuICAgIG5hbWU6ICdUb20nLFxuICAgIGFtb3VudDE6ICcyMzQnLFxuICAgIGFtb3VudDI6ICczLjInLFxuICAgIGFtb3VudDM6IDEwLFxuICB9LFxuICB7XG4gICAgaWQ6ICcxMjk4NzEyMycsXG4gICAgbmFtZTogJ1RvbScsXG4gICAgYW1vdW50MTogJzE2NScsXG4gICAgYW1vdW50MjogJzQuNDMnLFxuICAgIGFtb3VudDM6IDEyLFxuICB9LFxuICB7XG4gICAgaWQ6ICcxMjk4NzEyNCcsXG4gICAgbmFtZTogJ1RvbScsXG4gICAgYW1vdW50MTogJzMyNCcsXG4gICAgYW1vdW50MjogJzEuOScsXG4gICAgYW1vdW50MzogOSxcbiAgfSxcbiAge1xuICAgIGlkOiAnMTI5ODcxMjUnLFxuICAgIG5hbWU6ICdUb20nLFxuICAgIGFtb3VudDE6ICc2MjEnLFxuICAgIGFtb3VudDI6ICcyLjInLFxuICAgIGFtb3VudDM6IDE3LFxuICB9LFxuICB7XG4gICAgaWQ6ICcxMjk4NzEyNicsXG4gICAgbmFtZTogJ1RvbScsXG4gICAgYW1vdW50MTogJzUzOScsXG4gICAgYW1vdW50MjogJzQuMScsXG4gICAgYW1vdW50MzogMTUsXG4gIH0sXG5dXG48L3NjcmlwdD5cbiIsInNyYy9QbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL3ByZXZpZXctMTQ1MjMtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5mdWxsLm1pbi5tanNcIixcbiAgICBcImVsZW1lbnQtcGx1cy9cIjogXCJ1bnN1cHBvcnRlZFwiXG4gIH1cbn0iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWUsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwic3JjL2VsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcbmltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgIGxpbmsuaHJlZiA9ICdodHRwczovL3ByZXZpZXctMTQ1MjMtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5jc3MnXG4gICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gIH0pXG59IiwiX28iOnsic2hvd0hpZGRlbiI6dHJ1ZSwic3R5bGVTb3VyY2UiOiJodHRwczovL3ByZXZpZXctMTQ1MjMtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5jc3MifX0=)

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fcce49e</samp>

This pull request enhances the table component by making the footer sticky when the table is vertically scrollable. It modifies the `table.vue` and `table.scss` files to implement this feature.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fcce49e</samp>

* Add `scrollable-y` class to table element when height exceeds available space ([link](https://github.com/element-plus/element-plus/pull/14523/files?diff=unified&w=0#diff-616bb754e750605914ca6b8e064991f1b1c91c581fd22ce883f77ee438f53c03R103))
* Apply sticky positioning and z-index to table body header and footer elements when `scrollable-y` class is present ([link](https://github.com/element-plus/element-plus/pull/14523/files?diff=unified&w=0#diff-50fcce7b86d8998ca0385dda1351e7376e5fa09b4939adec02eb34dda9e32ba5L561-R577))
* Prevent table footer wrapper element from overflowing or shrinking when table is scrollable vertically ([link](https://github.com/element-plus/element-plus/pull/14523/files?diff=unified&w=0#diff-50fcce7b86d8998ca0385dda1351e7376e5fa09b4939adec02eb34dda9e32ba5R396-R400))
* Use `el-table__body-footer` class to target table body footer element in `packages/theme-chalk/src/table.scss` ([link](https://github.com/element-plus/element-plus/pull/14523/files?diff=unified&w=0#diff-616bb754e750605914ca6b8e064991f1b1c91c581fd22ce883f77ee438f53c03R103),[link](https://github.com/element-plus/element-plus/pull/14523/files?diff=unified&w=0#diff-50fcce7b86d8998ca0385dda1351e7376e5fa09b4939adec02eb34dda9e32ba5L561-R577))
