### PR TITLE
fix(style): [col] media sm max-wdith 768 to 767

### DIFF
--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -1425,7 +1425,7 @@ $lg: 1200px !default;
 $xl: 1920px !default;
 
 $breakpoints: (
-  'xs': '(max-width: #{$sm})',
+  'xs': '(max-width: #{$sm - 1})',
   'sm': '(min-width: #{$sm})',
   'md': '(min-width: #{$md})',
   'lg': '(min-width: #{$lg})',


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c5c68e8</samp>

Refactored the responsive grid system in `theme-chalk` and fixed a breakpoint issue for xs screens.

## Related Issue

Fixes #15081.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c5c68e8</samp>

* Refactor the responsive grid system in the theme-chalk package to use CSS variables and mixins for more flexibility and consistency ([link](https://github.com/element-plus/element-plus/pull/15085/files?diff=unified&w=0#diff-eb85fc73444e26f19f950007c73a7d86028b1453c33efc86d2b5478ea027c01aL1428-R1428),                     
