### PR TITLE
feat(components): tour component

### DIFF
--- a/docs/.vitepress/crowdin/en-US/pages/component.json
+++ b/docs/.vitepress/crowdin/en-US/pages/component.json
@@ -216,6 +216,11 @@
         "text": "Timeline"
       },
       {
+        "link": "/tour",
+        "text": "Tour",
+        "promotion": "2.5.0"
+      },
+      {
         "link": "/tree",
         "text": "Tree"
       },

--- a/docs/en-US/component/tour.md
+++ b/docs/en-US/component/tour.md
@@ -1,0 +1,129 @@
+---
+title: Tour
+lang: en-US
+---
+
+# Tour
+
+A popup component for guiding users through a product. Use when you want to guide users through a product.
+
+## Basic usage
+
+The most basic usage
+
+:::demo
+
+tour/basic
+
+:::
+
+## Non modal
+
+Use `:mask="false"` to make Tour non-modal. At the meantime it is recommended to use with `type="primary"` to emphasize the guide itself.
+
+:::demo
+
+tour/non-modal
+
+:::
+
+## Placement
+
+Change the placement of the guide relative to the target, there are 12 placements available. When `target` is empty the guide will show in the center.
+
+:::demo
+
+tour/placement
+
+:::
+
+## Custom mask style
+
+Custom mask style.
+
+:::demo
+
+tour/mask
+
+:::
+
+## Custom indicator
+
+Custom indicator.
+
+:::demo
+
+tour/indicator
+
+:::
+
+
+## Tour API
+
+:::tip
+tour-step component configuration with the same name has higher priority
+:::
+
+### Tour Attributes
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| show-arrow | whether to show the arrow | `boolean` | true |
+| placement | position of the guide card relative to the target element | ^[enum]`'top' \| 'top-start' \| 'top-end' \| 'bottom' \| 'bottom-start' \| 'bottom-end' \| 'left' \| 'left-start' \| 'left-end' \| 'right' \| 'right-start' \| 'right-end'` | `bottom` |
+| content-style | custom style for content | `CSSProperties` | - |
+| mask | whether to enable masking, change mask style and fill color by pass custom props | `boolean` \| ^[Object]`{ style?: CSSProperties; color?: string; }` | `true` |
+| type | type, affects the background color and text color | `default` \| `primary` | `default` |
+| model-value / v-model | open tour | `boolean` | - |
+| current / v-model:current | what is the current step | `number` | - |
+| scroll-into-view-options | support pass custom scrollIntoView options | `boolean` \| `ScrollIntoViewOptions` | ^[Object]`{ block: 'center' }` |
+| z-index | Tour's zIndex | `number` | `2001` |
+| show-close | whether to show a close button | `boolean` | `true` |
+| close-icon | custom close icon, default is Close | `string` \| `Component` | - |
+| close-on-press-escape | whether the Dialog can be closed by pressing ESC | `boolean` | `true` |
+| target-area-clickable | whether the target element can be clickable, when using mask | `boolean` | `true` |
+
+### Tour slots
+
+| Name                | Description                |
+| ------------------- | -------------------------- |
+| default             | tourStep component list    |
+| indicators          | custom indicator, The scope parameter is `{ current, total }` |
+
+### Tour events
+
+| Name | Description | Type |
+| --- | --- | --- |
+| close | callback function on shutdown | ^[Function]`(current: number) => void` | 
+| finish | callback function on finished | ^[Function]`() => void` |
+| change | callback when the step changes | ^[Function]`(current: number) => void` |
+
+### TourStep Attributes
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| target | get the element the guide card points to. Empty makes it show in center of screen | `HTMLElement` | - |
+| show-arrow | whether to show the arrow | `boolean` | `true` |
+| title | title | `string` | - |
+| description | description | `string` | - |
+| placement | position of the guide card relative to the target element | ^[enum]`'top' \| 'top-start' \| 'top-end' \| 'bottom' \| 'bottom-start' \| 'bottom-end' \| 'left' \| 'left-start' \| 'left-end' \| 'right' \| 'right-start' \| 'right-end'` | `bottom` |
+| content-style | custom style for content | `CSSProperties` | - |
+| mask | whether to enable masking, change mask style and fill color by pass custom props | `boolean` \| ^[Object]`{ style?: CSSProperties; color?: string; }` | `true` |
+| type | type, affects the background color and text color | `default` \| `primary` | `default` |
+| next-button-props | properties of the Next button | ^[Object]`{ children: VueNode \| string; onClick: Function }` | - |
+| prev-button-props | properties of the previous button | ^[Object]`{ children: VueNode \| string; onClick: Function }` | - |
+| scroll-into-view-options | support pass custom scrollIntoView options, the default follows the `scrollIntoViewOptions` property of Tour | `boolean` \| `ScrollIntoViewOptions` | - |
+| show-close | whether to show a close button | `boolean` | `true` |
+| close-icon | custom close icon, default is Close | `string` \| `Component` | - |
+
+### TourStep slots
+
+| Name                | Description                  |
+| ------------------- | ---------------------------- |
+| default             | description                  |
+| title               | title                        |
+
+### TourStep events
+
+| Name        | Description                   | Arguments  |
+| ----------- | ----------------------------- | ---------- |
+| close       | callback function on shutdown | ^[Function]`() => void` |

--- a/docs/examples/tour/basic.vue
+++ b/docs/examples/tour/basic.vue
@@ -1,0 +1,43 @@
+<template>
+  <el-button type="primary" @click="open = true">Begin Tour</el-button>
+
+  <el-divider />
+
+  <el-space>
+    <el-button ref="ref1">upload</el-button>
+    <el-button ref="ref2" type="primary">save</el-button>
+    <el-button ref="ref3" :icon="MoreFilled" />
+  </el-space>
+
+  <el-tour v-model="open">
+    <el-tour-step :target="ref1?.$el" title="Upload File">
+      <img
+        src="https://element-plus.org/images/element-plus-logo.svg"
+        alt="tour.png"
+      />
+      <div>Put you files here.</div>
+    </el-tour-step>
+    <el-tour-step
+      :target="ref2?.$el"
+      title="Save"
+      description="Save your changes"
+    />
+    <el-tour-step
+      :target="ref3?.$el"
+      title="Other Actions"
+      description="Click to see other"
+    />
+  </el-tour>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { type ElButton } from 'element-plus'
+import { MoreFilled } from '@element-plus/icons-vue'
+
+const ref1 = ref<InstanceType<typeof ElButton> | null>(null)
+const ref2 = ref<InstanceType<typeof ElButton> | null>(null)
+const ref3 = ref<InstanceType<typeof ElButton> | null>(null)
+
+const open = ref(false)
+</script>

--- a/docs/examples/tour/indicator.vue
+++ b/docs/examples/tour/indicator.vue
@@ -1,0 +1,44 @@
+<template>
+  <el-button type="primary" @click="open = true">Begin Tour</el-button>
+
+  <el-divider />
+
+  <el-space>
+    <el-button ref="ref1">upload</el-button>
+    <el-button ref="ref2" type="primary">save</el-button>
+    <el-button ref="ref3" :icon="MoreFilled" />
+  </el-space>
+
+  <el-tour v-model="open">
+    <el-tour-step
+      :target="ref1?.$el"
+      title="Upload File"
+      description="Put you files here."
+    />
+    <el-tour-step
+      :target="ref2?.$el"
+      title="Save"
+      description="Save your changes"
+    />
+    <el-tour-step
+      :target="ref3?.$el"
+      title="Other Actions"
+      description="Click to see other"
+    />
+    <template #indicators="{ current, total }">
+      <span>{{ current + 1 }} / {{ total }}</span>
+    </template>
+  </el-tour>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { type ElButton } from 'element-plus'
+import { MoreFilled } from '@element-plus/icons-vue'
+
+const ref1 = ref<InstanceType<typeof ElButton> | null>(null)
+const ref2 = ref<InstanceType<typeof ElButton> | null>(null)
+const ref3 = ref<InstanceType<typeof ElButton> | null>(null)
+
+const open = ref(false)
+</script>

