### PR TITLE
docs(components): [carousel] use new display tag

### DIFF
--- a/docs/en-US/component/carousel.md
+++ b/docs/en-US/component/carousel.md
@@ -75,52 +75,56 @@ carousel/vertical
 
 :::
 
-## Carousel Attributes
+## Carousel API
 
-| Name                 | Description                                           | Type    | Accepted Values     | Default    |
-| -------------------- | ----------------------------------------------------- | ------- | ------------------- | ---------- |
-| height               | height of the carousel                                | string  | —                   | —          |
-| initial-index        | index of the initially active slide (starting from 0) | number  | —                   | 0          |
-| trigger              | how indicators are triggered                          | string  | hover/click         | hover      |
-| autoplay             | whether automatically loop the slides                 | boolean | —                   | true       |
-| interval             | interval of the auto loop, in milliseconds            | number  | —                   | 3000       |
-| indicator-position   | position of the indicators                            | string  | outside/none        | —          |
-| arrow                | when arrows are shown                                 | string  | always/hover/never  | hover      |
-| type                 | type of the Carousel                                  | string  | card                | —          |
-| loop                 | display the items in loop                             | boolean | -                   | true       |
-| direction            | display direction                                     | string  | horizontal/vertical | horizontal |
-| pause-on-hover       | pause autoplay when hover                             | boolean | -                   | true       |
-| motion-blur ^(2.6.0) | infuse dynamism and smoothness into the carousel      | boolean | -                   | false      |
+### Carousel Attributes
 
-## Carousel Events
+| Name                 | Description                                           | Type                                    | Default    |
+| -------------------- | ----------------------------------------------------- | --------------------------------------- | ---------- |
+| height               | height of the carousel                                | ^[string]                               | ''         |
+| initial-index        | index of the initially active slide (starting from 0) | ^[number]                               | 0          |
+| trigger              | how indicators are triggered                          | ^[enum]`'hover' \| 'click'`             | hover      |
+| autoplay             | whether automatically loop the slides                 | ^[boolean]                              | true       |
+| interval             | interval of the auto loop, in milliseconds            | ^[number]                               | 3000       |
+| indicator-position   | position of the indicators                            | ^[enum]`'' \| 'none' \| 'outside'`      | ''         |
+| arrow                | when arrows are shown                                 | ^[enum]`'always' \| 'hover' \| 'never'` | hover      |
+| type                 | type of the Carousel                                  | ^[enum]`'' \| 'card'`                   | ''         |
+| loop                 | display the items in loop                             | ^[boolean]                              | true       |
+| direction            | display direction                                     | ^[enum]`'horizontal' \| 'vertical'`     | horizontal |
+| pause-on-hover       | pause autoplay when hover                             | ^[boolean]                              | true       |
+| motion-blur ^(2.6.0) | infuse dynamism and smoothness into the carousel      | ^[boolean]                              | false      |
 
-| Name   | Description                             | Parameters                                                   |
-| ------ | --------------------------------------- | ------------------------------------------------------------ |
-| change | triggers when the active slide switches | index of the new active slide, index of the old active slide |
+### Carousel Events
 
-## Carousel Methods
+| Name   | Description                                                                                                                                              | Type                                                    |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| change | triggers when the active slide switches, it has two parameters, the one is the index of the new active slide, and other is index of the old active slide | ^[Function]`(current: number, prev: number) => boolean` |
 
-| Method        | Description                  | Parameters                                                                                               |
-| ------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------- |
-| setActiveItem | manually switch slide        | index of the slide to be switched to, starting from 0; or the `name` of corresponding `el-carousel-item` |
-| prev          | switch to the previous slide | —                                                                                                        |
-| next          | switch to the next slide     | —                                                                                                        |
+### Carousel Slots
 
-## Carousel Slots
+| Name    | Description               | Subtags       |
+| ------- | ------------------------- | ------------- |
+| default | customize default content | Carousel-Item |
 
-| Name | Description               | Subtags       |
-| ---- | ------------------------- | ------------- |
-| -    | customize default content | Carousel-Item |
+### Carousel Exposes
 
-## Carousel-Item Attributes
+| Method        | Description                                                                                                                     | Type                                          |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| setActiveItem | manually switch slide, index of the slide to be switched to, starting from 0; or the `name` of corresponding `el-carousel-item` | ^[Function]`(index: string \| number) => void` |
+| prev          | switch to the previous slide                                                                                                    | ^[Function]`() => void`                       |
+| next          | switch to the next slide                                                                                                        | ^[Function]`() => void`                       |
 
-| Name  | Description                                      | Type   | Accepted Values | Default |
-| ----- | ------------------------------------------------ | ------ | --------------- | ------- |
-| name  | name of the item, can be used in `setActiveItem` | string | —               | —       |
-| label | text content for the corresponding indicator     | string | —               | —       |
+## Carousel-Item API
 
-## Carousel-Item Slots
+### Carousel-Item Attributes
 
-| Name | Description               |
-| ---- | ------------------------- |
-| —    | customize default content |
+| Name  | Description                                      | Type                  | Default |
+| ----- | ------------------------------------------------ | --------------------- | ------- |
+| name  | name of the item, can be used in `setActiveItem` | ^[string]             | ''      |
+| label | text content for the corresponding indicator     | ^[string] / ^[number] | ''      |
+
+### Carousel-Item Slots
+
+| Name    | Description               |
+| ------- | ------------------------- |
+| default | customize default content |

