### PR TITLE
style(theme-chalk): remove select `!important`&fix form select style

### DIFF
--- a/.github/workflows/publish-docs-deploy-manual.yml
+++ b/.github/workflows/publish-docs-deploy-manual.yml
@@ -57,6 +57,7 @@ jobs:
         run: pnpm docs:build
         env:
           DOC_ENV: production
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.3.4

--- a/.github/workflows/publish-docs-deploy.yml
+++ b/.github/workflows/publish-docs-deploy.yml
@@ -64,6 +64,7 @@ jobs:
         run: pnpm docs:build
         env:
           DOC_ENV: production
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.3.4

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,59 @@
 ## Changelog
 
+### 2.4.0
+
+_2023-10-13_
+
+#### Features
+
+- Components watermark component (#14236 by @TomatoDroid)
+- Add menu horizontal height for img center (#14307 by @YunYouJun)
+- Components [tabs] add addIcon slot (#12970 by @btea)
+- Components [form-item]Label attribute for judging modification (#14344 by @Xaw-xu)
+- Components [color-picker] add focus and blur event (#14244 by @tolking)
+- Docs theme switch use startViewTransition api (#14489 by @btea)
+- Feat(components): [date-picker] add dateFormat and timeFormat props (#14330 by @FrontEndDog)
+- Components [select] accessibility enhancement (#14503 by @tolking)
+- Components [image-viewer] add `minScale` and `maxScale` (#14120 by @IceyWu)
+
+#### Bug fixes
+
+- Components [menu] export MenuInstance (#14284 by @HeftyKoo)
+- Components [carousel] Watch items causing state loss(#13010 by @SaberA1ter) (#13011)
+- Components [collapse] fix triggering form action when inside it (#14308 by @Karolis-Stoncius)
+- Docs [form] `label-position` type error (#14312 by @btea)
+- Components row-class-name bgColor can not cover fixed column (#14225 by @StephenKe)
+- Components [tabs] Fix some events accidentally firing (#14224 by @Mario34)
+- Cannot find type definition file for `element-plus/global` (#13698 by @mioxs)
+- Components [description] use `withDirectives` add custom directive (#14299 by @btea)
+- Components fix: update timepicker options when changing locale (#14287 by @cuongle-hdwebsoft)
+- Components [popper] invalid when props z-index is zero (#14375 by @betavs)
+- Theme-chalk table tr bg in dark mode (#14443 by @YunYouJun)
+- Components [date-picker] slot compatible with Vue3.3.x (#14354 by @FrontEndDog)
+- Components [select-v2] read properties of null (#14321 by @FrontEndDog)
+- Play apply esbuild plugin to tsx component (#14480 by @btea)
+- Components [color-picker] exposed show method wrong behavior (#14064 by @wonderl17)
+- Components [table] table-layout auto fixed by sticky (#11742 by @MrWeilian)
+- Components [carousel] two length transform optimize (#12174 by @MrWeilian)
+- Components inline style doesn't use the custom sass setting value (#14117 by @kamesan012)
+- Components [table] fix summary row cells on table with layout auto not aligned with data cells (#14315 by @FrontEndDog)
+- Components [upload] icon style abnormal (#14471 by @betavs)
+- Components [table] show-summary style error when table-layout=auto (#14523 by @tolking)
+- Components [checkbox] indeterminate checkbox a11y fix (#14322 by @Karolis-Stoncius)
+- Components [sub-menu] style error in collapsed state (#13135 by @Lucky-Ya-Q)
+- Components [menu] remove excess inline styles (#13693 by @tolking)
+- Components [text] not support multi-line ellipsis (#11976 by @gimjin)
+- Chore(MessageBox): unused keyframe (#14335 by @zhousg)
+- Chore(components): [table] fix typo (#14473 by @FrontEndDog)
+
+#### Refactors
+
+- Descriptions improve types (#14313 by @makedopamine)
+- Components [tabs] enhance instance type (#14352 by @HeftyKoo)
+- Components [select] use utils function (#14345 by @btea)
+- Components [checkbox] set the label default value to `undefined` (#14011 by @btea)
+- Components!: [select-v2] value-key is used for object select (#13263 by @tolking)
+
 ### 2.3.14
 
 _2023-09-14_

--- a/docs/.vitepress/crowdin/en-US/pages/component.json
+++ b/docs/.vitepress/crowdin/en-US/pages/component.json
@@ -326,7 +326,8 @@
       },
       {
         "link": "/watermark",
-        "text": "Watermark"
+        "text": "Watermark",
+        "promotion": "2.4.0"
       }
     ]
   }

--- a/docs/.vitepress/crowdin/en-US/pages/component.json
+++ b/docs/.vitepress/crowdin/en-US/pages/component.json
@@ -323,6 +323,10 @@
       {
         "link": "/divider",
         "text": "Divider"
+      },
+      {
+        "link": "/watermark",
+        "text": "Watermark"
       }
     ]
   }

--- a/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
+++ b/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 import { isDark, toggleDark } from '../../composables/dark'
 import DarkIcon from '../icons/dark.vue'
 import LightIcon from '../icons/light.vue'
@@ -12,13 +12,60 @@ watch(
     toggleDark()
   }
 )
+
+let resolveFn: (value: boolean | PromiseLike<boolean>) => void
+const switchTheme = (event: MouseEvent) => {
+  const isAppearanceTransition =
+    // @ts-expect-error
+    document.startViewTransition &&
+    !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  if (!isAppearanceTransition || !event) {
+    resolveFn(true)
+    return
+  }
+  const x = event.clientX
+  const y = event.clientY
+  const endRadius = Math.hypot(
+    Math.max(x, innerWidth - x),
+    Math.max(y, innerHeight - y)
+  )
+  // @ts-expect-error: Transition API
+  const transition = document.startViewTransition(async () => {
+    resolveFn(true)
+    await nextTick()
+  })
+  transition.ready.then(() => {
+    const clipPath = [
+      `circle(0px at ${x}px ${y}px)`,
+      `circle(${endRadius}px at ${x}px ${y}px)`,
+    ]
+    document.documentElement.animate(
+      {
+        clipPath: isDark.value ? [...clipPath].reverse() : clipPath,
+      },
+      {
+        duration: 400,
+        easing: 'ease-in',
+        pseudoElement: isDark.value
+          ? '::view-transition-old(root)'
+          : '::view-transition-new(root)',
+      }
+    )
+  })
+}
+const beforeChange = (): Promise<boolean> => {
+  return new Promise((resolve) => {
+    resolveFn = resolve
+  })
+}
 </script>
 
 <template>
-  <div>
+  <div @click.stop="switchTheme">
     <ClientOnly>
       <el-switch
         v-model="darkMode"
+        :before-change="beforeChange"
         :active-action-icon="DarkIcon"
         :inactive-action-icon="LightIcon"
       />

--- a/docs/.vitepress/vitepress/styles/base.scss
+++ b/docs/.vitepress/vitepress/styles/base.scss
@@ -171,6 +171,7 @@ a.header-anchor {
   padding-right: 0.23em;
   font-size: 0.85em;
   opacity: 0;
+
   &:hover,
   :focus {
     text-decoration: none;
@@ -200,6 +201,7 @@ li > ol {
   overflow-y: hidden;
   overflow-x: auto;
   margin-bottom: 45px;
+
   & > table {
     border-collapse: collapse;
     width: 100%;
@@ -271,6 +273,7 @@ details {
   p:not(.custom-block-title) {
     font-size: 0.9rem;
   }
+
   &.tip {
     padding: 8px 16px;
     background-color: var(--block-tip-bg-color);
@@ -296,4 +299,26 @@ details {
   position: absolute;
   white-space: nowrap;
   width: 1px;
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+::view-transition-old(root) {
+  z-index: 1;
+}
+
+::view-transition-new(root) {
+  z-index: 2147483646;
+}
+
+.dark::view-transition-old(root) {
+  z-index: 2147483646;
+}
+
+.dark::view-transition-new(root) {
+  z-index: 1;
 }

--- a/docs/en-US/component/color-picker.md
+++ b/docs/en-US/component/color-picker.md
@@ -60,20 +60,24 @@ color-picker/sizes
 | predefine             | predefined color options                     | ^[object]`string[]`                                                                                              | —       |
 | validate-event        | whether to trigger form validation           | ^[boolean]                                                                                                       | true    |
 | tabindex              | ColorPicker tabindex                         | ^[string] / ^[number]                                                                                            | 0       |
-| label<A11yTag/>       | ColorPicker aria-label                       | ^[string]                                                                                                        | —       |
+| label ^(a11y)         | ColorPicker aria-label                       | ^[string]                                                                                                        | —       |
 | id                    | ColorPicker id                               | ^[string]                                                                                                        | —       |
 
 ### Events
 
-| Name          | Description                                    | Type                                 |
-| ------------- | ---------------------------------------------- | ------------------------------------ |
-| change        | triggers when input value changes              | ^[Function]`(value: string) => void` |
-| active-change | triggers when the current active color changes | ^[Function]`(value: string) => void` |
+| Name           | Description                                    | Type                                     |
+| -------------- | ---------------------------------------------- | ---------------------------------------- |
+| change         | triggers when input value changes              | ^[Function]`(value: string) => void`     |
+| active-change  | triggers when the current active color changes | ^[Function]`(value: string) => void`     |
+| focus ^(2.4.0) | triggers when Component focuses                | ^[Function]`(event: FocusEvent) => void` |
+| blur ^(2.4.0)  | triggers when Component blurs                  | ^[Function]`(event: FocusEvent) => void` |
 
 ### Exposes
 
-| Name          | Description               | Type                    |
-| ------------- | ------------------------- | ----------------------- |
-| color         | current color object      | ^[object]`Color`        |
-| show ^(2.3.3) | manually show ColorPicker | ^[Function]`() => void` |
-| hide ^(2.3.3) | manually hide ColorPicker | ^[Function]`() => void` |
+| Name            | Description               | Type                    |
+| --------------- | ------------------------- | ----------------------- |
+| color           | current color object      | ^[object]`Color`        |
+| show ^(2.3.3)   | manually show ColorPicker | ^[Function]`() => void` |
+| hide ^(2.3.3)   | manually hide ColorPicker | ^[Function]`() => void` |
+| focus ^(2.3.13) | focus the picker element  | ^[Function]`() => void` |
+| blur ^(2.3.13)  | blur the picker element   | ^[Function]`() => void` |

--- a/docs/en-US/component/datetime-picker.md
+++ b/docs/en-US/component/datetime-picker.md
@@ -47,6 +47,16 @@ datetime-picker/date-and-time-formats
 
 :::
 
+## Date and time formats in dropdown panel
+
+Use `date-format` and `time-format` to control displayed text's format in the dropdown panel's input box.
+
+:::demo
+
+datetime-picker/date-and-time-formats-panel
+
+:::
+
 ## Date and time range
 
 :::demo You can select date and time range by setting `type` to `datetimerange`.
@@ -84,6 +94,8 @@ datetime-picker/default-time
 | default-value         | optional, default date of the calendar                                                                | Date / [Date, Date]                              |                                                               | —                   |
 | default-time          | the default time value after picking a date. Time `00:00:00` will be used if not specified            | Date / [Date, Date]                              | —                                                             | —                   |
 | value-format          | optional, format of binding value. If not specified, the binding value will be a Date object          | string                                           | see [date formats](https://day.js.org/docs/en/display/format) | —                   |
+| date-format ^(2.4.0) | optional, format of the date displayed value in TimePicker's dropdown                                 | string                                           | see [date formats](https://day.js.org/docs/en/display/format) | —                   |
+| time-format ^(2.4.0) | optional, format of the time displayed value in TimePicker's dropdown                                 | string                                           | see [date formats](https://day.js.org/docs/en/display/format) | —                   |
 | id                    | same as `id` in native input                                                                          | string / [string, string]                        | —                                                             | —                   |
 | name                  | same as `name` in native input                                                                        | string                                           | —                                                             | —                   |
 | unlink-panels         | unlink two date-panels in range-picker                                                                | boolean                                          | —                                                             | false               |

--- a/docs/en-US/component/descriptions.md
+++ b/docs/en-US/component/descriptions.md
@@ -39,41 +39,45 @@ descriptions/customized-style
 
 :::
 
-## Descriptions Attributes
+## Descriptions API
 
-| Name      | Description                                | Type    | Accepted Values         | Default    |
-| --------- | ------------------------------------------ | ------- | ----------------------- | ---------- |
-| border    | with or without border                     | boolean | —                       | false      |
-| column    | numbers of `Descriptions Item` in one line | number  | —                       | 3          |
-| direction | direction of list                          | string  | vertical / horizontal   | horizontal |
-| size      | size of list                               | string  | large / default / small | default    |
-| title     | title text, display on the top left        | string  | —                       | —          |
-| extra     | extra text, display on the top right       | string  | —                       | —          |
+### Descriptions Attributes
 
-## Descriptions Slots
+| Name      | Description                                | Type                                           | Default    |
+| --------- | ------------------------------------------ | ---------------------------------------------- | ---------- |
+| border    | with or without border                     | ^[boolean]                                     | false      |
+| column    | numbers of `Descriptions Item` in one line | ^[number]                                      | 3          |
+| direction | direction of list                          | ^[enum]`'vertical' \| 'horizontal'`            | horizontal |
+| size      | size of list                               | ^[enum]`'' \| 'large' \| 'default' \| 'small'` | —          |
+| title     | title text, display on the top left        | ^[string]                                      | ''         |
+| extra     | extra text, display on the top right       | ^[string]                                      | ''         |
 
-| Name  | Description                                 | Subtags           |
-| ----- | ------------------------------------------- | ----------------- |
-| —     | customize default content                   | Descriptions Item |
-| title | custom title, display on the top left       | —                 |
-| extra | custom extra area, display on the top right | —                 |
+### Descriptions Slots
 
-## Descriptions Item Attributes
+| Name    | Description                                 | Subtags           |
+| ------- | ------------------------------------------- | ----------------- |
+| default | customize default content                   | Descriptions Item |
+| title   | custom title, display on the top left       | —                 |
+| extra   | custom extra area, display on the top right | —                 |
 
-| Name             | Description                                                                                                                                                                                  | Type            | Accepted Values       | Default |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | --------------------- | ------- |
-| label            | label text                                                                                                                                                                                   | string          | —                     | —       |
-| span             | colspan of column                                                                                                                                                                            | number          | —                     | 1       |
-| width            | column width, the width of the same column in different rows is set by the max value (If no `border`, width contains label and content)                                                      | string / number | —                     | —       |
-| min-width        | column minimum width, columns with `width` has a fixed width, while columns with `min-width` has a width that is distributed in proportion (If no`border`, width contains label and content) | string / number | —                     | —       |
-| align            | column content alignment (If no `border`, effective for both label and content)                                                                                                              | string          | left / center / right | left    |
-| label-align      | column label alignment, if omitted, the value of the above `align` attribute will be applied (If no `border`, please use `align` attribute)                                                  | string          | left / center / right | —       |
-| class-name       | column content custom class name                                                                                                                                                             | string          | —                     | —       |
-| label-class-name | column label custom class name                                                                                                                                                               | string          | —                     | —       |
+## DescriptionsItem API
 
-## Descriptions Item Slots
+### DescriptionsItem Attributes
 
-| Name  | Description               |
-| ----- | ------------------------- |
-| —     | customize default content |
-| label | custom label              |
+| Name             | Description                                                                                                                                                                                  | Type                                  | Default |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------- |
+| label            | label text                                                                                                                                                                                   | ^[string]                              | ''      |
+| span             | colspan of column                                                                                                                                                                            | ^[number]                              | 1       |
+| width            | column width, the width of the same column in different rows is set by the max value (If no `border`, width contains label and content)                                                      | ^[string] / ^[number]                  | ''      |
+| min-width        | column minimum width, columns with `width` has a fixed width, while columns with `min-width` has a width that is distributed in proportion (If no`border`, width contains label and content) | ^[string] / ^[number]                  | ''      |
+| align            | column content alignment (If no `border`, effective for both label and content)                                                                                                              | ^[enum]`'left' \| 'center' \| 'right'` | left    |
+| label-align      | column label alignment, if omitted, the value of the above `align` attribute will be applied (If no `border`, please use `align` attribute)                                                  | ^[enum]`'left' \| 'center' \| 'right'` | ''      |
+| class-name       | column content custom class name                                                                                                                                                             | ^[string]                              | ''      |
+| label-class-name | column label custom class name                                                                                                                                                               | ^[string]                              | ''      |
+
+### DescriptionsItem Slots
+
+| Name    | Description               |
+| ------- | ------------------------- |
+| default | customize default content |
+| label   | custom label              |

--- a/docs/en-US/component/dialog.md
+++ b/docs/en-US/component/dialog.md
@@ -111,7 +111,7 @@ When using `modal` = false, please make sure that `append-to-body` was set to **
 
 :::
 
-## Attributes
+## API
 
 ### Attributes
 

--- a/docs/en-US/component/image.md
+++ b/docs/en-US/component/image.md
@@ -76,6 +76,8 @@ image/image-preview
 | preview-teleported    | whether to append image-viewer to body. A nested parent element attribute transform should have this attribute set to `true`.                     | ^[boolean]                                                              | false   |
 | infinite              | whether the viewer preview is infinite.                                                                                                           | ^[boolean]                                                              | true    |
 | zoom-rate             | the zoom rate of the image viewer zoom event.                                                                                                     | ^[number]                                                               | 1.2     |
+| min-scale ^(2.4.0)    | the min scale of the image viewer zoom event.                                                                                                     | ^[number]                                                               | 0.2     |
+| max-scale ^(2.4.0)    | the max scale of the image viewer zoom event.                                                                                                     | ^[number]                                                               | 7       |
 
 ### Image Events
 
@@ -108,6 +110,8 @@ image/image-preview
 | hide-on-click-modal   | whether user can emit close event when clicking backdrop.                                                                     | ^[boolean]            | false   |
 | teleported            | whether to append image itself to body. A nested parent element attribute transform should have this attribute set to `true`. | ^[boolean]            | false   |
 | zoom-rate ^(2.2.27)   | the zoom rate of the image viewer zoom event.                                                                                 | ^[number]             | 1.2     |
+| min-scale ^(2.4.0)   | the min scale of the image viewer zoom event.                                                                                 | ^[number]             | 0.2     |
+| max-scale ^(2.4.0)   | the max scale of the image viewer zoom event.                                                                                 | ^[number]             | 7       |
 | close-on-press-escape | whether the image-viewer can be closed by pressing ESC.                                                                       | ^[boolean]            | true    |
 
 ### Image Viewer Events

--- a/docs/en-US/component/scrollbar.md
+++ b/docs/en-US/component/scrollbar.md
@@ -43,19 +43,23 @@ scrollbar/manual-scroll
 
 ### Attributes
 
-| Name       | Description                                                                                                                     | Type                                                                | Default |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------- |
-| height     | height of scrollbar                                                                                                             | ^[string] / ^[number]                                               | —       |
-| max-height | max height of scrollbar                                                                                                         | ^[string] / ^[number]                                               | —       |
-| native     | whether to use the native scrollbar style                                                                                       | ^[boolean]                                                          | false   |
-| wrap-style | style of wrap container                                                                                                         | ^[string] / ^[object]`CSSProperties \| CSSProperties[] \| string[]` | —       |
-| wrap-class | class of wrap container                                                                                                         | ^[string]                                                           | —       |
-| view-style | style of view                                                                                                                   | ^[string] / ^[object]`CSSProperties \| CSSProperties[] \| string[]` | —       |
-| view-class | class of view                                                                                                                   | ^[string]                                                           | —       |
-| noresize   | do not respond to container size changes, if the container size does not change, it is better to set it to optimize performance | ^[boolean]                                                          | false   |
-| tag        | element tag of the view                                                                                                         | ^[string]                                                           | div     |
-| always     | always show scrollbar                                                                                                           | ^[boolean]                                                          | false   |
-| min-size   | minimum size of scrollbar                                                                                                       | ^[number]                                                           | 20      |
+| Name                              | Description                                                                                                                     | Type                                                                | Default |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------- |
+| height                            | height of scrollbar                                                                                                             | ^[string] / ^[number]                                               | —       |
+| max-height                        | max height of scrollbar                                                                                                         | ^[string] / ^[number]                                               | —       |
+| native                            | whether to use the native scrollbar style                                                                                       | ^[boolean]                                                          | false   |
+| wrap-style                        | style of wrap container                                                                                                         | ^[string] / ^[object]`CSSProperties \| CSSProperties[] \| string[]` | —       |
+| wrap-class                        | class of wrap container                                                                                                         | ^[string]                                                           | —       |
+| view-style                        | style of view                                                                                                                   | ^[string] / ^[object]`CSSProperties \| CSSProperties[] \| string[]` | —       |
+| view-class                        | class of view                                                                                                                   | ^[string]                                                           | —       |
+| noresize                          | do not respond to container size changes, if the container size does not change, it is better to set it to optimize performance | ^[boolean]                                                          | false   |
+| tag                               | element tag of the view                                                                                                         | ^[string]                                                           | div     |
+| always                            | always show scrollbar                                                                                                           | ^[boolean]                                                          | false   |
+| min-size                          | minimum size of scrollbar                                                                                                       | ^[number]                                                           | 20      |
+| id ^(2.4.0)                       | id of view                                                                                                                      | ^[string]                                                           | —       |
+| role ^(2.4.0) ^(a11y)             | role of view                                                                                                                    | ^[string]                                                           | —       |
+| aria-label ^(2.4.0) ^(a11y)       | aria-label of view                                                                                                              | ^[string]                                                           | —       |
+| aria-orientation ^(2.4.0) ^(a11y) | aria-orientation of view                                                                                                        | ^[enum]`'horizontal' \| 'vertical'`                                 | —       |
 
 ### Events
 

--- a/docs/en-US/component/tabs.md
+++ b/docs/en-US/component/tabs.md
@@ -67,7 +67,7 @@ tabs/dynamic-tabs
 
 :::
 
-## Customized add button icon ^(2.3.15)
+## Customized add button icon ^(2.4.0)
 
 :::demo
 
@@ -108,10 +108,10 @@ tabs/customized-trigger
 
 ## Tabs Slots
 
-| Name              | Description               | Subtags  |
-| ----------------- | ------------------------- | -------- |
-| -                 | customize default content | Tab-pane |
-| addIcon ^(2.3.15) | customize add button icon | -        |
+| Name             | Description               | Subtags  |
+| ---------------- | ------------------------- | -------- |
+| -                | customize default content | Tab-pane |
+| addIcon ^(2.4.0) | customize add button icon | -        |
 
 ## Tab-pane Attributes
 

--- a/docs/en-US/component/text.md
+++ b/docs/en-US/component/text.md
@@ -25,7 +25,7 @@ text/sizes
 
 ## Ellipsis
 
-:::demo Pass the `truncated` prop to render an ellipsis when the text exceeds the width of the viewport or max-width set.
+:::demo Pass the `truncated` prop to render an ellipsis when the text exceeds the width of the viewport or max-width set. `line-clamp` prop to render multiline ellipsis.
 
 text/truncated
 
@@ -51,12 +51,13 @@ text/mixed
 
 ### Attributes
 
-| Name      | Description        | Type                                                               | Default |
-| --------- | ------------------ | ------------------------------------------------------------------ | ------- |
-| type      | text type          | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info'` | —       |
-| size      | text size          | ^[enum]`'large' \| 'default' \| 'small'`                           | default |
-| truncated | render ellipsis    | ^[boolean]                                                         | false   |
-| tag       | custom element tag | ^[string]                                                          | span    |
+| Name                | Description        | Type                                                               | Default |
+| ------------------- | ------------------ | ------------------------------------------------------------------ | ------- |
+| type                | text type          | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info'` | —       |
+| size                | text size          | ^[enum]`'large' \| 'default' \| 'small'`                           | default |
+| truncated           | render ellipsis    | ^[boolean]                                                         | false   |
+| line-clamp ^(2.4.0) | maximum lines      | ^[string] / ^[number]                                              | -       |
+| tag                 | custom element tag | ^[string]                                                          | span    |
 
 ### Slots
 

--- a/docs/en-US/component/upload.md
+++ b/docs/en-US/component/upload.md
@@ -89,53 +89,106 @@ upload/manual
 
 :::
 
-## Upload API
+## API
 
 ### Attributes
 
-| Name                              | Description                                                                                                                                                                           | Type                                                                                                                    | Default  | Required |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------- | -------- |
-| `action`                          | request URL.                                                                                                                                                                          | `string`                                                                                                                | —        | Yes      |
-| `headers`                         | request headers.                                                                                                                                                                      | `Headers \| Record<string, any>`                                                                                        | —        | No       |
-| `method`                          | set upload request method.                                                                                                                                                            | `string`                                                                                                                | `'post'` | No       |
-| `multiple`                        | whether uploading multiple files is permitted.                                                                                                                                        | `boolean`                                                                                                               | `false`  | No       |
-| `data`                            | additions options of request. support `Awaitable` data and `Function` since v2.3.13                                                                                                   | `Record<string, any> \| Awaitable<Record<string, any>> \| ((rawFile: UploadRawFile) => Awaitable<Record<string, any>>)` | —        | No       |
-| `name`                            | key name for uploaded file.                                                                                                                                                           | `string`                                                                                                                | `'file'` | No       |
-| `with-credentials`                | whether cookies are sent.                                                                                                                                                             | `boolean`                                                                                                               | `false`  | No       |
-| `show-file-list`                  | whether to show the uploaded file list.                                                                                                                                               | `boolean`                                                                                                               | `true`   | No       |
-| `drag`                            | whether to activate drag and drop mode.                                                                                                                                               | `boolean`                                                                                                               | `false`  | No       |
-| `accept`                          | accepted [file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-accept), will not work when `thumbnail-mode === true`.                                     | `string`                                                                                                                | —        | No       |
-| `on-preview`                      | hook function when clicking the uploaded files.                                                                                                                                       | `(uploadFile: UploadFile) => void`                                                                                      | —        | No       |
-| `on-remove`                       | hook function when files are removed.                                                                                                                                                 | `(uploadFile: UploadFile, uploadFiles: UploadFiles) => void`                                                            | —        | No       |
-| `on-success`                      | hook function when uploaded successfully.                                                                                                                                             | `(response: any, uploadFile: UploadFile, uploadFiles: UploadFiles) => void`                                             | —        | No       |
-| `on-error`                        | hook function when some errors occurs.                                                                                                                                                | `(error: Error, uploadFile: UploadFile, uploadFiles: UploadFiles) => void`                                              | —        | No       |
-| `on-progress`                     | hook function when some progress occurs.                                                                                                                                              | `(evt: UploadProgressEvent, uploadFile: UploadFile, uploadFiles: UploadFiles) => void`                                  | —        | No       |
-| `on-change`                       | hook function when select file or upload file success or upload file fail.                                                                                                            | `(uploadFile: UploadFile, uploadFiles: UploadFiles) => void`                                                            | —        | No       |
-| `on-exceed`                       | hook function when limit is exceeded.                                                                                                                                                 | `(files: File[], uploadFiles: UploadUserFile[]) => void`                                                                | —        | No       |
-| `before-upload`                   | hook function before uploading with the file to be uploaded as its parameter. If `false` is returned or a `Promise` is returned and then is rejected, uploading will be aborted.      | `(rawFile: UploadRawFile) => Awaitable<void \| undefined \| null \| boolean \| File \| Blob>`                           | —        | No       |
-| `before-remove`                   | hook function before removing a file with the file and file list as its parameters. If `false` is returned or a `Promise` is returned and then is rejected, removing will be aborted. | `(uploadFile: UploadFile, uploadFiles: UploadFiles) => Awaitable<boolean>`                                              | —        | No       |
-| `file-list` / `v-model:file-list` | default uploaded files.                                                                                                                                                               | `UploadUserFile[]`                                                                                                      | `[]`     | No       |
-| `list-type`                       | type of file list.                                                                                                                                                                    | `'text' \| 'picture' \| 'picture-card'`                                                                                 | `'text'` | No       |
-| `auto-upload`                     | whether to auto upload file.                                                                                                                                                          | `boolean`                                                                                                               | `true`   | No       |
-| `http-request`                    | override default xhr behavior, allowing you to implement your own upload-file's request.                                                                                              | `(options: UploadRequestOptions) => XMLHttpRequest \| Promise<unknown>`                                                 | —        | No       |
-| `disabled`                        | whether to disable upload.                                                                                                                                                            | `boolean`                                                                                                               | `false`  | No       |
-| `limit`                           | maximum number of uploads allowed.                                                                                                                                                    | `number`                                                                                                                | —        | No       |
+| Name                          | Description                                                                                                                                                                           | Type                                                                                                                                         | Default                                                                                                            |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| action ^(required)            | request URL.                                                                                                                                                                          | ^[string]                                                                                                                                    | #                                                                                                                  |
+| headers                       | request headers.                                                                                                                                                                      | ^[object]`Headers \| Record<string, any>`                                                                                                    | —                                                                                                                  |
+| method                        | set upload request method.                                                                                                                                                            | ^[string]                                                                                                                                    | post                                                                                                               |
+| multiple                      | whether uploading multiple files is permitted.                                                                                                                                        | ^[boolean]                                                                                                                                   | false                                                                                                              |
+| data                          | additions options of request. support `Awaitable` data and `Function` since v2.3.13.                                                                                                  | ^[object]`Record<string, any> \| Awaitable<Record<string, any>>` / ^[Function]`(rawFile: UploadRawFile) => Awaitable<Record<string, any>>` | {}                                                                                                                 |
+| name                          | key name for uploaded file.                                                                                                                                                           | ^[string]                                                                                                                                    | file                                                                                                               |
+| with-credentials              | whether cookies are sent.                                                                                                                                                             | ^[boolean]                                                                                                                                   | false                                                                                                              |
+| show-file-list                | whether to show the uploaded file list.                                                                                                                                               | ^[boolean]                                                                                                                                   | true                                                                                                               |
+| drag                          | whether to activate drag and drop mode.                                                                                                                                               | ^[boolean]                                                                                                                                   | false                                                                                                              |
+| accept                        | accepted [file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-accept), will not work when `thumbnail-mode === true`.                                     | ^[string]                                                                                                                                    | ''                                                                                                                 |
+| on-preview                    | hook function when clicking the uploaded files.                                                                                                                                       | ^[Function]`(uploadFile: UploadFile) => void`                                                                                                | —                                                                                                                  |
+| on-remove                     | hook function when files are removed.                                                                                                                                                 | ^[Function]`(uploadFile: UploadFile, uploadFiles: UploadFiles) => void`                                                                      | —                                                                                                                  |
+| on-success                    | hook function when uploaded successfully.                                                                                                                                             | ^[Function]`(response: any, uploadFile: UploadFile, uploadFiles: UploadFiles) => void`                                                       | —                                                                                                                  |
+| on-error                      | hook function when some errors occurs.                                                                                                                                                | ^[Function]`(error: Error, uploadFile: UploadFile, uploadFiles: UploadFiles) => void`                                                        | —                                                                                                                  |
+| on-progress                   | hook function when some progress occurs.                                                                                                                                              | ^[Function]`(evt: UploadProgressEvent, uploadFile: UploadFile, uploadFiles: UploadFiles) => void`                                            | —                                                                                                                  |
+| on-change                     | hook function when select file or upload file success or upload file fail.                                                                                                            | ^[Function]`(uploadFile: UploadFile, uploadFiles: UploadFiles) => void`                                                                      | —                                                                                                                  |
+| on-exceed                     | hook function when limit is exceeded.                                                                                                                                                 | ^[Function]`(files: File[], uploadFiles: UploadUserFile[]) => void`                                                                          | —                                                                                                                  |
+| before-upload                 | hook function before uploading with the file to be uploaded as its parameter. If `false` is returned or a `Promise` is returned and then is rejected, uploading will be aborted.      | ^[Function]`(rawFile: UploadRawFile) => Awaitable<void \| undefined \| null \| boolean \| File \| Blob>`                                     | —                                                                                                                  |
+| before-remove                 | hook function before removing a file with the file and file list as its parameters. If `false` is returned or a `Promise` is returned and then is rejected, removing will be aborted. | ^[Function]`(uploadFile: UploadFile, uploadFiles: UploadFiles) => Awaitable<boolean>`                                                        | —                                                                                                                  |
+| file-list / v-model:file-list | default uploaded files.                                                                                                                                                               | ^[object]`UploadUserFile[]`                                                                                                                  | []                                                                                                                 |
+| list-type                     | type of file list.                                                                                                                                                                    | ^[enum]`'text' \| 'picture' \| 'picture-card'`                                                                                               | text                                                                                                               |
+| auto-upload                   | whether to auto upload file.                                                                                                                                                          | ^[boolean]                                                                                                                                   | true                                                                                                               |
+| http-request                  | override default xhr behavior, allowing you to implement your own upload-file's request.                                                                                              | ^[Function]`(options: UploadRequestOptions) => XMLHttpRequest \| Promise<unknown>`                                                           | ajaxUpload [see](https://github.com/element-plus/element-plus/blob/dev/packages/components/upload/src/ajax.ts#L55) |
+| disabled                      | whether to disable upload.                                                                                                                                                            | ^[boolean]                                                                                                                                   | false                                                                                                              |
+| limit                         | maximum number of uploads allowed.                                                                                                                                                    | ^[number]                                                                                                                                    | —                                                                                                                  |
 
 ### Slots
 
-| Name      | Description                         | Type                   |
-| --------- | ----------------------------------- | ---------------------- |
-| `default` | customize default content.          | -                      |
-| `trigger` | content which triggers file dialog. | -                      |
-| `tip`     | content of tips.                    | -                      |
-| `file`    | content of thumbnail template.      | `{ file: UploadFile }` |
+| Name    | Description                         | Type                            |
+| ------- | ----------------------------------- | ------------------------------- |
+| default | customize default content.          | -                               |
+| trigger | content which triggers file dialog. | -                               |
+| tip     | content of tips.                    | -                               |
+| file    | content of thumbnail template.      | ^[object]`{ file: UploadFile }` |
 
 ### Exposes
 
-| Name           | Description                                                                                            | Type                                                                      |
-| -------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
-| `abort`        | cancel upload request.                                                                                 | `(file: UploadFile) => void`                                              |
-| `submit`       | upload the file list manually.                                                                         | `() => void`                                                              |
-| `clearFiles`   | clear the file list (this method is not supported in the `before-upload` hook).                        | `(status?: Array<"ready" \| "uploading" \| "success" \| "fail">) => void` |
-| `handleStart`  | select the file manually.                                                                              | `(rawFile: UploadRawFile) => void`                                        |
-| `handleRemove` | remove the file manually. `file` and `rawFile` has been merged. `rawFile` will be removed in `v2.2.0`. | `(file: UploadFile \| UploadRawFile, rawFile?: UploadRawFile) => void`    |
+| Name         | Description                                                                                            | Type                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| abort        | cancel upload request.                                                                                 | ^[Function]`(file: UploadFile) => void`                                              |
+| submit       | upload the file list manually.                                                                         | ^[Function]`() => void`                                                              |
+| clearFiles   | clear the file list (this method is not supported in the `before-upload` hook).                        | ^[Function]`(status?: UploadStatus[]) => void`                                       |
+| handleStart  | select the file manually.                                                                              | ^[Function]`(rawFile: UploadRawFile) => void`                                        |
+| handleRemove | remove the file manually. `file` and `rawFile` has been merged. `rawFile` will be removed in `v2.2.0`. | ^[Function]`(file: UploadFile \| UploadRawFile, rawFile?: UploadRawFile) => void`    |
+
+## Type Declarations
+
+<details>
+  <summary>Show declarations</summary>
+
+```ts
+
+type UploadFiles = UploadFile[]
+
+type UploadUserFile = Omit<UploadFile, 'status' | 'uid'> &
+  Partial<Pick<UploadFile, 'status' | 'uid'>>
+
+type UploadStatus = 'ready' | 'uploading' | 'success' | 'fail'
+
+type Awaitable<T> = Promise<T> | T
+
+type Mutable<T> = { -readonly [P in keyof T]: T[P] }
+
+interface UploadFile {
+  name: string
+  percentage?: number
+  status: UploadStatus
+  size?: number
+  response?: unknown
+  uid: number
+  url?: string
+  raw?: UploadRawFile
+}
+
+interface UploadProgressEvent extends ProgressEvent {
+  percent: number
+}
+
+interface UploadRawFile extends File {
+  uid: number
+}
+
+interface UploadRequestOptions {
+  action: string
+  method: string
+  data: Record<string, string | Blob | [string | Blob, string]>
+  filename: string
+  file: File
+  headers: Headers | Record<string, string | number | null | undefined>
+  onError: (evt: UploadAjaxError) => void
+  onProgress: (evt: UploadProgressEvent) => void
+  onSuccess: (response: any) => void
+  withCredentials: boolean
+}
+```
+
+</details>

--- a/docs/en-US/component/watermark.md
+++ b/docs/en-US/component/watermark.md
@@ -47,29 +47,28 @@ watermark/custom
 
 :::
 
-## Watermark API
+## API
 
-### Watermark Attributes
+### Attributes
 
-
-| Name    | Description                                                                                     | Type               | Default                    |
-| ------- | ----------------------------------------------------------------------------------------------- | ------------------ | -------------------------- |
-| width   | The width of the watermark, the default value of `content` is its own width                     | number             | 120                        |
-| height  | The height of the watermark, the default value of `content` is its own height                   | number             | 64                         |
-| rotate  | When the watermark is drawn, the rotation Angle, unit `°`                                       | number             | -22                        |
-| zIndex  | The z-index of the appended watermark element                                                   | number             | 9                          |
-| image   | Image source, it is recommended to export 2x or 3x image, high priority                         | string             | -                          |
-| content | Watermark text content                                                                          | string \| string[] | -                          |
-| font    | Text style                                                                                      | [Font](#font)      | [Font](#font)              |
-| gap     | The spacing between watermarks                                                                  | \[number, number\] | \[100, 100\]               |
-| offset  | The offset of the watermark from the upper left corner of the container. The default is `gap/2` | \[number, number\] | \[gap\[0\]/2, gap\[1\]/2\] |
+| Name    | Description                                                                                     | Type                             | Default                    |
+| ------- | ----------------------------------------------------------------------------------------------- | -------------------------------- | -------------------------- |
+| width   | The width of the watermark, the default value of `content` is its own width                     | ^[number]                        | 120                        |
+| height  | The height of the watermark, the default value of `content` is its own height                   | ^[number]                        | 64                         |
+| rotate  | When the watermark is drawn, the rotation Angle, unit `°`                                       | ^[number]                        | -22                        |
+| zIndex  | The z-index of the appended watermark element                                                   | ^[number]                        | 9                          |
+| image   | Image source, it is recommended to export 2x or 3x image, high priority                         | ^[string]                        | -                          |
+| content | Watermark text content                                                                          | ^[string] \| ^[object]`string[]` | -                          |
+| font    | Text style                                                                                      | [Font](#font)                    | [Font](#font)              |
+| gap     | The spacing between watermarks                                                                  | ^[object]`[number, number]`      | \[100, 100\]               |
+| offset  | The offset of the watermark from the upper left corner of the container. The default is `gap/2` | ^[object]`[number, number]`      | \[gap\[0\]/2, gap\[1\]/2\] |
 
 ### Font
 
 | Name       | Description | Type                                                 | Default         |
 | ---------- | ----------- | ---------------------------------------------------- | --------------- |
-| color      | font color  | string                                               | rgba(0,0,0,.15) |
-| fontSize   | font size   | number                                               | 16              |
+| color      | font color  | ^[string]                                            | rgba(0,0,0,.15) |
+| fontSize   | font size   | ^[number]                                            | 16              |
 | fontWeight | font weight | ^[enum]`'normal \| 'light' \| 'weight' \| number`    | normal          |
-| fontFamily | font family | string                                               | sans-serif      |
+| fontFamily | font family | ^[string]                                            | sans-serif      |
 | fontStyle  | font style  | ^[enum]`'none' \| 'normal' \| 'italic' \| 'oblique'` | normal          |

--- a/docs/en-US/component/watermark.md
+++ b/docs/en-US/component/watermark.md
@@ -1,0 +1,75 @@
+---
+title: Watermark
+lang: en-US
+---
+
+# Watermark
+
+Add specific text or patterns to the page.
+
+## Basic usage
+
+The most basic usage
+
+:::demo
+
+watermark/basic
+
+:::
+
+## Multi-line watermark
+
+Use "content" to set an array of strings to specify multi-line text watermark content.
+
+:::demo
+
+watermark/multi-line
+
+:::
+
+## Image watermark
+
+Specify the image address via 'image'. To ensure that the image is high definition and not stretched, set the width and height, and upload at least twice the width and height of the logo image address.
+
+:::demo
+
+watermark/image
+
+:::
+
+## Custom configuration
+
+Preview the watermark effect by configuring custom parameters.
+
+:::demo
+
+watermark/custom
+
+:::
+
+## Watermark API
+
+### Watermark Attributes
+
+
+| Name    | Description                                                                                     | Type               | Default                    |
+| ------- | ----------------------------------------------------------------------------------------------- | ------------------ | -------------------------- |
+| width   | The width of the watermark, the default value of `content` is its own width                     | number             | 120                        |
+| height  | The height of the watermark, the default value of `content` is its own height                   | number             | 64                         |
+| rotate  | When the watermark is drawn, the rotation Angle, unit `°`                                       | number             | -22                        |
+| zIndex  | The z-index of the appended watermark element                                                   | number             | 9                          |
+| image   | Image source, it is recommended to export 2x or 3x image, high priority                         | string             | -                          |
+| content | Watermark text content                                                                          | string \| string[] | -                          |
+| font    | Text style                                                                                      | [Font](#font)      | [Font](#font)              |
+| gap     | The spacing between watermarks                                                                  | \[number, number\] | \[100, 100\]               |
+| offset  | The offset of the watermark from the upper left corner of the container. The default is `gap/2` | \[number, number\] | \[gap\[0\]/2, gap\[1\]/2\] |
+
+### Font
+
+| Name       | Description | Type                                                 | Default         |
+| ---------- | ----------- | ---------------------------------------------------- | --------------- |
+| color      | font color  | string                                               | rgba(0,0,0,.15) |
+| fontSize   | font size   | number                                               | 16              |
+| fontWeight | font weight | ^[enum]`'normal \| 'light' \| 'weight' \| number`    | normal          |
+| fontFamily | font family | string                                               | sans-serif      |
+| fontStyle  | font style  | ^[enum]`'none' \| 'normal' \| 'italic' \| 'oblique'` | normal          |

--- a/docs/en-US/component/watermark.md
+++ b/docs/en-US/component/watermark.md
@@ -69,6 +69,6 @@ watermark/custom
 | ---------- | ----------- | ---------------------------------------------------- | --------------- |
 | color      | font color  | ^[string]                                            | rgba(0,0,0,.15) |
 | fontSize   | font size   | ^[number]                                            | 16              |
-| fontWeight | font weight | ^[enum]`'normal \| 'light' \| 'weight' \| number`    | normal          |
+| fontWeight | font weight | ^[enum]`'normal' \| 'light' \| 'weight' \| number`   | normal          |
 | fontFamily | font family | ^[string]                                            | sans-serif      |
 | fontStyle  | font style  | ^[enum]`'none' \| 'normal' \| 'italic' \| 'oblique'` | normal          |

--- a/docs/examples/datetime-picker/date-and-time-formats-panel.vue
+++ b/docs/examples/datetime-picker/date-and-time-formats-panel.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="demo-datetime-picker">
+    <div class="block">
+      <el-date-picker
+        v-model="value1"
+        type="datetime"
+        placeholder="Pick a Date"
+        format="YYYY-MM-DD HH:mm:ss"
+        date-format="MMM DD, YYYY"
+        time-format="HH:mm"
+      />
+    </div>
+    <div class="line" />
+    <div class="block">
+      <el-date-picker
+        v-model="value2"
+        type="datetimerange"
+        start-placeholder="Start date"
+        end-placeholder="End date"
+        format="YYYY-MM-DD HH:mm:ss"
+        date-format="YYYY/MM/DD ddd"
+        time-format="A hh:mm:ss"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+const value1 = ref('')
+const value2 = ref('')
+</script>
+<style scoped>
+.demo-datetime-picker {
+  display: flex;
+  width: 100%;
+  padding: 0;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  align-items: stretch;
+}
+.demo-datetime-picker .block {
+  padding: 30px 0;
+  text-align: center;
+}
+.line {
+  width: 1px;
+  background-color: var(--el-border-color);
+}
+</style>

--- a/docs/examples/image/image-preview.vue
+++ b/docs/examples/image/image-preview.vue
@@ -4,6 +4,8 @@
       style="width: 100px; height: 100px"
       :src="url"
       :zoom-rate="1.2"
+      :max-scale="7"
+      :min-scale="0.2"
       :preview-src-list="srcList"
       :initial-index="4"
       fit="cover"

--- a/docs/examples/select-v2/use-valueKey.vue
+++ b/docs/examples/select-v2/use-valueKey.vue
@@ -3,7 +3,7 @@
     v-model="value"
     :options="options"
     placeholder="Please select"
-    value-key="value.name"
+    value-key="name"
   />
 </template>
 
@@ -11,7 +11,7 @@
 import { ref } from 'vue'
 const initials = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
 
-const value = ref()
+const value = ref({ name: 'Option 1', test: 'test 0' })
 const options = Array.from({ length: 1000 }).map((_, idx) => ({
   value: {
     name: `Option ${idx + 1}`,

--- a/docs/examples/text/truncated.vue
+++ b/docs/examples/text/truncated.vue
@@ -1,8 +1,13 @@
 <template>
-  <el-text class="w-100px" truncated>Self element set width 100px</el-text>
-  <el-row>
-    <el-col :span="4">
-      <el-text truncated>Squeezed by parent element</el-text>
-    </el-col>
+  <el-text class="w-150px mb-2" truncated>
+    Self element set width 100px
+  </el-text>
+  <el-row class="w-150px mb-2">
+    <el-text truncated>Squeezed by parent element</el-text>
   </el-row>
+  <el-text line-clamp="2">
+    The -webkit-line-clamp CSS property<br />
+    allows limiting of the contents of<br />
+    a block to the specified number of lines.
+  </el-text>
 </template>

--- a/docs/examples/watermark/basic.vue
+++ b/docs/examples/watermark/basic.vue
@@ -1,0 +1,5 @@
+<template>
+  <el-watermark>
+    <div style="height: 500px" />
+  </el-watermark>
+</template>

--- a/docs/examples/watermark/custom.vue
+++ b/docs/examples/watermark/custom.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { reactive } from 'vue'
+
+const config = reactive({
+  content: 'Element Plus',
+  font: {
+    fontSize: 16,
+    color: 'rgba(0, 0, 0, 0.15)',
+  },
+  zIndex: -1,
+  rotate: -22,
+  gap: [100, 100] as [number, number],
+  offset: [] as unknown as [number, number],
+})
+</script>
+
+<template>
+  <div class="wrapper">
+    <el-watermark
+      class="watermark"
+      :content="config.content"
+      :font="config.font"
+      :z-index="config.zIndex"
+      :rotate="config.rotate"
+      :gap="config.gap"
+      :offset="config.offset"
+    >
+      <div class="demo">
+        <h1>Element Plus</h1>
+        <h2>a Vue 3 based component library for designers and developers</h2>
+        <img src="/images/hamburger.png" alt="示例图片" />
+      </div>
+    </el-watermark>
+    <el-form
+      class="form"
+      :model="config"
+      label-position="top"
+      label-width="50px"
+    >
+      <el-form-item label="Content">
+        <el-input v-model="config.content" />
+      </el-form-item>
+      <el-form-item label="Color">
+        <el-color-picker v-model="config.font.color" show-alpha />
+      </el-form-item>
+      <el-form-item label="FontSize">
+        <el-slider v-model="config.font.fontSize" />
+      </el-form-item>
+      <el-form-item label="zIndex">
+        <el-slider v-model="config.zIndex" />
+      </el-form-item>
+      <el-form-item label="Rotate">
+        <el-slider v-model="config.rotate" :min="-180" :max="180" />
+      </el-form-item>
+      <el-form-item label="Gap">
+        <el-space>
+          <el-input-number v-model="config.gap[0]" controls-position="right" />
+          <el-input-number v-model="config.gap[1]" controls-position="right" />
+        </el-space>
+      </el-form-item>
+      <el-form-item label="Offset">
+        <el-space>
+          <el-input-number
+            v-model="config.offset[0]"
+            placeholder="offsetLeft"
+            controls-position="right"
+          />
+          <el-input-number
+            v-model="config.offset[1]"
+            placeholder="offsetTop"
+            controls-position="right"
+          />
+        </el-space>
+      </el-form-item>
+    </el-form>
+  </div>
+</template>
+
+<style scoped>
+.wrapper {
+  display: flex;
+}
+.watermark {
+  display: flex;
+  flex: auto;
+}
+.demo {
+  flex: auto;
+}
+.form {
+  width: 330px;
+  margin-left: 20px;
+  border-left: 1px solid #eee;
+  padding-left: 20px;
+}
+
+img {
+  z-index: 10;
+  width: 100%;
+  max-width: 300px;
+  position: relative;
+}
+</style>

--- a/docs/examples/watermark/image.vue
+++ b/docs/examples/watermark/image.vue
@@ -1,0 +1,9 @@
+<template>
+  <el-watermark
+    :width="130"
+    :height="30"
+    image="https://element-plus.org/images/element-plus-logo.svg"
+  >
+    <div style="height: 500px" />
+  </el-watermark>
+</template>

--- a/docs/examples/watermark/multi-line.vue
+++ b/docs/examples/watermark/multi-line.vue
@@ -1,0 +1,5 @@
+<template>
+  <el-watermark :content="['Element+', 'Element Plus']">
+    <div style="height: 500px" />
+  </el-watermark>
+</template>

--- a/packages/components/alert/__tests__/alert.test.tsx
+++ b/packages/components/alert/__tests__/alert.test.tsx
@@ -34,7 +34,11 @@ describe('Alert.vue', () => {
   })
 
   test('title slot', () => {
-    const wrapper = mount(() => <Alert title={AXIOM} />)
+    const wrapper = mount(Alert, {
+      slots: {
+        title: AXIOM,
+      },
+    })
     expect(wrapper.find('.el-alert__title').text()).toEqual(AXIOM)
   })
 

--- a/packages/components/carousel/__tests__/carousel.test.tsx
+++ b/packages/components/carousel/__tests__/carousel.test.tsx
@@ -249,7 +249,6 @@ describe('Carousel', () => {
     })
 
     await nextTick()
-
     expect(items[0].classList.contains('is-active')).toBeTruthy()
 
     const container = wrapper.find<HTMLElement>(

--- a/packages/components/carousel/src/carousel.vue
+++ b/packages/components/carousel/src/carousel.vue
@@ -39,11 +39,13 @@
           </ElIcon>
         </button>
       </transition>
+      <PlaceholderItem />
       <slot />
     </div>
     <ul v-if="indicatorPosition !== 'none'" :class="indicatorsClasses">
       <li
         v-for="(item, index) in items"
+        v-show="isTwoLengthShow(index)"
         :key="index"
         :class="[
           ns.e('indicator'),
@@ -94,6 +96,8 @@ const {
   setActiveItem,
   prev,
   next,
+  PlaceholderItem,
+  isTwoLengthShow,
   throttledArrowClick,
   throttledIndicatorHover,
 } = useCarousel(props, emit, COMPONENT_NAME)

--- a/packages/components/carousel/src/use-carousel.ts
+++ b/packages/components/carousel/src/use-carousel.ts
@@ -212,7 +212,7 @@ export const useCarousel = (
 
   function resetTimer() {
     pauseTimer()
-    startTimer()
+    if (!props.pauseOnHover) startTimer()
   }
 
   function setContainerHeight(height: number) {

--- a/packages/components/carousel/src/use-carousel.ts
+++ b/packages/components/carousel/src/use-carousel.ts
@@ -1,17 +1,19 @@
 import {
   computed,
   getCurrentInstance,
+  isVNode,
   onBeforeUnmount,
   onMounted,
   provide,
   ref,
   shallowRef,
   unref,
+  useSlots,
   watch,
 } from 'vue'
 import { throttle } from 'lodash-unified'
 import { useResizeObserver } from '@vueuse/core'
-import { debugWarn, isString } from '@element-plus/utils'
+import { debugWarn, flattedChildren, isString } from '@element-plus/utils'
 import { useOrderedChildren } from '@element-plus/hooks'
 import { carouselContextKey } from './constants'
 
@@ -35,12 +37,15 @@ export const useCarousel = (
     'ElCarouselItem'
   )
 
+  const slots = useSlots()
+
   // refs
   const activeIndex = ref(-1)
   const timer = ref<ReturnType<typeof setInterval> | null>(null)
   const hover = ref(false)
   const root = ref<HTMLDivElement>()
   const containerHeight = ref<number>(0)
+  const isItemsTwoLength = ref(true)
 
   // computed
   const arrowDisplay = computed(
@@ -78,6 +83,11 @@ export const useCarousel = (
   const throttledIndicatorHover = throttle((index: number) => {
     handleIndicatorHover(index)
   }, THROTTLE_TIME)
+
+  const isTwoLengthShow = (index: number) => {
+    if (!isItemsTwoLength.value) return true
+    return activeIndex.value <= 1 ? index <= 1 : index > 1
+  }
 
   function pauseTimer() {
     if (timer.value) {
@@ -210,11 +220,36 @@ export const useCarousel = (
     containerHeight.value = height
   }
 
+  function PlaceholderItem() {
+    // fix: https://github.com/element-plus/element-plus/issues/12139
+    const defaultSlots = slots.default?.()
+    if (!defaultSlots) return null
+
+    const flatSlots = flattedChildren(defaultSlots)
+
+    const carouselItemsName = 'ElCarouselItem'
+
+    const normalizeSlots = flatSlots.filter((slot) => {
+      return isVNode(slot) && (slot.type as any).name === carouselItemsName
+    })
+
+    if (normalizeSlots?.length === 2 && props.loop && !isCardType.value) {
+      isItemsTwoLength.value = true
+      return normalizeSlots
+    }
+    isItemsTwoLength.value = false
+    return null
+  }
+
   // watch
   watch(
     () => activeIndex.value,
     (current, prev) => {
       resetItemPosition(prev)
+      if (isItemsTwoLength.value) {
+        current = current % 2
+        prev = prev % 2
+      }
       if (prev > -1) {
         emit('change', current, prev)
       }
@@ -287,6 +322,7 @@ export const useCarousel = (
     items,
     isVertical,
     containerStyle,
+    isItemsTwoLength,
     handleButtonEnter,
     handleButtonLeave,
     handleIndicatorClick,
@@ -295,6 +331,8 @@ export const useCarousel = (
     setActiveItem,
     prev,
     next,
+    PlaceholderItem,
+    isTwoLengthShow,
     throttledArrowClick,
     throttledIndicatorHover,
   }

--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -21,6 +21,11 @@ describe('Checkbox', () => {
     expect(wrapper.classes('is-checked')).toBe(false)
   })
 
+  test('label set to number 0', async () => {
+    const wrapper = mount(() => <Checkbox label={0} />)
+    expect(wrapper.find('.el-checkbox__label').text()).toBe('0')
+  })
+
   describe('no v-model', () => {
     test('checkbox without label', async () => {
       const checked = ref(false)

--- a/packages/components/checkbox/src/checkbox.ts
+++ b/packages/components/checkbox/src/checkbox.ts
@@ -20,6 +20,7 @@ export const checkboxProps = {
    */
   label: {
     type: [String, Boolean, Number, Object],
+    default: undefined,
   },
   /**
    * @description Set indeterminate state, only responsible for style control

--- a/packages/components/checkbox/src/checkbox.vue
+++ b/packages/components/checkbox/src/checkbox.vue
@@ -5,19 +5,14 @@
     :aria-controls="indeterminate ? controls : null"
     @click="onClickRoot"
   >
-    <span
-      :class="spanKls"
-      :tabindex="indeterminate ? 0 : undefined"
-      :role="indeterminate ? 'checkbox' : undefined"
-      :aria-checked="indeterminate ? 'mixed' : undefined"
-    >
+    <span :class="spanKls">
       <input
         v-if="trueLabel || falseLabel"
         :id="inputId"
         v-model="model"
         :class="ns.e('original')"
         type="checkbox"
-        :aria-hidden="indeterminate ? 'true' : 'false'"
+        :indeterminate="indeterminate"
         :name="name"
         :tabindex="tabindex"
         :disabled="isDisabled"
@@ -34,7 +29,7 @@
         v-model="model"
         :class="ns.e('original')"
         type="checkbox"
-        :aria-hidden="indeterminate ? 'true' : 'false'"
+        :indeterminate="indeterminate"
         :disabled="isDisabled"
         :value="label"
         :name="name"

--- a/packages/components/checkbox/src/composables/use-checkbox-status.ts
+++ b/packages/components/checkbox/src/composables/use-checkbox-status.ts
@@ -1,5 +1,5 @@
 import { computed, inject, ref, toRaw } from 'vue'
-import { isEqual } from 'lodash-unified'
+import { isEqual, isNil } from 'lodash-unified'
 import { useFormSize } from '@element-plus/components/form'
 import { isArray, isBoolean, isObject } from '@element-plus/utils'
 import { checkboxGroupContextKey } from '../constants'
@@ -41,7 +41,7 @@ export const useCheckboxStatus = (
   const checkboxSize = useFormSize(computed(() => checkboxGroup?.size?.value))
 
   const hasOwnLabel = computed<boolean>(() => {
-    return !!(slots.default || props.label)
+    return !!slots.default || !isNil(props.label)
   })
 
   return {

--- a/packages/components/color-picker/__tests__/color-picker.test.tsx
+++ b/packages/components/color-picker/__tests__/color-picker.test.tsx
@@ -453,4 +453,20 @@ describe('Color-picker', () => {
       expect(formItem.attributes().role).toBe('group')
     })
   })
+
+  it('it will target the focus & blur', async () => {
+    const focusHandler = vi.fn()
+    const blurHandler = vi.fn()
+    const wrapper = mount(() => (
+      <ColorPicker onFocus={focusHandler} onBlur={blurHandler} />
+    ))
+
+    await nextTick()
+    await wrapper.find('.el-color-picker').trigger('focus')
+    expect(focusHandler).toHaveBeenCalledTimes(1)
+
+    await wrapper.find('.el-color-picker').trigger('blur')
+    expect(blurHandler).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
 })

--- a/packages/components/color-picker/src/color-picker.ts
+++ b/packages/components/color-picker/src/color-picker.ts
@@ -70,6 +70,8 @@ export const colorPickerEmits = {
   [UPDATE_MODEL_EVENT]: (val: string | null) => isString(val) || isNil(val),
   [CHANGE_EVENT]: (val: string | null) => isString(val) || isNil(val),
   activeChange: (val: string | null) => isString(val) || isNil(val),
+  focus: (event: FocusEvent) => event instanceof FocusEvent,
+  blur: (event: FocusEvent) => event instanceof FocusEvent,
 }
 
 export type ColorPickerProps = ExtractPropTypes<typeof colorPickerProps>

--- a/packages/components/color-picker/src/color-picker.vue
+++ b/packages/components/color-picker/src/color-picker.vue
@@ -215,7 +215,7 @@ function setShowPicker(value: boolean) {
   showPicker.value = value
 }
 
-const debounceSetShowPicker = debounce(setShowPicker, 100)
+const debounceSetShowPicker = debounce(setShowPicker, 100, { leading: true })
 
 function show() {
   if (colorDisabled.value) return

--- a/packages/components/date-picker/__tests__/date-time-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-time-picker.test.tsx
@@ -28,8 +28,16 @@ describe('Datetime Picker', () => {
   it('both picker show correct formated value (extract date-format and time-format from format property', async () => {
     const value = ref(new Date(2018, 2, 5, 10, 15, 24))
     const format = ref('YYYY/MM/DD HH:mm A')
+    const dateFormat = ref('')
+    const timeFormat = ref('')
     const wrapper = _mount(() => (
-      <DatePicker v-model={value.value} type="datetime" format={format.value} />
+      <DatePicker
+        v-model={value.value}
+        type="datetime"
+        format={format.value}
+        dateFormat={dateFormat.value}
+        timeFormat={timeFormat.value}
+      />
     ))
 
     const input = wrapper.find('input')
@@ -52,6 +60,12 @@ describe('Datetime Picker', () => {
     await nextTick()
     expect(dateInput.value).toBe('03-05-2018')
     expect(timeInput.value).toBe('10 am')
+
+    dateFormat.value = 'YYYY/MM/DD ddd'
+    timeFormat.value = 'A hh:mm:ss'
+    await nextTick()
+    expect(dateInput.value).toBe('2018/03/05 Mon')
+    expect(timeInput.value).toBe('AM 10:15:24')
   })
 
   it('both picker show correct value', async () => {
@@ -378,12 +392,16 @@ describe('Datetimerange', () => {
       new Date(2000, 10, 8, 10, 10),
       new Date(2000, 10, 11, 10, 10),
     ])
+    const dateFormat = ref('')
+    const timeFormat = ref('')
     const wrapper = _mount(() => (
       <DatePicker
         v-model={value.value}
         type="datetimerange"
         default-time={new Date(2020, 1, 1, 1, 1, 1)}
         format="YYYY/MM/DD HH:mm A"
+        dateFormat={dateFormat.value}
+        timeFormat={timeFormat.value}
       />
     ))
 
@@ -436,6 +454,14 @@ describe('Datetimerange', () => {
     expect((left.timeInput as HTMLInputElement).value).toBe('01:01 AM')
     expect((right.dateInput as HTMLInputElement).value).toBe('2000/12/01')
     expect((right.timeInput as HTMLInputElement).value).toBe('01:01 AM')
+
+    dateFormat.value = 'YYYY/MM/DD ddd'
+    timeFormat.value = 'A hh:mm:ss'
+    await nextTick()
+    expect((left.dateInput as HTMLInputElement).value).toBe('2000/11/01 Wed')
+    expect((left.timeInput as HTMLInputElement).value).toBe('AM 01:01:01')
+    expect((right.dateInput as HTMLInputElement).value).toBe('2000/12/01 Fri')
+    expect((right.timeInput as HTMLInputElement).value).toBe('AM 01:01:01')
   })
 
   it('input date', async () => {

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -493,11 +493,11 @@ const changeToNow = () => {
 }
 
 const timeFormat = computed(() => {
-  return extractTimeFormat(props.format)
+  return props.timeFormat || extractTimeFormat(props.format)
 })
 
 const dateFormat = computed(() => {
-  return extractDateFormat(props.format)
+  return props.dateFormat || extractDateFormat(props.format)
 })
 
 const visibleTime = computed(() => {

--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -388,11 +388,11 @@ const maxVisibleTime = computed(() => {
 })
 
 const timeFormat = computed(() => {
-  return extractTimeFormat(format)
+  return props.timeFormat || extractTimeFormat(format)
 })
 
 const dateFormat = computed(() => {
-  return extractDateFormat(format)
+  return props.dateFormat || extractDateFormat(format)
 })
 
 const isValidValue = (date: [Dayjs, Dayjs]) => {

--- a/packages/components/date-picker/src/props/shared.ts
+++ b/packages/components/date-picker/src/props/shared.ts
@@ -44,6 +44,8 @@ export const panelSharedProps = buildProps({
     required: true,
     values: datePickTypes,
   },
+  dateFormat: String,
+  timeFormat: String,
 } as const)
 
 export const panelRangeSharedProps = buildProps({

--- a/packages/components/descriptions/src/description-item.ts
+++ b/packages/components/descriptions/src/description-item.ts
@@ -4,34 +4,58 @@ import { buildProps } from '@element-plus/utils'
 import type { ExtractPropTypes, Slot, VNode } from 'vue'
 
 const descriptionItemProps = buildProps({
+  /**
+   * @description label text
+   */
   label: {
     type: String,
     default: '',
   },
+  /**
+   * @description colspan of column
+   */
   span: {
     type: Number,
     default: 1,
   },
+  /**
+   * @description column width, the width of the same column in different rows is set by the max value (If no `border`, width contains label and content)
+   */
   width: {
     type: [String, Number],
     default: '',
   },
+  /**
+   * @description column minimum width, columns with `width` has a fixed width, while columns with `min-width` has a width that is distributed in proportion (If no`border`, width contains label and content)
+   */
   minWidth: {
     type: [String, Number],
     default: '',
   },
+  /**
+   * @description column content alignment (If no `border`, effective for both label and content)
+   */
   align: {
     type: String,
     default: 'left',
   },
+  /**
+   * @description column label alignment, if omitted, the value of the above `align` attribute will be applied (If no `border`, please use `align` attribute)
+   */
   labelAlign: {
     type: String,
     default: '',
   },
+  /**
+   * @description column content custom class name
+   */
   className: {
     type: String,
     default: '',
   },
+  /**
+   * @description column label custom class name
+   */
   labelClassName: {
     type: String,
     default: '',

--- a/packages/components/descriptions/src/description.ts
+++ b/packages/components/descriptions/src/description.ts
@@ -4,24 +4,42 @@ import { useSizeProp } from '@element-plus/hooks'
 import type Description from './description.vue'
 
 export const descriptionProps = buildProps({
+  /**
+   * @description with or without border
+   */
   border: {
     type: Boolean,
     default: false,
   },
+  /**
+   * @description numbers of `Descriptions Item` in one line
+   */
   column: {
     type: Number,
     default: 3,
   },
+  /**
+   * @description direction of list
+   */
   direction: {
     type: String,
     values: ['horizontal', 'vertical'],
     default: 'horizontal',
   },
+  /**
+   * @description size of list
+   */
   size: useSizeProp,
+  /**
+   * @description title text, display on the top left
+   */
   title: {
     type: String,
     default: '',
   },
+  /**
+   * @description extra text, display on the top right
+   */
   extra: {
     type: String,
     default: '',

--- a/packages/components/image-viewer/src/image-viewer.ts
+++ b/packages/components/image-viewer/src/image-viewer.ts
@@ -64,6 +64,20 @@ export const imageViewerProps = buildProps({
     type: Number,
     default: 1.2,
   },
+  /**
+   * @description the min scale of the image viewer zoom event.
+   */
+  minScale: {
+    type: Number,
+    default: 0.2,
+  },
+  /**
+   * @description the max scale of the image viewer zoom event.
+   */
+  maxScale: {
+    type: Number,
+    default: 7,
+  },
 } as const)
 export type ImageViewerProps = ExtractPropTypes<typeof imageViewerProps>
 

--- a/packages/components/image-viewer/src/image-viewer.vue
+++ b/packages/components/image-viewer/src/image-viewer.vue
@@ -322,6 +322,7 @@ function next() {
 
 function handleActions(action: ImageViewerAction, options = {}) {
   if (loading.value) return
+  const { minScale, maxScale } = props
   const { zoomRate, rotateDeg, enableTransition } = {
     zoomRate: props.zoomRate,
     rotateDeg: 90,
@@ -330,14 +331,14 @@ function handleActions(action: ImageViewerAction, options = {}) {
   }
   switch (action) {
     case 'zoomOut':
-      if (transform.value.scale > 0.2) {
+      if (transform.value.scale > minScale) {
         transform.value.scale = Number.parseFloat(
           (transform.value.scale / zoomRate).toFixed(3)
         )
       }
       break
     case 'zoomIn':
-      if (transform.value.scale < 7) {
+      if (transform.value.scale < maxScale) {
         transform.value.scale = Number.parseFloat(
           (transform.value.scale * zoomRate).toFixed(3)
         )

--- a/packages/components/image/src/image.ts
+++ b/packages/components/image/src/image.ts
@@ -89,6 +89,20 @@ export const imageProps = buildProps({
     type: Number,
     default: 1.2,
   },
+  /**
+   * @description the min scale of the image viewer zoom event.
+   */
+  minScale: {
+    type: Number,
+    default: 0.2,
+  },
+  /**
+   * @description the max scale of the image viewer zoom event.
+   */
+  maxScale: {
+    type: Number,
+    default: 7,
+  },
 } as const)
 export type ImageProps = ExtractPropTypes<typeof imageProps>
 

--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -28,6 +28,8 @@
         :initial-index="imageIndex"
         :infinite="infinite"
         :zoom-rate="zoomRate"
+        :min-scale="minScale"
+        :max-scale="maxScale"
         :url-list="previewSrcList"
         :hide-on-click-modal="hideOnClickModal"
         :teleported="previewTeleported"

--- a/packages/components/menu/src/sub-menu.ts
+++ b/packages/components/menu/src/sub-menu.ts
@@ -30,7 +30,7 @@ import useMenu from './use-menu'
 import { useMenuCssVar } from './use-menu-css-var'
 
 import type { Placement } from '@element-plus/components/popper'
-import type { CSSProperties, ExtractPropTypes, VNodeArrayChildren } from 'vue'
+import type { ExtractPropTypes, VNodeArrayChildren } from 'vue'
 import type { MenuProvider, SubMenuProvider } from './types'
 
 export const subMenuProps = buildProps({
@@ -187,9 +187,6 @@ export default defineComponent({
       return isActive
     })
 
-    const backgroundColor = computed(() => rootMenu.props.backgroundColor || '')
-    const activeTextColor = computed(() => rootMenu.props.activeTextColor || '')
-    const textColor = computed(() => rootMenu.props.textColor || '')
     const mode = computed(() => rootMenu.props.mode)
     const item = reactive({
       index: props.index,
@@ -198,21 +195,6 @@ export default defineComponent({
     })
 
     const ulStyle = useMenuCssVar(rootMenu.props, subMenu.level + 1)
-    const titleStyle = computed<CSSProperties>(() => {
-      if (mode.value !== 'horizontal') {
-        return {
-          color: textColor.value,
-        }
-      }
-      return {
-        borderBottomColor: active.value
-          ? rootMenu.props.activeTextColor
-            ? activeTextColor.value
-            : ''
-          : 'transparent',
-        color: active.value ? activeTextColor.value : textColor.value,
-      }
-    })
 
     // methods
     const doDestroy = () =>
@@ -412,10 +394,6 @@ export default defineComponent({
                   'div',
                   {
                     class: nsSubMenu.e('title'),
-                    style: [
-                      titleStyle.value,
-                      { backgroundColor: backgroundColor.value },
-                    ],
                     onClick: handleClick,
                   },
                   titleTag
@@ -427,10 +405,6 @@ export default defineComponent({
               'div',
               {
                 class: nsSubMenu.e('title'),
-                style: [
-                  titleStyle.value,
-                  { backgroundColor: backgroundColor.value },
-                ],
                 ref: verticalTitleRef,
                 onClick: handleClick,
               },

--- a/packages/components/scrollbar/src/scrollbar.ts
+++ b/packages/components/scrollbar/src/scrollbar.ts
@@ -74,6 +74,25 @@ export const scrollbarProps = buildProps({
     type: Number,
     default: 20,
   },
+  /**
+   * @description id of view
+   */
+  id: String,
+  /**
+   * @description role of view
+   */
+  role: String,
+  /**
+   * @description aria-label of view
+   */
+  ariaLabel: String,
+  /**
+   * @description aria-orientation of view
+   */
+  ariaOrientation: {
+    type: String,
+    values: ['horizontal', 'vertical'],
+  },
 } as const)
 export type ScrollbarProps = ExtractPropTypes<typeof scrollbarProps>
 

--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -1,11 +1,20 @@
 <template>
   <div ref="scrollbarRef" :class="ns.b()">
-    <div ref="wrapRef" :class="wrapKls" :style="style" @scroll="handleScroll">
+    <div
+      ref="wrapRef"
+      :class="wrapKls"
+      :style="wrapStyle"
+      @scroll="handleScroll"
+    >
       <component
         :is="tag"
+        :id="id"
         ref="resizeRef"
         :class="resizeKls"
         :style="viewStyle"
+        :role="role"
+        :aria-label="ariaLabel"
+        :aria-orientation="ariaOrientation"
       >
         <slot />
       </component>
@@ -67,7 +76,7 @@ const barRef = ref<BarInstance>()
 const ratioY = ref(1)
 const ratioX = ref(1)
 
-const style = computed<StyleValue>(() => {
+const wrapStyle = computed<StyleValue>(() => {
   const style: CSSProperties = {}
   if (props.height) style.height = addUnit(props.height)
   if (props.maxHeight) style.maxHeight = addUnit(props.maxHeight)

--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -272,22 +272,19 @@ describe('Select', () => {
   it('default value is Object', async () => {
     const wrapper = createSelect({
       data: () => ({
-        valueKey: 'value',
-        value: {
-          value: '1',
-          label: 'option_a',
-        },
+        valueKey: 'id',
+        value: { id: 1 },
         options: [
           {
-            value: '1',
+            value: { id: 1 },
             label: 'option_a',
           },
           {
-            value: '2',
+            value: { id: 2 },
             label: 'option_b',
           },
           {
-            value: '3',
+            value: { id: 3 },
             label: 'option_c',
           },
         ],
@@ -298,9 +295,7 @@ describe('Select', () => {
     expect(wrapper.find(`.${PLACEHOLDER_CLASS_NAME}`).text()).toBe(
       vm.options[0].label
     )
-    expect(wrapper.find(`.${PLACEHOLDER_CLASS_NAME}`).text()).toBe(
-      vm.value.label
-    )
+    expect(vm.value).toEqual(vm.options[0].value)
   })
 
   it('sync set value and options', async () => {
@@ -352,22 +347,19 @@ describe('Select', () => {
         return {
           options: [
             {
-              id: 'id 1',
-              value: 'value 1',
+              value: { id: 1 },
               label: 'option 1',
             },
             {
-              id: 'id 2',
-              value: 'value 2',
+              value: { id: 2 },
               label: 'option 2',
             },
             {
-              id: 'id 3',
-              value: 'value 3',
+              value: { id: 3 },
               label: 'option 3',
             },
           ],
-          value: '',
+          value: undefined,
           valueKey: 'id',
         }
       },
@@ -378,12 +370,11 @@ describe('Select', () => {
     const options = getOptions()
     options[1].click()
     await nextTick()
-    expect(vm.value).toBe(vm.options[1].id)
-    vm.valueKey = 'value'
-    await nextTick()
+    expect(vm.value).toEqual(vm.options[1].value)
+
     options[2].click()
     await nextTick()
-    expect(vm.value).toBe(vm.options[2].value)
+    expect(vm.value).toEqual(vm.options[2].value)
   })
 
   it('disabled option', async () => {
@@ -616,18 +607,15 @@ describe('Select', () => {
           return {
             options: [
               {
-                id: 'id 1',
-                value: 'value 1',
+                value: { id: 1, value: 'a' },
                 label: 'option 1',
               },
               {
-                id: 'id 2',
-                value: 'value 2',
+                value: { id: 2, value: 'b' },
                 label: 'option 2',
               },
               {
-                id: 'id 3',
-                value: 'value 3',
+                value: { id: 3, value: 'c' },
                 label: 'option 3',
               },
             ],
@@ -644,13 +632,24 @@ describe('Select', () => {
       options[1].click()
       await nextTick()
       expect(vm.value.length).toBe(1)
-      expect(vm.value[0]).toBe(vm.options[1].id)
-      vm.valueKey = 'value'
-      await nextTick()
+      expect(vm.value).toContainEqual(vm.options[1].value)
       options[2].click()
       await nextTick()
       expect(vm.value.length).toBe(2)
-      expect(vm.value[1]).toBe(vm.options[2].value)
+      expect(vm.value).toContainEqual(vm.options[2].value)
+      options[2].click()
+      await nextTick()
+      expect(vm.value.length).toBe(1)
+      expect(vm.value).not.toContainEqual(vm.options[2].value)
+
+      vm.valueKey = 'value'
+      await nextTick()
+      expect(vm.value.length).toBe(1)
+      expect(vm.value).toContainEqual(vm.options[1].value)
+      options[0].click()
+      await nextTick()
+      expect(vm.value.length).toBe(2)
+      expect(vm.value).toContainEqual(vm.options[0].value)
     })
   })
 

--- a/packages/components/select-v2/src/select-dropdown.tsx
+++ b/packages/components/select-v2/src/select-dropdown.tsx
@@ -1,4 +1,12 @@
-import { computed, defineComponent, inject, ref, unref, watch } from 'vue'
+import {
+  computed,
+  defineComponent,
+  inject,
+  ref,
+  toRaw,
+  unref,
+  watch,
+} from 'vue'
 import { get } from 'lodash-unified'
 import { isObject, isUndefined } from '@element-plus/utils'
 import {
@@ -69,7 +77,7 @@ export default defineComponent({
       return (
         arr &&
         arr.some((item) => {
-          return get(item, valueKey) === get(target, valueKey)
+          return toRaw(get(item, valueKey)) === get(target, valueKey)
         })
       )
     }
@@ -83,11 +91,10 @@ export default defineComponent({
     }
 
     const isItemSelected = (modelValue: any[] | any, target: Option) => {
-      const { valueKey } = select.props
       if (select.props.multiple) {
-        return contains(modelValue, get(target, valueKey))
+        return contains(modelValue, target.value)
       }
-      return isEqual(modelValue, get(target, valueKey))
+      return isEqual(modelValue, target.value)
     }
 
     const isItemDisabled = (modelValue: any[] | any, selected: boolean) => {

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -755,7 +755,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
 
   // fix the problem that scrollTop is not reset in filterable mode
   watch(filteredOptions, () => {
-    return nextTick(menuRef.value.resetScrollTop)
+    return menuRef.value && nextTick(menuRef.value.resetScrollTop)
   })
 
   watch(

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -176,7 +176,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
     const valueMap = new Map()
 
     filteredOptions.value.forEach((option, index) => {
-      valueMap.set(getValueKey(option), { option, index })
+      valueMap.set(getValueKey(option.value), { option, index })
     })
     return valueMap
   })
@@ -409,7 +409,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
     if (props.multiple) {
       let selectedOptions = (props.modelValue as any[]).slice()
 
-      const index = getValueIndex(selectedOptions, getValueKey(option))
+      const index = getValueIndex(selectedOptions, option.value)
       if (index > -1) {
         selectedOptions = [
           ...selectedOptions.slice(0, index),
@@ -421,7 +421,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
         props.multipleLimit <= 0 ||
         selectedOptions.length < props.multipleLimit
       ) {
-        selectedOptions = [...selectedOptions, getValueKey(option)]
+        selectedOptions = [...selectedOptions, option.value]
         states.cachedOptions.push(option)
         selectNewOption(option)
         updateHoveringIndex(idx)
@@ -445,7 +445,7 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
     } else {
       selectedIndex.value = idx
       states.selectedLabel = option.label
-      update(getValueKey(option))
+      update(option.value)
       expanded.value = false
       states.isComposing = false
       states.isSilentBlur = byClick
@@ -457,20 +457,21 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
     }
   }
 
-  const deleteTag = (event: MouseEvent, tag: Option) => {
-    const { valueKey } = props
-    const index = (props.modelValue as Array<any>).indexOf(get(tag, valueKey))
+  const deleteTag = (event: MouseEvent, option: Option) => {
+    let selectedOptions = (props.modelValue as any[]).slice()
+
+    const index = getValueIndex(selectedOptions, option.value)
 
     if (index > -1 && !selectDisabled.value) {
-      const value = [
+      selectedOptions = [
         ...(props.modelValue as Array<unknown>).slice(0, index),
         ...(props.modelValue as Array<unknown>).slice(index + 1),
       ]
       states.cachedOptions.splice(index, 1)
-      update(value)
-      emit('remove-tag', get(tag, valueKey))
+      update(selectedOptions)
+      emit('remove-tag', option.value)
       states.softFocus = true
-      removeNewOption(tag)
+      removeNewOption(option)
       return nextTick(focusAndUpdatePopup)
     }
     event.stopPropagation()
@@ -673,8 +674,12 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
         states.previousValue = props.modelValue.toString()
 
         for (const value of props.modelValue) {
-          if (filteredOptionsValueMap.value.has(value)) {
-            const { index, option } = filteredOptionsValueMap.value.get(value)
+          const selectValue = getValueKey(value)
+
+          if (filteredOptionsValueMap.value.has(selectValue)) {
+            const { index, option } =
+              filteredOptionsValueMap.value.get(selectValue)
+
             states.cachedOptions.push(option)
             if (!initHovering) {
               updateHoveringIndex(index)
@@ -691,7 +696,8 @@ const useSelect = (props: ExtractPropTypes<typeof SelectProps>, emit) => {
         states.previousValue = props.modelValue
         const options = filteredOptions.value
         const selectedItemIndex = options.findIndex(
-          (option) => getValueKey(option) === getValueKey(props.modelValue)
+          (option) =>
+            getValueKey(option.value) === getValueKey(props.modelValue)
         )
         if (~selectedItemIndex) {
           states.selectedLabel = options[selectedItemIndex].label

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -2435,4 +2435,39 @@ describe('Select', () => {
       expect(wrapper.findAll('.el-tag').length).toBe(1)
     })
   })
+
+  it('It should generate accessible attributes', async () => {
+    wrapper = _mount(
+      `<el-select v-model="value">
+        <el-option label="label" value="1" />
+        <el-option label="disabled" value="2" disabled />
+      </el-select>`,
+      () => ({ value: '1' })
+    )
+
+    const dropdown = wrapper.findComponent({ name: 'ElSelectDropdown' })
+    const input = wrapper.find('input')
+    const list = dropdown.find('.el-select-dropdown__list')
+    const option = dropdown.find('.el-select-dropdown__item')
+    const disabledOption = dropdown.find(
+      '.el-select-dropdown__item:nth-child(2)'
+    )
+
+    expect(input.attributes('role')).toBe('combobox')
+    expect(input.attributes('aria-autocomplete')).toBe('none')
+    expect(input.attributes('aria-controls')).toBe(list.attributes('id'))
+    expect(input.attributes('aria-expanded')).toBe('false')
+    expect(input.attributes('aria-haspopup')).toBe('listbox')
+    expect(input.attributes('aria-activedescendant')).toBe('')
+
+    expect(list.attributes('id')).toBeTruthy()
+    expect(list.attributes('role')).toBe('listbox')
+    expect(list.attributes('aria-orientation')).toBe('vertical')
+
+    expect(option.attributes('id')).toBeTruthy()
+    expect(option.attributes('role')).toBe('option')
+    expect(option.attributes('aria-disabled')).toBe(undefined)
+    expect(option.attributes('aria-selected')).toBe('true')
+    expect(disabledOption.attributes('aria-disabled')).toBe('true')
+  })
 })

--- a/packages/components/select/src/option.vue
+++ b/packages/components/select/src/option.vue
@@ -1,7 +1,11 @@
 <template>
   <li
     v-show="visible"
+    :id="id"
     :class="containerKls"
+    role="option"
+    :aria-disabled="isDisabled || undefined"
+    :aria-selected="itemSelected"
     @mouseenter="hoverItem"
     @click.stop="selectOptionClick"
   >
@@ -23,7 +27,7 @@ import {
   toRefs,
   unref,
 } from 'vue'
-import { useNamespace } from '@element-plus/hooks'
+import { useId, useNamespace } from '@element-plus/hooks'
 import { useOption } from './useOption'
 import type { SelectOptionProxy } from './token'
 
@@ -52,6 +56,7 @@ export default defineComponent({
 
   setup(props) {
     const ns = useNamespace('select')
+    const id = useId()
 
     const containerKls = computed(() => [
       ns.be('dropdown', 'item'),
@@ -103,6 +108,7 @@ export default defineComponent({
 
     return {
       ns,
+      id,
       containerKls,
       currentLabel,
       itemSelected,

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -149,7 +149,13 @@
               :disabled="selectDisabled"
               :autocomplete="autocomplete"
               :style="inputStyle"
+              role="combobox"
+              :aria-activedescendant="hoverOption?.id || ''"
+              :aria-controls="contentId"
+              :aria-expanded="dropMenuVisible"
               :aria-label="ariaLabel"
+              aria-autocomplete="none"
+              aria-haspopup="listbox"
               @focus="handleFocus"
               @blur="handleBlur"
               @keyup="managePlaceholder"
@@ -166,7 +172,6 @@
               @input="debouncedQueryChange"
             />
           </div>
-          <!-- fix: https://github.com/element-plus/element-plus/issues/11415 -->
           <input
             v-if="isIOS && !multiple && filterable && readonly"
             ref="iOSInput"
@@ -192,7 +197,13 @@
             :validate-event="false"
             :class="[nsSelect.is('focus', visible)]"
             :tabindex="multiple && filterable ? -1 : undefined"
+            role="combobox"
+            :aria-activedescendant="hoverOption?.id || ''"
+            :aria-controls="contentId"
+            :aria-expanded="dropMenuVisible"
             :label="ariaLabel"
+            aria-autocomplete="none"
+            aria-haspopup="listbox"
             @focus="handleFocus"
             @blur="handleBlur"
             @input="debouncedOnInputChange"
@@ -240,11 +251,15 @@
         <el-select-menu>
           <el-scrollbar
             v-show="options.size > 0 && !loading"
+            :id="contentId"
             ref="scrollbar"
             tag="ul"
             :wrap-class="nsSelect.be('dropdown', 'wrap')"
             :view-class="nsSelect.be('dropdown', 'list')"
             :class="scrollbarKls"
+            role="listbox"
+            :aria-label="ariaLabel"
+            aria-orientation="vertical"
           >
             <el-option v-if="showNewOption" :value="query" :created="true" />
             <el-options @update-options="onOptionsRendered">
@@ -283,7 +298,7 @@ import {
 import { useResizeObserver } from '@vueuse/core'
 import { placements } from '@popperjs/core'
 import { ClickOutside } from '@element-plus/directives'
-import { useLocale, useNamespace } from '@element-plus/hooks'
+import { useId, useLocale, useNamespace } from '@element-plus/hooks'
 import ElInput from '@element-plus/components/input'
 import ElTooltip, {
   useTooltipContentProps,
@@ -550,10 +565,12 @@ export default defineComponent({
     const nsSelect = useNamespace('select')
     const nsInput = useNamespace('input')
     const { t } = useLocale()
+    const contentId = useId()
     const states = useSelectStates(props)
     const {
       optionList,
       optionsArray,
+      hoverOption,
       selectSize,
       readonly,
       handleResize,
@@ -833,6 +850,8 @@ export default defineComponent({
       showTagList,
       collapseTagList,
       tagTooltipRef,
+      contentId,
+      hoverOption,
     }
   },
 })

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -102,7 +102,7 @@ export const useSelect = (props, states: States, ctx) => {
   const scrollbar = ref<{
     handleScroll: () => void
   } | null>(null)
-  const hoverOption = ref(-1)
+  const hoverOption = ref()
   const queryChange = shallowRef<QueryChangeCtx>({ query: '' })
   const groupQueryChange = shallowRef('')
   const optionList = ref<string[]>([])
@@ -980,6 +980,7 @@ export const useSelect = (props, states: States, ctx) => {
   return {
     optionList,
     optionsArray,
+    hoverOption,
     selectSize,
     handleResize,
     debouncedOnInputChange,

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -407,7 +407,11 @@ export const useSelect = (props, states: States, ctx) => {
         originClientHeight ||
         (input.clientHeight > 0 ? input.clientHeight + 2 : 0)
       const _tags = tags.value
-      const gotSize = getComponentSize(selectSize.value || form?.size)
+      const cssVarOfSelectSize = getComputedStyle(input).getPropertyValue(
+        ns.cssVarName('input-height')
+      )
+      const gotSize =
+        cssVarOfSelectSize || getComponentSize(selectSize.value || form?.size)
 
       const sizeInMap =
         selectSize.value ||

--- a/packages/components/table/src/table-footer/index.ts
+++ b/packages/components/table/src/table-footer/index.ts
@@ -1,7 +1,6 @@
 // @ts-nocheck
 import { defineComponent, h } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
-import { hColgroup } from '../h-helper'
 import useStyle from './style-helper'
 import type { Store } from '../store'
 
@@ -56,14 +55,8 @@ export default defineComponent({
     }
   },
   render() {
-    const {
-      columns,
-      getCellStyles,
-      getCellClasses,
-      summaryMethod,
-      sumText,
-      ns,
-    } = this
+    const { columns, getCellStyles, getCellClasses, summaryMethod, sumText } =
+      this
     const data = this.store.states.data.value
     let sums = []
     if (summaryMethod) {
@@ -105,43 +98,31 @@ export default defineComponent({
       })
     }
     return h(
-      'table',
-      {
-        class: ns.e('footer'),
-        cellspacing: '0',
-        cellpadding: '0',
-        border: '0',
-      },
-      [
-        hColgroup({
-          columns,
-        }),
-        h('tbody', [
-          h('tr', {}, [
-            ...columns.map((column, cellIndex) =>
-              h(
-                'td',
-                {
-                  key: cellIndex,
-                  colspan: column.colSpan,
-                  rowspan: column.rowSpan,
-                  class: getCellClasses(columns, cellIndex),
-                  style: getCellStyles(column, cellIndex),
-                },
-                [
-                  h(
-                    'div',
-                    {
-                      class: ['cell', column.labelClassName],
-                    },
-                    [sums[cellIndex]]
-                  ),
-                ]
-              )
-            ),
-          ]),
+      h('tfoot', [
+        h('tr', {}, [
+          ...columns.map((column, cellIndex) =>
+            h(
+              'td',
+              {
+                key: cellIndex,
+                colspan: column.colSpan,
+                rowspan: column.rowSpan,
+                class: getCellClasses(columns, cellIndex),
+                style: getCellStyles(column, cellIndex),
+              },
+              [
+                h(
+                  'div',
+                  {
+                    class: ['cell', column.labelClassName],
+                  },
+                  [sums[cellIndex]]
+                ),
+              ]
+            )
+          ),
         ]),
-      ]
+      ])
     )
   },
 })

--- a/packages/components/table/src/table-header/index.ts
+++ b/packages/components/table/src/table-header/index.ts
@@ -65,7 +65,7 @@ export default defineComponent({
     const filterPanels = ref({})
     const { onColumnsChange, onScrollableChange } = useLayoutObserver(parent!)
     onMounted(async () => {
-      // Need double await, because udpateColumns is executed after nextTick for now
+      // Need double await, because updateColumns is executed after nextTick for now
       await nextTick()
       await nextTick()
       const { prop, order } = props.defaultSort

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -100,6 +100,7 @@
             />
             <table-footer
               v-if="showSummary && tableLayout === 'auto'"
+              :class="ns.e('body-footer')"
               :border="border"
               :default-sort="defaultSort"
               :store="store"

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -82,6 +82,7 @@
             <table-header
               v-if="showHeader && tableLayout === 'auto'"
               ref="tableHeaderRef"
+              :class="ns.e('body-header')"
               :border="border"
               :default-sort="defaultSort"
               :store="store"

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -98,6 +98,14 @@
               :store="store"
               :stripe="stripe"
             />
+            <table-footer
+              v-if="showSummary && tableLayout === 'auto'"
+              :border="border"
+              :default-sort="defaultSort"
+              :store="store"
+              :sum-text="computedSumText"
+              :summary-method="summaryMethod"
+            />
           </table>
           <div
             v-if="isEmpty"
@@ -119,20 +127,31 @@
         </el-scrollbar>
       </div>
       <div
-        v-if="showSummary"
+        v-if="showSummary && tableLayout === 'fixed'"
         v-show="!isEmpty"
         ref="footerWrapper"
         v-mousewheel="handleHeaderFooterMousewheel"
         :class="ns.e('footer-wrapper')"
       >
-        <table-footer
-          :border="border"
-          :default-sort="defaultSort"
-          :store="store"
+        <table
+          :class="ns.e('footer')"
+          cellspacing="0"
+          cellpadding="0"
+          border="0"
           :style="tableBodyStyles"
-          :sum-text="computedSumText"
-          :summary-method="summaryMethod"
-        />
+        >
+          <hColgroup
+            :columns="store.states.columns.value"
+            :table-layout="tableLayout"
+          />
+          <table-footer
+            :border="border"
+            :default-sort="defaultSort"
+            :store="store"
+            :sum-text="computedSumText"
+            :summary-method="summaryMethod"
+          />
+        </table>
       </div>
       <div v-if="border || isGroup" :class="ns.e('border-left-patch')" />
     </div>

--- a/packages/components/text/__tests__/text.test.tsx
+++ b/packages/components/text/__tests__/text.test.tsx
@@ -5,7 +5,43 @@ import Text from '../src/text.vue'
 const AXIOM = 'Rem is the best girl'
 
 describe('Text.vue', () => {
-  test('render text & class', () => {
+  test('create', () => {
+    const wrapper = mount(() => <Text />)
+
+    expect(wrapper.classes()).toContain('el-text')
+  })
+
+  test('type', () => {
+    const wrapper = mount(() => <Text type="success" />)
+
+    expect(wrapper.classes()).toContain('el-text--success')
+  })
+
+  test('size', () => {
+    const wrapper = mount(() => <Text size="large" />)
+
+    expect(wrapper.classes()).toContain('el-text--large')
+  })
+
+  test('truncated', () => {
+    const wrapper = mount(() => <Text truncated />)
+
+    expect(wrapper.classes()).toContain('is-truncated')
+  })
+
+  test('line-clamp', () => {
+    const wrapper = mount(() => <Text line-clamp="2" />)
+
+    expect(wrapper.classes()).toContain('is-line-clamp')
+  })
+
+  test('tag', () => {
+    const wrapper = mount(() => <Text tag="del" />)
+
+    expect(wrapper.vm.$el.tagName).toEqual('DEL')
+  })
+
+  test('default slot', () => {
     const wrapper = mount(() => (
       <Text
         v-slots={{
@@ -13,35 +49,7 @@ describe('Text.vue', () => {
         }}
       />
     ))
-    const vm = wrapper.vm
 
-    expect(vm.$el.classList.contains('el-text')).toEqual(true)
     expect(wrapper.text()).toEqual(AXIOM)
-  })
-
-  test('type', () => {
-    const wrapper = mount(() => <Text type="success" />)
-    const vm = wrapper.vm
-    expect(vm.$el.classList.contains('el-text--success')).toEqual(true)
-  })
-
-  test('size', () => {
-    const wrapper = mount(() => <Text size="large" />)
-    const vm = wrapper.vm
-    expect(vm.$el.className.includes('el-text--large')).toEqual(true)
-    expect(vm.$el.className.includes('el-text--default')).toEqual(false)
-    expect(vm.$el.className.includes('el-text--small')).toEqual(false)
-  })
-
-  test('truncated', () => {
-    const wrapper = mount(() => <Text truncated />)
-    const vm = wrapper.vm
-    expect(vm.$el.className.includes('is-truncated')).toEqual(true)
-  })
-
-  test('tag', () => {
-    const wrapper = mount(() => <Text tag="del" />)
-    const vm = wrapper.vm
-    expect(vm.$el.tagName).toEqual('DEL')
   })
 })

--- a/packages/components/text/src/text.ts
+++ b/packages/components/text/src/text.ts
@@ -1,6 +1,5 @@
 import { buildProps } from '@element-plus/utils'
 import { componentSizes } from '@element-plus/constants'
-import type Text from './text.vue'
 
 import type { ExtractPropTypes } from 'vue'
 
@@ -28,6 +27,12 @@ export const textProps = buildProps({
     type: Boolean,
   },
   /**
+   * @description maximum lines
+   */
+  lineClamp: {
+    type: [String, Number],
+  },
+  /**
    * @description custom element tag
    */
   tag: {
@@ -35,5 +40,5 @@ export const textProps = buildProps({
     default: 'span',
   },
 } as const)
+
 export type TextProps = ExtractPropTypes<typeof textProps>
-export type TextInstance = InstanceType<typeof Text>

--- a/packages/components/text/src/text.vue
+++ b/packages/components/text/src/text.vue
@@ -1,5 +1,9 @@
 <template>
-  <component :is="tag" :class="textKls">
+  <component
+    :is="tag"
+    :class="textKls"
+    :style="{ '-webkit-line-clamp': lineClamp }"
+  >
     <slot />
   </component>
 </template>
@@ -8,6 +12,7 @@
 import { computed } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { useFormSize } from '@element-plus/components/form'
+import { isUndefined } from '@element-plus/utils'
 import { textProps } from './text'
 
 defineOptions({
@@ -24,5 +29,6 @@ const textKls = computed(() => [
   ns.m(props.type),
   ns.m(textSize.value),
   ns.is('truncated', props.truncated),
+  ns.is('line-clamp', !isUndefined(props.lineClamp)),
 ])
 </script>

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -138,6 +138,8 @@
         :actual-visible="pickerActualVisible"
         :parsed-value="parsedValue"
         :format="format"
+        :date-format="dateFormat"
+        :time-format="timeFormat"
         :unlink-panels="unlinkPanels"
         :type="type"
         :default-value="defaultValue"

--- a/packages/components/time-picker/src/common/props.ts
+++ b/packages/components/time-picker/src/common/props.ts
@@ -56,6 +56,14 @@ export const timePickerDefaultProps = buildProps({
    */
   valueFormat: String,
   /**
+   * @description optional, format of the date displayed value in TimePicker's dropdown
+   */
+  dateFormat: String,
+  /**
+   * @description optional, format of the time displayed value in TimePicker's dropdown
+   */
+  timeFormat: String,
+  /**
    * @description type of the picker
    */
   type: {

--- a/packages/components/upload/src/upload-list.vue
+++ b/packages/components/upload/src/upload-list.vue
@@ -1,13 +1,5 @@
 <template>
-  <transition-group
-    tag="ul"
-    :class="[
-      nsUpload.b('list'),
-      nsUpload.bm('list', listType),
-      nsUpload.is('disabled', disabled),
-    ]"
-    :name="nsList.b()"
-  >
+  <transition-group tag="ul" :class="containerKls" :name="nsList.b()">
     <li
       v-for="file in files"
       :key="file.uid || file.name"
@@ -112,7 +104,7 @@
   </transition-group>
 </template>
 <script lang="ts" setup>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { ElIcon } from '@element-plus/components/icon'
 import {
   Check,
@@ -133,7 +125,7 @@ defineOptions({
   name: 'ElUploadList',
 })
 
-defineProps(uploadListProps)
+const props = defineProps(uploadListProps)
 const emit = defineEmits(uploadListEmits)
 
 const { t } = useLocale()
@@ -143,6 +135,12 @@ const nsList = useNamespace('list')
 const disabled = useFormDisabled()
 
 const focusing = ref(false)
+
+const containerKls = computed(() => [
+  nsUpload.b('list'),
+  nsUpload.bm('list', props.listType),
+  nsUpload.is('disabled', props.disabled),
+])
 
 const handleRemove = (file: UploadFile) => {
   emit('remove', file)

--- a/packages/components/upload/src/upload.ts
+++ b/packages/components/upload/src/upload.ts
@@ -81,17 +81,29 @@ export interface UploadHooks {
 export type UploadData = Mutable<Record<string, any>>
 
 export const uploadBaseProps = buildProps({
+  /**
+   * @description request URL
+   */
   action: {
     type: String,
     default: '#',
   },
+  /**
+   * @description request headers
+   */
   headers: {
     type: definePropType<Headers | Record<string, any>>(Object),
   },
+  /**
+   * @description set upload request method
+   */
   method: {
     type: String,
     default: 'post',
   },
+  /**
+   * @description additions options of request
+   */
   data: {
     type: definePropType<
       | Awaitable<UploadData>
@@ -99,85 +111,144 @@ export const uploadBaseProps = buildProps({
     >([Object, Function, Promise]),
     default: () => mutable({} as const),
   },
+  /**
+   * @description whether uploading multiple files is permitted
+   */
   multiple: {
     type: Boolean,
     default: false,
   },
+  /**
+   * @description key name for uploaded file
+   */
   name: {
     type: String,
     default: 'file',
   },
+  /**
+   * @description whether to activate drag and drop mode
+   */
   drag: {
     type: Boolean,
     default: false,
   },
+  /**
+   * @description whether cookies are sent
+   */
   withCredentials: Boolean,
+  /**
+   * @description whether to show the uploaded file list
+   */
   showFileList: {
     type: Boolean,
     default: true,
   },
+  /**
+   * @description accepted [file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-accept), will not work when `thumbnail-mode === true`
+   */
   accept: {
     type: String,
     default: '',
   },
-  type: {
-    type: String,
-    default: 'select',
-  },
+  /**
+   * @description default uploaded files
+   */
   fileList: {
     type: definePropType<UploadUserFile[]>(Array),
     default: () => mutable([] as const),
   },
+  /**
+   * @description whether to auto upload file
+   */
   autoUpload: {
     type: Boolean,
     default: true,
   },
+  /**
+   * @description type of file list
+   */
   listType: {
     type: String,
     values: uploadListTypes,
     default: 'text',
   },
+  /**
+   * @description override default xhr behavior, allowing you to implement your own upload-file's request
+   */
   httpRequest: {
     type: definePropType<UploadRequestHandler>(Function),
     default: ajaxUpload,
   },
+  /**
+   * @description whether to disable upload
+   */
   disabled: Boolean,
+  /**
+   * @description maximum number of uploads allowed
+   */
   limit: Number,
 } as const)
 
 export const uploadProps = buildProps({
   ...uploadBaseProps,
+  /**
+   * @description hook function before uploading with the file to be uploaded as its parameter. If `false` is returned or a `Promise` is returned and then is rejected, uploading will be aborted
+   */
   beforeUpload: {
     type: definePropType<UploadHooks['beforeUpload']>(Function),
     default: NOOP,
   },
+  /**
+   * @description hook function before removing a file with the file and file list as its parameters. If `false` is returned or a `Promise` is returned and then is rejected, removing will be aborted
+   */
   beforeRemove: {
     type: definePropType<UploadHooks['beforeRemove']>(Function),
   },
+  /**
+   * @description hook function when files are removed
+   */
   onRemove: {
     type: definePropType<UploadHooks['onRemove']>(Function),
     default: NOOP,
   },
+  /**
+   * @description hook function when select file or upload file success or upload file fail
+   */
   onChange: {
     type: definePropType<UploadHooks['onChange']>(Function),
     default: NOOP,
   },
+  /**
+   * @description hook function when clicking the uploaded files
+   */
   onPreview: {
     type: definePropType<UploadHooks['onPreview']>(Function),
     default: NOOP,
   },
+  /**
+   * @description hook function when uploaded successfully
+   */
   onSuccess: {
     type: definePropType<UploadHooks['onSuccess']>(Function),
     default: NOOP,
   },
+  /**
+   * @description hook function when some progress occurs
+   */
   onProgress: {
     type: definePropType<UploadHooks['onProgress']>(Function),
     default: NOOP,
   },
+  /**
+   * @description hook function when some errors occurs
+   */
   onError: {
     type: definePropType<UploadHooks['onError']>(Function),
     default: NOOP,
   },
+  /**
+   * @description hook function when limit is exceeded
+   */
   onExceed: {
     type: definePropType<UploadHooks['onExceed']>(Function),
     default: NOOP,

--- a/packages/components/watermark/__tests__/__snapshots__/watermark.test.tsx.snap
+++ b/packages/components/watermark/__tests__/__snapshots__/watermark.test.tsx.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1
+
+exports[`Watermark.vue > create 1`] = `"<div style=\\"position: relative;\\" class=\\"watermark\\">Rem is the best girl</div>"`;

--- a/packages/components/watermark/__tests__/watermark.test.tsx
+++ b/packages/components/watermark/__tests__/watermark.test.tsx
@@ -1,0 +1,22 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import Watermark from '../src/watermark.vue'
+
+const AXIOM = 'Rem is the best girl'
+
+describe('Watermark.vue', () => {
+  it('create', () => {
+    const wrapper = mount(() => (
+      <Watermark class="watermark">{AXIOM}</Watermark>
+    ))
+
+    expect(wrapper.classes()).toContain('watermark')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('slots', () => {
+    const wrapper = mount(() => <Watermark>{AXIOM}</Watermark>)
+
+    expect(wrapper.text()).toContain(AXIOM)
+  })
+})

--- a/packages/components/watermark/index.ts
+++ b/packages/components/watermark/index.ts
@@ -1,0 +1,7 @@
+import { withInstall } from '@element-plus/utils'
+import Watermark from './src/watermark.vue'
+
+export const ElWatermark = withInstall(Watermark)
+export default ElWatermark
+
+export * from './src/watermark'

--- a/packages/components/watermark/src/useClips.ts
+++ b/packages/components/watermark/src/useClips.ts
@@ -1,0 +1,145 @@
+import type { WatermarkProps } from './watermark'
+
+export const FontGap = 3
+
+function prepareCanvas(
+  width: number,
+  height: number,
+  ratio = 1
+): [
+  ctx: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  realWidth: number,
+  realHeight: number
+] {
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')!
+  const realWidth = width * ratio
+  const realHeight = height * ratio
+  canvas.setAttribute('width', `${realWidth}px`)
+  canvas.setAttribute('height', `${realHeight}px`)
+  ctx.save()
+
+  return [ctx, canvas, realWidth, realHeight]
+}
+
+/**
+ * Get the clips of text content.
+ * This is a lazy hook function since SSR no need this
+ */
+export default function useClips() {
+  // Get single clips
+  function getClips(
+    content: NonNullable<WatermarkProps['content']> | HTMLImageElement,
+    rotate: number,
+    ratio: number,
+    width: number,
+    height: number,
+    font: Required<NonNullable<WatermarkProps['font']>>,
+    gapX: number,
+    gapY: number
+  ): [dataURL: string, finalWidth: number, finalHeight: number] {
+    // ================= Text / Image =================
+    const [ctx, canvas, contentWidth, contentHeight] = prepareCanvas(
+      width,
+      height,
+      ratio
+    )
+
+    if (content instanceof HTMLImageElement) {
+      // Image
+      ctx.drawImage(content, 0, 0, contentWidth, contentHeight)
+    } else {
+      // Text
+      const { color, fontSize, fontStyle, fontWeight, fontFamily } = font
+      const mergedFontSize = Number(fontSize) * ratio
+
+      ctx.font = `${fontStyle} normal ${fontWeight} ${mergedFontSize}px/${height}px ${fontFamily}`
+      ctx.fillStyle = color
+      ctx.textAlign = 'center'
+      ctx.textBaseline = 'top'
+      const contents = Array.isArray(content) ? content : [content]
+      contents?.forEach((item, index) => {
+        ctx.fillText(
+          item ?? '',
+          contentWidth / 2,
+          index * (mergedFontSize + FontGap * ratio)
+        )
+      })
+    }
+
+    // ==================== Rotate ====================
+    const angle = (Math.PI / 180) * Number(rotate)
+    const maxSize = Math.max(width, height)
+    const [rCtx, rCanvas, realMaxSize] = prepareCanvas(maxSize, maxSize, ratio)
+
+    // Copy from `ctx` and rotate
+    rCtx.translate(realMaxSize / 2, realMaxSize / 2)
+    rCtx.rotate(angle)
+    if (contentWidth > 0 && contentHeight > 0) {
+      rCtx.drawImage(canvas, -contentWidth / 2, -contentHeight / 2)
+    }
+
+    // Get boundary of rotated text
+    function getRotatePos(x: number, y: number) {
+      const targetX = x * Math.cos(angle) - y * Math.sin(angle)
+      const targetY = x * Math.sin(angle) + y * Math.cos(angle)
+      return [targetX, targetY]
+    }
+
+    let left = 0
+    let right = 0
+    let top = 0
+    let bottom = 0
+
+    const halfWidth = contentWidth / 2
+    const halfHeight = contentHeight / 2
+    const points = [
+      [0 - halfWidth, 0 - halfHeight],
+      [0 + halfWidth, 0 - halfHeight],
+      [0 + halfWidth, 0 + halfHeight],
+      [0 - halfWidth, 0 + halfHeight],
+    ]
+    points.forEach(([x, y]) => {
+      const [targetX, targetY] = getRotatePos(x, y)
+      left = Math.min(left, targetX)
+      right = Math.max(right, targetX)
+      top = Math.min(top, targetY)
+      bottom = Math.max(bottom, targetY)
+    })
+
+    const cutLeft = left + realMaxSize / 2
+    const cutTop = top + realMaxSize / 2
+    const cutWidth = right - left
+    const cutHeight = bottom - top
+
+    // ================ Fill Alternate ================
+    const realGapX = gapX * ratio
+    const realGapY = gapY * ratio
+    const filledWidth = (cutWidth + realGapX) * 2
+    const filledHeight = cutHeight + realGapY
+
+    const [fCtx, fCanvas] = prepareCanvas(filledWidth, filledHeight)
+
+    function drawImg(targetX = 0, targetY = 0) {
+      fCtx.drawImage(
+        rCanvas,
+        cutLeft,
+        cutTop,
+        cutWidth,
+        cutHeight,
+        targetX,
+        targetY,
+        cutWidth,
+        cutHeight
+      )
+    }
+    drawImg()
+    drawImg(cutWidth + realGapX, -cutHeight / 2 - realGapY / 2)
+    drawImg(cutWidth + realGapX, +cutHeight / 2 + realGapY / 2)
+
+    return [fCanvas.toDataURL(), filledWidth / ratio, filledHeight / ratio]
+  }
+
+  return getClips
+}

--- a/packages/components/watermark/src/utils.ts
+++ b/packages/components/watermark/src/utils.ts
@@ -1,0 +1,37 @@
+import type { CSSProperties } from 'vue'
+
+/** converting camel-cased strings to be lowercase and link it with Separato */
+export function toLowercaseSeparator(key: string) {
+  return key.replace(/([A-Z])/g, '-$1').toLowerCase()
+}
+
+export function getStyleStr(style: CSSProperties): string {
+  return Object.keys(style)
+    .map(
+      (key) =>
+        `${toLowercaseSeparator(key)}: ${style[key as keyof CSSProperties]};`
+    )
+    .join(' ')
+}
+
+/** Returns the ratio of the device's physical pixel resolution to the css pixel resolution */
+export function getPixelRatio() {
+  return window.devicePixelRatio || 1
+}
+
+/** Whether to re-render the watermark */
+export const reRendering = (
+  mutation: MutationRecord,
+  watermarkElement?: HTMLElement
+) => {
+  let flag = false
+  // Whether to delete the watermark node
+  if (mutation.removedNodes.length && watermarkElement) {
+    flag = Array.from(mutation.removedNodes).includes(watermarkElement)
+  }
+  // Whether the watermark dom property value has been modified
+  if (mutation.type === 'attributes' && mutation.target === watermarkElement) {
+    flag = true
+  }
+  return flag
+}

--- a/packages/components/watermark/src/watermark.ts
+++ b/packages/components/watermark/src/watermark.ts
@@ -1,0 +1,70 @@
+import { buildProps, definePropType } from '@element-plus/utils'
+
+import type { ExtractPropTypes } from 'vue'
+import type Watermark from './watermark.vue'
+
+export interface WatermarkFontType {
+  color?: string
+  fontSize?: number | string
+  fontWeight?: 'normal' | 'light' | 'weight' | number
+  fontStyle?: 'none' | 'normal' | 'italic' | 'oblique'
+  fontFamily?: string
+}
+
+export const watermarkProps = buildProps({
+  /**
+   * @description The z-index of the appended watermark element
+   */
+  zIndex: {
+    type: Number,
+    default: 9,
+  },
+  /**
+   * @description The rotation angle of the watermark
+   */
+  rotate: {
+    type: Number,
+    default: -22,
+  },
+  /**
+   * @description The width of the watermark
+   */
+  width: Number,
+  /**
+   * @description The height of the watermark
+   */
+  height: Number,
+  /**
+   * @description Image source, it is recommended to export 2x or 3x image, high priority (support base64 format)
+   */
+  image: String,
+  /**
+   * @description Watermark text content
+   */
+  content: {
+    type: definePropType<string | string[]>([String, Array]),
+    default: 'Element Plus',
+  },
+  /**
+   * @description Text style
+   */
+  font: {
+    type: definePropType<WatermarkFontType>(Object),
+  },
+  /**
+   * @description The spacing between watermarks
+   */
+  gap: {
+    type: definePropType<[number, number]>(Array),
+    default: () => [100, 100],
+  },
+  /**
+   * @description The offset of the watermark from the upper left corner of the container. The default is gap/2
+   */
+  offset: {
+    type: definePropType<[number, number]>(Array),
+  },
+} as const)
+
+export type WatermarkProps = ExtractPropTypes<typeof watermarkProps>
+export type WatermarkInstance = InstanceType<typeof Watermark>

--- a/packages/components/watermark/src/watermark.vue
+++ b/packages/components/watermark/src/watermark.vue
@@ -1,0 +1,225 @@
+<template>
+  <div ref="containerRef" :style="[style]">
+    <slot />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  shallowRef,
+  watch,
+} from 'vue'
+import { useMutationObserver } from '@vueuse/core'
+import { watermarkProps } from './watermark'
+import { getPixelRatio, getStyleStr, reRendering } from './utils'
+import useClips, { FontGap } from './useClips'
+import type { WatermarkProps } from './watermark'
+import type { CSSProperties } from 'vue'
+
+defineOptions({
+  name: 'ElWatermark',
+})
+
+const style: CSSProperties = {
+  position: 'relative',
+}
+
+const props = defineProps(watermarkProps)
+const color = computed(() => props.font?.color ?? 'rgba(0,0,0,.15)')
+const fontSize = computed(() => props.font?.fontSize ?? 16)
+const fontWeight = computed(() => props.font?.fontWeight ?? 'normal')
+const fontStyle = computed(() => props.font?.fontStyle ?? 'normal')
+const fontFamily = computed(() => props.font?.fontFamily ?? 'sans-serif')
+
+const gapX = computed(() => props.gap[0])
+const gapY = computed(() => props.gap[1])
+const gapXCenter = computed(() => gapX.value / 2)
+const gapYCenter = computed(() => gapY.value / 2)
+const offsetLeft = computed(() => props.offset?.[0] ?? gapXCenter.value)
+const offsetTop = computed(() => props.offset?.[1] ?? gapYCenter.value)
+
+const getMarkStyle = () => {
+  const markStyle: CSSProperties = {
+    zIndex: props.zIndex,
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: '100%',
+    height: '100%',
+    pointerEvents: 'none',
+    backgroundRepeat: 'repeat',
+  }
+
+  /** Calculate the style of the offset */
+  let positionLeft = offsetLeft.value - gapXCenter.value
+  let positionTop = offsetTop.value - gapYCenter.value
+  if (positionLeft > 0) {
+    markStyle.left = `${positionLeft}px`
+    markStyle.width = `calc(100% - ${positionLeft}px)`
+    positionLeft = 0
+  }
+  if (positionTop > 0) {
+    markStyle.top = `${positionTop}px`
+    markStyle.height = `calc(100% - ${positionTop}px)`
+    positionTop = 0
+  }
+  markStyle.backgroundPosition = `${positionLeft}px ${positionTop}px`
+
+  return markStyle
+}
+
+const containerRef = shallowRef<HTMLDivElement | null>(null)
+const watermarkRef = shallowRef<HTMLDivElement>()
+const stopObservation = ref(false)
+
+const destroyWatermark = () => {
+  if (watermarkRef.value) {
+    watermarkRef.value.remove()
+    watermarkRef.value = undefined
+  }
+}
+const appendWatermark = (base64Url: string, markWidth: number) => {
+  if (containerRef.value && watermarkRef.value) {
+    stopObservation.value = true
+    watermarkRef.value.setAttribute(
+      'style',
+      getStyleStr({
+        ...getMarkStyle(),
+        backgroundImage: `url('${base64Url}')`,
+        backgroundSize: `${Math.floor(markWidth)}px`,
+      })
+    )
+    containerRef.value?.append(watermarkRef.value)
+    // Delayed execution
+    setTimeout(() => {
+      stopObservation.value = false
+    })
+  }
+}
+
+/**
+ * Get the width and height of the watermark. The default values are as follows
+ * Image: [120, 64]; Content: It's calculated by content;
+ */
+const getMarkSize = (ctx: CanvasRenderingContext2D) => {
+  let defaultWidth = 120
+  let defaultHeight = 64
+  const image = props.image
+  const content = props.content
+  const width = props.width
+  const height = props.height
+  if (!image && ctx.measureText) {
+    ctx.font = `${Number(fontSize.value)}px ${fontFamily.value}`
+    const contents = Array.isArray(content) ? content : [content]
+    const sizes = contents.map((item) => {
+      const metrics = ctx.measureText(item!)
+
+      return [
+        metrics.width,
+        metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent,
+      ]
+    })
+    defaultWidth = Math.ceil(Math.max(...sizes.map((size) => size[0])))
+    defaultHeight =
+      Math.ceil(Math.max(...sizes.map((size) => size[1]))) * contents.length +
+      (contents.length - 1) * FontGap
+  }
+  return [width ?? defaultWidth, height ?? defaultHeight] as const
+}
+
+const getClips = useClips()
+
+const renderWatermark = () => {
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')
+  const image = props.image
+  const content = props.content
+  const rotate = props.rotate
+
+  if (ctx) {
+    if (!watermarkRef.value) {
+      watermarkRef.value = document.createElement('div')
+    }
+
+    const ratio = getPixelRatio()
+    const [markWidth, markHeight] = getMarkSize(ctx)
+
+    const drawCanvas = (
+      drawContent?: NonNullable<WatermarkProps['content']> | HTMLImageElement
+    ) => {
+      const [textClips, clipWidth] = getClips(
+        drawContent || '',
+        rotate,
+        ratio,
+        markWidth,
+        markHeight,
+        {
+          color: color.value,
+          fontSize: fontSize.value,
+          fontStyle: fontStyle.value,
+          fontWeight: fontWeight.value,
+          fontFamily: fontFamily.value,
+        },
+        gapX.value,
+        gapY.value
+      )
+
+      appendWatermark(textClips, clipWidth)
+    }
+
+    if (image) {
+      const img = new Image()
+      img.onload = () => {
+        drawCanvas(img)
+      }
+      img.onerror = () => {
+        drawCanvas(content)
+      }
+      img.crossOrigin = 'anonymous'
+      img.referrerPolicy = 'no-referrer'
+      img.src = image
+    } else {
+      drawCanvas(content)
+    }
+  }
+}
+
+onMounted(() => {
+  renderWatermark()
+})
+
+watch(
+  () => props,
+  () => {
+    renderWatermark()
+  },
+  {
+    deep: true,
+    flush: 'post',
+  }
+)
+
+onBeforeUnmount(() => {
+  destroyWatermark()
+})
+
+const onMutate = (mutations: MutationRecord[]) => {
+  if (stopObservation.value) {
+    return
+  }
+  mutations.forEach((mutation) => {
+    if (reRendering(mutation, watermarkRef.value)) {
+      destroyWatermark()
+      renderWatermark()
+    }
+  })
+}
+
+useMutationObserver(containerRef, onMutate, {
+  attributes: true,
+})
+</script>

--- a/packages/element-plus/component.ts
+++ b/packages/element-plus/component.ts
@@ -102,6 +102,7 @@ import { ElTree } from '@element-plus/components/tree'
 import { ElTreeSelect } from '@element-plus/components/tree-select'
 import { ElTreeV2 } from '@element-plus/components/tree-v2'
 import { ElUpload } from '@element-plus/components/upload'
+import { ElWatermark } from '@element-plus/components/watermark'
 
 import type { Plugin } from 'vue'
 
@@ -204,4 +205,5 @@ export default [
   ElTreeSelect,
   ElTreeV2,
   ElUpload,
+  ElWatermark,
 ] as Plugin[]

--- a/packages/hooks/__tests__/use-focus-controller.test.tsx
+++ b/packages/hooks/__tests__/use-focus-controller.test.tsx
@@ -8,6 +8,92 @@ describe('useFocusController', () => {
     vi.restoreAllMocks()
   })
 
+  it('it will trigger focus & blur without wrapperRef', async () => {
+    const focusHandler = vi.fn()
+    const blurHandler = vi.fn()
+    const wrapper = mount({
+      emits: ['focus', 'blur'],
+      setup() {
+        const targetRef = ref()
+        const { isFocused, handleFocus, handleBlur } = useFocusController(
+          targetRef,
+          {
+            afterFocus: focusHandler,
+            afterBlur: blurHandler,
+          }
+        )
+
+        return () => (
+          <div>
+            <input ref={targetRef} onFocus={handleFocus} onBlur={handleBlur} />
+            <span>{String(isFocused.value)}</span>
+          </div>
+        )
+      },
+    })
+
+    await nextTick()
+    expect(wrapper.find('span').text()).toBe('false')
+    expect(focusHandler).toHaveBeenCalledTimes(0)
+    expect(blurHandler).toHaveBeenCalledTimes(0)
+
+    await wrapper.find('input').trigger('focus')
+    expect(wrapper.emitted()).toHaveProperty('focus')
+    expect(wrapper.find('span').text()).toBe('true')
+    expect(focusHandler).toHaveBeenCalledTimes(1)
+    expect(blurHandler).toHaveBeenCalledTimes(0)
+
+    await wrapper.find('input').trigger('blur')
+    expect(wrapper.emitted()).toHaveProperty('blur')
+    expect(wrapper.find('span').text()).toBe('false')
+    expect(blurHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('it will trigger focus & blur with tabindex', async () => {
+    const focusHandler = vi.fn()
+    const blurHandler = vi.fn()
+    const wrapper = mount({
+      emits: ['focus', 'blur'],
+      setup() {
+        const targetRef = ref()
+        const { isFocused, handleFocus, handleBlur } = useFocusController(
+          targetRef,
+          {
+            afterFocus: focusHandler,
+            afterBlur: blurHandler,
+          }
+        )
+
+        return () => (
+          <div
+            ref={targetRef}
+            tabindex="0"
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+          >
+            <span>{String(isFocused.value)}</span>
+          </div>
+        )
+      },
+    })
+
+    await nextTick()
+    expect(wrapper.find('span').text()).toBe('false')
+    expect(focusHandler).toHaveBeenCalledTimes(0)
+    expect(blurHandler).toHaveBeenCalledTimes(0)
+
+    await wrapper.find('div').trigger('focus')
+    expect(wrapper.emitted()).toHaveProperty('focus')
+    expect(wrapper.find('span').text()).toBe('true')
+    expect(focusHandler).toHaveBeenCalledTimes(1)
+    expect(blurHandler).toHaveBeenCalledTimes(0)
+
+    await wrapper.find('div').trigger('blur')
+    expect(wrapper.emitted()).toHaveProperty('blur')
+    expect(wrapper.find('span').text()).toBe('false')
+    expect(blurHandler).toHaveBeenCalledTimes(1)
+  })
+
   it('it will avoid trigger unnecessary blur event', async () => {
     const focusHandler = vi.fn()
     const blurHandler = vi.fn()
@@ -51,5 +137,48 @@ describe('useFocusController', () => {
     expect(wrapper.emitted()).toHaveProperty('blur')
     expect(wrapper.find('span').text()).toBe('false')
     expect(blurHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('it will avoid trigger unnecessary blur event by beforeBlur', async () => {
+    const beforeBlur = vi.fn()
+    const wrapper = mount({
+      emits: ['focus', 'blur'],
+      setup() {
+        const targetRef = ref()
+        const { wrapperRef, isFocused, handleFocus, handleBlur } =
+          useFocusController(targetRef, {
+            afterBlur: () => {
+              beforeBlur()
+              return true
+            },
+          })
+
+        return () => (
+          <>
+            <div ref={wrapperRef}>
+              <input
+                ref={targetRef}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+              />
+            </div>
+            <span>{String(isFocused.value)}</span>
+          </>
+        )
+      },
+    })
+
+    await nextTick()
+    expect(wrapper.find('span').text()).toBe('false')
+    expect(beforeBlur).toHaveBeenCalledTimes(0)
+
+    await wrapper.find('input').trigger('focus')
+    expect(wrapper.emitted()).toHaveProperty('focus')
+    expect(wrapper.find('span').text()).toBe('true')
+    expect(beforeBlur).toHaveBeenCalledTimes(0)
+
+    await wrapper.find('span').trigger('click')
+    expect(wrapper.emitted()).not.toHaveProperty('blur')
+    expect(beforeBlur).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/hooks/use-focus-controller/index.ts
+++ b/packages/hooks/use-focus-controller/index.ts
@@ -1,15 +1,21 @@
 import { getCurrentInstance, ref, shallowRef, watch } from 'vue'
 import { useEventListener } from '@vueuse/core'
+import { isFunction } from '@element-plus/utils'
 import type { ShallowRef } from 'vue'
 
 interface UseFocusControllerOptions {
   afterFocus?: () => void
+  /**
+   * return true to cancel blur
+   * @param event FocusEvent
+   */
+  beforeBlur?: (event: FocusEvent) => boolean | undefined
   afterBlur?: () => void
 }
 
 export function useFocusController<T extends HTMLElement>(
   target: ShallowRef<T | undefined>,
-  { afterFocus, afterBlur }: UseFocusControllerOptions = {}
+  { afterFocus, beforeBlur, afterBlur }: UseFocusControllerOptions = {}
 ) {
   const instance = getCurrentInstance()!
   const { emit } = instance
@@ -24,9 +30,11 @@ export function useFocusController<T extends HTMLElement>(
   }
 
   const handleBlur = (event: FocusEvent) => {
+    const cancelBlur = isFunction(beforeBlur) ? beforeBlur(event) : false
     if (
-      event.relatedTarget &&
-      wrapperRef.value?.contains(event.relatedTarget as Node)
+      cancelBlur ||
+      (event.relatedTarget &&
+        wrapperRef.value?.contains(event.relatedTarget as Node))
     )
       return
 

--- a/packages/theme-chalk/src/button.scss
+++ b/packages/theme-chalk/src/button.scss
@@ -148,6 +148,7 @@ $button-icon-span-gap: map.merge(
     border-radius: getCssVar('border-radius', 'round');
   }
   @include when(circle) {
+    width: map.get($input-height, 'default');
     border-radius: 50%;
     padding: map.get($button-padding-vertical, 'default') - $button-border-width;
   }

--- a/packages/theme-chalk/src/color-picker.scss
+++ b/packages/theme-chalk/src/color-picker.scss
@@ -246,9 +246,9 @@ $color-picker-size: map.merge($common-component-size, $color-picker-size);
   line-height: normal;
   outline: none;
 
-  &:hover:not(.is-disabled) {
+  &:hover:not(.is-disabled, .is-focused) {
     .#{$namespace}-color-picker__trigger {
-      border: 1px solid getCssVar('border-color-hover');
+      border-color: getCssVar('border-color-hover');
     }
   }
 
@@ -256,6 +256,12 @@ $color-picker-size: map.merge($common-component-size, $color-picker-size);
     .#{$namespace}-color-picker__trigger {
       outline: 2px solid getCssVar('color-primary');
       outline-offset: 1px;
+    }
+  }
+
+  @include when(focused) {
+    .#{$namespace}-color-picker__trigger {
+      border-color: getCssVar('color-primary');
     }
   }
 

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -776,6 +776,7 @@ $table: map.merge(
     'expanded-cell-bg-color': getCssVar('fill-color', 'blank'),
     'fixed-left-column': inset 10px 0 10px -10px rgb(0 0 0 / 15%),
     'fixed-right-column': inset -10px 0 10px -10px rgb(0 0 0 / 15%),
+    'index': getCssVar('index-normal')
   ),
   $table
 );

--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -5,54 +5,49 @@
 @use 'mixins/var' as *;
 @use 'common/var' as *;
 
-$form-item-margin-bottom: () !default;
-$form-item-margin-bottom: map.merge(
-  (
-    'large': 22px,
-    'default': 18px,
-    'small': 18px,
-  ),
-  $form-item-margin-bottom
+$form-item-margin-bottom: (
+  ) !default;
+$form-item-margin-bottom: map.merge(('large': 22px,
+      'default': 18px,
+      'small': 18px,
+    ),
+    $form-item-margin-bottom
 );
 
-$form-item-line-height: () !default;
-$form-item-line-height: map.merge(
-  (
-    'large': 40px,
-    'default': 32px,
-    'small': 24px,
-  ),
-  $form-item-line-height
+$form-item-line-height: (
+  ) !default;
+$form-item-line-height: map.merge(('large': 40px,
+      'default': 32px,
+      'small': 24px,
+    ),
+    $form-item-line-height
 );
 
-$form-item-error-padding-top: () !default;
-$form-item-error-padding-top: map.merge(
-  (
-    'large': 4px,
-    'default': 2px,
-    'small': 2px,
-  ),
-  $form-item-error-padding-top
+$form-item-error-padding-top: (
+  ) !default;
+$form-item-error-padding-top: map.merge(('large': 4px,
+      'default': 2px,
+      'small': 2px,
+    ),
+    $form-item-error-padding-top
 );
 
-$form-item-label-top-line-height: () !default;
-$form-item-label-top-line-height: map.merge(
-  (
-    'large': 22px,
-    'default': 22px,
-    'small': 20px,
-  ),
-  $form-item-label-top-line-height
+$form-item-label-top-line-height: (
+  ) !default;
+$form-item-label-top-line-height: map.merge(('large': 22px,
+      'default': 22px,
+      'small': 20px,
+    ),
+    $form-item-label-top-line-height
 );
 
-$form-item-label-top-margin-bottom: () !default;
-$form-item-label-top-margin-bottom: map.merge(
-  (
-    'large': 12px,
-    'default': 8px,
-    'small': 4px,
-  ),
-  $form-item-label-top-margin-bottom
+$form-item-label-top-margin-bottom: (
+  ) !default;
+$form-item-label-top-margin-bottom: map.merge(('large': 12px,
+      'default': 8px,
+      'small': 4px,
+    ),
+    $form-item-label-top-margin-bottom
 );
 
 @include b(form) {
@@ -63,6 +58,7 @@ $form-item-label-top-margin-bottom: map.merge(
       justify-content: flex-start;
     }
   }
+
   @include m(label-top) {
     .#{$namespace}-form-item {
       display: block;
@@ -76,6 +72,7 @@ $form-item-label-top-margin-bottom: map.merge(
       }
     }
   }
+
   @include m(inline) {
     .#{$namespace}-form-item {
       display: inline-flex;
@@ -131,9 +128,11 @@ $form-item-label-top-margin-bottom: map.merge(
         height: #{map.get($form-item-line-height, $size)};
         line-height: #{map.get($form-item-line-height, $size)};
       }
+
       @include e(content) {
         line-height: #{map.get($form-item-line-height, $size)};
       }
+
       @include e(error) {
         padding-top: #{map.get($form-item-error-padding-top, $size)};
       }
@@ -159,6 +158,7 @@ $form-item-label-top-margin-bottom: map.merge(
     padding: 0 12px 0 0;
     box-sizing: border-box;
   }
+
   @include e(content) {
     display: flex;
     flex-wrap: wrap;
@@ -173,6 +173,7 @@ $form-item-label-top-margin-bottom: map.merge(
       vertical-align: top;
     }
   }
+
   @include e(error) {
     color: getCssVar('color-danger');
     font-size: 12px;
@@ -194,18 +195,19 @@ $form-item-label-top-margin-bottom: map.merge(
   @include when(required) {
     @include pseudo('not(.is-no-asterisk)') {
       &.asterisk-left {
-        > .#{$namespace}-form-item__label:before,
-        > .#{$namespace}-form-item__label-wrap
-          > .#{$namespace}-form-item__label:before {
+
+        >.#{$namespace}-form-item__label:before,
+        >.#{$namespace}-form-item__label-wrap>.#{$namespace}-form-item__label:before {
           content: '*';
           color: getCssVar('color-danger');
           margin-right: 4px;
         }
       }
+
       &.asterisk-right {
-        > .#{$namespace}-form-item__label:after,
-        > .#{$namespace}-form-item__label-wrap
-          > .#{$namespace}-form-item__label:after {
+
+        >.#{$namespace}-form-item__label:after,
+        >.#{$namespace}-form-item__label-wrap>.#{$namespace}-form-item__label:after {
           content: '*';
           color: getCssVar('color-danger');
           margin-left: 4px;
@@ -223,21 +225,32 @@ $form-item-label-top-margin-bottom: map.merge(
 
     .#{$namespace}-select-v2__wrapper,
     .#{$namespace}-textarea__inner {
+
       &,
       &:focus {
         box-shadow: 0 0 0 1px getCssVar('color-danger') inset;
       }
     }
 
+    .#{$namespace}-select {
+      .#{$namespace}-input {
+        .#{$namespace}-input__wrapper {
+          box-shadow: 0 0 0 1px getCssVar('color-danger') inset;
+        }
+      }
+    }
+
     .#{$namespace}-input__wrapper {
       box-shadow: 0 0 0 1px getCssVar('color-danger') inset;
     }
+
     .#{$namespace}-input-group__append,
     .#{$namespace}-input-group__prepend {
       .#{$namespace}-input__wrapper {
         box-shadow: 0 0 0 1px transparent inset;
       }
     }
+
     .#{$namespace}-input__validateIcon {
       color: getCssVar('color-danger');
     }

--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -5,49 +5,54 @@
 @use 'mixins/var' as *;
 @use 'common/var' as *;
 
-$form-item-margin-bottom: (
-  ) !default;
-$form-item-margin-bottom: map.merge(('large': 22px,
-      'default': 18px,
-      'small': 18px,
-    ),
-    $form-item-margin-bottom
+$form-item-margin-bottom: () !default;
+$form-item-margin-bottom: map.merge(
+  (
+    'large': 22px,
+    'default': 18px,
+    'small': 18px,
+  ),
+  $form-item-margin-bottom
 );
 
-$form-item-line-height: (
-  ) !default;
-$form-item-line-height: map.merge(('large': 40px,
-      'default': 32px,
-      'small': 24px,
-    ),
-    $form-item-line-height
+$form-item-line-height: () !default;
+$form-item-line-height: map.merge(
+  (
+    'large': 40px,
+    'default': 32px,
+    'small': 24px,
+  ),
+  $form-item-line-height
 );
 
-$form-item-error-padding-top: (
-  ) !default;
-$form-item-error-padding-top: map.merge(('large': 4px,
-      'default': 2px,
-      'small': 2px,
-    ),
-    $form-item-error-padding-top
+$form-item-error-padding-top: () !default;
+$form-item-error-padding-top: map.merge(
+  (
+    'large': 4px,
+    'default': 2px,
+    'small': 2px,
+  ),
+  $form-item-error-padding-top
 );
 
-$form-item-label-top-line-height: (
-  ) !default;
-$form-item-label-top-line-height: map.merge(('large': 22px,
-      'default': 22px,
-      'small': 20px,
-    ),
-    $form-item-label-top-line-height
+$form-item-label-top-line-height: () !default;
+$form-item-label-top-line-height: map.merge(
+  (
+    'large': 22px,
+    'default': 22px,
+    'small': 20px,
+  ),
+  $form-item-label-top-line-height
 );
 
-$form-item-label-top-margin-bottom: (
-  ) !default;
-$form-item-label-top-margin-bottom: map.merge(('large': 12px,
-      'default': 8px,
-      'small': 4px,
-    ),
-    $form-item-label-top-margin-bottom
+$form-item-label-top-margin-bottom: () !default;
+$form-item-label-top-margin-bottom: map.merge(
+  (
+    'large': 12px,
+    'default': 8px,
+    'small': 4px,
+  ),
+  $form-item-label-top-margin-bottom
 );
 
 @include b(form) {
@@ -195,9 +200,9 @@ $form-item-label-top-margin-bottom: map.merge(('large': 12px,
   @include when(required) {
     @include pseudo('not(.is-no-asterisk)') {
       &.asterisk-left {
-
-        >.#{$namespace}-form-item__label:before,
-        >.#{$namespace}-form-item__label-wrap>.#{$namespace}-form-item__label:before {
+        > .#{$namespace}-form-item__label:before,
+        > .#{$namespace}-form-item__label-wrap
+          > .#{$namespace}-form-item__label:before {
           content: '*';
           color: getCssVar('color-danger');
           margin-right: 4px;
@@ -205,9 +210,9 @@ $form-item-label-top-margin-bottom: map.merge(('large': 12px,
       }
 
       &.asterisk-right {
-
-        >.#{$namespace}-form-item__label:after,
-        >.#{$namespace}-form-item__label-wrap>.#{$namespace}-form-item__label:after {
+        > .#{$namespace}-form-item__label:after,
+        > .#{$namespace}-form-item__label-wrap
+          > .#{$namespace}-form-item__label:after {
           content: '*';
           color: getCssVar('color-danger');
           margin-left: 4px;
@@ -225,7 +230,6 @@ $form-item-label-top-margin-bottom: map.merge(('large': 12px,
 
     .#{$namespace}-select-v2__wrapper,
     .#{$namespace}-textarea__inner {
-
       &,
       &:focus {
         box-shadow: 0 0 0 1px getCssVar('color-danger') inset;

--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -130,7 +130,7 @@
         color: getCssVar('menu-text-color');
 
         &:hover {
-          background-color: getCssVar('bg-color', 'overlay');
+          background-color: getCssVar('menu-bg-color');
         }
       }
     }

--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -73,6 +73,12 @@
     }
   }
 
+  &:not(.#{$namespace}-menu--collapse) .#{$namespace}-sub-menu__title {
+    padding-right: calc(
+      #{getCssVar('menu-base-level-padding')} + #{getCssVar('menu-icon-width')}
+    );
+  }
+
   @include m(horizontal) {
     display: flex;
     flex-wrap: nowrap;
@@ -250,9 +256,6 @@
 
   @include e(title) {
     @include menu-item;
-    padding-right: calc(
-      #{getCssVar('menu-base-level-padding')} + #{getCssVar('menu-icon-width')}
-    );
 
     &:hover {
       background-color: getCssVar('menu-hover-bg-color');

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -57,9 +57,11 @@
   line-height: map.get($input-height, 'default');
 
   @include e(popper) {
-    @include picker-popper(map.get($select-dropdown, 'bg-color'),
+    @include picker-popper(
+      map.get($select-dropdown, 'bg-color'),
       map.get($select-dropdown, 'border'),
-      map.get($select-dropdown, 'shadow'));
+      map.get($select-dropdown, 'shadow')
+    );
   }
 
   .#{$namespace}-select-tags-wrapper {
@@ -80,7 +82,7 @@
     }
   }
 
-  .#{$namespace}-select__tags>span {
+  .#{$namespace}-select__tags > span {
     display: inline-block;
   }
 

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -19,6 +19,7 @@
     box-sizing: border-box;
     border-color: transparent;
     margin: 2px 6px 2px 0;
+
     &:last-child {
       margin-right: 0;
     }
@@ -39,6 +40,7 @@
       }
     }
   }
+
   .#{$namespace}-tag--info {
     background-color: getCssVar('fill-color');
   }
@@ -55,11 +57,9 @@
   line-height: map.get($input-height, 'default');
 
   @include e(popper) {
-    @include picker-popper(
-      map.get($select-dropdown, 'bg-color'),
+    @include picker-popper(map.get($select-dropdown, 'bg-color'),
       map.get($select-dropdown, 'border'),
-      map.get($select-dropdown, 'shadow')
-    );
+      map.get($select-dropdown, 'shadow'));
   }
 
   .#{$namespace}-select-tags-wrapper {
@@ -71,6 +71,7 @@
   @each $size in (large, small) {
     @include m($size) {
       line-height: map.get($input-height, $size);
+
       .#{$namespace}-select-tags-wrapper {
         &.has-prefix {
           margin-left: map.get($select-tags-prefix-padding, $size);
@@ -79,7 +80,7 @@
     }
   }
 
-  .#{$namespace}-select__tags > span {
+  .#{$namespace}-select__tags>span {
     display: inline-block;
   }
 
@@ -95,10 +96,7 @@
     cursor: pointer;
 
     @include when(focus) {
-      @include inset-input-border(
-        getCssVar('select-input-focus-border-color'),
-        true
-      );
+      @include inset-input-border(getCssVar('select-input-focus-border-color'));
     }
   }
 
@@ -148,19 +146,18 @@
           @include inset-input-border(#{getCssVar('select-disabled-border')});
         }
       }
+
       & .#{$namespace}-input__inner {
         cursor: not-allowed;
       }
+
       & .#{$namespace}-select__caret {
         cursor: not-allowed;
       }
     }
 
     &.is-focus .#{$namespace}-input__wrapper {
-      @include inset-input-border(
-        getCssVar('select-input-focus-border-color'),
-        true
-      );
+      @include inset-input-border(getCssVar('select-input-focus-border-color'));
     }
   }
 
@@ -212,6 +209,7 @@
     top: 50%;
     transform: translateY(-50%);
     @include select-tag-normal;
+
     @include when(disabled) {
       cursor: not-allowed;
     }

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -141,6 +141,13 @@
     }
   }
 
+  tfoot {
+    td.#{$namespace}-table__cell {
+      background-color: getCssVar('table-row-hover-bg-color');
+      color: getCssVar('table-text-color');
+    }
+  }
+
   .#{$namespace}-table__cell {
     padding: map.get($table-padding, 'default');
     min-width: 0;
@@ -244,10 +251,6 @@
     &.gutter {
       width: 0;
     }
-  }
-
-  @include e((footer-wrapper)) {
-    border-top: getCssVar('table-border');
   }
 
   // 拥有多级表头
@@ -381,7 +384,7 @@
     border-collapse: separate;
   }
 
-  @include e((header-wrapper, footer-wrapper)) {
+  @include e((header-wrapper)) {
     overflow: hidden;
 
     & tbody td.#{$namespace}-table__cell {

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -393,6 +393,11 @@
     }
   }
 
+  @include e((footer-wrapper)) {
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+
   @include e((header-wrapper, body-wrapper)) {
     .#{$namespace}-table-column--selection {
       > .cell {
@@ -558,10 +563,18 @@
     }
   }
 
-  @include e(body-header) {
-    position: sticky;
-    top: 0;
-    z-index: calc(getCssVar('table-index') + 2);
+  &.#{$namespace}-table--scrollable-y {
+    @include e(body-header) {
+      position: sticky;
+      top: 0;
+      z-index: calc(getCssVar('table-index') + 2);
+    }
+
+    @include e(body-footer) {
+      position: sticky;
+      bottom: 0;
+      z-index: calc(getCssVar('table-index') + 2);
+    }
   }
 
   @include e(column-resize-proxy) {

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -149,7 +149,7 @@
     vertical-align: middle;
     position: relative;
     text-align: left;
-    z-index: 1;
+    z-index: getCssVar('table-index');
     @include when(center) {
       text-align: center;
     }
@@ -256,7 +256,7 @@
       content: '';
       position: absolute;
       background-color: getCssVar('table-border-color');
-      z-index: 3;
+      z-index: calc(getCssVar('table-index') + 2);
     }
   }
 
@@ -269,6 +269,7 @@
         top: 0;
         width: 100%;
         height: 1px;
+        z-index: calc(getCssVar('table-index') + 2);
       }
     }
 
@@ -324,8 +325,8 @@
         &.#{$namespace}-table-fixed-column--left,
         &.#{$namespace}-table-fixed-column--right {
           position: sticky !important;
-          z-index: 2;
           background: inherit;
+          z-index: calc(getCssVar('table-index') + 1);
           &.is-last-column,
           &.is-first-column {
             &::before {
@@ -355,7 +356,7 @@
         }
         &.#{$namespace}-table__fixed-right-patch {
           position: sticky !important;
-          z-index: 2;
+          z-index: calc(getCssVar('table-index') + 1);
           background: #fff;
           right: 0;
         }
@@ -474,7 +475,7 @@
     position: relative;
     flex: 1;
     .#{$namespace}-scrollbar__bar {
-      z-index: 2;
+      z-index: calc(getCssVar('table-index') + 2);
     }
   }
 
@@ -554,6 +555,12 @@
     }
   }
 
+  @include e(body-header) {
+    position: sticky;
+    top: 0;
+    z-index: calc(getCssVar('table-index') + 2);
+  }
+
   @include e(column-resize-proxy) {
     position: absolute;
     left: 200px;
@@ -561,7 +568,7 @@
     bottom: 0;
     width: 0;
     border-left: getCssVar('table-border');
-    z-index: 10;
+    z-index: calc(getCssVar('table-index') + 9);
   }
 
   @include e(column-filter-trigger) {
@@ -580,7 +587,7 @@
     left: 0;
     width: 1px;
     height: 100%;
-    z-index: 3;
+    z-index: calc(getCssVar('table-index') + 2);
     position: absolute;
     background-color: getCssVar('table-border-color');
   }
@@ -588,7 +595,7 @@
   @include e(border-bottom-patch) {
     left: 0;
     height: 1px;
-    z-index: 3;
+    z-index: calc(getCssVar('table-index') + 2);
     position: absolute;
     background-color: getCssVar('table-border-color');
   }
@@ -597,7 +604,7 @@
     top: 0;
     height: 100%;
     width: 1px;
-    z-index: 3;
+    z-index: calc(getCssVar('table-index') + 2);
     position: absolute;
     background-color: getCssVar('table-border-color');
   }

--- a/packages/theme-chalk/src/text.scss
+++ b/packages/theme-chalk/src/text.scss
@@ -24,6 +24,12 @@
     overflow: hidden;
   }
 
+  @include when(line-clamp) {
+    display: -webkit-inline-box;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
   @each $size in (large, default, small) {
     @include m($size) {
       @include set-css-var-value(

--- a/packages/theme-chalk/src/upload.scss
+++ b/packages/theme-chalk/src/upload.scss
@@ -62,7 +62,7 @@
 
     @include utils-inline-flex-center;
 
-    i {
+    > i {
       font-size: 28px;
       color: getCssVar('text-color', 'secondary');
     }

--- a/play/vite.config.ts
+++ b/play/vite.config.ts
@@ -22,7 +22,6 @@ import './vite.init'
 const esbuildPlugin = (): Plugin => ({
   ...esbuild({
     target: 'chrome64',
-    include: /\.vue$/,
     loaders: {
       '.vue': 'js',
     },

--- a/typings/components.d.ts
+++ b/typings/components.d.ts
@@ -97,6 +97,7 @@ declare module '@vue/runtime-core' {
     ElDescriptionsItem: typeof import('../packages/element-plus')['ElDescriptionsItem']
     ElResult: typeof import('../packages/element-plus')['ElResult']
     ElSelectV2: typeof import('../packages/element-plus')['ElSelectV2']
+    ElWatermark: typeof import('../packages/element-plus')['ElWatermark']
   }
 
   interface ComponentCustomProperties {


### PR DESCRIPTION
remove select box-shadow `!important`

fixed the hover style error of select in the form state

closed #14515

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b1dbfa</samp>

This pull request refactors and fixes some style issues in the `form.scss` and `select.scss` files of the theme-chalk package. It improves the code quality and appearance of the form and select components.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b1dbfa</samp>

* Reformat Sass maps for form item variables to use consistent indentation and line breaks ([link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29L8-R50))
* Add empty lines to separate form item variables, selectors, and sub-selectors for readability ([link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29R61), [link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29R75), [link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29L134-R135), [link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29R161), [link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29R176), [link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29R228), [link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29R253))
* Remove spaces before child selectors to follow Sass style guide ([link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29L197-R200), [link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29L205-R210), [link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-cb8f9194ab7f36f2aceafe27b8c5e84e741cb7c5a598244ab2199242563e6c74L82-R83))
* Move select input wrapper box shadow to a separate selector to avoid affecting other input types ([link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29L232-R246))
* Reformat input group append and prepend selectors to use consistent indentation and line breaks ([link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29L251-L250))
* Remove unnecessary second arguments of inset input border mixin for select input focus border color ([link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-cb8f9194ab7f36f2aceafe27b8c5e84e741cb7c5a598244ab2199242563e6c74L98-R99), [link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-cb8f9194ab7f36f2aceafe27b8c5e84e741cb7c5a598244ab2199242563e6c74L160-R160))
* Add empty lines to separate select disabled selector and sub-selectors for readability ([link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-cb8f9194ab7f36f2aceafe27b8c5e84e741cb7c5a598244ab2199242563e6c74L151-R153))
* Reformat select multiple input selector to use consistent indentation and line breaks ([link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-cb8f9194ab7f36f2aceafe27b8c5e84e741cb7c5a598244ab2199242563e6c74L229-L228))
* Apply picker popper mixin to select popper selector with consistent indentation and line breaks ([link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-cb8f9194ab7f36f2aceafe27b8c5e84e741cb7c5a598244ab2199242563e6c74L58-R62))
* Add empty lines to separate select variables, selectors, and sub-selectors for readability ([link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-cb8f9194ab7f36f2aceafe27b8c5e84e741cb7c5a598244ab2199242563e6c74R22), [link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-cb8f9194ab7f36f2aceafe27b8c5e84e741cb7c5a598244ab2199242563e6c74R43), [link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-cb8f9194ab7f36f2aceafe27b8c5e84e741cb7c5a598244ab2199242563e6c74R74), [link](https://github.com/element-plus/element-plus/pull/14555/files?diff=unified&w=0#diff-cb8f9194ab7f36f2aceafe27b8c5e84e741cb7c5a598244ab2199242563e6c74R212))
