### PR TITLE
fix(components): [menu] openedMenus changed to computed property #14991

### DIFF
--- a/packages/components/menu/src/menu.ts
+++ b/packages/components/menu/src/menu.ts
@@ -114,11 +114,6 @@ export default defineComponent({
     // data
     const sliceIndex = ref(-1)
 
-    const openedMenus = ref<MenuProvider['openedMenus']>(
-      props.defaultOpeneds && !props.collapse
-        ? props.defaultOpeneds.slice(0)
-        : []
-    )
     const activeIndex = ref<MenuProvider['activeIndex']>(props.defaultActive)
     const items = ref<MenuProvider['items']>({})
     const subMenus = ref<MenuProvider['subMenus']>({})
@@ -129,6 +124,12 @@ export default defineComponent({
         props.mode === 'horizontal' ||
         (props.mode === 'vertical' && props.collapse)
       )
+    })
+
+    const openedMenus = computed<MenuProvider['openedMenus']>(() => {
+      return props.defaultOpeneds && !props.collapse
+        ? props.defaultOpeneds.slice(0)
+        : []
     })
 
     // methods


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at be5b092</samp>

Refactor menu component to use computed property for opened submenus. This enhances the reactivity and simplifies the logic of `packages/components/menu/src/menu.ts`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at be5b092</samp>

*  Remove `openedMenus` ref to avoid inconsistency with props ([link](https://github.com/element-plus/element-plus/pull/15002/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5L117-L121))
*  Add `openedMenus` computed property to reflect props changes ([link](https://github.com/element-plus/element-plus/pull/15002/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5R129-R134))
