### PR TITLE
fix(components): [collapse-transition] collapse get el exists height

### DIFF
--- a/docs/examples/transitions/collapse.vue
+++ b/docs/examples/transitions/collapse.vue
@@ -2,9 +2,9 @@
   <div>
     <el-button @click="show = !show">Click Me</el-button>
 
-    <div style="margin-top: 20px; height: 200px">
+    <div style="margin-top: 20px">
       <el-collapse-transition>
-        <div v-show="show">
+        <div v-show="show" style="height: 400px">
           <div class="transition-box">el-collapse-transition</div>
           <div class="transition-box">el-collapse-transition</div>
         </div>

--- a/packages/components/collapse-transition/src/collapse-transition.vue
+++ b/packages/components/collapse-transition/src/collapse-transition.vue
@@ -26,6 +26,7 @@ const on = {
 
     el.dataset.oldPaddingTop = el.style.paddingTop
     el.dataset.oldPaddingBottom = el.style.paddingBottom
+    if (el.style.height) el.dataset.elExistsHeight = el.style.height
 
     el.style.maxHeight = 0
     el.style.paddingTop = 0
@@ -33,15 +34,20 @@ const on = {
   },
 
   enter(el: RendererElement) {
-    el.dataset.oldOverflow = el.style.overflow
-    if (el.scrollHeight !== 0) {
-      el.style.maxHeight = `${el.scrollHeight}px`
-    } else {
-      el.style.maxHeight = 0
-    }
-    el.style.paddingTop = el.dataset.oldPaddingTop
-    el.style.paddingBottom = el.dataset.oldPaddingBottom
-    el.style.overflow = 'hidden'
+    requestAnimationFrame(() => {
+      el.dataset.oldOverflow = el.style.overflow
+      if (el.dataset.elExistsHeight) {
+        el.style.maxHeight = el.dataset.elExistsHeight
+      } else if (el.scrollHeight !== 0) {
+        el.style.maxHeight = `${el.scrollHeight}px`
+      } else {
+        el.style.maxHeight = 0
+      }
+
+      el.style.paddingTop = el.dataset.oldPaddingTop
+      el.style.paddingBottom = el.dataset.oldPaddingBottom
+      el.style.overflow = 'hidden'
+    })
   },
 
   afterEnter(el: RendererElement) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff5b1b3</samp>

The pull request enhances the `el-collapse-transition` component by using the element's height and requestAnimationFrame for smoother transitions. It also updates the `docs/examples/transitions/collapse.vue` file to show the component's behavior with different content heights.

## Related Issue

The problem I found when repairing affine.pro UI https://github.com/toeverything/AFFiNE.pro/pull/112

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ff5b1b3</samp>

* Improve el-collapse-transition component to handle elements with fixed or min-height ([link](https://github.com/element-plus/element-plus/pull/14801/files?diff=unified&w=0#diff-9c5ba063cc54a80ba6ee44e1a273512f7021f7fa587b27a2f1dac4fb982d951cR29), [link](https://github.com/element-plus/element-plus/pull/14801/files?diff=unified&w=0#diff-9c5ba063cc54a80ba6ee44e1a273512f7021f7fa587b27a2f1dac4fb982d951cL36-R50))
  - Store existing height in data attribute before transition starts ([link](https://github.com/element-plus/element-plus/pull/14801/files?diff=unified&w=0#diff-9c5ba063cc54a80ba6ee44e1a273512f7021f7fa587b27a2f1dac4fb982d951cR29))
  - Use requestAnimationFrame and stored height to set maxHeight in enter hook ([link](https://github.com/element-plus/element-plus/pull/14801/files?diff=unified&w=0#diff-9c5ba063cc54a80ba6ee44e1a273512f7021f7fa587b27a2f1dac4fb982d951cL36-R50))
* Adjust height of div element and content in collapse.vue example to demonstrate transition effect better ([link](https://github.com/element-plus/element-plus/pull/14801/files?diff=unified&w=0#diff-e3325dcc986c6250c08ab6cb49da6400c32888ee2379c82d062159471ff58245L5-R7))
  - Remove height from div element to allow el-collapse-transition to expand and collapse ([link](https://github.com/element-plus/element-plus/pull/14801/files?diff=unified&w=0#diff-e3325dcc986c6250c08ab6cb49da6400c32888ee2379c82d062159471ff58245L5-R7))
  - Add style attribute to v-show directive to set content height to 400px ([link](https://github.com/element-plus/element-plus/pull/14801/files?diff=unified&w=0#diff-e3325dcc986c6250c08ab6cb49da6400c32888ee2379c82d062159471ff58245L5-R7))
