### PR TITLE
fix(components): [table] background color of fixed summary column is white

### DIFF
--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -328,7 +328,6 @@
         &.#{$namespace}-table-fixed-column--left,
         &.#{$namespace}-table-fixed-column--right {
           position: sticky !important;
-          background: inherit;
           z-index: calc(getCssVar('table-index') + 1);
           &.is-last-column,
           &.is-first-column {

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -143,7 +143,7 @@
 
   tfoot {
     td.#{$namespace}-table__cell {
-      background-color: getCssVar('table-row-hover-bg-color');
+      background-color: getCssVar('table-row-hover-bg-color') !important;
       color: getCssVar('table-text-color');
     }
   }
@@ -328,6 +328,7 @@
         &.#{$namespace}-table-fixed-column--left,
         &.#{$namespace}-table-fixed-column--right {
           position: sticky !important;
+          background: inherit;
           z-index: calc(getCssVar('table-index') + 1);
           &.is-last-column,
           &.is-first-column {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

background color of fixed summary columns is white, it not right.


## Related Issue

Fixes #14821

## Explanation of Changes

Add `!important` to tfoot td `background-color` property from `table.scss` to fix fixed summary column background color problem