--- a/docs/examples/tour/mask.vue
+++ b/docs/examples/tour/mask.vue
@@ -1,0 +1,58 @@
+<template>
+  <el-button type="primary" @click="open = true">Begin Tour</el-button>
+
+  <el-divider />
+
+  <el-space>
+    <el-button ref="ref1">upload</el-button>
+    <el-button ref="ref2" type="primary">save</el-button>
+    <el-button ref="ref3" :icon="MoreFilled" />
+  </el-space>
+
+  <el-tour
+    v-model="open"
+    :mask="{
+      style: {
+        boxShadow: 'inset 0 0 15px #333',
+      },
+      color: 'rgba(80, 255, 255, .4)',
+    }"
+  >
+    <el-tour-step :target="ref1?.$el" title="Upload File">
+      <img
+        src="https://element-plus.org/images/element-plus-logo.svg"
+        alt="tour.png"
+      />
+      <div>Put you files here.</div>
+    </el-tour-step>
+    <el-tour-step
+      :target="ref2?.$el"
+      title="Save"
+      description="Save your changes"
+      :mask="{
+        style: {
+          boxShadow: 'inset 0 0 15px #fff',
+        },
+        color: 'rgba(40, 0, 255, .4)',
+      }"
+    />
+    <el-tour-step
+      :target="ref3?.$el"
+      title="Other Actions"
+      description="Click to see other"
+      :mask="false"
+    />
+  </el-tour>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { type ElButton } from 'element-plus'
+import { MoreFilled } from '@element-plus/icons-vue'
+
+const ref1 = ref<InstanceType<typeof ElButton> | null>(null)
+const ref2 = ref<InstanceType<typeof ElButton> | null>(null)
+const ref3 = ref<InstanceType<typeof ElButton> | null>(null)
+
+const open = ref(false)
+</script>

--- a/docs/examples/tour/non-modal.vue
+++ b/docs/examples/tour/non-modal.vue
@@ -1,0 +1,41 @@
+<template>
+  <el-button type="primary" @click="open = true">Begin Tour</el-button>
+
+  <el-divider />
+
+  <el-space>
+    <el-button ref="ref1">upload</el-button>
+    <el-button ref="ref2" type="primary">save</el-button>
+    <el-button ref="ref3" :icon="MoreFilled" />
+  </el-space>
+
+  <el-tour v-model="open" type="primary" :mask="false">
+    <el-tour-step
+      :target="ref1?.$el"
+      title="Upload File"
+      description="Put you files here."
+    />
+    <el-tour-step
+      :target="ref2?.$el"
+      title="Save"
+      description="Save your changes"
+    />
+    <el-tour-step
+      :target="ref3?.$el"
+      title="Other Actions"
+      description="Click to see other"
+    />
+  </el-tour>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { type ElButton } from 'element-plus'
+import { MoreFilled } from '@element-plus/icons-vue'
+
+const ref1 = ref<InstanceType<typeof ElButton> | null>(null)
+const ref2 = ref<InstanceType<typeof ElButton> | null>(null)
+const ref3 = ref<InstanceType<typeof ElButton> | null>(null)
+
+const open = ref(false)
+</script>

--- a/docs/examples/tour/placement.vue
+++ b/docs/examples/tour/placement.vue
@@ -1,0 +1,33 @@
+<template>
+  <el-button ref="btnRef" type="primary" @click="open = true">
+    Begin Tour
+  </el-button>
+
+  <el-tour v-model="open">
+    <el-tour-step
+      title="Center"
+      description="Displayed in the center of screen."
+    />
+    <el-tour-step
+      title="Right"
+      description="On the right of target."
+      placement="right"
+      :target="btnRef?.$el"
+    />
+    <el-tour-step
+      title="Top"
+      description="On the top of target."
+      placement="top"
+      :target="btnRef?.$el"
+    />
+  </el-tour>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { type ElButton } from 'element-plus'
+
+const btnRef = ref<InstanceType<typeof ElButton> | null>(null)
+
+const open = ref(false)
+</script>

--- a/packages/components/index.ts
+++ b/packages/components/index.ts
@@ -70,6 +70,7 @@ export * from './tree-v2'
 export * from './upload'
 export * from './virtual-list'
 export * from './watermark'
+export * from './tour'
 
 // plugins
 export * from './infinite-scroll'

--- a/packages/components/tour/__tests__/tour.test.tsx
+++ b/packages/components/tour/__tests__/tour.test.tsx
@@ -1,0 +1,166 @@
+import { nextTick, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, test } from 'vitest'
+import Tour from '../src/tour.vue'
+import TourStep from '../src/step.vue'
+
+describe('Tour.vue', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('basic', () => {
+    mount({
+      setup() {
+        const btnRef = ref<HTMLElement | null>(null)
+        return () => (
+          <>
+            <button ref={btnRef}>cover</button>
+            <Tour modelValue={true}>
+              <TourStep
+                title="cover title"
+                description="cover description."
+                target={btnRef.value}
+              />
+            </Tour>
+          </>
+        )
+      },
+    })
+
+    expect(document.querySelector('.el-tour__title')?.innerHTML).toEqual(
+      'cover title'
+    )
+    expect(document.querySelector('.el-tour__body span')?.innerHTML).toEqual(
+      'cover description.'
+    )
+  })
+
+  test('controlled current', async () => {
+    const wrapper = mount({
+      setup() {
+        const btnRef = ref<HTMLElement | null>(null)
+        const current = ref(0)
+        return () => (
+          <>
+            <button ref={btnRef} onClick={() => (current.value = 1)}>
+              setCurrent
+            </button>
+            <Tour modelValue={true} v-model:current={current.value}>
+              <TourStep
+                title="first"
+                description="cover description."
+                target={btnRef.value}
+              />
+              <TourStep
+                title="second"
+                description="cover description."
+                target={btnRef.value}
+              />
+            </Tour>
+          </>
+        )
+      },
+    })
+
+    expect(document.querySelector('.el-tour__title')?.innerHTML).toEqual(
+      'first'
+    )
+    wrapper.find('button').trigger('click')
+    await nextTick()
+    expect(document.querySelector('.el-tour__title')?.innerHTML).toEqual(
+      'second'
+    )
+  })
+
+  test('no mask', () => {
+    mount({
+      setup() {
+        const btnRef = ref<HTMLElement | null>(null)
+        return () => (
+          <>
+            <button ref={btnRef}>cover</button>
+            <Tour modelValue={true} mask={false}>
+              <TourStep
+                title="cover title"
+                description="cover description."
+                target={btnRef.value}
+              />
+            </Tour>
+          </>
+        )
+      },
+    })
+
+    expect(document.querySelector('.el-tour-mask')?.innerHTML).toBeFalsy()
+  })
+
+  test('custom indicator', () => {
+    mount({
+      setup() {
+        const btnRef = ref<HTMLElement | null>(null)
+        const slots = {
+          indicators: ({ current, total }: any) => `${current + 1} / ${total}`,
+          default: () => (
+            <TourStep
+              title="cover title"
+              description="cover description."
+              target={btnRef.value}
+            />
+          ),
+        }
+        return () => (
+          <>
+            <button ref={btnRef}>cover</button>
+            <Tour modelValue={true} v-slots={slots} />
+          </>
+        )
+      },
+    })
+
+    expect(document.querySelector('.el-tour-indicators')?.innerHTML).toBe(
+      '1 / 1'
+    )
+  })
+
+  test('primary', () => {
+    mount({
+      setup() {
+        const btnRef = ref<HTMLElement | null>(null)
+        return () => (
+          <>
+            <button ref={btnRef}>cover</button>
+            <Tour modelValue={true} type="primary">
+              <TourStep
+                title="cover title"
+                description="cover description."
+                target={btnRef.value}
+              />
+            </Tour>
+          </>
+        )
+      },
+    })
+
+    expect(document.querySelector('.el-tour.el-tour--primary')).toBeTruthy()
+  })
+
+  test('no target', () => {
+    mount({
+      setup() {
+        return () => (
+          <Tour modelValue={true} type="primary">
+            <TourStep title="cover title" description="cover description." />
+          </Tour>
+        )
+      },
+    })
+
+    const style = getComputedStyle(document.querySelector('.el-tour__content')!)
+    expect(style.position).toBe('fixed')
+    expect(style.top).toBe('50%')
+    expect(style.left).toBe('50%')
+    expect(style.transform).toBe('translate3d(-50%, -50%, 0)')
+    expect(style.maxWidth).toBe('100vw')
+  })
+})

--- a/packages/components/tour/index.ts
+++ b/packages/components/tour/index.ts
@@ -1,0 +1,13 @@
+import { withInstall, withNoopInstall } from '@element-plus/utils'
+import Tour from './src/tour.vue'
+import TourStep from './src/step.vue'
+
+export const ElTour = withInstall(Tour, {
+  TourStep,
+})
+export const ElTourStep = withNoopInstall(TourStep)
+export default ElTour
+
+export * from './src/tour'
+
+export type { TourMask, TourGap, TourBtnProps } from './src/types'

