### PR TITLE
feat(components): [menu] add `ellipsisPopperOffset` and `ellipsisIcon` props(#14923)

### DIFF
--- a/docs/en-US/component/menu.md
+++ b/docs/en-US/component/menu.md
@@ -51,23 +51,35 @@ menu/collapse
 
 :::
 
+## Ellipsis PopperOffset And Icon ^(2.4.4)
+
+Ellipsis Menus and override ellipsis icon and popperOffset 10.
+
+:::demo
+
+menu/ellipsis
+
+:::
+
 ## Menu Attributes
 
-| Name                    | Description                                                                                                                                                           | Type    | Accepted Values       | Default  |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | --------------------- | -------- |
-| mode                    | menu display mode                                                                                                                                                     | string  | horizontal / vertical | vertical |
-| collapse                | whether the menu is collapsed (available only in vertical mode)                                                                                                       | boolean | —                     | false    |
-| ellipsis                | whether the menu is ellipsis (available only in horizontal mode)                                                                                                      | boolean | —                     | true     |
-| background-color        | background color of Menu (hex format) (deprecated, use `--bg-color` instead)                                                                                          | string  | —                     | #ffffff  |
-| text-color              | text color of Menu (hex format) (deprecated, use `--text-color` instead)                                                                                              | string  | —                     | #303133  |
-| active-text-color       | text color of currently active menu item (hex format) (deprecated, use `--active-color` instead)                                                                      | string  | —                     | #409EFF  |
-| default-active          | index of active menu on page load                                                                                                                                     | string  | —                     | —        |
-| default-openeds         | array that contains indexes of currently active sub-menus                                                                                                             | Array   | —                     | —        |
-| unique-opened           | whether only one sub-menu can be active                                                                                                                               | boolean | —                     | false    |
-| menu-trigger            | how sub-menus are triggered, only works when `mode` is 'horizontal'                                                                                                   | string  | hover / click         | hover    |
-| router                  | whether `vue-router` mode is activated. If true, index will be used as 'path' to activate the route action. Use with `default-active` to set the active item on load. | boolean | —                     | false    |
-| collapse-transition     | whether to enable the collapse transition                                                                                                                             | boolean | —                     | true     |
-| popper-effect ^(2.2.26) | Tooltip theme, built-in theme: `dark` / `light` when menu is collapsed                                                                                                | string  | dark / light          | dark     |
+| Name                           | Description                                                                                                                                                           | Type                  | Accepted Values       | Default  |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | --------------------- | -------- |
+| mode                           | menu display mode                                                                                                                                                     | string                | horizontal / vertical | vertical |
+| collapse                       | whether the menu is collapsed (available only in vertical mode)                                                                                                       | boolean               | —                     | false    |
+| ellipsis                       | whether the menu is ellipsis (available only in horizontal mode)                                                                                                      | boolean               | —                     | true     |
+| ellipsis-icon^(2.4.4)          | custom ellipsis icon（available only in horizontal mode and ellipsis is true）                                                                                        | `string \| Component` | —                     | —        |
+| ellipsis-popper-offset^(2.4.4) | offset of the ellipsis menu popper（available only in horizontal mode and ellipsis is true）                                                                          | number                | —                     | 6        |
+| background-color               | background color of Menu (hex format) (deprecated, use `--bg-color` instead)                                                                                          | string                | —                     | #ffffff  |
+| text-color                     | text color of Menu (hex format) (deprecated, use `--text-color` instead)                                                                                              | string                | —                     | #303133  |
+| active-text-color              | text color of currently active menu item (hex format) (deprecated, use `--active-color` instead)                                                                      | string                | —                     | #409EFF  |
+| default-active                 | index of active menu on page load                                                                                                                                     | string                | —                     | —        |
+| default-openeds                | array that contains indexes of currently active sub-menus                                                                                                             | Array                 | —                     | —        |
+| unique-opened                  | whether only one sub-menu can be active                                                                                                                               | boolean               | —                     | false    |
+| menu-trigger                   | how sub-menus are triggered, only works when `mode` is 'horizontal'                                                                                                   | string                | hover / click         | hover    |
+| router                         | whether `vue-router` mode is activated. If true, index will be used as 'path' to activate the route action. Use with `default-active` to set the active item on load. | boolean               | —                     | false    |
+| collapse-transition            | whether to enable the collapse transition                                                                                                                             | boolean               | —                     | true     |
+| popper-effect ^(2.2.26)        | Tooltip theme, built-in theme: `dark` / `light` when menu is collapsed                                                                                                | string                | dark / light          | dark     |
 
 ## Menu Methods
 

--- a/docs/examples/menu/ellipsis.vue
+++ b/docs/examples/menu/ellipsis.vue
@@ -1,0 +1,30 @@
+<template>
+  <el-menu
+    ellipsis
+    class="el-menu-ellipsis-demo"
+    mode="horizontal"
+    :ellipsis-popper-offset="10"
+    :ellipsis-icon="MoreFilled"
+    style="width: 400px"
+  >
+    <el-menu-item index="1">Processing Center</el-menu-item>
+    <el-sub-menu index="2" :popper-offset="10">
+      <template #title>Workspace</template>
+      <el-menu-item index="2-1">item one</el-menu-item>
+      <el-menu-item index="2-2">item two</el-menu-item>
+      <el-menu-item index="2-3">item three</el-menu-item>
+      <el-sub-menu index="2-4">
+        <template #title>item four</template>
+        <el-menu-item index="2-4-1">item one</el-menu-item>
+        <el-menu-item index="2-4-2">item two</el-menu-item>
+        <el-menu-item index="2-4-3">item three</el-menu-item>
+      </el-sub-menu>
+    </el-sub-menu>
+    <el-menu-item index="3" disabled>Info</el-menu-item>
+    <el-menu-item index="4">Orders</el-menu-item>
+  </el-menu>
+</template>
+
+<script lang="ts" setup>
+import { MoreFilled } from '@element-plus/icons-vue'
+</script>

--- a/packages/components/menu/src/menu.ts
+++ b/packages/components/menu/src/menu.ts
@@ -19,6 +19,7 @@ import {
   buildProps,
   definePropType,
   flattedChildren,
+  iconPropType,
   isObject,
   isString,
   mutable,
@@ -31,7 +32,12 @@ import { useMenuCssVar } from './use-menu-css-var'
 
 import type { MenuItemClicked, MenuProvider, SubMenuProvider } from './types'
 import type { NavigationFailure, Router } from 'vue-router'
-import type { ExtractPropTypes, VNode, VNodeArrayChildren } from 'vue'
+import type {
+  Component,
+  ExtractPropTypes,
+  VNode,
+  VNodeArrayChildren,
+} from 'vue'
 import type { UseResizeObserverReturn } from '@vueuse/core'
 
 export const menuProps = buildProps({
@@ -66,6 +72,13 @@ export const menuProps = buildProps({
   ellipsis: {
     type: Boolean,
     default: true,
+  },
+  ellipsisPopperOffset: {
+    type: Number,
+    default: 6,
+  },
+  ellipsisIcon: {
+    type: iconPropType,
   },
   popperEffect: {
     type: String,
@@ -393,6 +406,7 @@ export default defineComponent({
               {
                 index: 'sub-menu-more',
                 class: nsSubMenu.e('hide-arrow'),
+                popperOffset: props.ellipsisPopperOffset,
               },
               {
                 title: () =>
@@ -401,7 +415,12 @@ export default defineComponent({
                     {
                       class: nsSubMenu.e('icon-more'),
                     },
-                    { default: () => h(More) }
+                    {
+                      default: () =>
+                        props.ellipsisIcon
+                          ? h(props.ellipsisIcon as Component)
+                          : h(More),
+                    }
                   ),
                 default: () => slotMore,
               }


### PR DESCRIPTION
- feat(components): [menu] add `ellipsisPopperOffset`、`ellipsisIcon` props
- docs(components): [menu] add `ellipsisPopperOffset`、`ellipsisIcon` props

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 79edca1</samp>

This pull request enhances the menu component by adding two new props: `ellipsis-icon` and `ellipsis-popper-offset`. These props allow users to customize the appearance and position of the ellipsis menu, which shows hidden menu items. The pull request also updates the documentation and adds an example for the new features.

## Related Issue

Fixes #14923 .

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 79edca1</samp>

*  Add new features to menu component to customize ellipsis menu icon and popper offset ([link](https://github.com/element-plus/element-plus/pull/15033/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5R22), [link](https://github.com/element-plus/element-plus/pull/15033/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5L34-R40), [link](https://github.com/element-plus/element-plus/pull/15033/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5R76-R82), [link](https://github.com/element-plus/element-plus/pull/15033/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5R409), [link](https://github.com/element-plus/element-plus/pull/15033/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5L404-R423))
  * Import `iconPropType` and `Component` types from `utils/props` and `vue` modules ([link](https://github.com/element-plus/element-plus/pull/15033/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5R22), [link](https://github.com/element-plus/element-plus/pull/15033/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5L34-R40))
  * Declare `ellipsis-icon` and `ellipsis-popper-offset` props with types, default values, and validators in `menuProps` object ([link](https://github.com/element-plus/element-plus/pull/15033/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5R76-R82))
  * Pass `ellipsis-popper-offset` prop value to `popperOffset` option of `usePopper` hook in `menu.ts` ([link](https://github.com/element-plus/element-plus/pull/15033/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5R409))
  * Render `ellipsis-icon` prop value as default slot of `el-tooltip` component in `menu.ts`, with fallback to default `More` icon ([link](https://github.com/element-plus/element-plus/pull/15033/files?diff=unified&w=0#diff-f9cfce3f7ed6319f8bb3a5b1fe2c62988bc10954b89bd1f93d7bf3b49fcd5bc5L404-R423))
* Update documentation of menu component to include new section on ellipsis popper offset and icon in `menu.md` ([link](https://github.com/element-plus/element-plus/pull/15033/files?diff=unified&w=0#diff-68f9957a7840b355dcdda10667dc726edd89eefcade651c450066137e7c5e3a8L54-R82))
* Add new example file for menu component to demonstrate usage of new features in `ellipsis.vue` ([link](https://github.com/element-plus/element-plus/pull/15033/files?diff=unified&w=0#diff-284d278a25fa942ead46e0acbf73f175b25abe3da2a04348a36e2ca1ddc67b9fR1-R30))
