### PR TITLE
fix(components): [form] undeclared attribute is modified to undefined

### DIFF
--- a/packages/components/form/__tests__/form.test.tsx
+++ b/packages/components/form/__tests__/form.test.tsx
@@ -303,7 +303,6 @@ describe('Form', () => {
     vi.useFakeTimers()
     const form = reactive({
       name: '',
-      address: '',
       type: new Array<string>(),
     })
 
@@ -364,7 +363,7 @@ describe('Form', () => {
     // after timer fired, we should wait for the UI to be updated.
     await nextTick()
     expect(form.name).toBe('')
-    expect(form.address).toBe('')
+    expect('address' in form).toBeFalsy()
     expect(form.type.length).toBe(0)
     expect(wrapper.findAll('.el-form-item__error')).toHaveLength(0)
     vi.useRealTimers()

--- a/packages/components/form/src/constants.ts
+++ b/packages/components/form/src/constants.ts
@@ -5,3 +5,5 @@ export const formContextKey: InjectionKey<FormContext> =
   Symbol('formContextKey')
 export const formItemContextKey: InjectionKey<FormItemContext> =
   Symbol('formItemContextKey')
+
+export const undeclaredValue = Symbol('undeclared')

--- a/packages/components/form/src/form-item.vue
+++ b/packages/components/form/src/form-item.vue
@@ -65,7 +65,11 @@ import { useId, useNamespace } from '@element-plus/hooks'
 import { useFormSize } from './hooks'
 import { formItemProps } from './form-item'
 import FormLabelWrap from './form-label-wrap'
-import { formContextKey, formItemContextKey } from './constants'
+import {
+  formContextKey,
+  formItemContextKey,
+  undeclaredValue,
+} from './constants'
 
 import type { CSSProperties } from 'vue'
 import type { RuleItem } from 'async-validator'
@@ -97,8 +101,7 @@ const validateStateDebounced = refDebounced(validateState, 100)
 const validateMessage = ref('')
 const formItemRef = ref<HTMLDivElement>()
 // special inline value.
-const emptyValue = Symbol('empty')
-let initialValue: any = emptyValue
+let initialValue: any = undeclaredValue
 let isResettingField = false
 
 const labelStyle = computed<CSSProperties>(() => {
@@ -339,7 +342,7 @@ const resetField: FormItemContext['resetField'] = async () => {
   // prevent validation from being triggered
   isResettingField = true
 
-  if (initialValue === emptyValue) {
+  if (initialValue === undeclaredValue) {
     unset(model, props.prop)
   } else {
     computedValue.value = clone(initialValue)


### PR DESCRIPTION
The initial value is

```ts
const ruleForm = reactive<RuleForm>({
  name: 'Hello',
  region: undefined,
})
```

After clicking the reset button

```ts
{
  count: undefined
  date1: undefined
  date2: undefined
  delivery: undefined
  desc: undefined
  name: "Hello"
  region: undefined
  resource: undefined
  type: undefined
}
```

[before](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6Ijx0ZW1wbGF0ZT5cbiAgPGVsLWZvcm1cbiAgICByZWY9XCJydWxlRm9ybVJlZlwiXG4gICAgOm1vZGVsPVwicnVsZUZvcm1cIlxuICAgIDpydWxlcz1cInJ1bGVzXCJcbiAgICBsYWJlbC13aWR0aD1cIjEyMHB4XCJcbiAgICBjbGFzcz1cImRlbW8tcnVsZUZvcm1cIlxuICAgIDpzaXplPVwiZm9ybVNpemVcIlxuICAgIHN0YXR1cy1pY29uXG4gID5cbiAgICA8ZWwtZm9ybS1pdGVtIGxhYmVsPVwiQWN0aXZpdHkgbmFtZVwiIHByb3A9XCJuYW1lXCI+XG4gICAgICA8ZWwtaW5wdXQgdi1tb2RlbD1cInJ1bGVGb3JtLm5hbWVcIiAvPlxuICAgIDwvZWwtZm9ybS1pdGVtPlxuICAgIDxlbC1mb3JtLWl0ZW0gbGFiZWw9XCJBY3Rpdml0eSB6b25lXCIgcHJvcD1cInJlZ2lvblwiPlxuICAgICAgPGVsLXNlbGVjdCB2LW1vZGVsPVwicnVsZUZvcm0ucmVnaW9uXCIgcGxhY2Vob2xkZXI9XCJBY3Rpdml0eSB6b25lXCI+XG4gICAgICAgIDxlbC1vcHRpb24gbGFiZWw9XCJab25lIG9uZVwiIHZhbHVlPVwic2hhbmdoYWlcIiAvPlxuICAgICAgICA8ZWwtb3B0aW9uIGxhYmVsPVwiWm9uZSB0d29cIiB2YWx1ZT1cImJlaWppbmdcIiAvPlxuICAgICAgPC9lbC1zZWxlY3Q+XG4gICAgPC9lbC1mb3JtLWl0ZW0+XG4gICAgPGVsLWZvcm0taXRlbSBsYWJlbD1cIkFjdGl2aXR5IGNvdW50XCIgcHJvcD1cImNvdW50XCI+XG4gICAgICA8ZWwtc2VsZWN0LXYyXG4gICAgICAgIHYtbW9kZWw9XCJydWxlRm9ybS5jb3VudFwiXG4gICAgICAgIHBsYWNlaG9sZGVyPVwiQWN0aXZpdHkgY291bnRcIlxuICAgICAgICA6b3B0aW9ucz1cIm9wdGlvbnNcIlxuICAgICAgLz5cbiAgICA8L2VsLWZvcm0taXRlbT5cbiAgICA8ZWwtZm9ybS1pdGVtIGxhYmVsPVwiQWN0aXZpdHkgdGltZVwiIHJlcXVpcmVkPlxuICAgICAgPGVsLWNvbCA6c3Bhbj1cIjExXCI+XG4gICAgICAgIDxlbC1mb3JtLWl0ZW0gcHJvcD1cImRhdGUxXCI+XG4gICAgICAgICAgPGVsLWRhdGUtcGlja2VyXG4gICAgICAgICAgICB2LW1vZGVsPVwicnVsZUZvcm0uZGF0ZTFcIlxuICAgICAgICAgICAgdHlwZT1cImRhdGVcIlxuICAgICAgICAgICAgbGFiZWw9XCJQaWNrIGEgZGF0ZVwiXG4gICAgICAgICAgICBwbGFjZWhvbGRlcj1cIlBpY2sgYSBkYXRlXCJcbiAgICAgICAgICAgIHN0eWxlPVwid2lkdGg6IDEwMCVcIlxuICAgICAgICAgIC8+XG4gICAgICAgIDwvZWwtZm9ybS1pdGVtPlxuICAgICAgPC9lbC1jb2w+XG4gICAgICA8ZWwtY29sIGNsYXNzPVwidGV4dC1jZW50ZXJcIiA6c3Bhbj1cIjJcIj5cbiAgICAgICAgPHNwYW4gY2xhc3M9XCJ0ZXh0LWdyYXktNTAwXCI+LTwvc3Bhbj5cbiAgICAgIDwvZWwtY29sPlxuICAgICAgPGVsLWNvbCA6c3Bhbj1cIjExXCI+XG4gICAgICAgIDxlbC1mb3JtLWl0ZW0gcHJvcD1cImRhdGUyXCI+XG4gICAgICAgICAgPGVsLXRpbWUtcGlja2VyXG4gICAgICAgICAgICB2LW1vZGVsPVwicnVsZUZvcm0uZGF0ZTJcIlxuICAgICAgICAgICAgbGFiZWw9XCJQaWNrIGEgdGltZVwiXG4gICAgICAgICAgICBwbGFjZWhvbGRlcj1cIlBpY2sgYSB0aW1lXCJcbiAgICAgICAgICAgIHN0eWxlPVwid2lkdGg6IDEwMCVcIlxuICAgICAgICAgIC8+XG4gICAgICAgIDwvZWwtZm9ybS1pdGVtPlxuICAgICAgPC9lbC1jb2w+XG4gICAgPC9lbC1mb3JtLWl0ZW0+XG4gICAgPGVsLWZvcm0taXRlbSBsYWJlbD1cIkluc3RhbnQgZGVsaXZlcnlcIiBwcm9wPVwiZGVsaXZlcnlcIj5cbiAgICAgIDxlbC1zd2l0Y2ggdi1tb2RlbD1cInJ1bGVGb3JtLmRlbGl2ZXJ5XCIgLz5cbiAgICA8L2VsLWZvcm0taXRlbT5cbiAgICA8ZWwtZm9ybS1pdGVtIGxhYmVsPVwiQWN0aXZpdHkgdHlwZVwiIHByb3A9XCJ0eXBlXCI+XG4gICAgICA8ZWwtY2hlY2tib3gtZ3JvdXAgdi1tb2RlbD1cInJ1bGVGb3JtLnR5cGVcIj5cbiAgICAgICAgPGVsLWNoZWNrYm94IGxhYmVsPVwiT25saW5lIGFjdGl2aXRpZXNcIiBuYW1lPVwidHlwZVwiIC8+XG4gICAgICAgIDxlbC1jaGVja2JveCBsYWJlbD1cIlByb21vdGlvbiBhY3Rpdml0aWVzXCIgbmFtZT1cInR5cGVcIiAvPlxuICAgICAgICA8ZWwtY2hlY2tib3ggbGFiZWw9XCJPZmZsaW5lIGFjdGl2aXRpZXNcIiBuYW1lPVwidHlwZVwiIC8+XG4gICAgICAgIDxlbC1jaGVja2JveCBsYWJlbD1cIlNpbXBsZSBicmFuZCBleHBvc3VyZVwiIG5hbWU9XCJ0eXBlXCIgLz5cbiAgICAgIDwvZWwtY2hlY2tib3gtZ3JvdXA+XG4gICAgPC9lbC1mb3JtLWl0ZW0+XG4gICAgPGVsLWZvcm0taXRlbSBsYWJlbD1cIlJlc291cmNlc1wiIHByb3A9XCJyZXNvdXJjZVwiPlxuICAgICAgPGVsLXJhZGlvLWdyb3VwIHYtbW9kZWw9XCJydWxlRm9ybS5yZXNvdXJjZVwiPlxuICAgICAgICA8ZWwtcmFkaW8gbGFiZWw9XCJTcG9uc29yc2hpcFwiIC8+XG4gICAgICAgIDxlbC1yYWRpbyBsYWJlbD1cIlZlbnVlXCIgLz5cbiAgICAgIDwvZWwtcmFkaW8tZ3JvdXA+XG4gICAgPC9lbC1mb3JtLWl0ZW0+XG4gICAgPGVsLWZvcm0taXRlbSBsYWJlbD1cIkFjdGl2aXR5IGZvcm1cIiBwcm9wPVwiZGVzY1wiPlxuICAgICAgPGVsLWlucHV0IHYtbW9kZWw9XCJydWxlRm9ybS5kZXNjXCIgdHlwZT1cInRleHRhcmVhXCIgLz5cbiAgICA8L2VsLWZvcm0taXRlbT5cbiAgICA8ZWwtZm9ybS1pdGVtPlxuICAgICAgPGVsLWJ1dHRvbiB0eXBlPVwicHJpbWFyeVwiIEBjbGljaz1cInN1Ym1pdEZvcm0ocnVsZUZvcm1SZWYpXCI+XG4gICAgICAgIENyZWF0ZVxuICAgICAgPC9lbC1idXR0b24+XG4gICAgICA8ZWwtYnV0dG9uIEBjbGljaz1cInJlc2V0Rm9ybShydWxlRm9ybVJlZilcIj5SZXNldDwvZWwtYnV0dG9uPlxuICAgIDwvZWwtZm9ybS1pdGVtPlxuICA8L2VsLWZvcm0+XG4gIDx1bD5cbiAgICA8bGk+Q2xpY2sgQ3JlYXRlPC9saT5cbiAgICA8bGk+Q2xpY2sgUmVzZXQ8L2xpPlxuICAgIDxsaT5DaGVjayB0aGUgY29uc29sZSB2YWx1ZTwvbGk+XG4gIDwvdWw+XG48L3RlbXBsYXRlPlxuXG48c2NyaXB0IGxhbmc9XCJ0c1wiIHNldHVwPlxuaW1wb3J0IHsgcmVhY3RpdmUsIHJlZiB9IGZyb20gJ3Z1ZSdcbmltcG9ydCB0eXBlIHsgRm9ybUluc3RhbmNlLCBGb3JtUnVsZXMgfSBmcm9tICdlbGVtZW50LXBsdXMnXG5cbmludGVyZmFjZSBSdWxlRm9ybSB7XG4gIG5hbWU/OiBzdHJpbmdcbiAgcmVnaW9uPzogc3RyaW5nXG4gIGNvdW50Pzogc3RyaW5nXG4gIGRhdGUxPzogc3RyaW5nXG4gIGRhdGUyPzogc3RyaW5nXG4gIGRlbGl2ZXJ5PzogYm9vbGVhblxuICB0eXBlPzogc3RyaW5nW11cbiAgcmVzb3VyY2U/OiBzdHJpbmdcbiAgZGVzYz86IHN0cmluZ1xufVxuXG5jb25zdCBmb3JtU2l6ZSA9IHJlZignZGVmYXVsdCcgYXMgY29uc3QpXG5jb25zdCBydWxlRm9ybVJlZiA9IHJlZjxGb3JtSW5zdGFuY2U+KClcbmNvbnN0IHJ1bGVGb3JtID0gcmVhY3RpdmU8UnVsZUZvcm0+KHtcbiAgbmFtZTogJ0hlbGxvJyxcbiAgcmVnaW9uOiB1bmRlZmluZWQsXG59KVxuXG5jb25zdCBydWxlcyA9IHJlYWN0aXZlPEZvcm1SdWxlczxSdWxlRm9ybT4+KHtcbiAgbmFtZTogW1xuICAgIHsgcmVxdWlyZWQ6IHRydWUsIG1lc3NhZ2U6ICdQbGVhc2UgaW5wdXQgQWN0aXZpdHkgbmFtZScsIHRyaWdnZXI6ICdibHVyJyB9LFxuICAgIHsgbWluOiAzLCBtYXg6IDUsIG1lc3NhZ2U6ICdMZW5ndGggc2hvdWxkIGJlIDMgdG8gNScsIHRyaWdnZXI6ICdibHVyJyB9LFxuICBdLFxuICByZWdpb246IFtcbiAgICB7XG4gICAgICByZXF1aXJlZDogdHJ1ZSxcbiAgICAgIG1lc3NhZ2U6ICdQbGVhc2Ugc2VsZWN0IEFjdGl2aXR5IHpvbmUnLFxuICAgICAgdHJpZ2dlcjogJ2NoYW5nZScsXG4gICAgfSxcbiAgXSxcbiAgY291bnQ6IFtcbiAgICB7XG4gICAgICByZXF1aXJlZDogdHJ1ZSxcbiAgICAgIG1lc3NhZ2U6ICdQbGVhc2Ugc2VsZWN0IEFjdGl2aXR5IGNvdW50JyxcbiAgICAgIHRyaWdnZXI6ICdjaGFuZ2UnLFxuICAgIH0sXG4gIF0sXG4gIGRhdGUxOiBbXG4gICAge1xuICAgICAgdHlwZTogJ2RhdGUnLFxuICAgICAgcmVxdWlyZWQ6IHRydWUsXG4gICAgICBtZXNzYWdlOiAnUGxlYXNlIHBpY2sgYSBkYXRlJyxcbiAgICAgIHRyaWdnZXI6ICdjaGFuZ2UnLFxuICAgIH0sXG4gIF0sXG4gIGRhdGUyOiBbXG4gICAge1xuICAgICAgdHlwZTogJ2RhdGUnLFxuICAgICAgcmVxdWlyZWQ6IHRydWUsXG4gICAgICBtZXNzYWdlOiAnUGxlYXNlIHBpY2sgYSB0aW1lJyxcbiAgICAgIHRyaWdnZXI6ICdjaGFuZ2UnLFxuICAgIH0sXG4gIF0sXG4gIHR5cGU6IFtcbiAgICB7XG4gICAgICB0eXBlOiAnYXJyYXknLFxuICAgICAgcmVxdWlyZWQ6IHRydWUsXG4gICAgICBtZXNzYWdlOiAnUGxlYXNlIHNlbGVjdCBhdCBsZWFzdCBvbmUgYWN0aXZpdHkgdHlwZScsXG4gICAgICB0cmlnZ2VyOiAnY2hhbmdlJyxcbiAgICB9LFxuICBdLFxuICByZXNvdXJjZTogW1xuICAgIHtcbiAgICAgIHJlcXVpcmVkOiB0cnVlLFxuICAgICAgbWVzc2FnZTogJ1BsZWFzZSBzZWxlY3QgYWN0aXZpdHkgcmVzb3VyY2UnLFxuICAgICAgdHJpZ2dlcjogJ2NoYW5nZScsXG4gICAgfSxcbiAgXSxcbiAgZGVzYzogW1xuICAgIHsgcmVxdWlyZWQ6IHRydWUsIG1lc3NhZ2U6ICdQbGVhc2UgaW5wdXQgYWN0aXZpdHkgZm9ybScsIHRyaWdnZXI6ICdibHVyJyB9LFxuICBdLFxufSlcblxuY29uc3Qgc3VibWl0Rm9ybSA9IGFzeW5jIChmb3JtRWw6IEZvcm1JbnN0YW5jZSB8IHVuZGVmaW5lZCkgPT4ge1xuICBpZiAoIWZvcm1FbCkgcmV0dXJuXG4gIGNvbnNvbGUubG9nKCdzdWJtaXRGb3JtJywgcnVsZUZvcm0pXG4gIGF3YWl0IGZvcm1FbC52YWxpZGF0ZSgodmFsaWQsIGZpZWxkcykgPT4ge1xuICAgIGlmICh2YWxpZCkge1xuICAgICAgY29uc29sZS5sb2coJ3N1Ym1pdCEnKVxuICAgIH0gZWxzZSB7XG4gICAgICBjb25zb2xlLmxvZygnZXJyb3Igc3VibWl0IScsIGZpZWxkcylcbiAgICB9XG4gIH0pXG59XG5cbmNvbnN0IHJlc2V0Rm9ybSA9IChmb3JtRWw6IEZvcm1JbnN0YW5jZSB8IHVuZGVmaW5lZCkgPT4ge1xuICBpZiAoIWZvcm1FbCkgcmV0dXJuXG4gIGZvcm1FbC5yZXNldEZpZWxkcygpXG4gIGNvbnNvbGUubG9nKCdyZXNldEZvcm0nLCBydWxlRm9ybSlcbn1cblxuY29uc3Qgb3B0aW9ucyA9IEFycmF5LmZyb20oeyBsZW5ndGg6IDEwMDAwIH0pLm1hcCgoXywgaWR4KSA9PiAoe1xuICB2YWx1ZTogYCR7aWR4ICsgMX1gLFxuICBsYWJlbDogYCR7aWR4ICsgMX1gLFxufSkpXG48L3NjcmlwdD5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHt9XG59IiwidHNjb25maWcuanNvbiI6IntcbiAgXCJjb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVSZXNvbHV0aW9uXCI6IFwiQnVuZGxlclwiLFxuICAgIFwiYWxsb3dJbXBvcnRpbmdUc0V4dGVuc2lvbnNcIjogdHJ1ZSxcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXVxuICB9LFxuICBcInZ1ZUNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogMy4zXG4gIH1cbn1cbiIsIl9vIjp7fX0=)

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7324281</samp>

This pull request fixes a bug where form items with no initial value or undefined model value would not be reset properly. It updates the `form-item.vue` component and the corresponding test case in `form.test.tsx` to use a consistent and robust way of checking and unsetting the model value.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7324281</samp>

*  Add logic to unset model value for form items with no initial value ([link](https://github.com/element-plus/element-plus/pull/14612/files?diff=unified&w=0#diff-ec639edfd5d7463de4e60beb64943914663f64e5e4fc14ca2d93166e1ef2bad3L54-R54), [link](https://github.com/element-plus/element-plus/pull/14612/files?diff=unified&w=0#diff-ec639edfd5d7463de4e60beb64943914663f64e5e4fc14ca2d93166e1ef2bad3L100-R101), [link](https://github.com/element-plus/element-plus/pull/14612/files?diff=unified&w=0#diff-ec639edfd5d7463de4e60beb64943914663f64e5e4fc14ca2d93166e1ef2bad3L341-R346), [link](https://github.com/element-plus/element-plus/pull/14612/files?diff=unified&w=0#diff-ec639edfd5d7463de4e60beb64943914663f64e5e4fc14ca2d93166e1ef2bad3L394-R401))
* Update test case to reflect changes in form item behavior ([link](https://github.com/element-plus/element-plus/pull/14612/files?diff=unified&w=0#diff-b15ed880239bac56ff12222df0a00fae2c4ef66ecfb1ea7a70b34a025e5b8629L306), [link](https://github.com/element-plus/element-plus/pull/14612/files?diff=unified&w=0#diff-b15ed880239bac56ff12222df0a00fae2c4ef66ecfb1ea7a70b34a025e5b8629L367-R366))
