### PR TITLE
fix(docs): replace `fonts.loli.net` with original `fonts.googleapis.com`

### DIFF
--- a/docs/.vitepress/config/head.ts
+++ b/docs/.vitepress/config/head.ts
@@ -129,7 +129,7 @@ gtag('config', 'UA-175337989-1');`,
     `
   var resource = document.createElement('link');
   resource.setAttribute("rel", "stylesheet");
-  resource.setAttribute("href","//fonts.loli.net/css?family=Inter:300,400,500,600,700,800|Open+Sans:400,600;display=swap");
+  resource.setAttribute("href","https://fonts.googleapis.com/css?family=Inter:300,400,500,600,700,800|Open+Sans:400,600;display=swap");
   resource.setAttribute("type","text/css");
   var head = document.querySelector('head');
   head.appendChild(resource);


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

It seems the Google Fonts mirror `fonts.loli.net` is unavailable for some regions in China, but the original server `fonts.googleapis.com` seems to work better now. See the comparison below.

| [loli.net](https://fonts.loli.net/css?family=Inter:300,400,500,600,700,800%7COpen+Sans:400,600;display=swap) | [Google](https://fonts.googleapis.com/css?family=Inter:300,400,500,600,700,800%7COpen+Sans:400,600;display=swap) |
| :----: | :----: |
| [![image](https://github.com/element-plus/element-plus/assets/26999792/3956faa7-561b-4019-8313-15d2e1613c28)](https://www.itdog.cn/ping/fonts.loli.net) | [![image](https://github.com/element-plus/element-plus/assets/26999792/8d2b1d6a-15a8-4c65-ba66-7d2c3a374b78)](https://www.itdog.cn/ping/fonts.googleapis.com) |

