### PR TITLE
style(components): [icon] Remove 'inherit' property of color

### DIFF
--- a/packages/components/icon/src/icon.vue
+++ b/packages/components/icon/src/icon.vue
@@ -24,7 +24,7 @@ const style = computed<CSSProperties>(() => {
 
   return {
     fontSize: isUndefined(size) ? undefined : addUnit(size),
-    '--color': color,
+    color,
   }
 })
 </script>

--- a/packages/theme-chalk/src/icon.scss
+++ b/packages/theme-chalk/src/icon.scss
@@ -22,7 +22,6 @@
 }
 
 @include b(icon) {
-  --color: inherit;
   height: 1em;
   width: 1em;
   line-height: 1em;
@@ -31,7 +30,6 @@
   align-items: center;
   position: relative;
   fill: currentColor;
-  color: var(--color);
   font-size: inherit;
 
   @include when(loading) {


### PR DESCRIPTION
closed #15094

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 68c3745</samp>

Simplified the icon component and its style by removing unnecessary color variables and using the `color` prop directly. This makes the icon component more consistent and easier to customize.

## Related Issue

Fixes #15094.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 68c3745</samp>

*  Simplify `icon.vue` component to use `color` prop directly ([link](https://github.com/element-plus/element-plus/pull/15095/files?diff=unified&w=0#diff-721ec51981ca8d86942a182a5f29cc535a640c331f48e609bcada6ef77310af4L27-R27))
*  Remove unused `--color` variable and `color` property from `icon.scss` file ([link](https://github.com/element-plus/element-plus/pull/15095/files?diff=unified&w=0#diff-b8da420d27b44cf529d11cac130942df8603290f1442f25a01df1b5de6514a96L25), [link](https://github.com/element-plus/element-plus/pull/15095/files?diff=unified&w=0#diff-b8da420d27b44cf529d11cac130942df8603290f1442f25a01df1b5de6514a96L34))
