### PR TITLE
fix(components): prevent carousel from auto playing

### DIFF
--- a/packages/components/carousel/src/use-carousel.ts
+++ b/packages/components/carousel/src/use-carousel.ts
@@ -212,7 +212,7 @@ export const useCarousel = (
 
   function resetTimer() {
     pauseTimer()
-    startTimer()
+    if (!props.pauseOnHover) startTimer()
   }
 
   function setContainerHeight(height: number) {


### PR DESCRIPTION
prevent carousel from auto playing

closed #14524

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88f2ce6</samp>

Fixed a bug in `use-carousel.ts` that ignored the `pauseOnHover` prop of the carousel component. This improves the user experience and accessibility of the carousel.

## Related Issue

Fixes https://github.com/element-plus/element-plus/issues/14524

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 88f2ce6</samp>

* Fix a bug where the carousel would resume autoplaying after the mouse leaves, even if `pauseOnHover` is true ([link](https://github.com/element-plus/element-plus/pull/14553/files?diff=unified&w=0#diff-e632d24feafd7b20af4a2099c10c653bb8a4fef22132db8440be071ac2b0cb94L215-R215))
