### PR TITLE
fix(components): [tree-select] case-insensitive when filterable

### DIFF
--- a/packages/components/tree-select/src/tree.ts
+++ b/packages/components/tree-select/src/tree.ts
@@ -2,7 +2,7 @@
 import { computed, nextTick, toRefs, watch } from 'vue'
 import { isEqual, pick } from 'lodash-unified'
 import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
-import { isFunction } from '@element-plus/utils'
+import { escapeStringRegexp, isFunction } from '@element-plus/utils'
 import ElTree from '@element-plus/components/tree'
 import TreeSelectOption from './tree-select-option'
 import {
@@ -148,15 +148,16 @@ export const useTree = (
         props.renderContent
           ? () => props.renderContent(h, { node, data, store })
           : slots.default
-          ? () => slots.default({ node, data, store })
-          : undefined
+            ? () => slots.default({ node, data, store })
+            : undefined
       )
     },
     filterNodeMethod: (value, data, node) => {
       if (props.filterNodeMethod)
         return props.filterNodeMethod(value, data, node)
       if (!value) return true
-      return getNodeValByProp('label', data)?.includes(value)
+      const regexp = new RegExp(escapeStringRegexp(value), 'i')
+      return regexp.test(getNodeValByProp('label', data) || '')
     },
     onNodeClick: (data, node, e) => {
       attrs.onNodeClick?.(data, node, e)
@@ -186,11 +187,11 @@ export const useTree = (
       const uncachedCheckedKeys = params.checkedKeys
       const cachedKeys = props.multiple
         ? toValidArray(props.modelValue).filter(
-            (item) =>
-              item in cacheOptionsMap.value &&
-              !tree.value.getNode(item) &&
-              !uncachedCheckedKeys.includes(item)
-          )
+          (item) =>
+            item in cacheOptionsMap.value &&
+            !tree.value.getNode(item) &&
+            !uncachedCheckedKeys.includes(item)
+        )
         : []
       const checkedKeys = uncachedCheckedKeys.concat(cachedKeys)
 
@@ -201,8 +202,8 @@ export const useTree = (
           props.multiple
             ? checkedKeys
             : checkedKeys.includes(dataValue)
-            ? dataValue
-            : undefined
+              ? dataValue
+              : undefined
         )
       }
       // only can select leaf node


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 304bdc5</samp>

Enhanced the filter functionality and code style of the `tree-select` component.

## Related Issue

Fixes #14613 .

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 304bdc5</samp>

* Import `escapeStringRegexp` function from `@element-plus/utils` to escape special characters in filter value for tree-select component ([link](https://github.com/element-plus/element-plus/pull/14615/files?diff=unified&w=0#diff-7edaee57f8bbaf143fa72bcdd51ef82eef9273119a3c89278eddfda4d62b9804L5-R5))
* Change filter logic to use case-insensitive regular expression instead of string inclusion check, to improve user experience and match behavior of other components ([link](https://github.com/element-plus/element-plus/pull/14615/files?diff=unified&w=0#diff-7edaee57f8bbaf143fa72bcdd51ef82eef9273119a3c89278eddfda4d62b9804L159-R160))
* Adjust indentation of ternary operators and filter function to follow code style of project ([link](https://github.com/element-plus/element-plus/pull/14615/files?diff=unified&w=0#diff-7edaee57f8bbaf143fa72bcdd51ef82eef9273119a3c89278eddfda4d62b9804L151-R152), [link](https://github.com/element-plus/element-plus/pull/14615/files?diff=unified&w=0#diff-7edaee57f8bbaf143fa72bcdd51ef82eef9273119a3c89278eddfda4d62b9804L159-R160), [link](https://github.com/element-plus/element-plus/pull/14615/files?diff=unified&w=0#diff-7edaee57f8bbaf143fa72bcdd51ef82eef9273119a3c89278eddfda4d62b9804L189-R194), [link](https://github.com/element-plus/element-plus/pull/14615/files?diff=unified&w=0#diff-7edaee57f8bbaf143fa72bcdd51ef82eef9273119a3c89278eddfda4d62b9804L204-R206))
