### PR TITLE
fix(theme-chalk): menu horizontal popover height, close #14566

### DIFF
--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -80,6 +80,11 @@
   }
 
   @include m(horizontal) {
+    // reset menu-item popup height
+    &.#{$namespace}-menu--popup-container {
+      height: unset;
+    }
+
     display: flex;
     flex-wrap: nowrap;
     border-right: none;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

![image](https://github.com/element-plus/element-plus/assets/25154432/ae2c2bf0-eaae-4b3a-ae65-fa06c6cd80ae)

`el-menu--popup-container` height overrode by `el-menu--horizontal`.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 263cc60</samp>

Fix popup menu height bug in `menu.scss`. Add style rule to reset popup container height when menu is in popup mode.

## Related Issue

Fixes #14566.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 263cc60</samp>

* Reset the height of the menu-item popup container in popup mode to avoid overflow issues ([link](https://github.com/element-plus/element-plus/pull/14573/files?diff=unified&w=0#diff-451ad66686a31c13be1b990962362c2ef9421c307729380fde9251ec87ea91baR83-R87))