--- a/packages/components/tour/src/content.ts
+++ b/packages/components/tour/src/content.ts
@@ -1,0 +1,71 @@
+import { buildProps, definePropType } from '@element-plus/utils'
+import type { ExtractPropTypes } from 'vue'
+import type { Placement, Strategy, VirtualElement } from '@floating-ui/dom'
+
+const tourStrategies = ['absolute', 'fixed'] as const
+
+const tourPlacements = [
+  'top-start',
+  'top-end',
+  'top',
+  'bottom-start',
+  'bottom-end',
+  'bottom',
+  'left-start',
+  'left-end',
+  'left',
+  'right-start',
+  'right-end',
+  'right',
+] as const
+
+export const tourContentProps = buildProps({
+  /**
+   * @description position of the guide card relative to the target element
+   */
+  placement: {
+    type: definePropType<Placement>(String),
+    values: tourPlacements,
+    default: 'bottom',
+  },
+  /**
+   * @description the reference dom
+   */
+  reference: {
+    type: definePropType<HTMLElement | VirtualElement | null>(Object),
+    default: null,
+  },
+  /**
+   * @description position strategy of the content
+   */
+  strategy: {
+    type: definePropType<Strategy>(String),
+    values: tourStrategies,
+    default: 'absolute',
+  },
+  /**
+   * @description offset of the arrow
+   */
+  offset: {
+    type: Number,
+    default: 10,
+  },
+  /**
+   * @description @description whether to show the arrow
+   */
+  showArrow: Boolean,
+  /**
+   * @description content's zIndex
+   */
+  zIndex: {
+    type: Number,
+    default: 2001,
+  },
+})
+
+export type TourContentProps = ExtractPropTypes<typeof tourContentProps>
+
+export const tourContentEmits = {
+  close: () => true,
+}
+export type TourContentEmits = typeof tourContentEmits

--- a/packages/components/tour/src/content.vue
+++ b/packages/components/tour/src/content.vue
@@ -1,0 +1,64 @@
+<template>
+  <div
+    ref="contentRef"
+    :style="contentStyle"
+    :class="ns.e('content')"
+    :data-side="side"
+    tabindex="-1"
+  >
+    <el-focus-trap
+      loop
+      trapped
+      focus-start-el="container"
+      :focus-trap-el="contentRef || undefined"
+      @release-requested="onCloseRequested"
+    >
+      <slot />
+    </el-focus-trap>
+    <span
+      v-if="showArrow"
+      ref="arrowRef"
+      :style="arrowStyle"
+      :class="ns.e('arrow')"
+    />
+  </div>
+</template>
+<script setup lang="ts">
+import { computed, inject, ref, toRef } from 'vue'
+import ElFocusTrap from '@element-plus/components/focus-trap'
+import { tourContentEmits, tourContentProps } from './content'
+import { tourKey, useFloating } from './helper'
+
+defineOptions({
+  name: 'ElTourContent',
+})
+
+const props = defineProps(tourContentProps)
+const emit = defineEmits(tourContentEmits)
+
+const placement = ref(props.placement)
+const strategy = ref(props.strategy)
+const contentRef = ref<HTMLElement | null>(null)
+const arrowRef = ref<HTMLElement | null>(null)
+
+const { contentStyle, arrowStyle } = useFloating(
+  toRef(props, 'reference'),
+  contentRef,
+  arrowRef,
+  placement,
+  strategy,
+  toRef(props, 'offset'),
+  toRef(props, 'zIndex'),
+  toRef(props, 'showArrow')
+)
+
+const side = computed(() => {
+  return placement.value.split('-')[0]
+})
+
+const { ns } = inject(tourKey)!
+
+const onCloseRequested = () => {
+  emit('close')
+}
+</script>

--- a/packages/components/tour/src/helper.ts
+++ b/packages/components/tour/src/helper.ts
@@ -1,0 +1,325 @@
+import {
+  camelize,
+  computed,
+  isVNode,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  unref,
+  watch,
+  watchEffect,
+} from 'vue'
+import {
+  arrow,
+  autoUpdate,
+  computePosition,
+  detectOverflow,
+  flip,
+  offset as offsetMiddelware,
+  shift,
+} from '@floating-ui/dom'
+import { hasOwn, isArray, isClient, keysOf } from '@element-plus/utils'
+
+import type {
+  CSSProperties,
+  Component,
+  ComputedRef,
+  InjectionKey,
+  Ref,
+  SetupContext,
+  VNode,
+} from 'vue'
+import type { UseNamespaceReturn } from '@element-plus/hooks'
+import type { PosInfo, TourGap, TourMask } from './types'
+import type {
+  ComputePositionReturn,
+  Middleware,
+  Placement,
+  Strategy,
+  VirtualElement,
+} from '@floating-ui/dom'
+
+export const useTarget = (
+  target: Ref<HTMLElement | null | undefined>,
+  open: Ref<boolean>,
+  gap: Ref<TourGap>,
+  mergedMask: Ref<TourMask>,
+  scrollIntoViewOptions: Ref<boolean | ScrollIntoViewOptions>
+) => {
+  const posInfo: Ref<PosInfo | null> = ref(null)
+
+  const updatePosInfo = () => {
+    if (!target.value || !open.value) {
+      posInfo.value = null
+      return
+    }
+    if (!isInViewPort(target.value) && open.value) {
+      target.value.scrollIntoView(scrollIntoViewOptions.value)
+    }
+    const { left, top, width, height } = target.value.getBoundingClientRect()
+    posInfo.value = {
+      left,
+      top,
+      width,
+      height,
+      radius: 0,
+    }
+  }
+
+  onMounted(() => {
+    watch(
+      [open, target],
+      () => {
+        updatePosInfo()
+      },
+      {
+        immediate: true,
+      }
+    )
+    window.addEventListener('resize', updatePosInfo)
+  })
+
+  onBeforeUnmount(() => {
+    window.removeEventListener('resize', updatePosInfo)
+  })
+
+  const getGapOffset = (index: number) =>
+    (isArray(gap.value.offset) ? gap.value.offset[index] : gap.value.offset) ??
+    6
+
+  const mergedPosInfo = computed(() => {
+    if (!posInfo.value) return posInfo.value
+
+    const gapOffsetX = getGapOffset(0)
+    const gapOffsetY = getGapOffset(1)
+    const gapRadius = gap.value?.radius || 2
+
+    return {
+      left: posInfo.value.left - gapOffsetX,
+      top: posInfo.value.top - gapOffsetY,
+      width: posInfo.value.width + gapOffsetX * 2,
+      height: posInfo.value.height + gapOffsetY * 2,
+      radius: gapRadius,
+    }
+  })
+
+  const triggerTarget = computed(() => {
+    if (!mergedMask.value || !target.value || !window.DOMRect) {
+      return target.value || undefined
+    }
+
+    return {
+      getBoundingClientRect() {
+        return window.DOMRect.fromRect({
+          width: mergedPosInfo.value?.width || 0,
+          height: mergedPosInfo.value?.height || 0,
+          x: mergedPosInfo.value?.left || 0,
+          y: mergedPosInfo.value?.top || 0,
+        })
+      },
+    }
+  })
+
+  return {
+    mergedPosInfo,
+    triggerTarget,
+  }
+}
+
+export interface TourContext {
+  current: Ref<number>
+  total: ComputedRef<number>
+  showClose: Ref<boolean>
+  closeIcon: Ref<string | Component>
+  mergedType: Ref<'default' | 'primary' | undefined>
+  ns: UseNamespaceReturn
+  slots: SetupContext['slots']
+  updateModelValue(modelValue: boolean): void
+  onClose(): void
+  onFinish(): void
+  onChange(): void
+}
+
+export const tourKey: InjectionKey<TourContext> = Symbol('ElTour')
+
+function isInViewPort(element: HTMLElement) {
+  const viewWidth = window.innerWidth || document.documentElement.clientWidth
+  const viewHeight = window.innerHeight || document.documentElement.clientHeight
+  const { top, right, bottom, left } = element.getBoundingClientRect()
+
+  return top >= 0 && left >= 0 && right <= viewWidth && bottom <= viewHeight
+}
+
+const isSameProps = (a: Record<string, any>, b: Record<string, any>) => {
+  if (Object.keys(a).length !== Object.keys(b).length) return false
+  for (const key in a) {
+    if (a[key] !== b[key]) {
+      return false
+    }
+  }
+  return true
+}
+
+export function isSameSteps(a: any[], b: any[]) {
+  if (a.length !== b.length) return false
+  for (const [index] of a.entries()) {
+    if (isSameProps(a[index], b[index])) {
+      return false
+    }
+  }
+  return true
+}
+
+export const getNormalizedProps = (node: VNode, booleanKeys: string[]) => {
+  if (!isVNode(node)) {
+    return {}
+  }
+
+  const raw = node.props || {}
+  const type = (node.type as any)?.props || {}
+  const props: Record<string, any> = {}
+  Object.keys(type).forEach((key) => {
+    if (hasOwn(type[key], 'default')) {
+      props[key] = type[key].default
+    }
+  })
+
+  Object.keys(raw).forEach((key) => {
+    const cameKey = camelize(key)
+    props[cameKey] = raw[key]
+    if (booleanKeys.includes(cameKey) && props[cameKey] === '') {
+      props[cameKey] = true
+    }
+  })
+
+  return props
+}
+
+export const useFloating = (
+  referenceRef: Ref<HTMLElement | VirtualElement | null>,
+  contentRef: Ref<HTMLElement | null>,
+  arrowRef: Ref<HTMLElement | null>,
+  placement: Ref<Placement | undefined>,
+  strategy: Ref<Strategy>,
+  offset: Ref<number>,
+  zIndex: Ref<number>,
+  showArrow: Ref<boolean>
+) => {
+  const x = ref<number>()
+  const y = ref<number>()
+  const middlewareData = ref<ComputePositionReturn['middlewareData']>({})
+
+  const states = {
+    x,
+    y,
+    placement,
+    strategy,
+    middlewareData,
+  } as const
+
+  const middleware = computed(() => {
+    const _middleware: Middleware[] = [
+      offsetMiddelware(unref(offset)),
+      flip(),
+      shift(),
+      overflowMiddleware(),
+    ]
+
+    if (unref(showArrow) && unref(arrowRef)) {
+      _middleware.push(
+        arrow({
+          element: unref(arrowRef)!,
+        })
+      )
+    }
+    return _middleware
+  })
+
+  const update = async () => {
+    if (!isClient) return
+
+    const referenceEl = unref(referenceRef)
+    const contentEl = unref(contentRef)
+    if (!referenceEl || !contentEl) return
+
+    const data = await computePosition(referenceEl, contentEl, {
+      placement: unref(placement),
+      strategy: unref(strategy),
+      middleware: unref(middleware),
+    })
+
+    keysOf(states).forEach((key) => {
+      states[key].value = data[key]
+    })
+  }
+
+  const contentStyle = computed<CSSProperties>(() => {
+    if (!unref(referenceRef)) {
+      return {
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate3d(-50%, -50%, 0)',
+        maxWidth: '100vw',
+        zIndex: unref(zIndex),
+      }
+    }
+
+    const { overflow } = unref(middlewareData)
+
+    return {
+      position: unref(strategy),
+      zIndex: unref(zIndex),
+      top: unref(y) != null ? `${unref(y)}px` : '',
+      left: unref(x) != null ? `${unref(x)}px` : '',
+      maxWidth: overflow?.maxWidth ? `${overflow?.maxWidth}px` : '',
+    }
+  })
+
+  const arrowStyle = computed<CSSProperties>(() => {
+    if (!unref(showArrow)) return {}
+
+    const { arrow } = unref(middlewareData)
+    return {
+      left: arrow?.x != null ? `${arrow?.x}px` : '',
+      top: arrow?.y != null ? `${arrow?.y}px` : '',
+    }
+  })
+
+  let cleanup: any
+  onMounted(() => {
+    cleanup = autoUpdate(unref(referenceRef)!, unref(contentRef)!, update)
+
+    watchEffect(() => {
+      update()
+    })
+  })
+
+  onBeforeUnmount(() => {
+    cleanup && cleanup()
+  })
+
+  return {
+    update,
+    contentStyle,
+    arrowStyle,
+  }
+}
+
+const overflowMiddleware = (): Middleware => {
+  return {
+    name: 'overflow',
+    async fn(state) {
+      const overflow = await detectOverflow(state)
+      let overWidth = 0
+      if (overflow.left > 0) overWidth = overflow.left
+      if (overflow.right > 0) overWidth = overflow.right
+      const floatingWidth = state.rects.floating.width
+      return {
+        data: {
+          maxWidth: floatingWidth - overWidth,
+        },
+      }
+    },
+  }
+}

