### PR TITLE
fix(components): [tree] node drag error when using custom `allowDrop` method

### DIFF
--- a/packages/components/tree/src/model/useDragNode.ts
+++ b/packages/components/tree/src/model/useDragNode.ts
@@ -90,6 +90,9 @@ export function useDragNodeHandler({ props, ctx, el$, dropIndicator$, store }) {
 
     if (dropPrev || dropInner || dropNext) {
       dragState.value.dropNode = dropNode
+    } else {
+      // Reset dragState.value.dropNode to null when allowDrop is transfer from true to false.(For issue #14704)
+      dragState.value.dropNode = null
     }
 
     if (dropNode.node.nextSibling === draggingNode.node) {


### PR DESCRIPTION
- Reset dragState.value.dropNode to null when allowDrop is transfered from true to false.(For issue #14704)

Please make sure these boxes are checked before submitting your PR, thank you!

- [X] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [X] Make sure you are merging your commits to `dev` branch.
- [X] Add some descriptions and refer to relative issues for your PR.

## Description

When the `allowDrop` function transfer from true to false, dragState.value.dropNode have not been reset, that casuse exception when `treeNodeDragEnd()` is triggered. 

## Related Issue

Fixes #14704.

## Explanation of Changes

I set `dragState.value.dropNode` to null when `dropPrev || dropInner || dropNext` is false, and it will not execute the following codes in `treeNodeDragEnd`:
```ts
if (draggingNode && dropNode) {
....
}
```


