### PR TITLE
fix(components): [date-picker] the time panel is closed without losing focus

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -39,6 +39,7 @@
             :class="dpNs.e('editor-wrap')"
           >
             <el-input
+              ref="timePickerInputRef"
               :placeholder="t('el.datepicker.selectTime')"
               :model-value="visibleTime"
               size="small"
@@ -248,6 +249,7 @@ const { shortcuts, disabledDate, cellClassName, defaultTime } = pickerBase.props
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 
 const currentViewRef = ref<{ focus: () => void }>()
+const timePickerInputRef = ref<{ blur: () => void }>()
 
 const innerDate = ref(dayjs().locale(lang.value))
 
@@ -761,6 +763,13 @@ watch(
   },
   { immediate: true }
 )
+
+// When close time-pick-panel, blur the timePickerInput
+watch(timePickerVisible, (newValue) => {
+  if (!newValue) {
+    timePickerInputRef.value?.blur()
+  }
+})
 
 contextEmit('set-picker-option', ['isValidValue', isValidValue])
 contextEmit('set-picker-option', ['formatToString', formatToString])

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -39,7 +39,6 @@
             :class="dpNs.e('editor-wrap')"
           >
             <el-input
-              ref="timePickerInputRef"
               :placeholder="t('el.datepicker.selectTime')"
               :model-value="visibleTime"
               size="small"
@@ -249,7 +248,6 @@ const { shortcuts, disabledDate, cellClassName, defaultTime } = pickerBase.props
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 
 const currentViewRef = ref<{ focus: () => void }>()
-const timePickerInputRef = ref<{ blur: () => void }>()
 
 const innerDate = ref(dayjs().locale(lang.value))
 
@@ -325,6 +323,10 @@ const handleDatePick = (value: DateTableEmits, keepOpen?: boolean) => {
     }
     innerDate.value = newDate
     emit(newDate, showTime.value || keepOpen)
+    // fix: https://github.com/element-plus/element-plus/issues/14728
+    if (props.type === 'datetime') {
+      handleFocusPicker()
+    }
   } else if (selectionMode.value === 'week') {
     emit((value as WeekPickerEmits).date)
   } else if (selectionMode.value === 'dates') {
@@ -763,13 +765,6 @@ watch(
   },
   { immediate: true }
 )
-
-// When close time-pick-panel, blur the timePickerInput
-watch(timePickerVisible, (newValue) => {
-  if (!newValue) {
-    timePickerInputRef.value?.blur()
-  }
-})
 
 contextEmit('set-picker-option', ['isValidValue', isValidValue])
 contextEmit('set-picker-option', ['formatToString', formatToString])


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [X] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [X] Make sure you are merging your commits to `dev` branch.
- [X] Add some descriptions and refer to relative issues for your PR.

## Description

Blur the timePickerInput when time-pick-panel is closed.

## Related Issue

Fixes #14728 

## Explanation of Changes

Watch ref timePickerVisible, when it is false, blur the timePickerInput el-input