### PR TITLE
docs(docs): fix typo errors in pagination component

### DIFF
--- a/docs/en-US/component/pagination.md
+++ b/docs/en-US/component/pagination.md
@@ -9,7 +9,7 @@ If you have too much data to display in one page, use pagination.
 
 ## Basic usage
 
-:::demo Set `layout` with different pagination elements you wish to display separated with a comma. Pagination elements are: `prev` (a button navigating to the previous page), `next` (a button navigating to the next page), `pager` (page list), `jumper` (a jump-to input), `total` (total item count), `size` (a select to determine page size) and `->`(every element after this symbol will be pulled to the right).
+:::demo Set `layout` with different pagination elements you wish to display separated with a comma. Pagination elements are: `prev` (a button navigating to the previous page), `next` (a button navigating to the next page), `pager` (page list), `jumper` (a jump-to input), `total` (total item count), `sizes` (a select to determine page size) and `->`(every element after this symbol will be pulled to the right).
 
 pagination/basic-usage
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8125792</samp>

Fix a typo and update the `layout` option for pagination in the documentation. This change affects the file `docs/en-US/component/pagination.md`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8125792</samp>

* Fix a typo in the pagination documentation by using `sizes` instead of `size` for the `layout` option ([link](https://github.com/element-plus/element-plus/pull/14815/files?diff=unified&w=0#diff-61f73428acb505f870e6fbf556fa73bdf788e881cb46baba88897f6c298d84a4L12-R12))