--- a/packages/components/tour/src/mask.ts
+++ b/packages/components/tour/src/mask.ts
@@ -1,0 +1,39 @@
+import { buildProps, definePropType } from '@element-plus/utils'
+import type { ExtractPropTypes } from 'vue'
+import type { PosInfo } from './types'
+
+export const maskProps = buildProps({
+  /**
+   * @description mask's zIndex
+   */
+  zIndex: {
+    type: Number,
+    default: 1001,
+  },
+  /**
+   * @description whether to show the mask
+   */
+  visible: Boolean,
+  /**
+   * @description mask's fill
+   */
+  fill: {
+    type: String,
+    default: 'rgba(0,0,0,0.5)',
+  },
+  /***
+   * @description mask's transparent space position
+   */
+  pos: {
+    type: definePropType<PosInfo | null>(Object),
+  },
+  /**
+   * @description whether the target element can be clickable, when using mask
+   */
+  targetAreaClickable: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+export type MaskProps = ExtractPropTypes<typeof maskProps>

--- a/packages/components/tour/src/mask.vue
+++ b/packages/components/tour/src/mask.vue
@@ -1,0 +1,99 @@
+<template>
+  <div
+    v-if="visible"
+    :class="ns.e('mask')"
+    :style="({
+      position: 'fixed',
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      zIndex,
+      pointerEvents: pos && targetAreaClickable ? 'none' : 'auto',
+    } as any)"
+    v-bind="$attrs"
+  >
+    <svg
+      :style="{
+        width: '100%',
+        height: '100%',
+      }"
+    >
+      <defs>
+        <mask :id="maskId">
+          <rect x="0" y="0" width="100vw" height="100vh" fill="white" />
+          <rect
+            v-if="pos"
+            :class="ns.e('hollow')"
+            :x="pos.left"
+            :y="pos.top"
+            :rx="pos.radius"
+            :width="pos.width"
+            :height="pos.height"
+            fill="black"
+          />
+        </mask>
+      </defs>
+      <rect
+        x="0"
+        y="0"
+        width="100%"
+        height="100%"
+        :fill="fill"
+        :mask="`url(#${maskId})`"
+      />
+      <template v-if="pos">
+        <rect v-bind="COVER_PROPS" x="0" y="0" width="100%" :height="pos.top" />
+        <rect
+          v-bind="COVER_PROPS"
+          x="0"
+          y="0"
+          :width="pos.left"
+          height="100%"
+        />
+        <rect
+          v-bind="COVER_PROPS"
+          x="0"
+          :y="pos.top + pos.height"
+          width="100%"
+          :height="`calc(100vh - ${pos.top + pos.height}px)`"
+        />
+        <rect
+          v-bind="COVER_PROPS"
+          :x="pos.left + pos.width"
+          y="0"
+          :width="`calc(100vw - ${pos.left + pos.width}px)`"
+          height="100%"
+        />
+      </template>
+    </svg>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { inject, toRef } from 'vue'
+import { useId, useLockscreen } from '@element-plus/hooks'
+import { maskProps } from './mask'
+import { tourKey } from './helper'
+
+defineOptions({
+  name: 'ElTourMask',
+  inheritAttrs: false,
+})
+
+const props = defineProps(maskProps)
+
+const { ns } = inject(tourKey)!
+
+const id = useId()
+const maskId = `el-tour-mask-${id.value}`
+
+useLockscreen(toRef(props, 'visible'), {
+  ns,
+})
+
+const COVER_PROPS = {
+  fill: 'transparent',
+  'pointer-events': 'auto',
+}
+</script>

