### PR TITLE
docs(components): [slider] use new display tag

### DIFF
--- a/docs/en-US/component/slider.md
+++ b/docs/en-US/component/slider.md
@@ -87,38 +87,53 @@ slider/show-marks
 
 :::
 
-## Attributes
 
-| Name                  | Description                                                                                              | Type            | Accepted Values                                                                                           | Default |
-| --------------------- | -------------------------------------------------------------------------------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------- | ------- |
-| model-value / v-model | binding value                                                                                            | number          | —                                                                                                         | 0       |
-| min                   | minimum value                                                                                            | number          | —                                                                                                         | 0       |
-| max                   | maximum value                                                                                            | number          | —                                                                                                         | 100     |
-| disabled              | whether Slider is disabled                                                                               | boolean         | —                                                                                                         | false   |
-| step                  | step size                                                                                                | number          | —                                                                                                         | 1       |
-| show-input            | whether to display an input box, works when `range` is false                                             | boolean         | —                                                                                                         | false   |
-| show-input-controls   | whether to display control buttons when `show-input` is true                                             | boolean         | —                                                                                                         | true    |
-| size                  | size of the slider wrapper, will not work in vertical mode                                               | string          | large / default / small                                                                                   | default |
-| input-size            | size of the input box, when set `size`, the default is the value of `size`                               | string          | large / default / small                                                                                   | default |
-| show-stops            | whether to display breakpoints                                                                           | boolean         | —                                                                                                         | false   |
-| show-tooltip          | whether to display tooltip value                                                                         | boolean         | —                                                                                                         | true    |
-| format-tooltip        | format to display tooltip value                                                                          | function(value) | —                                                                                                         | —       |
-| range                 | whether to select a range                                                                                | boolean         | —                                                                                                         | false   |
-| vertical              | vertical mode                                                                                            | boolean         | —                                                                                                         | false   |
-| height                | Slider height, required in vertical mode                                                                 | string          | —                                                                                                         | —       |
-| label                 | label for screen reader                                                                                  | string          | —                                                                                                         | —       |
-| range-start-label     | when `range` is true, screen reader label for the start of the range                                     | string          | —                                                                                                         | —       |
-| range-end-label       | when `range` is true, screen reader label for the end of the range                                       | string          | —                                                                                                         | —       |
-| format-value-text     | format to display the `aria-valuenow` attribute for screen readers                                       | function(value) | —                                                                                                         | —       |
-| debounce              | debounce delay when typing, in milliseconds, works when `show-input` is true                             | number          | —                                                                                                         | 300     |
-| tooltip-class         | custom class name for the tooltip                                                                        | string          | —                                                                                                         | —       |
-| placement             | position of Tooltip                                                                                      | string          | top/top-start/top-end/bottom/bottom-start/bottom-end/left/left-start/left-end/right/right-start/right-end | top     |
-| marks                 | marks, type of key must be `number` and must in closed interval `[min, max]`, each mark can custom style | object          | —                                                                                                         | —       |
-| validate-event        | whether to trigger form validation                                                                       | boolean         | -                                                                                                         | true    |
+## API
 
-## Events
+### Attributes
 
