### PR TITLE
docs(components): [alert] use new display tag

### DIFF
--- a/docs/en-US/component/alert.md
+++ b/docs/en-US/component/alert.md
@@ -79,16 +79,16 @@ alert/icon-description
 
 ### Attributes
 
-| Name        | Description                              | Type                                                  | Default   | Required |
-| ----------- | ---------------------------------------- | ----------------------------------------------------- | --------- | -------- |
-| title       | alert title.                             | ^[string]                                             | —         | No       |
-| type        | alert type.                              | ^[enum]`'success' \| 'warning' \| 'info' \| 'error' ` | `info`    | No       |
-| description | descriptive text.                        | ^[string]                                             | —         | No       |
-| closable    | whether alert can be dismissed.          | ^[boolean]                                            | `true`    | No       |
-| center      | whether content is placed in the center. | ^[boolean]                                            | `false`   | No       |
-| close-text  | customized close button text.            | ^[string]                                             | —         | No       |
-| show-icon   | whether a type icon is displayed.        | ^[boolean]                                            | `false`   | No       |
-| effect      | theme style.                             | ^[enum]`'light' \| 'dark'`                            | `'light'` | No       |
+| Name        | Description                              | Type                                                  | Default |
+| ----------- | ---------------------------------------- | ----------------------------------------------------- | ------- |
+| title       | alert title.                             | ^[string]                                             | —       |
+| type        | alert type.                              | ^[enum]`'success' \| 'warning' \| 'info' \| 'error' ` | info    |
+| description | descriptive text.                        | ^[string]                                             | —       |
+| closable    | whether alert can be dismissed.          | ^[boolean]                                            | true    |
+| center      | whether content is placed in the center. | ^[boolean]                                            | false   |
+| close-text  | customized close button text.            | ^[string]                                             | —       |
+| show-icon   | whether a type icon is displayed.        | ^[boolean]                                            | false   |
+| effect      | theme style.                             | ^[enum]`'light' \| 'dark'`                            | light   |
 
 ### Events
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2fb730f</samp>

Removed the `Required` column from the `Alert` component documentation in `docs/en-US/component/alert.md` to simplify and standardize the presentation of the component attributes.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2fb730f</samp>

*  Removed the `Required` column from the `Attributes` table of the `Alert` component documentation (`[link](https://github.com/element-plus/element-plus/pull/14963/files?diff=unified&w=0#diff-17c304c2f65a81e822b9207e56c58393d5f188a38dce3fff38ed13fa7d2541beL82-R91)`) to avoid redundancy and inconsistency with other component documentation
