### PR TITLE
fix(components): [time-picker]: Add a judgment to the use-time-panel.ts

### DIFF
--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -439,7 +439,8 @@ const parsedValue = computed(() => {
 
   if (pickerOptions.value.getRangeAvailableTime) {
     const availableResult = pickerOptions.value.getRangeAvailableTime(
-      dayOrDays!
+      dayOrDays!,
+      props.modelValue as SingleOrRange<DateModelType> | null
     )
     if (!isEqual(availableResult, dayOrDays!)) {
       dayOrDays = availableResult

--- a/packages/components/time-picker/src/common/props.ts
+++ b/packages/components/time-picker/src/common/props.ts
@@ -234,7 +234,10 @@ export interface PickerOptions {
   handleKeydownInput: (event: KeyboardEvent) => void
   parseUserInput: (value: UserInput) => DayOrDays
   formatToString: (value: DayOrDays) => UserInput
-  getRangeAvailableTime: (date: DayOrDays) => DayOrDays
+  getRangeAvailableTime: (
+    date: DayOrDays,
+    modelValue?: ModelValueType | null
+  ) => DayOrDays
   getDefaultValue: () => DayOrDays
   panelReady: boolean
   handleClear: () => void

--- a/packages/components/time-picker/src/composables/use-time-panel.ts
+++ b/packages/components/time-picker/src/composables/use-time-panel.ts
@@ -1,4 +1,5 @@
 import type { Dayjs } from 'dayjs'
+import type { ModelValueType } from '../common/props'
 
 import type {
   GetDisabledHoursState,
@@ -21,7 +22,8 @@ export const useTimePanel = ({
     date: Dayjs,
     role: string,
     first: boolean,
-    compareDate?: Dayjs
+    compareDate?: Dayjs,
+    modelValue?: ModelValueType | null
   ) => {
     const availableTimeGetters = {
       hour: getAvailableHours,
@@ -30,7 +32,7 @@ export const useTimePanel = ({
     } as const
     let result = date
     ;(['hour', 'minute', 'second'] as const).forEach((type) => {
-      if (availableTimeGetters[type]) {
+      if (availableTimeGetters[type] && modelValue) {
         let availableTimeSlots: number[]
         const method = availableTimeGetters[type]
         switch (type) {

--- a/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
@@ -52,6 +52,7 @@ import {
 import TimeSpinner from './basic-time-spinner.vue'
 
 import type { Dayjs } from 'dayjs'
+import type { ModelValueType } from '../common/props'
 
 const props = defineProps(panelTimePickerProps)
 const emit = defineEmits(['pick', 'select-range', 'set-picker-option'])
@@ -150,8 +151,17 @@ const { timePickerOptions, onSetOption, getAvailableTime } = useTimePanel({
   getAvailableSeconds,
 })
 
-const getRangeAvailableTime = (date: Dayjs) => {
-  return getAvailableTime(date, props.datetimeRole || '', true)
+const getRangeAvailableTime = (
+  date: Dayjs,
+  modelValue?: ModelValueType | null
+) => {
+  return getAvailableTime(
+    date,
+    props.datetimeRole || '',
+    true,
+    undefined,
+    modelValue
+  )
 }
 
 const parseUserInput = (value: Dayjs) => {


### PR DESCRIPTION
closed #14648

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f504eec</samp>

This pull request adds support for range time picker by passing the `modelValue` prop to the `getRangeAvailableTime` function in various files. This prop helps to determine the available time options based on the selected date or range of dates.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f504eec</samp>

*  Add `modelValue` as a second parameter to `getRangeAvailableTime` function in `picker.vue`, `props.ts`, `use-time-panel.ts`, and `panel-time-pick.vue` components to enable range picker to access selected date or range of dates ([link](https://github.com/element-plus/element-plus/pull/14743/files?diff=unified&w=0#diff-3d026a2d83f86f5dc2ce3aa7b95b77eff4a475e67c362841827e0e1bac7456abL442-R443), [link](https://github.com/element-plus/element-plus/pull/14743/files?diff=unified&w=0#diff-4d5804445bd2a26541567338da443fedac41179034d4ef377f967d6b1d66074cL237-R240), [link](https://github.com/element-plus/element-plus/pull/14743/files?diff=unified&w=0#diff-04b903a6859c34e9bd71c9f3bef2d529677fc8e8df8db7016023839a12ef9b32R2), [link](https://github.com/element-plus/element-plus/pull/14743/files?diff=unified&w=0#diff-04b903a6859c34e9bd71c9f3bef2d529677fc8e8df8db7016023839a12ef9b32L24-R26), [link](https://github.com/element-plus/element-plus/pull/14743/files?diff=unified&w=0#diff-04b903a6859c34e9bd71c9f3bef2d529677fc8e8df8db7016023839a12ef9b32L33-R35), [link](https://github.com/element-plus/element-plus/pull/14743/files?diff=unified&w=0#diff-60b8d640aee096b38e04f0f59a87c5d8c5ddc9e877a4bcbe50a86058b59b3ceaR55), [link](https://github.com/element-plus/element-plus/pull/14743/files?diff=unified&w=0#diff-60b8d640aee096b38e04f0f59a87c5d8c5ddc9e877a4bcbe50a86058b59b3ceaL153-R164))
*  Import `ModelValueType` type from `props.ts` file in `use-time-panel.ts` and `panel-time-pick.vue` components to use as the type of the second parameter of `getRangeAvailableTime` function ([link](https://github.com/element-plus/element-plus/pull/14743/files?diff=unified&w=0#diff-04b903a6859c34e9bd71c9f3bef2d529677fc8e8df8db7016023839a12ef9b32R2), [link](https://github.com/element-plus/element-plus/pull/14743/files?diff=unified&w=0#diff-60b8d640aee096b38e04f0f59a87c5d8c5ddc9e877a4bcbe50a86058b59b3ceaR55))
*  Add a condition to check the truthiness of `availableTimeGetters[type]` function and `modelValue` parameter before calling `availableTimeGetters[type]` function in `use-time-panel.ts` composable to prevent errors or unexpected results ([link](https://github.com/element-plus/element-plus/pull/14743/files?diff=unified&w=0#diff-04b903a6859c34e9bd71c9f3bef2d529677fc8e8df8db7016023839a12ef9b32L33-R35))
