### PR TITLE
feat(components): [switch] (in)active icon slot

### DIFF
--- a/docs/en-US/component/switch.md
+++ b/docs/en-US/component/switch.md
@@ -125,10 +125,10 @@ switch/custom-action-icon
 
 ### Switch Slots
 
-| Name               | Description                              |
-| ------------------ | ---------------------------------------- |
-| activeActionIcon   | customize active action icon component   |
-| inactiveActionIcon | customize inactive action icon component |
+| Name                     | Description               |
+| ------------------------ | ------------------------- |
+| active-action ^(2.5.0)   | customize active action   |
+| inactive-action ^(2.5.0) | customize inactive action |
 
 ### Exposes
 

--- a/docs/en-US/component/switch.md
+++ b/docs/en-US/component/switch.md
@@ -123,6 +123,13 @@ switch/custom-action-icon
 | ------ | --------------------------- | ------------------------------------------------------- |
 | change | triggers when value changes | ^[Function]`(val: boolean \| string \| number) => void` |
 
+### Switch Slots
+
+| Name               | Description                              |
+| ------------------ | ---------------------------------------- |
+| activeActionIcon   | customize active action icon component   |
+| inactiveActionIcon | customize inactive action icon component |
+
 ### Exposes
 
 | Method | Description                          | Type                    |

--- a/docs/en-US/component/switch.md
+++ b/docs/en-US/component/switch.md
@@ -87,6 +87,14 @@ switch/custom-action-icon
 
 :::
 
+## custom action slot ^(2.5.0)
+
+:::demo You can use `active-action` and `inactive-action` slot to customize action.
+
+switch/custom-action-slot
+
+:::
+
 ## API
 
 ### Attributes

--- a/docs/examples/switch/custom-action-slot.vue
+++ b/docs/examples/switch/custom-action-slot.vue
@@ -1,0 +1,14 @@
+<template>
+  <el-switch v-model="value1">
+    <template #active-action>
+      <span class="custom-active-action">T</span>
+    </template>
+    <template #inactive-action>
+      <span class="custom-inactive-action">F</span>
+    </template>
+  </el-switch>
+</template>
+<script setup lang="ts">
+import { ref } from 'vue'
+const value1 = ref(true)
+</script>

--- a/packages/components/switch/__tests__/switch.test.tsx
+++ b/packages/components/switch/__tests__/switch.test.tsx
@@ -380,5 +380,30 @@ describe('Switch.vue', () => {
       const formItem = wrapper.find('[data-test-ref="item"]')
       expect(formItem.attributes().role).toBe('group')
     })
+
+    test('custom switch action slots', async () => {
+      const value = ref(true)
+      const wrapper = mount({
+        setup: () => () =>
+          (
+            <Switch
+              v-model={value.value}
+              v-slots={{
+                'active-action': () => (
+                  <span class="custom-active-action">T</span>
+                ),
+                'inactive-action': () => (
+                  <span class="custom-inactive-action">F</span>
+                ),
+              }}
+            />
+          ),
+      })
+      await nextTick()
+
+      const coreWrapper = wrapper.find('.el-switch__core')
+      const actionWrapper = coreWrapper.find('.el-switch__action')
+      expect(actionWrapper.find('.custom-active-action').exists()).toBeTruthy()
+    })
   })
 })

--- a/packages/components/switch/src/switch.vue
+++ b/packages/components/switch/src/switch.vue
@@ -45,12 +45,12 @@
         <el-icon v-if="loading" :class="ns.is('loading')">
           <loading />
         </el-icon>
-        <slot v-else-if="checked" name="activeActionIcon">
+        <slot v-else-if="checked" name="active-action">
           <el-icon v-if="activeActionIcon">
             <component :is="activeActionIcon" />
           </el-icon>
         </slot>
-        <slot v-else-if="!checked" name="inactiveActionIcon">
+        <slot v-else-if="!checked" name="inactive-action">
           <el-icon v-if="inactiveActionIcon">
             <component :is="inactiveActionIcon" />
           </el-icon>

--- a/packages/components/switch/src/switch.vue
+++ b/packages/components/switch/src/switch.vue
@@ -45,12 +45,16 @@
         <el-icon v-if="loading" :class="ns.is('loading')">
           <loading />
         </el-icon>
-        <el-icon v-else-if="activeActionIcon && checked">
-          <component :is="activeActionIcon" />
-        </el-icon>
-        <el-icon v-else-if="inactiveActionIcon && !checked">
-          <component :is="inactiveActionIcon" />
-        </el-icon>
+        <slot v-else-if="checked" name="activeActionIcon">
+          <el-icon v-if="activeActionIcon">
+            <component :is="activeActionIcon" />
+          </el-icon>
+        </slot>
+        <slot v-else-if="!checked" name="inactiveActionIcon">
+          <el-icon v-if="inactiveActionIcon">
+            <component :is="inactiveActionIcon" />
+          </el-icon>
+        </slot>
       </div>
     </span>
     <span


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description
Add custom activeActionIcon and inactiveActionIcon slots to switch component

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 83c3e9e</samp>

This pull request adds two new slots `activeActionIcon` and `inactiveActionIcon` to the switch component, which enable users to customize the icons with any component. It also updates the template and the documentation of the component to use the slots.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 83c3e9e</samp>

* Add slots for active and inactive icons to switch component ([link](https://github.com/element-plus/element-plus/pull/15078/files?diff=unified&w=0#diff-a8d9aaca9c72c0998e021fe3e607217cbf71f0fe04eca2dbb0760b66e4755d76L48-R57), [link](https://github.com/element-plus/element-plus/pull/15078/files?diff=unified&w=0#diff-5fded0baca14bc85d6b3a235e24790419a6113d1861afd9bb388b3f5f2aba80cR126-R132))

tips: 这是 [#15013](https://github.com/element-plus/element-plus/pull/15013) 的重新 fork，不清楚为什么会出现校验不通过 :(