### PR TITLE
fix(components): [cascader] after lazyLoad, update leafNodes

### DIFF
--- a/packages/components/cascader-panel/src/store.ts
+++ b/packages/components/cascader-panel/src/store.ts
@@ -55,6 +55,8 @@ export default class Store {
   }
 
   appendNodes(nodeDataList: CascaderOption[], parentNode: Node) {
+    // After lazyLoad, determine whether parentNode is a leaf node
+    if (!nodeDataList.length) this.leafNodes.push(parentNode)
     nodeDataList.forEach((nodeData) => this.appendNode(nodeData, parentNode))
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

After lazyLoad, determine whether parentNode is a leaf node

## Related Issue

Fixes #9544.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 80033b6</samp>

* Fix a bug where the cascader panel would not show the check icon for leaf nodes that are loaded lazily by adding a condition to check if the nodeDataList is empty after lazy loading the children of a node ([link](https://github.com/element-plus/element-plus/pull/14703/files?diff=unified&w=0#diff-6ca8bec8f218071c13b487edabe4a63e55df6b304cd429d1998cecf1a35405c9R58-R59))
