### PR TITLE
docs(components): [progress] use new display tag

### DIFF
--- a/docs/en-US/component/progress.md
+++ b/docs/en-US/component/progress.md
@@ -100,6 +100,6 @@ progress/striped-progress
 
 ### Slots
 
-| Name    | Description        | Type                              |                                   |
+| Name    | Description        | Type                              |
 | ------- | ------------------ | --------------------------------- |
 | default | Customized content | ^[object]`{ percentage: number }` |

--- a/docs/en-US/component/progress.md
+++ b/docs/en-US/component/progress.md
@@ -81,25 +81,25 @@ progress/striped-progress
 
 ### Attributes
 
-| Name                  | Description                                                                           | Type                                                                                                        | Default |
-| --------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------- |
-| percentage            | percentage, **required**                                                              | ^[number]`(0-100)`                                                                                          | 0       |
-| type                  | the type of progress bar                                                              | ^[enum]`'line' \| 'circle' \| 'dashboard'`                                                                  | line    |
-| stroke-width          | the width of progress bar                                                             | ^[number]                                                                                                   | 6       |
-| text-inside           | whether to place the percentage inside progress bar, only works when `type` is 'line' | ^[boolean]                                                                                                  | false   |
-| status                | the current status of progress bar                                                    | ^[enum]`'success' \| 'exception' \| 'warning'`                                                              | —       |
-| indeterminate         | set indeterminate progress                                                            | ^[boolean]                                                                                                  | false   |
-| duration              | control the animation duration of indeterminate progress or striped flow progress     | ^[number]                                                                                                   | 3       |
-| color                 | background color of progress bar. Overrides `status` prop                             | ^[string] / ^[function]`(percentage: number) => string` / ^[Array]`{ color: string; percentage: number }[]` | ''      |
-| width                 | the canvas width of circle progress bar                                               | ^[number]                                                                                                   | 126     |
-| show-text             | whether to show percentage                                                            | ^[boolean]                                                                                                  | true    |
-| stroke-linecap        | circle/dashboard type shape at the end path                                           | ^[enum]`'butt' \| 'round' \| 'square'`                                                                      | round   |
-| format                | custom text format                                                                    | ^[Function]`(percentage: number) => string`                                                                 | —       |
-| striped ^(2.3.4)      | stripe over the progress bar's color                                                  | ^[boolean]                                                                                                  | false   |
-| striped-flow ^(2.3.4) | get the stripes to flow                                                               | ^[boolean]                                                                                                  | false   |
+| Name                   | Description                                                                           | Type                                                                                                        | Default |
+| ---------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------- |
+| percentage ^(required) | percentage                                                                            | ^[number]`(0-100)`                                                                                          | 0       |
+| type                   | the type of progress bar                                                              | ^[enum]`'line' \| 'circle' \| 'dashboard'`                                                                  | line    |
+| stroke-width           | the width of progress bar                                                             | ^[number]                                                                                                   | 6       |
+| text-inside            | whether to place the percentage inside progress bar, only works when `type` is 'line' | ^[boolean]                                                                                                  | false   |
+| status                 | the current status of progress bar                                                    | ^[enum]`'success' \| 'exception' \| 'warning'`                                                              | —       |
+| indeterminate          | set indeterminate progress                                                            | ^[boolean]                                                                                                  | false   |
+| duration               | control the animation duration of indeterminate progress or striped flow progress     | ^[number]                                                                                                   | 3       |
+| color                  | background color of progress bar. Overrides `status` prop                             | ^[string] / ^[function]`(percentage: number) => string` / ^[Array]`{ color: string; percentage: number }[]` | ''      |
+| width                  | the canvas width of circle progress bar                                               | ^[number]                                                                                                   | 126     |
+| show-text              | whether to show percentage                                                            | ^[boolean]                                                                                                  | true    |
+| stroke-linecap         | circle/dashboard type shape at the end path                                           | ^[enum]`'butt' \| 'round' \| 'square'`                                                                      | round   |
+| format                 | custom text format                                                                    | ^[Function]`(percentage: number) => string`                                                                 | —       |
+| striped ^(2.3.4)       | stripe over the progress bar's color                                                  | ^[boolean]                                                                                                  | false   |
+| striped-flow ^(2.3.4)  | get the stripes to flow                                                               | ^[boolean]                                                                                                  | false   |
 
 ### Slots
 
-| Name    | Description                                       |
-| ------- | ------------------------------------------------- |
-| default | Customized content, parameter is `{ percentage }` |
+| Name    | Description        |                                   |                                   |
+| ------- | ------------------ | --------------------------------- |
+| default | Customized content | ^[object]`{ percentage: number }` |

--- a/docs/en-US/component/progress.md
+++ b/docs/en-US/component/progress.md
@@ -100,6 +100,6 @@ progress/striped-progress
 
 ### Slots
 
-| Name    | Description        |                                   |                                   |
+| Name    | Description        | Type                              |                                   |
 | ------- | ------------------ | --------------------------------- |
 | default | Customized content | ^[object]`{ percentage: number }` |


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c3ed5df</samp>

Updated the documentation of the `progress` component to reflect its required `percentage` attribute and its `default` slot type. This makes the docs more consistent and accurate with the code.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c3ed5df</samp>

* Mark `percentage` attribute as required and add type for `default` slot in progress component documentation ([link](https://github.com/element-plus/element-plus/pull/14956/files?diff=unified&w=0#diff-d72a37cc2cb108d4416436c0fb3915cbef9f07e6b8ee929aa1527d15a437f8e5L84-R105))
