### PR TITLE
fix(components): [input-number] Fix not trigger change event and incorrect value display

### DIFF
--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -80,6 +80,23 @@ describe('InputNumber.vue', () => {
     expect(num.value).toEqual(null)
   })
 
+  // fix: #14438
+  test('Make sure display value will match actual value', async () => {
+    const num = ref<number>(111)
+    const wrapper = mount(() => <InputNumber v-model={num.value} />)
+    const inputWrapper = wrapper.find('input')
+    const nativeInput = inputWrapper.element
+    await inputWrapper.trigger('focus')
+    nativeInput.value = ''
+    await inputWrapper.trigger('input')
+    nativeInput.value = '111'
+    await inputWrapper.trigger('input')
+    await inputWrapper.trigger('blur')
+    num.value = 222
+    await nextTick()
+    expect(wrapper.find('input').element.value).toEqual('222')
+  })
+
   test('min', async () => {
     const num = ref(1)
     const wrapper = mount(() => <InputNumber min={3} v-model={num.value} />)

--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -312,6 +312,9 @@ describe('InputNumber.vue', () => {
     expect(
       wrapper.getComponent(InputNumber).emitted('update:modelValue')
     ).toHaveLength(4)
+    await wrapper.find('input').setValue('')
+    expect(wrapper.getComponent(InputNumber).emitted('change')).toHaveLength(4)
+    expect(num.value).toBe(null)
   })
 
   test('blur-event', async () => {

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -281,10 +281,9 @@ const handleBlur = (event: MouseEvent | FocusEvent) => {
 
 watch(
   () => props.modelValue,
-  (value) => {
-    const userInput = verifyValue(data.userInput)
+  (value, oldValue) => {
     const newValue = verifyValue(value, true)
-    if (data.userInput === null && userInput !== newValue) {
+    if (data.userInput === null && newValue !== oldValue) {
       data.currentValue = newValue
     }
   },

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -284,9 +284,8 @@ watch(
   (value) => {
     const userInput = verifyValue(data.userInput)
     const newValue = verifyValue(value, true)
-    if (!isNumber(userInput) && (!userInput || userInput !== newValue)) {
+    if (data.userInput === null && userInput !== newValue) {
       data.currentValue = newValue
-      data.userInput = null
     }
   },
   { immediate: true }

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -273,6 +273,7 @@ const handleFocus = (event: MouseEvent | FocusEvent) => {
 }
 
 const handleBlur = (event: MouseEvent | FocusEvent) => {
+  data.userInput = null
   emit('blur', event)
   if (props.validateEvent) {
     formItem?.validate?.('blur').catch((err) => debugWarn(err))


### PR DESCRIPTION
closed #14967 #14438

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2a54735</samp>

Simplify and fix `modelValue` watch handler in `input-number.vue`. Avoid updating internal value and triggering events when user is editing input or value is unchanged.

## Related Issue

Fixes #14967 #14438.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2a54735</samp>

*  Simplify the watch handler for `modelValue` prop of `input-number` component by removing unnecessary verification and updating of `userInput` and `currentValue` data ([link](https://github.com/element-plus/element-plus/pull/15066/files?diff=unified&w=0#diff-0ae90cff73c6316f25336e807f41c1ecaca3dfbe4210f80273a4310aa89ac5a8L284-R287))
*  Add `oldValue` parameter to the watch handler for `modelValue` prop of `input-number` component to avoid unnecessary re-rendering when the value is unchanged ([link](https://github.com/element-plus/element-plus/pull/15066/files?diff=unified&w=0#diff-0ae90cff73c6316f25336e807f41c1ecaca3dfbe4210f80273a4310aa89ac5a8L284-R287))
