### PR TITLE
fix(components): [select-v2] label error when value not in the options

### DIFF
--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -478,7 +478,7 @@ describe('Select', () => {
       [undefined, DEFAULT_PLACEHOLDER],
       ['', ''],
       [[], DEFAULT_PLACEHOLDER],
-      [{}, '[object Object]'],
+      [{}, ''],
     ])(
       '[single select] initial value is %s, placeholder is "%s"',
       async (value, placeholder) => {

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -700,7 +700,7 @@ const useSelect = (props: ISelectProps, emit) => {
           states.selectedLabel = getLabel(options[selectedItemIndex])
           updateHoveringIndex(selectedItemIndex)
         } else {
-          states.selectedLabel = `${props.modelValue}`
+          states.selectedLabel = getValueKey(props.modelValue)
         }
       } else {
         states.selectedLabel = ''


### PR DESCRIPTION
closed #14621

[before](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6Ijx0ZW1wbGF0ZT5cbiAgPGgzPk9iamVjdDwvaDM+XG4gIDxlbC1zZWxlY3QtdjIgdi1tb2RlbD1cInZhbHVlXCIgOm9wdGlvbnM9XCJvcHRpb25zXCIgdmFsdWUta2V5PVwibmFtZVwiIC8+XG4gIDxoMz5TdHJpbmc8L2gzPlxuICA8ZWwtc2VsZWN0LXYyIHYtbW9kZWw9XCJ2YWx1ZTFcIiA6b3B0aW9ucz1cIm9wdGlvbnMxXCIgLz5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5cbmNvbnN0IHZhbHVlID0gcmVmKHsgbmFtZTogJ09wdGlvbiAxMjInLCB0ZXN0OiAndGVzdCAxMjInIH0pXG5jb25zdCB2YWx1ZTEgPSByZWYoJ09wdGlvbjEyMicpXG5jb25zdCBvcHRpb25zID0gW1xuICB7XG4gICAgdmFsdWU6IHtcbiAgICAgIG5hbWU6ICdPcHRpb24gMicsXG4gICAgICB0ZXN0OiAndGVzdCBhJyxcbiAgICB9LFxuICAgIGxhYmVsOiAnT3B0aW9uIDInLFxuICB9XG5dXG5jb25zdCBvcHRpb25zMSA9IFtcbiAge1xuICAgIHZhbHVlOiAnT3B0aW9uMScsXG4gICAgbGFiZWw6ICdPcHRpb24xJyxcbiAgfSxcbl1cbjwvc2NyaXB0PlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge31cbn0iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWUsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwiX28iOnt9fQ==)

[after](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6Ijx0ZW1wbGF0ZT5cbiAgPGgzPk9iamVjdDwvaDM+XG4gIDxlbC1zZWxlY3QtdjIgdi1tb2RlbD1cInZhbHVlXCIgOm9wdGlvbnM9XCJvcHRpb25zXCIgdmFsdWUta2V5PVwibmFtZVwiIC8+XG4gIDxoMz5TdHJpbmc8L2gzPlxuICA8ZWwtc2VsZWN0LXYyIHYtbW9kZWw9XCJ2YWx1ZTFcIiA6b3B0aW9ucz1cIm9wdGlvbnMxXCIgLz5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5cbmNvbnN0IHZhbHVlID0gcmVmKHsgbmFtZTogJ09wdGlvbiAxMjInLCB0ZXN0OiAndGVzdCAxMjInIH0pXG5jb25zdCB2YWx1ZTEgPSByZWYoJ09wdGlvbjEyMicpXG5jb25zdCBvcHRpb25zID0gW1xuICB7XG4gICAgdmFsdWU6IHtcbiAgICAgIG5hbWU6ICdPcHRpb24gMicsXG4gICAgICB0ZXN0OiAndGVzdCBhJyxcbiAgICB9LFxuICAgIGxhYmVsOiAnT3B0aW9uIDInLFxuICB9XG5dXG5jb25zdCBvcHRpb25zMSA9IFtcbiAge1xuICAgIHZhbHVlOiAnT3B0aW9uMScsXG4gICAgbGFiZWw6ICdPcHRpb24xJyxcbiAgfSxcbl1cbjwvc2NyaXB0PlxuIiwic3JjL1BsYXlncm91bmRNYWluLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgQXBwIGZyb20gJy4vQXBwLnZ1ZSdcbmltcG9ydCB7IHNldHVwRWxlbWVudFBsdXMgfSBmcm9tICcuL2VsZW1lbnQtcGx1cy5qcydcbnNldHVwRWxlbWVudFBsdXMoKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPEFwcCAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vcHJldmlldy0xNDY1Ni1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcInVuc3VwcG9ydGVkXCJcbiAgfVxufSIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcImFsbG93SnNcIjogdHJ1ZSxcbiAgICBcImNoZWNrSnNcIjogdHJ1ZSxcbiAgICBcImpzeFwiOiBcInByZXNlcnZlXCIsXG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJ0eXBlc1wiOiBbXCJlbGVtZW50LXBsdXMvZ2xvYmFsLmQudHNcIl1cbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJzcmMvZWxlbWVudC1wbHVzLmpzIjoiaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuaW1wb3J0IEVsZW1lbnRQbHVzIGZyb20gJ2VsZW1lbnQtcGx1cydcblxubGV0IGluc3RhbGxlZCA9IGZhbHNlXG5hd2FpdCBsb2FkU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gc2V0dXBFbGVtZW50UGx1cygpIHtcbiAgaWYgKGluc3RhbGxlZCkgcmV0dXJuXG4gIGNvbnN0IGluc3RhbmNlID0gZ2V0Q3VycmVudEluc3RhbmNlKClcbiAgaW5zdGFuY2UuYXBwQ29udGV4dC5hcHAudXNlKEVsZW1lbnRQbHVzKVxuICBpbnN0YWxsZWQgPSB0cnVlXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkU3R5bGUoKSB7XG4gIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgbGluay5ocmVmID0gJ2h0dHBzOi8vcHJldmlldy0xNDY1Ni1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcydcbiAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2xvYWQnLCByZXNvbHZlKVxuICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgfSlcbn0iLCJfbyI6eyJzaG93SGlkZGVuIjp0cnVlLCJzdHlsZVNvdXJjZSI6Imh0dHBzOi8vcHJldmlldy0xNDY1Ni1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcyJ9fQ==)

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c7e44d</samp>

This pull request fixes a test case bug and improves the useSelect hook for the `select-v2` component. It uses a helper function `getValueKey` to generate unique keys for each option based on its value and label.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c7e44d</samp>

* Fix a bug in the single select test case that caused the placeholder to be '[object Object]' when the initial value was an object ([link](https://github.com/element-plus/element-plus/pull/14656/files?diff=unified&w=0#diff-fcb6e88a28a001059cca0b18d5425f18d2fc4de1a608031374b155a74e67e46aL481-R481))
* Refactor the useSelect hook to use a helper function getValueKey to generate unique keys for each option based on its value and label, instead of directly converting the model value to a string ([link](https://github.com/element-plus/element-plus/pull/14656/files?diff=unified&w=0#diff-6018da2b9e35c71aca0d0a0f881a93c00ab1f1958a3a9c69e332fa8d0b2e9865L703-R703))
