### PR TITLE
style(select): remove select `important`&fix form select style

### DIFF
--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -229,6 +229,14 @@ $form-item-label-top-margin-bottom: map.merge(
       }
     }
 
+    .#{$namespace}-select {
+      .#{$namespace}-input {
+        .#{$namespace}-input__wrapper {
+          box-shadow: 0 0 0 1px getCssVar('color-danger') inset;
+        }
+      }
+    }
+
     .#{$namespace}-input__wrapper {
       box-shadow: 0 0 0 1px getCssVar('color-danger') inset;
     }

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -95,10 +95,7 @@
     cursor: pointer;
 
     @include when(focus) {
-      @include inset-input-border(
-        getCssVar('select-input-focus-border-color'),
-        true
-      );
+      @include inset-input-border(getCssVar('select-input-focus-border-color'));
     }
   }
 
@@ -157,10 +154,7 @@
     }
 
     &.is-focus .#{$namespace}-input__wrapper {
-      @include inset-input-border(
-        getCssVar('select-input-focus-border-color'),
-        true
-      );
+      @include inset-input-border(getCssVar('select-input-focus-border-color'));
     }
   }
 


### PR DESCRIPTION
remove `important` from the select component style box-shadow attribute

fixed the inconsistent box-shadow style of select under the form form

closed #14515

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99214e9</samp>

Refactor and improve the select component styles. This includes using a consistent border width for the `select` input, and adding a red box shadow for invalid states. The changes affect the files `select.scss` and `form.scss` in the `theme-chalk` package.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 99214e9</samp>

* Add red box shadow to select input wrapper when invalid ([link](https://github.com/element-plus/element-plus/pull/14556/files?diff=unified&w=0#diff-a06b6b42645a48545ba60709fb57d198b7dc9b08b750e300e8ed8f8032489f29R232-R239))
* Simplify `inset-input-border` mixin and use same border width for all input states in `select.scss` ([link](https://github.com/element-plus/element-plus/pull/14556/files?diff=unified&w=0#diff-cb8f9194ab7f36f2aceafe27b8c5e84e741cb7c5a598244ab2199242563e6c74L98-R98), [link](https://github.com/element-plus/element-plus/pull/14556/files?diff=unified&w=0#diff-cb8f9194ab7f36f2aceafe27b8c5e84e741cb7c5a598244ab2199242563e6c74L160-R157))
