### PR TITLE
fix(components): [tree] default slots not displayed

### DIFF
--- a/packages/components/tree/__tests__/tree.test.ts
+++ b/packages/components/tree/__tests__/tree.test.ts
@@ -1521,4 +1521,66 @@ describe('Tree.vue', () => {
     )
     expect(flag).toBe(false)
   })
+
+  test('customize some node contents', async () => {
+    const wrapper = mount({
+      template: `
+        <el-tree :data="data">
+          <template #default="{ data }">
+            <div v-if="data.id === '1'">
+              customize: {{ data.label }}
+            </div>
+          </template>
+        </el-tree>
+      `,
+      components: {
+        'el-tree': Tree,
+      },
+      data() {
+        return {
+          data: [
+            {
+              id: '1',
+              label: 'Level one 1',
+              children: [
+                {
+                  id: '1-1',
+                  label: 'Level two 1-1',
+                  children: [
+                    {
+                      label: 'Level three 1-1-1',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: '2',
+              label: 'Level one 2',
+              children: [
+                {
+                  id: '2-1',
+                  label: 'Level two 2-1',
+                  children: [
+                    {
+                      label: 'Level three 2-1-1',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }
+      },
+    })
+    const nodeContentWrapper1 = wrapper.findAll('.el-tree-node__content')[0]
+    const nodeContentWrapper2 = wrapper.findAll('.el-tree-node__content')[1]
+
+    const nodeLabelWrapper1 = nodeContentWrapper1.find('div')
+    const nodeLabelWrapper2 = nodeContentWrapper2.find(
+      'span.el-tree-node__label'
+    )
+    expect(nodeLabelWrapper1.text()).toEqual('customize: Level one 1')
+    expect(nodeLabelWrapper2.text()).toEqual('Level one 2')
+  })
 })

--- a/packages/components/tree/src/tree-node-content.vue
+++ b/packages/components/tree/src/tree-node-content.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 // @ts-nocheck
-import { defineComponent, h, inject } from 'vue'
+import { defineComponent, h, inject, renderSlot } from 'vue'
 
 import { useNamespace } from '@element-plus/hooks'
 import type { ComponentInternalInstance } from 'vue'
@@ -24,9 +24,9 @@ export default defineComponent({
       const { data, store } = node
       return props.renderContent
         ? props.renderContent(h, { _self: nodeInstance, node, data, store })
-        : tree.ctx.slots.default
-        ? tree.ctx.slots.default({ node, data })
-        : h('span', { class: ns.be('node', 'label') }, [node.label])
+        : renderSlot(tree.ctx.slots, 'default', { node, data }, () => [
+            h('span', { class: ns.be('node', 'label') }, [node.label]),
+          ])
     }
   },
 })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

1. What do I want to do？

When I use `el-tree`, I want to customize some node contents instead of all
[example](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6Ijx0ZW1wbGF0ZT5cbiAgPGVsLXRyZWUgOmRhdGE9XCJkYXRhXCIgQG5vZGUtY2xpY2s9XCJoYW5kbGVOb2RlQ2xpY2tcIj5cbiAgICA8dGVtcGxhdGUgI2RlZmF1bHQ9XCJ7IGRhdGEgfVwiPlxuICAgICAgPGRpdiBzdHlsZT1cImNvbG9yOiByZWRcIiB2LWlmPVwiZGF0YS5pZCA9PT0gJzEnXCI+XG4gICAgICAgIOi/meaYr+aIkeiHquWumuS5ieeahHt7IGRhdGEubGFiZWwgfX1cbiAgICAgIDwvZGl2PlxuICAgIDwvdGVtcGxhdGU+XG4gIDwvZWwtdHJlZT5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgbGFuZz1cInRzXCIgc2V0dXA+XG5pbnRlcmZhY2UgVHJlZSB7XG4gIGlkPzogc3RyaW5nXG4gIGxhYmVsOiBzdHJpbmdcbiAgY2hpbGRyZW4/OiBUcmVlW11cbn1cblxuY29uc3QgaGFuZGxlTm9kZUNsaWNrID0gKGRhdGE6IFRyZWUpID0+IHtcbiAgY29uc29sZS5sb2coZGF0YSlcbn1cblxuY29uc3QgZGF0YTogVHJlZVtdID0gW1xuICB7XG4gICAgaWQ6ICcxJyxcbiAgICBsYWJlbDogJ0xldmVsIG9uZSAxJyxcbiAgICBjaGlsZHJlbjogW1xuICAgICAge1xuICAgICAgICBpZDogJzEtMScsXG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDEtMScsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgbGFiZWw6ICdMZXZlbCB0aHJlZSAxLTEtMScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgXSxcbiAgfSxcbiAge1xuICAgIGlkOiAnMicsXG4gICAgbGFiZWw6ICdMZXZlbCBvbmUgMicsXG4gICAgY2hpbGRyZW46IFtcbiAgICAgIHtcbiAgICAgICAgaWQ6ICcyLTEnLFxuICAgICAgICBsYWJlbDogJ0xldmVsIHR3byAyLTEnLFxuICAgICAgICBjaGlsZHJlbjogW1xuICAgICAgICAgIHtcbiAgICAgICAgICAgIGxhYmVsOiAnTGV2ZWwgdGhyZWUgMi0xLTEnLFxuICAgICAgICAgIH0sXG4gICAgICAgIF0sXG4gICAgICB9LFxuICAgIF0sXG4gIH0sXG5dXG48L3NjcmlwdD4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7fVxufSIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJfbyI6e319)

2. What happened

other node content not displayed

3. How did this happen

element-plus source code use `solts.default` to determine whether to display or not, I did a [test](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6IjxzY3JpcHQgc2V0dXAgbGFuZz1cInRzXCI+XG5cbmltcG9ydCB0ZXN0MSBmcm9tICcuL3Rlc3QxJztcbmltcG9ydCB0ZXN0MiBmcm9tICcuL3Rlc3QyLnZ1ZSc7XG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8dGVzdDE+XG4gICAgPHRlbXBsYXRlICNkZWZhdWx0PlxuICAgICAgPCEtLSBzc3MgLS0+XG4gICAgICA8ZGl2IHYtaWY9XCJmYWxzZVwiPjEyMzwvZGl2PlxuICAgIDwvdGVtcGxhdGU+XG4gIDwvdGVzdDE+XG4gIC0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tXG4gIDx0ZXN0Mj5cbiAgICA8dGVtcGxhdGUgI2RlZmF1bHQ+XG4gICAgICA8IS0tIHNzcyAtLT5cbiAgICAgIDxkaXYgdi1pZj1cImZhbHNlXCI+MTIzPC9kaXY+XG4gICAgPC90ZW1wbGF0ZT5cbiAgPC90ZXN0Mj5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7fVxufSIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJzcmMvdGVzdDEudHMiOiJpbXBvcnQgeyBkZWZpbmVDb21wb25lbnQsIGggfSBmcm9tIFwidnVlXCI7XG5cbmV4cG9ydCBkZWZhdWx0IGRlZmluZUNvbXBvbmVudCh7XG4gICAgc2V0dXAoXywgeyBzbG90cyB9KSB7XG4gICAgICAgIGNvbnN0IHRpdGxlID0gaChcImRpdlwiLCBcIui/meaYr3Rlc3QxLOS9v+eUqHNsb3RzLmRlZmF1bHRcIilcbiAgICAgICAgY29uc3QgZGVmYXVsdFNsb3QgPSBoKFwiZGl2XCIsIFwi6L+Z5pivdGVzdDHnmoTpu5jorqTlhoXlrrlcIilcbiAgICAgICAgcmV0dXJuICgpID0+IFt0aXRsZSwgc2xvdHMuZGVmYXVsdCA/IHNsb3RzLmRlZmF1bHQ/LigpIDogZGVmYXVsdFNsb3RdXG4gICAgfVxufSkiLCJzcmMvdGVzdDIudnVlIjoiPHRlbXBsYXRlPlxuICAgIDxkaXY+6L+Z5pivdGVzdDIs5L2/55Soc2xvdOagh+etvjwvZGl2PlxuICAgIDxzbG90PlxuICAgICAgICA8ZGl2PnRlc3Qy5a2Q57uE5Lu255qE6buY6K6k5YaF5a65PC9kaXY+XG4gICAgPC9zbG90PlxuPC90ZW1wbGF0ZT4iLCJfbyI6e319), `slots.default` encountered `v-if="false"` or the virtual comment nodes, will not render default slot content, The results of using `slots.default` and `<slot></slot>` are different,  Vue provides a `renderSlot` function, the results of using `renderSlot` is the same as using `<slot></slot>`. 

last, other components may also have the same issue. If this PR is merged, I will gradually fix other components



<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 269e1bc</samp>

Refactored the template rendering of `tree-node-content.vue` to use `renderSlot` from `vue`. This simplifies the code and makes it easier to customize the slot content.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 269e1bc</samp>

* Import the `renderSlot` function from `vue` to simplify the template rendering logic ([link](https://github.com/element-plus/element-plus/pull/14939/files?diff=unified&w=0#diff-ec81a42f6dd821c00b30a9225a315db462debd3edb912f70ce5955cec9c6fb05L3-R3))
* Use the `renderSlot` function to render the `default` slot with a fallback content of a `span` element with the node label ([link](https://github.com/element-plus/element-plus/pull/14939/files?diff=unified&w=0#diff-ec81a42f6dd821c00b30a9225a315db462debd3edb912f70ce5955cec9c6fb05L27-R29))
