### PR TITLE
docs(components): [tag] complete solt name

### DIFF
--- a/docs/en-US/component/tag.md
+++ b/docs/en-US/component/tag.md
@@ -97,9 +97,9 @@ tag/checkable
 
 ### Tag Slots
 
-| Name | Description               |
-| ---- | ------------------------- |
-| —    | customize default content |
+| Name    | Description               |
+| ------- | ------------------------- |
+| default | customize default content |
 
 ## CheckTag API
 
@@ -117,6 +117,6 @@ tag/checkable
 
 ### CheckTag Slots
 
-| Name | Description               |
-| ---- | ------------------------- |
-| —    | customize default content |
+| Name    | Description               |
+| ------- | ------------------------- |
+| default | customize default content |


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at eb1c0aa</samp>

Updated slot names in `Tag` and `CheckTag` documentation. Replaced `—` with `default` to align with Vue 3 and enhance readability.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at eb1c0aa</samp>

* Change slot name from `—` to `default` for `Tag` and `CheckTag` components to follow Vue 3 convention and avoid confusion ([link](https://github.com/element-plus/element-plus/pull/14957/files?diff=unified&w=0#diff-89679eded6231fc7528daf16d2982a97f63274a1e07af7841702a27d488207a8L100-R102), [link](https://github.com/element-plus/element-plus/pull/14957/files?diff=unified&w=0#diff-89679eded6231fc7528daf16d2982a97f63274a1e07af7841702a27d488207a8L120-R122))
