### PR TITLE
fix(components): [select-v2] popup height is not accurate (#15012)

### DIFF
--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -83,7 +83,7 @@ const useSelect = (props: ISelectProps, emit) => {
   const selectDisabled = computed(() => props.disabled || elForm?.disabled)
 
   const popupHeight = computed(() => {
-    const totalHeight = filteredOptions.value.length * 34
+    const totalHeight = filteredOptions.value.length * props.itemHeight
     return totalHeight > props.height ? props.height : totalHeight
   })
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a5956cd</samp>

Modified the `select-v2` component to support custom option item height. Fixed issue #3354 by using the `itemHeight` prop in the `popupHeight` computation.

## Related Issue

Fixes #15012 

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a5956cd</samp>

* Allow customizing the height of each option item in the select component by using the `itemHeight` prop in the `popupHeight` computed property ([link](https://github.com/element-plus/element-plus/pull/15014/files?diff=unified&w=0#diff-6018da2b9e35c71aca0d0a0f881a93c00ab1f1958a3a9c69e332fa8d0b2e9865L86-R86))
