### PR TITLE
perf(hooks): replace the ref object with a plain object

### DIFF
--- a/packages/hooks/use-cursor/index.ts
+++ b/packages/hooks/use-cursor/index.ts
@@ -1,19 +1,18 @@
-import { ref } from 'vue'
-
 import type { ShallowRef } from 'vue'
+
+interface SelectionInfo {
+  selectionStart?: number
+  selectionEnd?: number
+  value?: string
+  beforeTxt?: string
+  afterTxt?: string
+}
 
 // Keep input cursor in the correct position when we use formatter.
 export function useCursor(
   input: ShallowRef<HTMLInputElement | undefined>
 ): [() => void, () => void] {
-  const selectionRef = ref<{
-    selectionStart?: number
-    selectionEnd?: number
-    value?: string
-    beforeTxt?: string
-    afterTxt?: string
-  }>()
-
+  let selectionInfo: SelectionInfo
   function recordCursor() {
     if (input.value == undefined) return
 
@@ -24,7 +23,7 @@ export function useCursor(
     const beforeTxt = value.slice(0, Math.max(0, selectionStart))
     const afterTxt = value.slice(Math.max(0, selectionEnd))
 
-    selectionRef.value = {
+    selectionInfo = {
       selectionStart,
       selectionEnd,
       value,
@@ -33,10 +32,10 @@ export function useCursor(
     }
   }
   function setCursor() {
-    if (input.value == undefined || selectionRef.value == undefined) return
+    if (input.value == undefined || selectionInfo == undefined) return
 
     const { value } = input.value
-    const { beforeTxt, afterTxt, selectionStart } = selectionRef.value
+    const { beforeTxt, afterTxt, selectionStart } = selectionInfo
 
     if (
       beforeTxt == undefined ||


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2f7011e</samp>

Simplify cursor and text data handling in `use-cursor` hook. Replace reactive `ref` with normal variable and define `SelectionInfo` interface.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2f7011e</samp>

*  Define `SelectionInfo` interface to store cursor position and text data ([link](https://github.com/element-plus/element-plus/pull/15061/files?diff=unified&w=0#diff-184c021b56d7c001f80c0895a05bba1fe7e202a19f1ad16a192f5c85ef245280L1-R15))
*  Replace `selectionRef` with `selectionInfo` as a normal variable instead of a `ref` ([link](https://github.com/element-plus/element-plus/pull/15061/files?diff=unified&w=0#diff-184c021b56d7c001f80c0895a05bba1fe7e202a19f1ad16a192f5c85ef245280L27-R26), [link](https://github.com/element-plus/element-plus/pull/15061/files?diff=unified&w=0#diff-184c021b56d7c001f80c0895a05bba1fe7e202a19f1ad16a192f5c85ef245280L36-R38))
*  Remove unused import of `ref` from `vue` ([link](https://github.com/element-plus/element-plus/pull/15061/files?diff=unified&w=0#diff-184c021b56d7c001f80c0895a05bba1fe7e202a19f1ad16a192f5c85ef245280L1-R15))
