### PR TITLE
Update uz-uz.ts

### DIFF
--- a/packages/locale/lang/uz-uz.ts
+++ b/packages/locale/lang/uz-uz.ts
@@ -63,7 +63,7 @@ export default {
       loading: 'Yuklanmoqda',
       noMatch: 'Mos maʼlumot yoʻq',
       noData: 'Maʼlumot yoʻq',
-      placeholder: 'Tanladizngiz',
+      placeholder: 'Tanladingiz',
     },
     cascader: {
       noMatch: 'Mos maʼlumot topilmadi',
@@ -120,8 +120,8 @@ export default {
       title: 'Orqaga',
     },
     popconfirm: {
-      confirmButtonText: 'Yes', // to be translated
-      cancelButtonText: 'No', // to be translated
+      confirmButtonText: 'Ha',
+      cancelButtonText: 'Yo`q',
     },
   },
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 67c464f</samp>

This pull request improves the Uzbek localization by correcting a typo and adding missing translations for `select` and `popconfirm` components in `uz-uz.ts`.

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 67c464f</samp>

* Fix the spelling of the select component placeholder in Uzbek language ([link](https://github.com/element-plus/element-plus/pull/15109/files?diff=unified&w=0#diff-82972b50a301860ff7bb0ce4c2909474b506807e5ff13fb4fa560a8d6cde25f7L66-R66))
* Translate the popconfirm component button texts to Uzbek language ([link](https://github.com/element-plus/element-plus/pull/15109/files?diff=unified&w=0#diff-82972b50a301860ff7bb0ce4c2909474b506807e5ff13fb4fa560a8d6cde25f7L123-R124))