--- a/packages/components/carousel/src/carousel-item.ts
+++ b/packages/components/carousel/src/carousel-item.ts
@@ -2,7 +2,13 @@ import { buildProps } from '@element-plus/utils'
 import type { ExtractPropTypes } from 'vue'
 
 export const carouselItemProps = buildProps({
+  /**
+   * @description name of the item, can be used in `setActiveItem`
+   */
   name: { type: String, default: '' },
+  /**
+   * @description text content for the corresponding indicator
+   */
   label: {
     type: [String, Number],
     default: '',

--- a/packages/components/carousel/src/carousel.ts
+++ b/packages/components/carousel/src/carousel.ts
@@ -2,62 +2,100 @@ import { buildProps, isNumber } from '@element-plus/utils'
 import type { ExtractPropTypes } from 'vue'
 
 export const carouselProps = buildProps({
+  /**
+   * @description index of the initially active slide (starting from 0)
+   */
   initialIndex: {
     type: Number,
     default: 0,
   },
+  /**
+   * @description height of the carousel
+   */
   height: {
     type: String,
     default: '',
   },
+  /**
+   * @description how indicators are triggered
+   */
   trigger: {
     type: String,
     values: ['hover', 'click'],
     default: 'hover',
   },
+  /**
+   * @description whether automatically loop the slides
+   */
   autoplay: {
     type: Boolean,
     default: true,
   },
+  /**
+   * @description interval of the auto loop, in milliseconds
+   */
   interval: {
     type: Number,
     default: 3000,
   },
+  /**
+   * @description position of the indicators
+   */
   indicatorPosition: {
     type: String,
     values: ['', 'none', 'outside'],
     default: '',
   },
+  /**
+   * @description when arrows are shown
+   */
   arrow: {
     type: String,
     values: ['always', 'hover', 'never'],
     default: 'hover',
   },
+  /**
+   * @description type of the Carousel
+   */
   type: {
     type: String,
     values: ['', 'card'],
     default: '',
   },
+  /**
+   * @description display the items in loop
+   */
   loop: {
     type: Boolean,
     default: true,
   },
+  /**
+   * @description display direction
+   */
   direction: {
     type: String,
     values: ['horizontal', 'vertical'],
     default: 'horizontal',
   },
+  /**
+   * @description pause autoplay when hover
+   */
   pauseOnHover: {
     type: Boolean,
     default: true,
   },
-  motionBlur: {
-    type: Boolean,
-    default: false,
-  },
+  /**
+   * @description infuse dynamism and smoothness into the carousel
+   */
+  motionBlur: Boolean,
 } as const)
 
 export const carouselEmits = {
+  /**
+   * @description triggers when the active slide switches
+   * @param current index of the new active slide
+   * @param prev index of the old active slide
+   */
   change: (current: number, prev: number) => [current, prev].every(isNumber),
 }
 

--- a/packages/components/carousel/src/carousel.vue
+++ b/packages/components/carousel/src/carousel.vue
@@ -166,7 +166,7 @@ const indicatorsClasses = computed(() => {
 })
 
 defineExpose({
-  /** @description manually switch slide */
+  /** @description manually switch slide, index of the slide to be switched to, starting from 0; or the `name` of corresponding `el-carousel-item` */
   setActiveItem,
   /** @description switch to the previous slide */
   prev,


### PR DESCRIPTION
Related: #10754 

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 29ecedc</samp>

This pull request adds and updates JSDoc comments for the carousel and carousel-item components, to document their props, events, methods, slots and exposes. It also updates the carousel documentation page to reflect the new API format and structure. These changes aim to improve the code quality and the user experience of the carousel component.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 29ecedc</samp>

*  Update the carousel documentation to match the new API format ([link](https://github.com/element-plus/element-plus/pull/14953/files?diff=unified&w=0#diff-215671f8a5db337a59e1007c558792f36350442910fe246ae0358c71b4fcbd87L68-R119))
*  Add JSDoc comments for the carousel and carousel-item props and events ([link](https://github.com/element-plus/element-plus/pull/14953/files?diff=unified&w=0#diff-f6945358f152f3eb8b3c63af43f6b854634c5af1ae1dfa27db82d1775eabe0e0L5-R11), [link](https://github.com/element-plus/element-plus/pull/14953/files?diff=unified&w=0#diff-fffc72cc726dca6b0e5499ffd4818988e122e0442da375dc1c3bc4cf6ace6da8L5-R21), [link](https://github.com/element-plus/element-plus/pull/14953/files?diff=unified&w=0#diff-fffc72cc726dca6b0e5499ffd4818988e122e0442da375dc1c3bc4cf6ace6da8L18-R43), [link](https://github.com/element-plus/element-plus/pull/14953/files?diff=unified&w=0#diff-fffc72cc726dca6b0e5499ffd4818988e122e0442da375dc1c3bc4cf6ace6da8R49-R51), [link](https://github.com/element-plus/element-plus/pull/14953/files?diff=unified&w=0#diff-fffc72cc726dca6b0e5499ffd4818988e122e0442da375dc1c3bc4cf6ace6da8R57-R59), [link](https://github.com/element-plus/element-plus/pull/14953/files?diff=unified&w=0#diff-fffc72cc726dca6b0e5499ffd4818988e122e0442da375dc1c3bc4cf6ace6da8L41-R74), [link](https://github.com/element-plus/element-plus/pull/14953/files?diff=unified&w=0#diff-fffc72cc726dca6b0e5499ffd4818988e122e0442da375dc1c3bc4cf6ace6da8R80-R82), [link](https://github.com/element-plus/element-plus/pull/14953/files?diff=unified&w=0#diff-fffc72cc726dca6b0e5499ffd4818988e122e0442da375dc1c3bc4cf6ace6da8R90-R94))
*  Add JSDoc comment for the `setActiveItem` expose of the carousel component ([link](https://github.com/element-plus/element-plus/pull/14953/files?diff=unified&w=0#diff-d632898c628d99d3c5434f6560190a12d61b860e442439e90a358a34ddaa3ef9L129-R129))
