### PR TITLE
feat(element-plus): Support last 2 versions of browsers

### DIFF
--- a/docs/en-US/guide/installation.md
+++ b/docs/en-US/guide/installation.md
@@ -5,16 +5,17 @@ lang: en-US
 
 # Installation
 
-## Compatibility
+## Compatibility ^(2.5.0)
 
-Element Plus can run on browsers that support [ES2018](https://caniuse.com/?feats=mdn-javascript_builtins_regexp_dotall,mdn-javascript_builtins_regexp_lookbehind_assertion,mdn-javascript_builtins_regexp_named_capture_groups,mdn-javascript_builtins_regexp_property_escapes,mdn-javascript_builtins_symbol_asynciterator,mdn-javascript_functions_method_definitions_async_generator_methods,mdn-javascript_grammar_template_literals_template_literal_revision,mdn-javascript_operators_destructuring_rest_in_objects,mdn-javascript_operators_spread_spread_in_destructuring,promise-finally) and [ResizeObserver](https://caniuse.com/resizeobserver).
+Element Plus can run on browsers that support last 2 versions.
+
 If you really need to support outdated browsers, please add [Babel](https://babeljs.io/) and Polyfill yourself.
 
 Since Vue 3 no longer supports IE11, Element Plus does not support IE either.
 
-| ![IE](https://cdn.jsdelivr.net/npm/@browser-logos/edge/edge_32x32.png) | ![Firefox](https://cdn.jsdelivr.net/npm/@browser-logos/firefox/firefox_32x32.png) | ![Chrome](https://cdn.jsdelivr.net/npm/@browser-logos/chrome/chrome_32x32.png) | ![Safari](https://cdn.jsdelivr.net/npm/@browser-logos/safari/safari_32x32.png) |
-| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
-| Edge ≥ 79                                                              | Firefox ≥ 78                                                                      | Chrome ≥ 64                                                                    | Safari ≥ 12                                                                    |
+| ![IE](https://cdn.jsdelivr.net/npm/@browser-logos/edge/edge_32x32.png) <br> Edge | ![Firefox](https://cdn.jsdelivr.net/npm/@browser-logos/firefox/firefox_32x32.png) <br> Firefox | ![Chrome](https://cdn.jsdelivr.net/npm/@browser-logos/chrome/chrome_32x32.png) <br> Chrome | ![Safari](https://cdn.jsdelivr.net/npm/@browser-logos/safari/safari_32x32.png) <br> Safari |
+|------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| last 2 versions                                                              | last 2 versions                                                                            | last 2 versions                                                                        | last 2 versions                                                                        |
 
 ### Version
 


### PR DESCRIPTION
We're upgrading the supported browser versions to `last 2 versions` in version `2.5.0`. If you want to support the old version browsers, please add Babel  and Polyfill yourself, or use element-plus in version `2.4.x`.