### PR TITLE
fix(components): selection box content vanishes on page switch.#15082

### DIFF
--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -853,10 +853,12 @@ export const useSelect = (props, states: States, ctx) => {
   const handleBlur = (event: FocusEvent) => {
     // validate current focus event is inside el-tooltip-content or el-select
     // if so, ignore the blur event.
+    const isDocumentVisible = document.visibilityState === 'visible'
     if (
       tooltipRef.value?.isFocusInsideContent(event) ||
       tagTooltipRef.value?.isFocusInsideContent(event) ||
-      selectWrapper.value?.contains(event.relatedTarget)
+      selectWrapper.value?.contains(event.relatedTarget) ||
+      isDocumentVisible
     ) {
       return
     }


### PR DESCRIPTION
Repair the problem that input content in select component will disappear when the page is switched.

closed #15082

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

Repair the problem that select component input will disappear when the page is switched.

## Related Issue

Fixes #15082.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at feb5a52</samp>

* Fix select component not closing when switching tabs or windows by checking document visibility before ignoring blur event ([link](https://github.com/element-plus/element-plus/pull/15107/files?diff=unified&w=0#diff-ae55c3efc549b49d40b3f5b535ac2fc1572374d9309b6439f8d529b06edb1368L856-R861))