--- a/packages/components/tour/src/step.ts
+++ b/packages/components/tour/src/step.ts
@@ -1,0 +1,88 @@
+import { buildProps, definePropType, iconPropType } from '@element-plus/utils'
+import { tourContentProps } from './content'
+import type { CSSProperties, ExtractPropTypes } from 'vue'
+import type { TourBtnProps, TourMask } from './types'
+
+export const tourStepProps = buildProps({
+  /**
+   * @description get the element the guide card points to. empty makes it show in center of screen
+   */
+  target: {
+    type: definePropType<HTMLElement | null>(Object),
+  },
+  /**
+   * @description the title of the tour content
+   */
+  title: String,
+  /**
+   * @description description
+   */
+  description: String,
+  /**
+   * @description whether to show a close button
+   */
+  showClose: {
+    type: Boolean,
+    default: true,
+  },
+  /**
+   * @description custom close icon, default is Close
+   */
+  closeIcon: {
+    type: iconPropType,
+  },
+  /**
+   * @description whether to show the arrow
+   */
+  showArrow: {
+    type: Boolean,
+    default: true,
+  },
+  /**
+   * @description position of the guide card relative to the target element
+   */
+  placement: tourContentProps.placement,
+  /**
+   * @description whether to enable masking, change mask style and fill color by pass custom props
+   */
+  mask: {
+    type: definePropType<TourMask>([Boolean, Object]),
+  },
+  /**
+   * @description custom style for content
+   */
+  contentStyle: {
+    type: definePropType<CSSProperties>([Object]),
+  },
+  /**
+   * @description properties of the previous button
+   */
+  prevButtonProps: {
+    type: definePropType<TourBtnProps>(Object),
+  },
+  /**
+   * @description properties of the Next button
+   */
+  nextButtonProps: {
+    type: definePropType<TourBtnProps>(Object),
+  },
+  /**
+   * @description support pass custom scrollIntoView options
+   */
+  scrollIntoViewOptions: {
+    type: definePropType<boolean | ScrollIntoViewOptions>([Boolean, Object]),
+  },
+  /**
+   * @description type, affects the background color and text color
+   */
+  type: {
+    type: definePropType<'defalut' | 'primary'>(String),
+  },
+})
+
+export type TourStepProps = ExtractPropTypes<typeof tourStepProps>
+
+export const tourStepEmits = {
+  close: () => true,
+}
+export type TourStepEmits = typeof tourStepEmits

--- a/packages/components/tour/src/step.vue
+++ b/packages/components/tour/src/step.vue
@@ -1,0 +1,137 @@
+<template>
+  <button
+    v-if="mergedShowClose"
+    aria-label="Close"
+    :class="ns.e('closebtn')"
+    type="button"
+    @click="onClose"
+  >
+    <el-icon :class="ns.e('close')">
+      <component :is="mergedCloseIcon" />
+    </el-icon>
+  </button>
+  <header :class="ns.e('header')">
+    <slot name="header">
+      <span role="heading" :class="ns.e('title')">
+        {{ title }}
+      </span>
+    </slot>
+  </header>
+  <div :class="ns.e('body')">
+    <slot>
+      <span>{{ description }}</span>
+    </slot>
+  </div>
+  <footer :class="ns.e('footer')">
+    <div :class="ns.b('indicators')">
+      <component
+        :is="tourSlots.indicators"
+        v-if="tourSlots.indicators"
+        :current="current"
+        :total="total"
+      />
+      <template v-else>
+        <span
+          v-for="(item, index) in total"
+          :key="item"
+          :class="[ns.b('indicator'), index === current ? 'is-active' : '']"
+        />
+      </template>
+    </div>
+    <div :class="ns.b('buttons')">
+      <el-button
+        v-if="current > 0"
+        size="small"
+        :type="mergedType"
+        v-bind="prevButtonProps"
+        @click="onPrev"
+      >
+        {{ prevButtonProps?.children ?? t('el.tour.previous') }}
+      </el-button>
+      <el-button
+        v-if="current <= total - 1"
+        size="small"
+        :type="mergedType === 'primary' ? 'default' : 'primary'"
+        v-bind="nextButtonProps"
+        @click="onNext"
+      >
+        {{
+          nextButtonProps?.children ?? current === total - 1
+            ? t('el.tour.finish')
+            : t('el.tour.next')
+        }}
+      </el-button>
+    </div>
+  </footer>
+</template>
+
+<script lang="ts" setup>
+import { computed, inject } from 'vue'
+import { ElButton } from '@element-plus/components/button'
+import { ElIcon } from '@element-plus/components/icon'
+import { CloseComponents } from '@element-plus/utils'
+import { useLocale } from '@element-plus/hooks'
+import { tourStepEmits, tourStepProps } from './step'
+import { tourKey } from './helper'
+
+defineOptions({
+  name: 'ElTourStep',
+})
+
+const props = defineProps(tourStepProps)
+const emit = defineEmits(tourStepEmits)
+
+const { Close } = CloseComponents
+
+const { t } = useLocale()
+
+const {
+  current,
+  total,
+  showClose,
+  closeIcon,
+  mergedType,
+  ns,
+  slots: tourSlots,
+  updateModelValue,
+  onClose: tourOnClose,
+  onFinish: tourOnFinish,
+  onChange,
+} = inject(tourKey)!
+
+const mergedShowClose = computed(() => props.showClose ?? showClose.value)
+const mergedCloseIcon = computed(
+  () => props.closeIcon ?? closeIcon.value ?? Close
+)
+
+const onPrev = () => {
+  current.value -= 1
+  if (props.prevButtonProps?.onClick) {
+    props.prevButtonProps?.onClick()
+  }
+  onChange()
+}
+
+const onNext = () => {
+  if (current.value >= total.value - 1) {
+    onFinish()
+  } else {
+    current.value += 1
+  }
+  if (props.nextButtonProps?.onClick) {
+    props.nextButtonProps.onClick()
+  }
+  onChange()
+}
+
+const onFinish = () => {
+  onClose()
+  tourOnFinish()
+}
+
+const onClose = () => {
+  updateModelValue(false)
+  tourOnClose()
+  emit('close')
+}
+</script>

--- a/packages/components/tour/src/steps.ts
+++ b/packages/components/tour/src/steps.ts
@@ -1,0 +1,52 @@
+import { defineComponent } from 'vue'
+import { flattedChildren, isArray } from '@element-plus/utils'
+import { getNormalizedProps, isSameSteps } from './helper'
+import type { FlattenVNodes } from '@element-plus/utils'
+import type { Component, VNode } from 'vue'
+
+export default defineComponent({
+  name: 'ElTourSteps',
+  props: {
+    current: {
+      type: Number,
+      default: 0,
+    },
+  },
+  emits: ['update-steps'],
+  setup(props, { slots, emit }) {
+    let cachedSteps: any[] = []
+
+    return () => {
+      const children = slots.default?.()!
+      const filteredSteps: any[] = []
+      const result: VNode[] = []
+
+      function filterSteps(children?: FlattenVNodes) {
+        if (!isArray(children)) return
+        ;(children as VNode[]).forEach((item) => {
+          const name = ((item?.type || {}) as Component)?.name
+
+          if (name === 'ElTourStep') {
+            const booleanKeys = ['showArrow', 'mask', 'scrollIntoViewOptions']
+            filteredSteps.push(getNormalizedProps(item, booleanKeys))
+            result.push(item)
+          }
+        })
+      }
+
+      if (children.length) {
+        filterSteps(flattedChildren(children![0]?.children))
+      }
+
+      if (!isSameSteps(filteredSteps, cachedSteps)) {
+        cachedSteps = filteredSteps
+        emit('update-steps', filteredSteps)
+      }
+
+      if (result.length) {
+        return result[props.current]
+      }
+      return null
+    }
+  },
+})