-| Name   | Description                                                                                                       | Parameters           |
-| ------ | ----------------------------------------------------------------------------------------------------------------- | -------------------- |
-| change | triggers when the value changes (if the mouse is being dragged, this event only fires when the mouse is released) | value after changing |
-| input  | triggers when the data changes (It'll be emitted in real time during sliding)                                     | value after changing |
+| Name                  | Description                                                                                              | Type                                                                                                                                                                        | Default |
+| --------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| model-value / v-model | binding value                                                                                            | ^[number] / ^[object]`number[]`                                                                                                                                             | 0       |
+| min                   | minimum value                                                                                            | ^[number]                                                                                                                                                                   | 0       |
+| max                   | maximum value                                                                                            | ^[number]                                                                                                                                                                   | 100     |
+| disabled              | whether Slider is disabled                                                                               | ^[boolean]                                                                                                                                                                  | false   |
+| step                  | step size                                                                                                | ^[number]                                                                                                                                                                   | 1       |
+| show-input            | whether to display an input box, works when `range` is false                                             | ^[boolean]                                                                                                                                                                  | false   |
+| show-input-controls   | whether to display control buttons when `show-input` is true                                             | ^[boolean]                                                                                                                                                                  | true    |
+| size                  | size of the slider wrapper, will not work in vertical mode                                               | ^[enum]`'' \| 'large' \| 'default' \| 'small'`                                                                                                                              | default |
+| input-size            | size of the input box, when set `size`, the default is the value of `size`                               | ^[enum]`'' \| 'large' \| 'default' \| 'small'`                                                                                                                              | default |
+| show-stops            | whether to display breakpoints                                                                           | ^[boolean]                                                                                                                                                                  | false   |
+| show-tooltip          | whether to display tooltip value                                                                         | ^[boolean]                                                                                                                                                                  | true    |
+| format-tooltip        | format to display tooltip value                                                                          | ^[Function]`(value: number) => number \| string`                                                                                                                            | —       |
+| range                 | whether to select a range                                                                                | ^[boolean]                                                                                                                                                                  | false   |
+| vertical              | vertical mode                                                                                            | ^[boolean]                                                                                                                                                                  | false   |
+| height                | slider height, required in vertical mode                                                                 | ^[string]                                                                                                                                                                   | —       |
+| label                 | label for screen reader                                                                                  | ^[string]                                                                                                                                                                   | —       |
+| range-start-label     | when `range` is true, screen reader label for the start of the range                                     | ^[string]                                                                                                                                                                   | —       |
+| range-end-label       | when `range` is true, screen reader label for the end of the range                                       | ^[string]                                                                                                                                                                   | —       |
+| format-value-text     | format to display the `aria-valuenow` attribute for screen readers                                       | ^[Function]`(value: number) => string`                                                                                                                                      | —       |
+| debounce              | debounce delay when typing, in milliseconds, works when `show-input` is true                             | ^[number]                                                                                                                                                                   | 300     |
+| tooltip-class         | custom class name for the tooltip                                                                        | ^[string]                                                                                                                                                                   | —       |
+| placement             | position of Tooltip                                                                                      | ^[enum]`'top' \| 'top-start' \| 'top-end' \| 'bottom' \| 'bottom-start' \| 'bottom-end' \| 'left' \| 'left-start' \| 'left-end' \| 'right' \| 'right-start' \| 'right-end'` | top     |
+| marks                 | marks, type of key must be `number` and must in closed interval `[min, max]`, each mark can custom style | ^[object]`SliderMarks`                                                                                                                                                      | —       |
+| validate-event        | whether to trigger form validation                                                                       | ^[boolean]                                                                                                                                                                  | true    |
+
+### Events
+
+| Name   | Description                                                                                                       | Type                                               |
+| ------ | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| change | triggers when the value changes (if the mouse is being dragged, this event only fires when the mouse is released) | ^[Function]`(value: Arrayable<number>) => boolean` |
+| input  | triggers when the data changes (It'll be emitted in real time during sliding)                                     | ^[Function]`(value: Arrayable<number>) => boolean` |
+
+## Type Declarations
+
+<details>
+  <summary>Show declarations</summary>
+
+```ts
+type SliderMarks = Record<number, string | { style: CSSProperties,  label: any }>
+type Arrayable<T> = T | T[]
+```
+
+</details>

--- a/packages/components/slider/src/slider.ts
+++ b/packages/components/slider/src/slider.ts
@@ -27,6 +27,9 @@ export interface SliderInitData {
 }
 
 export const sliderProps = buildProps({
+  /**
+   * @description binding value
+   */
   modelValue: {
     type: definePropType<Arrayable<number>>([Number, Array]),
     default: 0,
@@ -35,70 +38,139 @@ export const sliderProps = buildProps({
     type: String,
     default: undefined,
   },
+  /**
+   * @description minimum value
+   */
   min: {
     type: Number,
     default: 0,
   },
+  /**
+   * @description maximum value
+   */
   max: {
     type: Number,
     default: 100,
   },
+  /**
+   * @description step size
+   */
   step: {
     type: Number,
     default: 1,
   },
+  /**
+   * @description whether to display an input box, works when `range` is false
+   */
   showInput: Boolean,
+  /**
+   * @description whether to display control buttons when `show-input` is true
+   */
   showInputControls: {
     type: Boolean,
     default: true,
   },
+  /**
+   * @description size of the slider wrapper, will not work in vertical mode
+   */
   size: useSizeProp,
+  /**
+   * @description size of the input box, when set `size`, the default is the value of `size`
+   */
   inputSize: useSizeProp,
+  /**
+   * @description whether to display breakpoints
+   */
   showStops: Boolean,
+  /**
+   * @description whether to display tooltip value
+   */
   showTooltip: {
     type: Boolean,
     default: true,
   },
+  /**
+   * @description format to display tooltip value
+   */
   formatTooltip: {
     type: definePropType<(val: number) => number | string>(Function),
     default: undefined,
   },
+  /**
+   * @description whether Slider is disabled
+   */
   disabled: Boolean,
+  /**
+   * @description whether to select a range
+   */
   range: Boolean,
+  /**
+   * @description vertical mode
+   */
   vertical: Boolean,
+  /**
+   * @description slider height, required in vertical mode
+   */
   height: String,
+  /**
+   * @description debounce delay when typing, in milliseconds, works when `show-input` is true
+   */
   debounce: {
     type: Number,
     default: 300,
   },
+  /**
+   * @description label for screen reader
+   */
   label: {
     type: String,
     default: undefined,
   },
+  /**
+   * @description when `range` is true, screen reader label for the start of the range
+   */
   rangeStartLabel: {
     type: String,
     default: undefined,
   },
+  /**
+   * @description when `range` is true, screen reader label for the end of the range
+   */
   rangeEndLabel: {
     type: String,
     default: undefined,
   },
+  /**
+   * @description format to display the `aria-valuenow` attribute for screen readers
+   */
   formatValueText: {
     type: definePropType<(val: number) => string>(Function),
     default: undefined,
   },
+  /**
+   * @description custom class name for the tooltip
+   */
   tooltipClass: {
     type: String,
     default: undefined,
   },
+  /**
+   * @description position of Tooltip
+   */
   placement: {
     type: String,
     values: placements,
     default: 'top',
   },
+  /**
+   * @description marks, type of key must be `number` and must in closed interval `[min, max]`, each mark can custom style
+   */
   marks: {
     type: definePropType<SliderMarks>(Object),
   },
+  /**
+   * @description whether to trigger form validation
+   */
   validateEvent: {
     type: Boolean,
     default: true,


### PR DESCRIPTION
Related: #10754 

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44cdd89</samp>

This pull request adds and updates comments and documentation for the Slider component. It enhances the code readability and the API generation for the `sliderProps` object in `./packages/components/slider/src/slider.ts`. It also revises the documentation format and content in `./docs/en-US/component/slider.md` to match the new API and fix some errors.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 44cdd89</samp>

*  Update the documentation of the Slider component in `./docs/en-US/component/slider.md` to use the new API format and fix typos and inconsistencies ([link](https://github.com/element-plus/element-plus/pull/14711/files?diff=unified&w=0#diff-592eff98a0924ec7d4748a0fc1eebdc4636c7ea854a127997c86325f5f3d3853L90-R139))
* Add description comments for the props in the `SliderInitData` interface and the `sliderProps` object in `packages/components/slider/src/slider.ts` to document the code and provide information for the type inference and the API generation ([link](https://github.com/element-plus/element-plus/pull/14711/files?diff=unified&w=0#diff-c1b490183fb5335d157be78adbef1515dc3441aa098a19a4c639e1a035d435b4R30-R32), [link](https://github.com/element-plus/element-plus/pull/14711/files?diff=unified&w=0#diff-c1b490183fb5335d157be78adbef1515dc3441aa098a19a4c639e1a035d435b4L38-R159), [link](https://github.com/element-plus/element-plus/pull/14711/files?diff=unified&w=0#diff-c1b490183fb5335d157be78adbef1515dc3441aa098a19a4c639e1a035d435b4L99-R173))
