### PR TITLE
refactor(components): [slider] use tooltip instance replace any type

### DIFF
--- a/packages/components/slider/src/composables/use-slider-button.ts
+++ b/packages/components/slider/src/composables/use-slider-button.ts
@@ -2,6 +2,7 @@ import { computed, inject, nextTick, ref, watch } from 'vue'
 import { debounce } from 'lodash-unified'
 import { EVENT_CODE, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { sliderContextKey } from '../constants'
+import type { TooltipInstance } from '@element-plus/components/tooltip'
 
 import type { CSSProperties, ComputedRef, Ref, SetupContext } from 'vue'
 import type { SliderProps } from '../slider'
@@ -18,8 +19,7 @@ const useTooltip = (
   formatTooltip: Ref<SliderProps['formatTooltip']>,
   showTooltip: Ref<SliderProps['showTooltip']>
 ) => {
-  // TODO any is temporary, replace with `TooltipInstance` later
-  const tooltip = ref<any>()
+  const tooltip = ref<TooltipInstance>()
 
   const tooltipVisible = ref(false)
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e485897</samp>

Add type annotation for `tooltip` ref in slider button component. This improves the code quality and functionality of the `useSliderButton` composable in `packages/components/slider/src/composables/use-slider-button.ts`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e485897</samp>

* Import `TooltipInstance` type from tooltip component module to annotate `tooltip` ref in `useTooltip` composable function ([link](https://github.com/element-plus/element-plus/pull/14712/files?diff=unified&w=0#diff-1dd2682d3de4e52e64acabdb261322caefea5bcb4e9db127d025d3e6ea7471ddR5), [link](https://github.com/element-plus/element-plus/pull/14712/files?diff=unified&w=0#diff-1dd2682d3de4e52e64acabdb261322caefea5bcb4e9db127d025d3e6ea7471ddL21-R22))
* Use `TooltipInstance` type instead of `any` for `tooltip` ref to improve type safety and readability, and remove TODO comment ([link](https://github.com/element-plus/element-plus/pull/14712/files?diff=unified&w=0#diff-1dd2682d3de4e52e64acabdb261322caefea5bcb4e9db127d025d3e6ea7471ddL21-R22))