--- a/packages/components/tour/src/tour.ts
+++ b/packages/components/tour/src/tour.ts
@@ -1,0 +1,127 @@
+import {
+  buildProps,
+  definePropType,
+  iconPropType,
+  isBoolean,
+  isNumber,
+} from '@element-plus/utils'
+import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
+import { tourContentProps } from './content'
+import type { CSSProperties, ExtractPropTypes } from 'vue'
+import type Tour from './tour.vue'
+import type { TourGap, TourMask } from './types'
+
+export const tourProps = buildProps({
+  /**
+   * @description open tour
+   */
+  modelValue: Boolean,
+  /**
+   * @description what is the current step
+   */
+  current: {
+    type: Number,
+    default: 0,
+  },
+  /**
+   * @description whether to show the arrow
+   */
+  showArrow: {
+    type: Boolean,
+    default: true,
+  },
+  /**
+   * @description whether to show a close button
+   */
+  showClose: {
+    type: Boolean,
+    default: true,
+  },
+  /**
+   * @description custom close icon
+   */
+  closeIcon: {
+    type: iconPropType,
+  },
+  /**
+   * @description position of the guide card relative to the target element
+   */
+  placement: tourContentProps.placement,
+  /**
+   * @description custom style for content
+   */
+  contentStyle: {
+    type: definePropType<CSSProperties>([Object]),
+  },
+  /**
+   * @description whether to enable masking, change mask style and fill color by pass custom props
+   */
+  mask: {
+    type: definePropType<TourMask>([Boolean, Object]),
+    default: true,
+  },
+  /**
+   * @description transparent gap between mask and target
+   */
+  gap: {
+    type: definePropType<TourGap>(Object),
+    default: () => ({
+      offset: 6,
+      radius: 2,
+    }),
+  },
+  /**
+   * @description tour's zIndex
+   */
+  zIndex: {
+    type: Number,
+  },
+  /**
+   * @description support pass custom scrollIntoView options
+   */
+  scrollIntoViewOptions: {
+    type: definePropType<boolean | ScrollIntoViewOptions>([Boolean, Object]),
+    default: () => ({
+      block: 'center',
+    }),
+  },
+  /**
+   * @description type, affects the background color and text color
+   */
+  type: {
+    type: definePropType<'defalut' | 'primary'>(String),
+  },
+  /**
+   * @description which element the TourContent appends to
+   */
+  appendTo: {
+    type: definePropType<string | HTMLElement>([String, Object]),
+    default: 'body',
+  },
+  /**
+   * @description whether the Tour can be closed by pressing ESC
+   */
+  closeOnPressEscape: {
+    type: Boolean,
+    default: true,
+  },
+  /**
+   * @description whether the target element can be clickable, when using mask
+   */
+  targetAreaClickable: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+export type TourProps = ExtractPropTypes<typeof tourProps>
+export type TourInstance = InstanceType<typeof Tour>
+
+export const tourEmits = {
+  [UPDATE_MODEL_EVENT]: (value: boolean) => isBoolean(value),
+  ['update:current']: (current: number) => isNumber(current),
+  close: (current: number) => isNumber(current),
+  finish: () => true,
+  change: (current: number) => isNumber(current),
+}
+export type TourEmits = typeof tourEmits

--- a/packages/components/tour/src/tour.vue
+++ b/packages/components/tour/src/tour.vue
@@ -1,0 +1,146 @@
+<template>
+  <teleport :to="appendTo">
+    <div :class="kls" v-bind="$attrs">
+      <el-tour-mask
+        :visible="mergedShowMask"
+        :fill="mergedMaskStyle?.color"
+        :style="mergedMaskStyle?.style"
+        :pos="pos"
+        :z-index="mergedZIndex"
+        :target-area-clickable="targetAreaClickable"
+      />
+      <el-tour-content
+        v-if="modelValue"
+        :key="current"
+        :reference="triggerTarget"
+        :placement="mergedPlacement"
+        :show-arrow="mergedShowArrow"
+        :z-index="mergedZIndex"
+        :style="mergedContentStyle"
+        @close="onEscClose"
+      >
+        <el-tour-steps :current="current" @update-steps="onUpdateSteps">
+          <slot />
+        </el-tour-steps>
+      </el-tour-content>
+    </div>
+  </teleport>
+  <!-- just for IDE -->
+  <slot v-if="false" name="indicators" :current="current + 1" :total="total" />
+</template>
+
+<script lang="ts" setup>
+import { computed, provide, ref, toRef, useSlots, watch } from 'vue'
+import { useVModel } from '@vueuse/core'
+import { useNamespace, useZIndex } from '@element-plus/hooks'
+import { isBoolean } from '@element-plus/utils'
+import ElTourMask from './mask.vue'
+import ElTourContent from './content.vue'
+import ElTourSteps from './steps'
+import { tourEmits, tourProps } from './tour'
+import { tourKey, useTarget } from './helper'
+import type { UsedTourStepProps } from './types'
+
+defineOptions({
+  name: 'ElTour',
+})
+
+const props = defineProps(tourProps)
+const emit = defineEmits(tourEmits)
+
+const ns = useNamespace('tour')
+const steps = ref<UsedTourStepProps[]>([])
+
+const current = useVModel(props, 'current', emit, {
+  passive: true,
+})
+const total = computed(() => steps.value.length)
+
+const currentStep = computed(() => steps.value[current.value] || {})
+const currentTarget = computed(() => currentStep.value.target)
+
+const kls = computed(() => [
+  ns.b(),
+  mergedType.value === 'primary' ? ns.m('primary') : '',
+])
+
+const mergedPlacement = computed(
+  () => currentStep.value.placement || props.placement
+)
+
+const mergedContentStyle = computed(
+  () => currentStep.value.contentStyle ?? props.contentStyle
+)
+
+const mergedMask = computed(() => currentStep.value.mask ?? props.mask)
+const mergedShowMask = computed(() => !!mergedMask.value && props.modelValue)
+const mergedMaskStyle = computed(() =>
+  isBoolean(mergedMask.value) ? undefined : mergedMask.value
+)
+
+const mergedShowArrow = computed(
+  () =>
+    !!currentTarget.value && (currentStep.value.showArrow ?? props.showArrow)
+)
+
+const mergedScrollIntoViewOptions = computed(
+  () => currentStep.value.scrollIntoViewOptions ?? props.scrollIntoViewOptions
+)
+const mergedType = computed(() => currentStep.value.type ?? props.type)
+
+const { nextZIndex } = useZIndex()
+const nowZIndex = nextZIndex()
+const mergedZIndex = computed(() => props.zIndex ?? nowZIndex)
+
+const { mergedPosInfo: pos, triggerTarget } = useTarget(
+  currentTarget,
+  toRef(props, 'modelValue'),
+  toRef(props, 'gap'),
+  mergedMask,
+  mergedScrollIntoViewOptions
+)
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    if (!val) {
+      current.value = 0
+    }
+  }
+)
+
+const onUpdateSteps = (v: any) => {
+  steps.value = v
+}
+
+const onEscClose = () => {
+  if (props.closeOnPressEscape) {
+    emit('update:modelValue', false)
+    emit('close', current.value)
+  }
+}
+
+const slots = useSlots()
+
+provide(tourKey, {
+  current,
+  total,
+  showClose: toRef(props, 'showClose'),
+  closeIcon: toRef(props, 'closeIcon') as any,
+  mergedType: mergedType as any,
+  ns,
+  slots,
+  updateModelValue(modelValue) {
+    emit('update:modelValue', modelValue)
+  },
+  onClose() {
+    emit('close', current.value)
+  },
+  onFinish() {
+    emit('finish')
+  },
+  onChange() {
+    emit('change', current.value)
+  },
+})
+</script>

--- a/packages/components/tour/src/types.ts
+++ b/packages/components/tour/src/types.ts
@@ -1,0 +1,39 @@
+import type { CSSProperties, VNode } from 'vue'
+import type { Placement } from '@floating-ui/dom'
+
+export type TourMask =
+  | boolean
+  | {
+      style?: CSSProperties
+      color?: string
+    }
+
+export interface TourGap {
+  offset?: number | [number, number]
+  radius?: number
+}
+
+export interface TourBtnProps {
+  children: VNode | string
+  onClick: () => void
+  className?: string
+  style?: CSSProperties
+}
+
+export interface PosInfo {
+  left: number
+  top: number
+  height: number
+  width: number
+  radius: number
+}
+
+export interface UsedTourStepProps {
+  target?: HTMLElement | null
+  showArrow?: boolean
+  placement?: Placement
+  contentStyle?: CSSProperties
+  mask?: TourMask
+  type?: 'default' | 'primary'
+  scrollIntoViewOptions?: boolean | ScrollIntoViewOptions
+}

--- a/packages/components/tour/style/css.ts
+++ b/packages/components/tour/style/css.ts
@@ -1,0 +1,3 @@
+import '@element-plus/components/base/style/css'
+import '@element-plus/components/button/style/css'
+import '@element-plus/theme-chalk/el-tour.css'

--- a/packages/components/tour/style/index.ts
+++ b/packages/components/tour/style/index.ts
@@ -1,0 +1,3 @@
+import '@element-plus/components/base/style'
+import '@element-plus/components/button/style'
+import '@element-plus/theme-chalk/src/tour.scss'

--- a/packages/element-plus/component.ts
+++ b/packages/element-plus/component.ts
@@ -103,6 +103,7 @@ import { ElTreeSelect } from '@element-plus/components/tree-select'
 import { ElTreeV2 } from '@element-plus/components/tree-v2'
 import { ElUpload } from '@element-plus/components/upload'
 import { ElWatermark } from '@element-plus/components/watermark'
+import { ElTour, ElTourStep } from '@element-plus/components/tour'
 
 import type { Plugin } from 'vue'
 
