### PR TITLE
test(hooks): fix typo

### DIFF
--- a/packages/hooks/__tests__/use-namespace.test.tsx
+++ b/packages/hooks/__tests__/use-namespace.test.tsx
@@ -44,7 +44,7 @@ const TestComp = defineComponent({
   },
 })
 
-describe('use-locale', () => {
+describe('use-namespace', () => {
   const Comp = defineComponent({
     setup(_props, { slots }) {
       provideGlobalConfig({ namespace: 'ep' })

--- a/packages/hooks/__tests__/use-teleport.test.tsx
+++ b/packages/hooks/__tests__/use-teleport.test.tsx
@@ -34,7 +34,7 @@ const Comp = defineComponent({
   },
 })
 
-describe('useModal', () => {
+describe('useTeleport', () => {
   let wrapper: VueWrapper<InstanceType<typeof Comp>>
 
   beforeEach(() => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

修改elementPlus/hooks包下部分单元测试描述

## Related Issue

Fixes #\_\_\_.

## Explanation of Changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 849e0ff</samp>

* Rename and reorganize test blocks for hooks `use-namespace` and `use-teleport` ([link](https://github.com/element-plus/element-plus/pull/15113/files?diff=unified&w=0#diff-1f8b3b3068204c6017fc9908b1b0e36dd7241a64d0ccf5b368478a359246e6ddL47-R47), [link](https://github.com/element-plus/element-plus/pull/15113/files?diff=unified&w=0#diff-57c45bfc97fdab7ae349bd19b0766967c321701b4cb135a5371c7f12c6c57b5aL37-R37))
