### PR TITLE
fix(components): [data-picker] use renderSlot simplified code

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/basic-cell-render.tsx
+++ b/packages/components/date-picker/src/date-picker-com/basic-cell-render.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, inject } from 'vue'
+import { defineComponent, inject, renderSlot } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { ROOT_PICKER_INJECTION_KEY } from '../constants'
 import { basicCellProps } from '../props/basic-cell'
@@ -11,24 +11,12 @@ export default defineComponent({
     const { slots } = inject(ROOT_PICKER_INJECTION_KEY)!
     return () => {
       const { cell } = props
-      if (slots.default) {
-        const list = slots.default(cell).filter((item) => {
-          return (
-            item.patchFlag !== -2 &&
-            item.type.toString() !== 'Symbol(Comment)' &&
-            item.type.toString() !== 'Symbol(v-cmt)'
-          )
-        })
-        if (list.length) {
-          return list
-        }
-      }
 
-      return (
+      return renderSlot(slots, 'default', { ...cell }, () => [
         <div class={ns.b()}>
           <span class={ns.e('text')}>{cell?.text}</span>
-        </div>
-      )
+        </div>,
+      ])
     }
   },
 })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

Similar to #14939 

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2a206e7</samp>

Simplify slot rendering in `BasicCellRender` component. Use `renderSlot` function from `vue` to avoid manual slot checking and rendering in `packages/components/date-picker/src/date-picker-com/basic-cell-render.tsx`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2a206e7</samp>

*  Simplify the rendering of the default slot in the `BasicCellRender` component by using the `renderSlot` function from `vue` ([link](https://github.com/element-plus/element-plus/pull/15036/files?diff=unified&w=0#diff-2d0a60e1bf84549bcbd25d8fb941ede708d4314e22f06bf363938b53547f4760L1-R1), [link](https://github.com/element-plus/element-plus/pull/15036/files?diff=unified&w=0#diff-2d0a60e1bf84549bcbd25d8fb941ede708d4314e22f06bf363938b53547f4760L14-R19))