@@ -206,4 +207,6 @@ export default [
   ElTreeV2,
   ElUpload,
   ElWatermark,
+  ElTour,
+  ElTourStep,
 ] as Plugin[]

--- a/packages/locale/lang/de.ts
+++ b/packages/locale/lang/de.ts
@@ -103,6 +103,11 @@ export default {
       clearFilter: 'Alles ',
       sumText: 'Summe',
     },
+    tour: {
+      next: 'Weiter',
+      previous: 'Zurück',
+      finish: 'Fertig',
+    },
     tree: {
       emptyText: 'Keine Einträge',
     },

--- a/packages/locale/lang/en.ts
+++ b/packages/locale/lang/en.ts
@@ -140,6 +140,11 @@ export default {
       clearFilter: 'All',
       sumText: 'Sum',
     },
+    tour: {
+      next: 'Next',
+      previous: 'Previous',
+      finish: 'Finish',
+    },
     tree: {
       emptyText: 'No Data',
     },

--- a/packages/locale/lang/eu.ts
+++ b/packages/locale/lang/eu.ts
@@ -102,6 +102,11 @@ export default {
       clearFilter: 'Guztia',
       sumText: 'Batura',
     },
+    tour: {
+      next: 'Hurrengoa',
+      previous: 'Aurrekoa',
+      finish: 'Bukatu',
+    },
     tree: {
       emptyText: 'Daturik ez',
     },

--- a/packages/locale/lang/fa.ts
+++ b/packages/locale/lang/fa.ts
@@ -102,6 +102,11 @@ export default {
       clearFilter: 'همه',
       sumText: 'جمع',
     },
+    tour: {
+      next: 'بعدی',
+      previous: 'قبلی',
+      finish: 'پایان',
+    },
     tree: {
       emptyText: 'اطلاعاتی وجود ندارد',
     },

--- a/packages/locale/lang/ja.ts
+++ b/packages/locale/lang/ja.ts
@@ -102,6 +102,11 @@ export default {
       clearFilter: 'すべて',
       sumText: '合計',
     },
+    tour: {
+      next: '次へ',
+      previous: '前へ',
+      finish: 'ツアー終了',
+    },
     tree: {
       emptyText: 'データなし',
     },

--- a/packages/locale/lang/ko.ts
+++ b/packages/locale/lang/ko.ts
@@ -130,6 +130,11 @@ export default {
       clearFilter: '전체',
       sumText: '합계',
     },
+    tour: {
+      next: '다음',
+      previous: '이전',
+      finish: '종료',
+    },
     tree: {
       emptyText: '데이터 없음',
     },

--- a/packages/locale/lang/lt.ts
+++ b/packages/locale/lang/lt.ts
@@ -102,6 +102,11 @@ export default {
       clearFilter: 'Išvalyti',
       sumText: 'Suma',
     },
+    tour: {
+      next: 'Kitas',
+      previous: 'Ankstesnis',
+      finish: 'Baigti',
+    },
     tree: {
       emptyText: 'Nėra duomenų',
     },

--- a/packages/locale/lang/pl.ts
+++ b/packages/locale/lang/pl.ts
@@ -102,6 +102,11 @@ export default {
       clearFilter: 'Wszystko',
       sumText: 'Razem',
     },
+    tour: {
+      next: 'Dalej',
+      previous: 'Wróć',
+      finish: 'Zakończ',
+    },
     tree: {
       emptyText: 'Brak danych',
     },

--- a/packages/locale/lang/pt-br.ts
+++ b/packages/locale/lang/pt-br.ts
@@ -102,6 +102,11 @@ export default {
       clearFilter: 'Todos',
       sumText: 'Total',
     },
+    tour: {
+      next: 'Próximo',
+      previous: 'Anterior',
+      finish: 'Finalizar',
+    },
     tree: {
       emptyText: 'Sem dados',
     },

--- a/packages/locale/lang/ru.ts
+++ b/packages/locale/lang/ru.ts
@@ -102,6 +102,11 @@ export default {
       clearFilter: 'Все',
       sumText: 'Сумма',
     },
+    tour: {
+      next: 'Далее',
+      previous: 'Назад',
+      finish: 'Завершить',
+    },
     tree: {
       emptyText: 'Нет данных',
     },

--- a/packages/locale/lang/sv.ts
+++ b/packages/locale/lang/sv.ts
@@ -102,6 +102,11 @@ export default {
       clearFilter: 'Alla',
       sumText: 'Summa',
     },
+    tour: {
+      next: 'Nästa',
+      previous: 'Föregående',
+      finish: 'Avsluta',
+    },
     tree: {
       emptyText: 'Ingen data',
     },

--- a/packages/locale/lang/th.ts
+++ b/packages/locale/lang/th.ts
@@ -102,6 +102,11 @@ export default {
       clearFilter: 'ทั้งหมด',
       sumText: 'รวม',
     },
+    tour: {
+      next: 'ถัดไป',
+      previous: 'ย้อนกลับ',
+      finish: 'เสร็จสิ้น',
+    },
     tree: {
       emptyText: 'ไม่พบข้อมูล',
     },

--- a/packages/locale/lang/uk.ts
+++ b/packages/locale/lang/uk.ts
@@ -102,6 +102,11 @@ export default {
       clearFilter: 'Все',
       sumText: 'Сума',
     },
+    tour: {
+      next: 'Далі',
+      previous: 'Назад',
+      finish: 'Завершити',
+    },
     tree: {
       emptyText: 'Немає даних',
     },

--- a/packages/locale/lang/vi.ts
+++ b/packages/locale/lang/vi.ts
@@ -102,6 +102,11 @@ export default {
       clearFilter: 'Xóa hết',
       sumText: 'Tổng',
     },
+    tour: {
+      next: 'Tiếp',
+      previous: 'Trước',
+      finish: 'Hoàn thành',
+    },
     tree: {
       emptyText: 'Không có dữ liệu',
     },

--- a/packages/locale/lang/zh-cn.ts
+++ b/packages/locale/lang/zh-cn.ts
@@ -104,6 +104,11 @@ export default {
       clearFilter: '全部',
       sumText: '合计',
     },
+    tour: {
+      next: '下一步',
+      previous: '上一步',
+      finish: '结束导览',
+    },
     tree: {
       emptyText: '暂无数据',
     },

--- a/packages/locale/lang/zh-tw.ts
+++ b/packages/locale/lang/zh-tw.ts
@@ -138,6 +138,11 @@ export default {
       clearFilter: '全部',
       sumText: '合計',
     },
+    tour: {
+      next: '下一步',
+      previous: '上一步',
+      finish: '結束導覽',
+    },
     tree: {
       emptyText: '暫無資料',
     },

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -760,6 +760,26 @@ $dialog: map.merge(
   $dialog
 );
 
+// Tour
+// css3 var in packages/theme-chalk/src/tour.scss
+$tour: () !default;
+$tour: map.merge(
+  (
+    'width': 520px,
+    'padding-primary': 16px,
+    'font-line-height': getCssVar('font-line-height-primary'),
+    'title-font-size': 16px,
+    'title-text-color': getCssVar('text-color-primary'),
+    'title-font-weight': 400,
+    'font-size': 14px,
+    'color': getCssVar('text-color-primary'),
+    'bg-color': getCssVar('bg-color'),
+    'border-radius': 4px,
+    'border-color': getCssVar('border-color-lighter'),
+  ),
+  $tour
+);
+
 // Table
 // css3 var in packages/theme-chalk/src/table.scss
 $table: () !default;

--- a/packages/theme-chalk/src/index.scss
+++ b/packages/theme-chalk/src/index.scss
@@ -104,3 +104,4 @@
 @use './option-group.scss';
 @use './option-item.scss';
 @use './statistic.scss';
+@use './tour.scss';

