### PR TITLE
fix(components): [watermark] Support for lower versions of Firefox

### DIFF
--- a/packages/components/watermark/src/watermark.vue
+++ b/packages/components/watermark/src/watermark.vue
@@ -123,7 +123,7 @@ const getMarkSize = (ctx: CanvasRenderingContext2D) => {
       return [
         metrics.width,
         // Using `actualBoundingBoxAscent` to be compatible with lower version browsers (eg: Firefox < 116)
-        metrics.fontBoundingBoxAscent != null
+        metrics.fontBoundingBoxAscent !== undefined
           ? metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent
           : metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent,
       ]

--- a/packages/components/watermark/src/watermark.vue
+++ b/packages/components/watermark/src/watermark.vue
@@ -122,6 +122,7 @@ const getMarkSize = (ctx: CanvasRenderingContext2D) => {
 
       return [
         metrics.width,
+        // Using `actualBoundingBoxAscent` to be compatible with lower version browsers (eg: Firefox < 116)
         metrics.fontBoundingBoxAscent != null
           ? metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent
           : metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent,

--- a/packages/components/watermark/src/watermark.vue
+++ b/packages/components/watermark/src/watermark.vue
@@ -122,7 +122,9 @@ const getMarkSize = (ctx: CanvasRenderingContext2D) => {
 
       return [
         metrics.width,
-        metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent,
+        metrics.fontBoundingBoxAscent != null
+          ? metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent
+          : metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent,
       ]
     })
     defaultWidth = Math.ceil(Math.max(...sizes.map((size) => size[0])))


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

水印组件中， 计算文本高度采用的 `fontBoundingBoxAscent` 和 `fontBoundingBoxDescent` 属性在firefox 116 版本才支持，导致对 firefox 兼容性很差。
在不支持 `fontBoundingBoxAscent` 和 `fontBoundingBoxDescent` 属性的浏览器中，采用 `actualBoundingBoxAscent` 和 `actualBoundingBoxDescent` 进行向下兼容，可以支持到 firefox 74，chrome 77，edge 79。

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 029c696</samp>

Fix watermark text height calculation bug on some browsers. Use `actualBoundingBoxAscent` and `actualBoundingBoxDescent` as fallbacks for `fontBoundingBoxAscent` and `fontBoundingBoxDescent` in `watermark.vue`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 029c696</samp>

* Fix watermark text height calculation on some browsers ([link](https://github.com/element-plus/element-plus/pull/14993/files?diff=unified&w=0#diff-c6c90c95997cf2bd5412dcad208a28a43a70addb4960c01a4a22440228b0a315L125-R127))
