### PR TITLE
docs(components): [drawer] use new display tag

### DIFF
--- a/docs/en-US/component/drawer.md
+++ b/docs/en-US/component/drawer.md
@@ -83,7 +83,7 @@ Drawer provides an API called `destroyOnClose`, which is a flag variable that in
 
 ## API
 
-## Attributes
+### Attributes
 
 | Name                       | Description                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                                           | Default |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
@@ -113,7 +113,16 @@ Drawer provides an API called `destroyOnClose`, which is a flag variable that in
 
 :::
 
-## Slots
+### Events
+
+| Name   | Description                                      | Type                    |
+| ------ | ------------------------------------------------ | ----------------------- |
+| open   | Triggered before Drawer opening animation begins | ^[Function]`() => void` |
+| opened | Triggered after Drawer opening animation ended   | ^[Function]`() => void` |
+| close  | Triggered before Drawer closing animation begins | ^[Function]`() => void` |
+| closed | Triggered after Drawer closing animation ended   | ^[Function]`() => void` |
+
+### Slots
 
 | Name                | Description                                                                                    |
 | ------------------- | ---------------------------------------------------------------------------------------------- |
@@ -122,17 +131,8 @@ Drawer provides an API called `destroyOnClose`, which is a flag variable that in
 | title ^(deprecated) | Works the same as the header slot. Use that instead.                                           |
 | footer              | Drawer footer Section                                                                          |
 
-## Methods
+### Exposes
 
 | Name        | Description                                                     |
 | ----------- | --------------------------------------------------------------- |
 | handleClose | In order to close Drawer, this method will call `before-close`. |
-
-## Events
-
-| Name   | Description                                      | Parameter |
-| ------ | ------------------------------------------------ | --------- |
-| open   | Triggered before Drawer opening animation begins | —         |
-| opened | Triggered after Drawer opening animation ended   | —         |
-| close  | Triggered before Drawer closing animation begins | —         |
-| closed | Triggered after Drawer closing animation ended   | —         |


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7e7aaf5</samp>

Updated `Drawer` component documentation to use `exposes` option and improve `API` section.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7e7aaf5</samp>

* Change the `Attributes` section to a subheading under `API` in `docs/en-US/component/drawer.md` to improve the document structure and readability. ([link](https://github.com/element-plus/element-plus/pull/14964/files?diff=unified&w=0#diff-ff5bed84c832b97435d3b2c5b5ce3e8994a2deac1332f7bc2540cf37828a11ddL86-R86))
* Add the `Events` section under `API` in `docs/en-US/component/drawer.md` to document the events emitted by the `Drawer` component and their types. ([link](https://github.com/element-plus/element-plus/pull/14964/files?diff=unified&w=0#diff-ff5bed84c832b97435d3b2c5b5ce3e8994a2deac1332f7bc2540cf37828a11ddL116-R126))
* Replace the `Methods` and `Events` sections at the end of `docs/en-US/component/drawer.md` with the `Exposes` section to follow the new convention of using the `exposes` option in the `defineComponent` function. ([link](https://github.com/element-plus/element-plus/pull/14964/files?diff=unified&w=0#diff-ff5bed84c832b97435d3b2c5b5ce3e8994a2deac1332f7bc2540cf37828a11ddL125-R138))
