### PR TITLE
fix(components):  issue14965

### DIFF
--- a/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
@@ -72,7 +72,7 @@ const ns = useNamespace('time')
 const { t, lang } = useLocale()
 // data
 const selectionRange = ref([0, 2])
-const oldValue = useOldValue(props)
+// const oldValue = useOldValue(props)
 // computed
 const transitionName = computed(() => {
   return isUndefined(props.actualVisible)
@@ -94,7 +94,7 @@ const isValidValue = (_date: Dayjs) => {
   return parsedDate.isSame(result)
 }
 const handleCancel = () => {
-  emit('pick', oldValue.value, false)
+  emit('pick', '', false)
 }
 const handleConfirm = (visible = false, first = false) => {
   if (first) return


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0283bc9</samp>

Fixed time picker reset bug by emitting empty string on cancel. Simplified `panel-time-pick.vue` by removing unused variable.

## Related Issue

Fixes #14965 .

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0283bc9</samp>

*  Removed `oldValue` variable and modified `handleCancel` function to emit an empty string instead of the previous value when the user cancels the selection in the time picker component ([link](https://github.com/element-plus/element-plus/pull/14974/files?diff=unified&w=0#diff-60b8d640aee096b38e04f0f59a87c5d8c5ddc9e877a4bcbe50a86058b59b3ceaL75-R75),[link](https://github.com/element-plus/element-plus/pull/14974/files?diff=unified&w=0#diff-60b8d640aee096b38e04f0f59a87c5d8c5ddc9e877a4bcbe50a86058b59b3ceaL97-R97)). This fixes a bug where the time picker would not reset to the default value when the user opens it again. The changes affect the file `panel-time-pick.vue`.
