### PR TITLE
fix(components): [tree-select] v-model invalid when source changes

### DIFF
--- a/packages/components/tree-select/__tests__/tree-select.test.tsx
+++ b/packages/components/tree-select/__tests__/tree-select.test.tsx
@@ -676,4 +676,31 @@ describe('TreeSelect.vue', () => {
     await nextTick()
     expect(select.vm.modelValue).equal(2)
   })
+
+  test('v-model source change', async () => {
+    const spy1 = vi.fn()
+    const wrapper = mount({
+      components: { TreeSelect },
+      data() {
+        return {
+          data: [{ value: 1, handleChange: spy1 }],
+          options: [{ value: 1 }, { value: 2 }],
+        }
+      },
+      template: `<TreeSelect v-for="item in data" v-model="item.value" :data="options" @update:modelValue="item.handleChange" />`,
+    })
+    const select = wrapper.findComponent({
+      name: 'ElSelect',
+    })
+
+    select.vm.handleOptionSelect(select.vm.options.get(1))
+    expect(spy1).toBeCalledWith(1)
+
+    const spy2 = vi.fn()
+    wrapper.vm.data = [{ value: 1, handleChange: spy2 }]
+    await nextTick()
+
+    select.vm.handleOptionSelect(select.vm.options.get(2))
+    expect(spy2).toBeCalledWith(2)
+  })
 })

--- a/packages/components/tree-select/src/select.ts
+++ b/packages/components/tree-select/src/select.ts
@@ -8,7 +8,7 @@ import type ElTree from '@element-plus/components/tree'
 
 export const useSelect = (
   props,
-  { attrs },
+  { attrs, emit },
   {
     tree,
     key,
@@ -23,6 +23,10 @@ export const useSelect = (
   const result = {
     ...pick(toRefs(props), Object.keys(ElSelect.props)),
     ...attrs,
+    // attrs is not reactive, when v-model binding source changes,
+    // this listener is still old, see the bug(or test 'v-model source change'):
+    // https://github.com/element-plus/element-plus/issues/14204
+    'onUpdate:modelValue': (value) => emit('update:modelValue', value),
     valueKey: key,
     popperClass: computed(() => {
       const classes = [ns.e('popper')]

--- a/packages/components/tree-select/src/select.ts
+++ b/packages/components/tree-select/src/select.ts
@@ -3,6 +3,7 @@ import { computed, nextTick, toRefs } from 'vue'
 import { pick } from 'lodash-unified'
 import ElSelect from '@element-plus/components/select'
 import { useNamespace } from '@element-plus/hooks'
+import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import type { Ref } from 'vue'
 import type ElTree from '@element-plus/components/tree'
 
@@ -26,7 +27,7 @@ export const useSelect = (
     // attrs is not reactive, when v-model binding source changes,
     // this listener is still old, see the bug(or test 'v-model source change'):
     // https://github.com/element-plus/element-plus/issues/14204
-    'onUpdate:modelValue': (value) => emit('update:modelValue', value),
+    'onUpdate:modelValue': (value) => emit(UPDATE_MODEL_EVENT, value),
     valueKey: key,
     popperClass: computed(() => {
       const classes = [ns.e('popper')]


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3083506</samp>

This pull request enhances the `TreeSelect` component with custom event emission and `v-model` reactivity. It also adds a test case to ensure the component works as expected with dynamic data.

## Related Issue

Fixes #14204.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3083506</samp>

* Fix bug where `TreeSelect` component does not update `v-model` value when binding source changes ([link](https://github.com/element-plus/element-plus/pull/14603/files?diff=unified&w=0#diff-d895cf8665299f6e338ee3fcd1259cbb2de31a2278a4bb30f691fe86fb497df7L11-R11), [link](https://github.com/element-plus/element-plus/pull/14603/files?diff=unified&w=0#diff-d895cf8665299f6e338ee3fcd1259cbb2de31a2278a4bb30f691fe86fb497df7R26-R29), [link](https://github.com/element-plus/element-plus/pull/14603/files?diff=unified&w=0#diff-38c0e66ee242d4981b4f2cd98f7a9fee72c2a789424872de31570565d475726dR679-R705))
  - Add `emit` parameter to `useSelect` function in `select.ts` to emit custom events from `TreeSelect` component ([link](https://github.com/element-plus/element-plus/pull/14603/files?diff=unified&w=0#diff-d895cf8665299f6e338ee3fcd1259cbb2de31a2278a4bb30f691fe86fb497df7L11-R11))
  - Add listener for `update:modelValue` event to `attrs` object in `select.ts` to re-emit the same event from `TreeSelect` component ([link](https://github.com/element-plus/element-plus/pull/14603/files?diff=unified&w=0#diff-d895cf8665299f6e338ee3fcd1259cbb2de31a2278a4bb30f691fe86fb497df7R26-R29))
  - Add test case in `tree-select.test.tsx` to verify that `TreeSelect` component can handle dynamic `v-model` binding source changes ([link](https://github.com/element-plus/element-plus/pull/14603/files?diff=unified&w=0#diff-38c0e66ee242d4981b4f2cd98f7a9fee72c2a789424872de31570565d475726dR679-R705))
