### PR TITLE
docs(components): [breadcrumb] fix attr typo

### DIFF
--- a/docs/en-US/component/breadcrumb.md
+++ b/docs/en-US/component/breadcrumb.md
@@ -30,7 +30,7 @@ breadcrumb/icon
 | Name           | Description                      | Type                     | Default |
 | -------------- | -------------------------------- | ------------------------ | ------- |
 | separator      | separator character              | ^[string]                | /       |
-| separator-icon | icon component of icon separator | ^[string] / ^[Component] | -       |
+| separator-icon | icon component of icon separator | ^[string] / ^[Component] | —       |
 
 ### Breadcrumb Slots
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 64bd884</samp>

Update the default value of `separator-icon` in the breadcrumb component documentation. Use an em dash instead of a hyphen to reflect the component and the doc style.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 64bd884</samp>

* Changed the default value of `separator-icon` prop in `ElBreadcrumb` component from a hyphen (-) to an em dash (—) to match the documentation and the actual behavior ([link](https://github.com/element-plus/element-plus/pull/14962/files?diff=unified&w=0#diff-c8d157ba900e4450596767bfd2f4b17704a123bf1c8df6aaf03b9c0605332c32L33-R33))
