### PR TITLE
fix(components): [space] did not render as expected using fill props

### DIFF
--- a/packages/components/space/src/use-space.ts
+++ b/packages/components/space/src/use-space.ts
@@ -27,6 +27,11 @@ export function useSpace(props: SpaceProps) {
     const alignment: CSSProperties = {
       alignItems: props.alignment,
     }
+
+    if (props.fill) {
+      wrapKls.width = '100%'
+    }
+
     return [wrapKls, alignment, props.style]
   })
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f666bd</samp>

Implement `fill` prop for `ElSpace` component. Modify `use-space.ts` to set `width` of wrapper element to `'100%'` when `fill` is true.

## Related Issue

Fixes #14638

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5f666bd</samp>

* Implement the `fill` prop feature for the `ElSpace` component, which allows the component to fill the available horizontal space ([link](https://github.com/element-plus/element-plus/pull/14647/files?diff=unified&w=0#diff-c156161c9b2baba154aa0f42cd5cef9efe0367b3edecd73f46a00c9a5914796aR30-R34))
