### PR TITLE
perf(components): [select & selectV2] hide `collapse-tags-tooltip` when dropdown

### DIFF
--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -76,7 +76,7 @@
               <el-tooltip
                 v-if="collapseTags && modelValue.length > maxCollapseTags"
                 ref="tagTooltipRef"
-                :disabled="!collapseTagsTooltip"
+                :disabled="dropdownMenuVisible || !collapseTagsTooltip"
                 :fallback-placements="['bottom', 'top', 'right', 'left']"
                 :effect="effect"
                 placement="bottom"

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -76,7 +76,7 @@
               <el-tooltip
                 v-if="collapseTags && states.selected.length > maxCollapseTags"
                 ref="tagTooltipRef"
-                :disabled="!collapseTagsTooltip"
+                :disabled="dropdownMenuVisible || !collapseTagsTooltip"
                 :fallback-placements="['bottom', 'top', 'right', 'left']"
                 :effect="effect"
                 placement="bottom"


### PR DESCRIPTION
Be consistent with cascader `collapse-tags-tooltip` behavior

<img width="1522" alt="image" src="https://github.com/element-plus/element-plus/assets/44761321/b4eb9a42-6e58-473a-9a53-a7c3080d5389">

before:

https://github.com/element-plus/element-plus/assets/44761321/e7fa6dee-aa07-4e7d-98e5-5e37e913f80a

after:

https://github.com/element-plus/element-plus/assets/44761321/fc870561-0818-4cd5-b391-26292ab4a460