### PR TITLE
fix(components): [input] the cursor is misplaced when type setting number

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -242,6 +242,10 @@
     &[type='password']::-ms-reveal {
       display: none;
     }
+
+    &[type='number'] {
+      line-height: 1;
+    }
   }
 
   @each $slot in (prefix, suffix) {


### PR DESCRIPTION
[PR 8193](https://github.com/element-plus/element-plus/pull/8193) 修复了 el-input-number 组件在输入中文时会出现光标向上偏移的问题。

同时 [issue 6660](https://github.com/element-plus/element-plus/issues/6660) 提到了造成这个问题的原因：

> 这个是原生input已知问题，number模式下在设置line-height后会使用输入法会导致光标漂移到左上角，组件对应的文档中已有tip。 后续是不是可以考虑通过padding的方式去调整高度？

……but，当 el-input 组件指定 type=number 时，el-input 渲染的同样是一个 type=number 的 input 元素，因而同样会导致该问题，不知道是不是改漏了_(:з)∠)_