--- a/packages/theme-chalk/src/tour.scss
+++ b/packages/theme-chalk/src/tour.scss
@@ -1,0 +1,166 @@
+@use 'sass:map';
+
+@use 'mixins/mixins' as *;
+@use 'mixins/var' as *;
+@use 'common/var' as *;
+
+@include b(tour) {
+  @include set-component-css-var('tour', $tour);
+
+  @include e(hollow) {
+    transition: all getCssVar('transition-duration') ease;
+  }
+
+  @include e(content) { 
+    padding: 0;
+    border-radius: getCssVar('tour-border-radius');
+    border: 1px solid getCssVar('tour-border-color');
+    width: var(#{getCssVarName('tour-width')});
+    background: getCssVar('tour-bg-color');
+    box-shadow: getCssVar('box-shadow-light');
+    box-sizing: border-box;
+
+    $content-selector: &;
+
+    $sides: (
+      'top': 'bottom',
+      'bottom': 'top',
+      'left': 'right',
+      'right': 'left',
+    );
+
+    @include e(arrow) {
+      position: absolute;
+      background: getCssVar('tour-bg-color');
+      border: 1px solid getCssVar('tour-border-color');
+      width: 10px;
+      height: 10px;
+      pointer-events: none;
+      transform: rotate(45deg);
+      box-sizing: border-box;
+
+      @each $side,
+      $adjacency
+        in ('top': 'left', 'bottom': 'right', 'left': 'bottom', 'right': 'top')
+      {
+        #{$content-selector}[data-side^='#{$side}'] & {
+          border-#{$side}-color: transparent;
+          border-#{$adjacency}-color: transparent;
+        }
+      }
+
+      @each $side, $opposite in $sides {
+        #{$content-selector}[data-side^='#{$side}'] & {
+          #{$opposite}: -5px;
+        }
+      }
+    }
+
+
+    @include e(closebtn) {
+      position: absolute;
+      top: 6px;
+      right: 0;
+      padding: 0;
+      width: 44px;
+      height: 44px;
+      background: transparent;
+      border: none;
+      outline: none;
+      cursor: pointer;
+      font-size: var(
+        #{getCssVarName('message-close-size')},
+        map.get($message, 'close-size')
+      );
+
+      .#{$namespace}-tour__close {
+        color: getCssVar('tour-title-text-color');
+        font-size: inherit;
+      }
+
+      &:focus,
+      &:hover {
+        .#{$namespace}-tour__close {
+          color: getCssVar('color', 'primary');
+        }
+      }
+    }
+
+    @include e(header) {
+      padding: getCssVar('tour', 'padding-primary');
+      padding-bottom: 10px;
+      margin-right: 16px;
+    }
+
+    @include e(title) {
+      line-height: getCssVar('tour-font-line-height');
+      font-size: getCssVar('tour-title-font-size');
+      color: getCssVar('tour-title-text-color');
+      font-weight: getCssVar('tour-title-font-weight');
+    }
+
+    @include e(body) {
+      padding: 0 getCssVar('tour-padding-primary');
+      color: getCssVar('tour-text-color');
+      font-size: getCssVar('tour-font-size');
+      img, video {
+        max-width: 100%;
+      }
+    }
+
+    @include e(footer) {
+      padding: getCssVar('tour-padding-primary');
+      padding-top: 10px;
+      box-sizing: border-box;
+      display: flex;
+      justify-content: space-between;
+    }
+
+    @include b(tour-indicators) {
+      display: inline-block;
+      flex: 1;
+    }
+
+    @include b(tour-indicator) {
+      width: 6px;
+      height: 6px;
+      display: inline-block;
+      border-radius: 50%;
+      background: getCssVar('color', 'info-light-9');
+      margin-right: 6px;
+
+      @include when(active) {
+        background: getCssVar('color', 'primary');
+      }
+    }
+  }
+
+  &.#{$namespace}-tour--primary {
+    @include set-css-var-value('tour-title-text-color',#fff);
+    @include set-css-var-value('tour-text-color',#fff);
+    @include set-css-var-value('tour-bg-color', getCssVar('color', 'primary'));
+    
+    .#{$namespace}-button--default {
+      color: getCssVar('color', 'primary');
+      border-color: getCssVar('color', 'primary');
+      background: #fff;
+    } 
+
+    .#{$namespace}-button--primary {
+      border-color: #fff;
+    } 
+
+    @include b(tour-indicator) {
+      background: rgba(255, 255, 255, 0.15);
+      @include when(active) {
+        background: #fff;
+      }
+    }
+  }
+}
+
+@include b(tour-parent) {
+  @include m(hidden) {
+    overflow: hidden;
+  }
+}

--- a/typings/components.d.ts
+++ b/typings/components.d.ts
@@ -98,6 +98,8 @@ declare module '@vue/runtime-core' {
     ElResult: typeof import('../packages/element-plus')['ElResult']
     ElSelectV2: typeof import('../packages/element-plus')['ElSelectV2']
     ElWatermark: typeof import('../packages/element-plus')['ElWatermark']
+    ElTour: typeof import('../packages/element-plus')['ElTour']
+    ElTourStep: typeof import('../packages/element-plus')['ElTourStep']
   }
 
   interface ComponentCustomProperties {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3aa9d89</samp>

This pull request adds a new Tour component to the element-plus library, which allows users to create guided tours for their products. The component consists of a main Tour component and three sub-components: TourStep, TourMask and TourSteps. The pull request also includes the documentation, examples and tests for the component, as well as the necessary changes to the components index file and the component sidebar menu.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3aa9d89</samp>

*  Add a new Tour component to the components package, which guides users through a product with a series of steps ([link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-d40ce6b2c28588dc3e0cc31974a68c2fc775e8eebbd6f97f044c23241aad3474R73), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-65987b5c3158f1ad4a793eb56d6e7c80ff7467c1c18b2c5c0ed4807f713f3dadR1-R13), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-d064f7b10c1c99a5c40c84d13ec0affc8c48663642a16432373da9be62c53b0cR1-R71), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-6463a1e40a0c6fe92afb927c514374a41999de965ccd1259dd18828d0b90d074R1-R161))
*  Implement the Tour component using sub-components for the mask, the step and the steps, which handle the masking effect, the guide card and the steps rendering respectively ([link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-17bd804841eb9701884051b56a512fafe789fdcb6cf50d4c0407904a4ce6440bR1-R24), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-3c3a12c58372d1401c1ae14304a0a63cfea70bdfd6b70c82245ededbf2805926R1-R107), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-7b849ec48de18f40c8cf6d77846c67eb3bf1041c3b184c1a0b6527ff74696612R1-R46), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-7a069f2106b3b17b3e65c91d1c1864ce814c3c877cf165d641accfd5ffb79944R1-R140), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-7030a9d4e89dad7e67197a9948d654c594fa21c5591847c234f7b37dbcb96dc7R1-R52))
*  Provide utility functions and types for the Tour component logic, such as useTarget, tourKey, isInViewPort, isSameProps, isSameSteps and getNormalizedProps ([link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-bc9e7236020dbaf17ab19e5108defa319b9c53a92aab1a8e53eb2694f3dcacdeR1-R176))
*  Use the withInstall and withNoopInstall helpers to enable global and local registration of the Tour component and its sub-component TourStep ([link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-65987b5c3158f1ad4a793eb56d6e7c80ff7467c1c18b2c5c0ed4807f713f3dadR1-R13))
*  Use the ElTooltip, ElButton and ElIcon components to enhance the Tour component UI and functionality ([link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-6463a1e40a0c6fe92afb927c514374a41999de965ccd1259dd18828d0b90d074R1-R161), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-7a069f2106b3b17b3e65c91d1c1864ce814c3c877cf165d641accfd5ffb79944R1-R140))
*  Use the useLockscreen hook to prevent scrolling when the mask is visible ([link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-3c3a12c58372d1401c1ae14304a0a63cfea70bdfd6b70c82245ededbf2805926R1-R107))
*  Add unit tests for the Tour component using the vitest framework ([link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-362ebcc0b37d3fd9b1c8facfe7d5da539492014f0116958ec2100ee8b15547b1R1-R166))
*  Add documentation for the Tour component, which includes the basic usage, examples, API, slots and events ([link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-4bad40879ab46cd17211eebfbbcc6fb9932052acbea4dc509d6aeba73c4c3244L1-R121), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-aa195b9bfa86f84651be846117d76b4cf1c6f902a91cc08a0f043c10b14d90a0R219-R222))
*  Add examples for the Tour component, which show how to use the component with different props and slots, such as mask, placement, type and indicator ([link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-d31ce48898f8c2e44ecfa9b16fabcd0474f9956e64bed471624449162a67821cR1-R49), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-fe916d36e3555d753c366cb86141644d715caff83b513951dfefa2acd31aebc9R1-R44), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-a6ec09ba0fa560d5090a505a41bc4bd6d64f7b6a8d5046eb1f275699b924b57cR1-R63), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-aa98bb4d2919a0f4cd5a61b0e530bd50951ed2f47258eb66e7f670d13043c8b5R1-R48), [link](https://github.com/element-plus/element-plus/pull/14952/files?diff=unified&w=0#diff-4827dfd33b157aeb373a61a3d6598f67a6cfc5a6da2fb30ea815d26ac7ec8dffR1-R33))
