### PR TITLE
修复 当 v-infinite-scroll 释放的时候, SCOPE 不存在导致的错误

### DIFF
--- a/packages/components/infinite-scroll/src/index.ts
+++ b/packages/components/infinite-scroll/src/index.ts
@@ -162,7 +162,12 @@ const InfiniteScroll: ObjectDirective<
     container.addEventListener('scroll', onScroll)
   },
   unmounted(el) {
-    const { container, onScroll } = el[SCOPE]
+    if (SCOPE && el[SCOPE]) {
+      const container = el[SCOPE]
+      const onScroll = el[SCOPE]
+
+      container?.removeEventListener('scroll', onScroll)
+    }
 
     container?.removeEventListener('scroll', onScroll)
     destroyObserver(el)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

详见： https://github.com/element-plus/element-plus/issues/14775

## Related Issue

Fixes #14775.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c0788e</samp>

* Refactor code to use destructuring assignment for `container` and `onScroll` ([link](https://github.com/element-plus/element-plus/pull/14776/files?diff=unified&w=0#diff-5397b5800d2dd338a8d923c01a0a3013560bb5ce3bedc8d341ea30b62649275fL149-R150))
