### PR TITLE
fix(components): [table-v2] cell, header-cell, empty slots not displayed

### DIFF
--- a/packages/components/table-v2/__tests__/table-v2.test.tsx
+++ b/packages/components/table-v2/__tests__/table-v2.test.tsx
@@ -1,4 +1,4 @@
-import { h, ref } from 'vue'
+import { h, nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, test } from 'vitest'
 import TableV2 from '../src/table-v2'
@@ -46,14 +46,23 @@ describe('TableV2.vue', () => {
         width={700}
         height={400}
         v-slots={{
-          cell: () => <span>{customText}</span>,
+          cell: ({ columnIndex, rowIndex }: TableV2RowCellRenderParam) =>
+            columnIndex === 0 && rowIndex === 0 ? (
+              <span>{customText}</span>
+            ) : null,
         }}
       />
     ))
     expect(wrapper.find('.el-table-v2').exists()).toBe(true)
-    const cell = wrapper.find('.el-table-v2__row-cell')
-    expect(cell.exists()).toBe(true)
-    expect(cell.find('span').text()).toBe(customText)
+    const cell = wrapper.findAll('.el-table-v2__row-cell')
+
+    expect(cell[0].find('.el-table-v2__cell-text').exists()).toBe(false)
+    expect(cell[0].find('span').exists()).toBe(true)
+    expect(cell[0].find('span').text()).toBe(customText)
+
+    expect(cell[1].find('span').exists()).toBe(false)
+    expect(cell[1].find('.el-table-v2__cell-text').exists()).toBe(true)
+    expect(cell[1].find('.el-table-v2__cell-text').text()).toBe('Row 0 - Col 1')
   })
 
   test('slots header-cell', async () => {
@@ -67,14 +76,57 @@ describe('TableV2.vue', () => {
         width={700}
         height={400}
         v-slots={{
-          'header-cell': () => <span>{customText}</span>,
+          'header-cell': ({
+            columnIndex,
+          }: TableV2HeaderRowCellRendererParams) =>
+            columnIndex === 0 ? <span>{customText}</span> : null,
         }}
       />
     ))
     expect(wrapper.find('.el-table-v2').exists()).toBe(true)
-    const cell = wrapper.find('.el-table-v2__header-cell')
-    expect(cell.exists()).toBe(true)
-    expect(cell.find('span').text()).toBe(customText)
+    const cell = wrapper.findAll('.el-table-v2__header-cell')
+    expect(cell[0].find('.el-table-v2__header-cell-text').exists()).toBe(false)
+    expect(cell[0].find('span').exists()).toBe(true)
+    expect(cell[0].find('span').text()).toBe(customText)
+
+    expect(cell[1].find('span').exists()).toBe(false)
+    expect(cell[1].find('.el-table-v2__header-cell-text').exists()).toBe(true)
+    expect(cell[1].find('.el-table-v2__header-cell-text').text()).toBe(
+      'Column 1'
+    )
+  })
+
+  test('slots empty', async () => {
+    const columns = ref(generateColumns(3))
+    const data = ref(generateData(columns.value, 0))
+    const isCustomEmpty = ref(true)
+    const wrapper = mount(() => (
+      <TableV2
+        columns={columns.value}
+        data={data.value}
+        width={700}
+        height={400}
+        v-slots={{
+          empty: () =>
+            isCustomEmpty.value ? (
+              <span class="custom-empty">custom-empty</span>
+            ) : null,
+        }}
+      />
+    ))
+    expect(wrapper.find('.el-table-v2').exists()).toBe(true)
+    let customEmpty = wrapper.find('span.custom-empty')
+    expect(customEmpty.exists()).toBe(true)
+    let defaultEmpty = wrapper.find('.el-empty')
+    expect(defaultEmpty.exists()).toBe(false)
+
+    isCustomEmpty.value = false
+    await nextTick()
+
+    customEmpty = wrapper.find('span.custom-empty')
+    expect(customEmpty.exists()).toBe(false)
+    defaultEmpty = wrapper.find('.el-empty')
+    expect(defaultEmpty.exists()).toBe(true)
   })
 
   test('slots cell scope', async () => {

--- a/packages/components/table-v2/src/components/cell.tsx
+++ b/packages/components/table-v2/src/components/cell.tsx
@@ -1,3 +1,4 @@
+import { renderSlot } from 'vue'
 import type { FunctionalComponent } from 'vue'
 import type { TableV2CellProps } from '../cell'
 
@@ -7,9 +8,10 @@ const TableV2Cell: FunctionalComponent<TableV2CellProps> = (
 ) => {
   const { cellData, style } = props
   const displayText = cellData?.toString?.() || ''
+  const defaultSlot = renderSlot(slots, 'default', props, () => [displayText])
   return (
     <div class={props.class} title={displayText} style={style}>
-      {slots.default ? slots.default(props) : displayText}
+      {defaultSlot}
     </div>
   )
 }

--- a/packages/components/table-v2/src/components/header-cell.tsx
+++ b/packages/components/table-v2/src/components/header-cell.tsx
@@ -1,14 +1,13 @@
+import { renderSlot } from 'vue'
 import type { FunctionalComponent } from 'vue'
 import type { TableV2HeaderCell } from '../header-cell'
 
 const HeaderCell: FunctionalComponent<TableV2HeaderCell> = (props, { slots }) =>
-  slots.default ? (
-    slots.default(props)
-  ) : (
+  renderSlot(slots, 'default', props, () => [
     <div class={props.class} title={props.column?.title}>
       {props.column?.title}
-    </div>
-  )
+    </div>,
+  ])
 
 HeaderCell.displayName = 'ElTableV2HeaderCell'
 HeaderCell.inheritAttrs = false

--- a/packages/components/table-v2/src/renderers/cell.tsx
+++ b/packages/components/table-v2/src/renderers/cell.tsx
@@ -1,3 +1,4 @@
+import { renderSlot } from 'vue'
 import { get } from 'lodash-unified'
 import { isFunction, isObject } from '@element-plus/utils'
 import { ExpandIcon, TableCell } from '../components'
@@ -6,7 +7,6 @@ import { placeholderSign } from '../private'
 import { componentToSlot, enforceUnit, tryCall } from '../utils'
 
 import type { FunctionalComponent, UnwrapNestedRefs, VNode } from 'vue'
-import type { CellRendererParams } from '../types'
 import type { TableV2RowCellRenderParam } from '../components'
 import type { UseNamespaceReturn } from '@element-plus/hooks'
 import type { UseTableReturn } from '../use-table'
@@ -52,13 +52,6 @@ const CellRenderer: FunctionalComponent<CellRendererProps> = (
   }
   const { cellRenderer, dataKey, dataGetter } = column
 
-  const columnCellRenderer = componentToSlot(cellRenderer)
-
-  const CellComponent =
-    columnCellRenderer ||
-    slots.default ||
-    ((props: CellRendererParams<any>) => <TableCell {...props} />)
-
   const cellData = isFunction(dataGetter)
     ? dataGetter({ columns, column, columnIndex, rowData, rowIndex })
     : get(rowData, dataKey ?? '')
@@ -82,8 +75,12 @@ const CellRenderer: FunctionalComponent<CellRendererProps> = (
     rowData,
     rowIndex,
   }
-
-  const Cell = CellComponent(cellProps)
+  const columnCellRenderer = componentToSlot<typeof cellProps>(cellRenderer)
+  const Cell = columnCellRenderer
+    ? columnCellRenderer(cellProps)
+    : renderSlot(slots, 'default', cellProps, () => [
+        <TableCell {...cellProps}></TableCell>,
+      ])
 
   const kls = [
     ns.e('row-cell'),

--- a/packages/components/table-v2/src/renderers/empty.tsx
+++ b/packages/components/table-v2/src/renderers/empty.tsx
@@ -1,3 +1,4 @@
+import { renderSlot } from 'vue'
 import ElEmpty from '@element-plus/components/empty'
 import type { CSSProperties, FunctionalComponent } from 'vue'
 
@@ -7,9 +8,10 @@ type EmptyRendererProps = {
 }
 
 const Footer: FunctionalComponent<EmptyRendererProps> = (props, { slots }) => {
+  const defaultSlot = renderSlot(slots, 'default', {}, () => [<ElEmpty />])
   return (
     <div class={props.class} style={props.style}>
-      {slots.default ? slots.default() : <ElEmpty />}
+      {defaultSlot}
     </div>
   )
 }

--- a/packages/components/table-v2/src/renderers/header-cell.tsx
+++ b/packages/components/table-v2/src/renderers/header-cell.tsx
@@ -1,3 +1,4 @@
+import { renderSlot } from 'vue'
 import { HeaderCell, SortIcon } from '../components'
 // import ColumnResizer from '../table-column-resizer'
 import { Alignment, SortOrder, oppositeOrderMap } from '../constants'
@@ -9,7 +10,6 @@ import type { UseNamespaceReturn } from '@element-plus/hooks'
 import type { TableV2HeaderRowCellRendererParams } from '../components'
 import type { UseTableReturn } from '../use-table'
 import type { TableV2Props } from '../table'
-import type { TableV2HeaderCell } from '../header-cell'
 
 export type HeaderCellRendererProps = TableV2HeaderRowCellRendererParams &
   UnwrapNestedRefs<Pick<UseTableReturn, 'onColumnSorted'>> &
@@ -42,12 +42,14 @@ const HeaderCellRenderer: FunctionalComponent<HeaderCellRendererProps> = (
     class: ns.e('header-cell-text'),
   }
 
-  const cellRenderer =
-    componentToSlot<typeof cellProps>(headerCellRenderer) ||
-    slots.default ||
-    ((props: TableV2HeaderCell) => <HeaderCell {...props} />)
+  const columnCellRenderer =
+    componentToSlot<typeof cellProps>(headerCellRenderer)
 
-  const Cell = cellRenderer(cellProps)
+  const Cell = columnCellRenderer
+    ? columnCellRenderer(cellProps)
+    : renderSlot(slots, 'default', cellProps, () => [
+        <HeaderCell {...cellProps} />,
+      ])
 
   /**
    * Render cell container and sort indicator


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

Similar to #14939 

[test example](https://element-plus.run/#eyJzcmMvQXBwLnZ1ZSI6Ijx0ZW1wbGF0ZT5cbiAgPGVsLXRhYmxlLXYyIDpjb2x1bW5zPVwiY29sdW1uc1wiIDpkYXRhPVwiZGF0YVwiIDp3aWR0aD1cIjcwMFwiIDpoZWlnaHQ9XCI0MDBcIiBmaXhlZD5cbiAgICA8dGVtcGxhdGUgI2NlbGw9XCJ7IGNvbHVtbkluZGV4IH1cIj5cbiAgICAgIDxzcGFuIHYtaWY9XCJjb2x1bW5JbmRleCA9PT0gMVwiPuiHquWumuS5iTwvc3Bhbj5cbiAgICA8L3RlbXBsYXRlPlxuICAgIDx0ZW1wbGF0ZSAjaGVhZGVyLWNlbGw9XCJ7IGNvbHVtbkluZGV4IH1cIj5cbiAgICAgIDxzcGFuIHYtaWY9XCJjb2x1bW5JbmRleCA9PT0gMVwiPuiHquWumuS5ieWktDwvc3Bhbj5cbiAgICA8L3RlbXBsYXRlPlxuICA8L2VsLXRhYmxlLXYyPlxuXG4gIC0tLS0tLS0tLS0tLS0tMVxuXG4gIDxlbC10YWJsZS12MiA6Y29sdW1ucz1cImNvbHVtbnNcIiA6ZGF0YT1cIltdXCIgOndpZHRoPVwiNzAwXCIgOmhlaWdodD1cIjQwMFwiIGZpeGVkPlxuICAgIDx0ZW1wbGF0ZSAjZW1wdHk+XG4gICAgICA8c3BhbiB2LWlmPVwiZmFsc2VcIj7oh6rlrprkuYnnqbo8L3NwYW4+XG4gICAgPC90ZW1wbGF0ZT5cbiAgPC9lbC10YWJsZS12Mj5cblxuICAtLS0tLS0tLS0tLS0tMlxuICBcbiAgPGVsLXRhYmxlLXYyIDpjb2x1bW5zPVwiY29sdW1uc1wiIDpkYXRhPVwiW11cIiA6d2lkdGg9XCI3MDBcIiA6aGVpZ2h0PVwiNDAwXCIgZml4ZWQ+XG4gICAgPHRlbXBsYXRlICNlbXB0eT5cbiAgICAgIDxzcGFuPuiHquWumuS5ieepujwvc3Bhbj5cbiAgICA8L3RlbXBsYXRlPlxuICA8L2VsLXRhYmxlLXYyPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmNvbnN0IGdlbmVyYXRlQ29sdW1ucyA9IChsZW5ndGggPSAxMCwgcHJlZml4ID0gJ2NvbHVtbi0nLCBwcm9wcz86IGFueSkgPT5cbiAgQXJyYXkuZnJvbSh7IGxlbmd0aCB9KS5tYXAoKF8sIGNvbHVtbkluZGV4KSA9PiAoe1xuICAgIC4uLnByb3BzLFxuICAgIGtleTogYCR7cHJlZml4fSR7Y29sdW1uSW5kZXh9YCxcbiAgICBkYXRhS2V5OiBgJHtwcmVmaXh9JHtjb2x1bW5JbmRleH1gLFxuICAgIHRpdGxlOiBgQ29sdW1uICR7Y29sdW1uSW5kZXh9YCxcbiAgICB3aWR0aDogMTUwLFxuICB9KSlcblxuY29uc3QgZ2VuZXJhdGVEYXRhID0gKFxuICBjb2x1bW5zOiBSZXR1cm5UeXBlPHR5cGVvZiBnZW5lcmF0ZUNvbHVtbnM+LFxuICBsZW5ndGggPSAyMDAsXG4gIHByZWZpeCA9ICdyb3ctJ1xuKSA9PlxuICBBcnJheS5mcm9tKHsgbGVuZ3RoIH0pLm1hcCgoXywgcm93SW5kZXgpID0+IHtcbiAgICByZXR1cm4gY29sdW1ucy5yZWR1Y2UoXG4gICAgICAocm93RGF0YSwgY29sdW1uLCBjb2x1bW5JbmRleCkgPT4ge1xuICAgICAgICByb3dEYXRhW2NvbHVtbi5kYXRhS2V5XSA9IGBSb3cgJHtyb3dJbmRleH0gLSBDb2wgJHtjb2x1bW5JbmRleH1gXG4gICAgICAgIHJldHVybiByb3dEYXRhXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICBpZDogYCR7cHJlZml4fSR7cm93SW5kZXh9YCxcbiAgICAgICAgcGFyZW50SWQ6IG51bGwsXG4gICAgICB9XG4gICAgKVxuICB9KVxuXG5jb25zdCBjb2x1bW5zID0gZ2VuZXJhdGVDb2x1bW5zKDEwKVxuY29uc3QgZGF0YSA9IGdlbmVyYXRlRGF0YShjb2x1bW5zLCAxMDAwKVxuPC9zY3JpcHQ+IiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge31cbn0iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcbiAgICBcImpzeFwiOiBcInByZXNlcnZlXCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJ0eXBlc1wiOiBbXCJlbGVtZW50LXBsdXMvZ2xvYmFsLmQudHNcIl0sXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwiX28iOnt9fQ==)
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9f58022</samp>

This pull request refactors and improves the slot rendering of the table-v2 component by using the `renderSlot` function from `vue` in various components and renderers. It also enhances the test coverage and fixes some minor issues with the `cell` and `header-cell` slots.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9f58022</samp>

*  Refactor table-v2 component to use `renderSlot` function for consistent slot rendering and fallback content ([link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-03853799c92af51dc8efb4a19604b900841a8e6ad198211b7c2ee0d5a1bbd9c6L10-R14), [link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-972ce42af02e9a2de46697d2b39253373488acded5d2ddd1a72e2e8eacb7c309L1-R10), [link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-f87a2e53b80221eb7ba6dd1ff99f1ac8c1f7a8034864ee0b3ace61323c321a7dR1), [link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-f87a2e53b80221eb7ba6dd1ff99f1ac8c1f7a8034864ee0b3ace61323c321a7dL85-R84), [link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-3b91dd3917fa329bc41ac03663a020dd125e7d2ea99c3795be1d8cd007b590e3R1), [link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-3b91dd3917fa329bc41ac03663a020dd125e7d2ea99c3795be1d8cd007b590e3L10-R14), [link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-ada44bf9fa30e8bfae11e3a804df3e1215651dcf0130cecd94f231cba0a867aeR1), [link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-ada44bf9fa30e8bfae11e3a804df3e1215651dcf0130cecd94f231cba0a867aeL45-R52))
* Import `nextTick` function from `vue` in `table-v2.test.tsx` to test reactivity of slot props ([link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-f249509637051f58d56937248b1d31ad40f492a6ac0e9c865a0806a65915f398L1-R1))
* Modify and update `cell` slot test in `table-v2.test.tsx` to check custom and default cell elements ([link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-f249509637051f58d56937248b1d31ad40f492a6ac0e9c865a0806a65915f398L49-R65))
* Modify and update `header-cell` slot test in `table-v2.test.tsx` to check custom and default header cell elements ([link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-f249509637051f58d56937248b1d31ad40f492a6ac0e9c865a0806a65915f398L70-R131))
* Add `empty` slot test in `table-v2.test.tsx` to check custom and default empty elements ([link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-f249509637051f58d56937248b1d31ad40f492a6ac0e9c865a0806a65915f398L70-R131))
* Remove unused types `CellRendererParams` and `TableV2HeaderCell` from `cell.tsx` and `header-cell.tsx` respectively ([link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-f87a2e53b80221eb7ba6dd1ff99f1ac8c1f7a8034864ee0b3ace61323c321a7dL9), [link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-ada44bf9fa30e8bfae11e3a804df3e1215651dcf0130cecd94f231cba0a867aeL12))
* Remove redundant variable `CellComponent` from `cell.tsx` and rename `cellRenderer` to `columnCellRenderer` to avoid confusion ([link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-f87a2e53b80221eb7ba6dd1ff99f1ac8c1f7a8034864ee0b3ace61323c321a7dL55-L61), [link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-f87a2e53b80221eb7ba6dd1ff99f1ac8c1f7a8034864ee0b3ace61323c321a7dL85-R84), [link](https://github.com/element-plus/element-plus/pull/15016/files?diff=unified&w=0#diff-ada44bf9fa30e8bfae11e3a804df3e1215651dcf0130cecd94f231cba0a867aeL45-R52))
