### PR TITLE
feat(components): [select] add slot to customize the option group title

### DIFF
--- a/docs/en-US/component/select.md
+++ b/docs/en-US/component/select.md
@@ -233,6 +233,7 @@ select/value-key
 | Name    | Description               | Subtags |
 | ------- | ------------------------- | ------- |
 | default | customize default content | Option  |
+| title   | customize title           | label  |
 
 ## Option API
 

--- a/docs/examples/select/grouping.vue
+++ b/docs/examples/select/grouping.vue
@@ -1,18 +1,46 @@
 <template>
-  <el-select v-model="value" placeholder="Select">
-    <el-option-group
-      v-for="group in options"
-      :key="group.label"
-      :label="group.label"
-    >
-      <el-option
-        v-for="item in group.options"
-        :key="item.value"
-        :label="item.label"
-        :value="item.value"
-      />
-    </el-option-group>
-  </el-select>
+  <div class="flex flex-wrap">
+    <div class="m-4">
+      <p>default</p>
+      <el-select v-model="value" placeholder="Select">
+        <el-option-group
+          v-for="group in options"
+          :key="group.label"
+          :label="group.label"
+        >
+          <el-option
+            v-for="item in group.options"
+            :key="item.value"
+            :label="item.label"
+            :value="item.value"
+          />
+        </el-option-group>
+      </el-select>
+    </div>
+    <div class="m-4">
+      <p>use slot to customize the option group title</p>
+      <el-select v-model="value" placeholder="Select">
+        <el-option-group
+          v-for="group in options"
+          :key="group.label"
+          :label="group.label"
+        >
+          <template #title="{ label, disabled }">
+            <div class="flex justify-between">
+              <span>{{ label }}</span>
+              <span class="mr-4">disabled={{ disabled }}</span>
+            </div>
+          </template>
+          <el-option
+            v-for="item in group.options"
+            :key="item.value"
+            :label="item.label"
+            :value="item.value"
+          />
+        </el-option-group>
+      </el-select>
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/packages/components/select/src/option-group.vue
+++ b/packages/components/select/src/option-group.vue
@@ -1,6 +1,10 @@
 <template>
   <ul v-show="visible" :class="ns.be('group', 'wrap')">
-    <li :class="ns.be('group', 'title')">{{ label }}</li>
+    <li :class="ns.be('group', 'title')">
+      <slot name="title" :label="label" :disabled="disabled">
+        {{ label }}
+      </slot>
+    </li>
     <li>
       <ul :class="ns.b('group')">
         <slot />


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description
> This is a new feature, add slot to customize the option group title.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 29dbe25</samp>

Added a `title` slot to the `el-option-group` component to allow customizing the group title in the `el-select` component. Updated the grouping example in `docs/examples/select/grouping.vue` to demonstrate the usage of the slot.

## Related Issue

Fixes #\_\_\_. close #15705

## Explanation of Changes
feat: add slot to customize the option group title

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 29dbe25</samp>

* Add a `title` slot to `el-option-group` component to allow customizing the group title ([link](https://github.com/element-plus/element-plus/pull/15003/files?diff=unified&w=0#diff-33c46490231f28214b88a69e3e74603b07037f8c644ab8be8d4ed3eebda97489L3-R7))
* Modify the grouping example template to show two different ways of using `el-select` with `el-option-group` and `el-option` ([link](https://github.com/element-plus/element-plus/pull/15003/files?diff=unified&w=0#diff-b06c339aa56025261caab0fe7ed9f4945bc4f199326c68d2a8b355bd798f2fd0L2-R43))
