### PR TITLE
docs(components): [affix] use new display tag

### DIFF
--- a/docs/en-US/component/affix.md
+++ b/docs/en-US/component/affix.md
@@ -37,33 +37,34 @@ affix/fixed
 
 :::
 
-## Affix API
+## API
 
-### Affix Attributes
+### Attributes
 
-| Name       | Description                      | Type                       | Default | Required |
-| ---------- | -------------------------------- | -------------------------- | ------- | -------- |
-| `offset`   | offset distance.                 | ^[number]                  | `0`     | No       |
-| `position` | position of affix.               | ^[enum]`'top' \| 'bottom'` | `'top'` | No       |
-| `target`   | target container. (CSS selector) | ^[string]                  | —       | No       |
-| `z-index`  | `z-index` of affix               | ^[number]                  | `100`   | No       |
+| Name     | Description                     | Type                       | Default |
+| -------- | ------------------------------- | -------------------------- | ------- |
+| offset   | offset distance                 | ^[number]                  | 0       |
+| position | position of affix               | ^[enum]`'top' \| 'bottom'` | top     |
+| target   | target container (CSS selector) | ^[string]                  | —       |
+| z-index  | `z-index` of affix              | ^[number]                  | 100     |
 
-### Affix Events
+### Events
 
-| Name     | Description                        | Type                                                                |
-| -------- | ---------------------------------- | ------------------------------------------------------------------- |
-| `change` | triggers when fixed state changed. | ^[Function]`(fixed: boolean) => void`                               |
-| `scroll` | triggers when scrolling.           | ^[Function]`(value: { scrollTop: number, fixed: boolean }) => void` |
+| Name   | Description                       | Type                                                                |
+| ------ | --------------------------------- | ------------------------------------------------------------------- |
+| change | triggers when fixed state changed | ^[Function]`(fixed: boolean) => void`                               |
+| scroll | triggers when scrolling           | ^[Function]`(value: { scrollTop: number, fixed: boolean }) => void` |
 
-### Affix Exposes
+### Slots
 
-| Method       | Description                 | Type                    |
-| ------------ | --------------------------- | ----------------------- |
-| `update`     | update affix state manually | ^[Function]`() => void` |
-| `updateRoot` | update rootRect info        | ^[Function]`() => void` |
+| Name    | Description               |
+| ------- | ------------------------- |
+| default | customize default content |
 
-### Affix Slots
+### Exposes
 
-| Name      | Description                |
-| --------- | -------------------------- |
-| `default` | customize default content. |
+| Name       | Description                 | Type                    |
+| ---------- | --------------------------- | ----------------------- |
+| update     | update affix state manually | ^[Function]`() => void` |
+| updateRoot | update rootRect info        | ^[Function]`() => void` |
+


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ae876c9</samp>

Improved consistency and readability of `affix.md` documentation. Reordered and reformatted Affix API section and simplified headings.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ae876c9</samp>

* Reorganized and simplified the API section of `affix.md` ([link](https://github.com/element-plus/element-plus/pull/14961/files?diff=unified&w=0#diff-b8f12b031f4a68bfb84721917a30f40cb4ae35c9860967fc62d35089051da51bL40-R70))
