### PR TITLE
fix(theme-chalk): replace margin with padding

### DIFF
--- a/packages/theme-chalk/src/date-picker/date-picker.scss
+++ b/packages/theme-chalk/src/date-picker/date-picker.scss
@@ -48,7 +48,7 @@
   }
 
   @include e(header) {
-    margin: 12px;
+    padding: 12px 12px 0;
     text-align: center;
 
     @include m(bordered) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### Problem Description:

In the `el-date-picker` component, it was observed that the background of the `el-popover` is being displayed. 

Upon investigation, it was found that the issue is caused by the **collapsing height** due to the margin in `el-date-picker__header`. 

To resolve the collapsing height problem, the previous solution involved adding CSS to trigger the Block Formatting Context (BFC) in `el-date-picker__header`. 

However, it was discovered that this caused a collapsing margin issue with margin-bottom because `el-picker-panel__content` relies on the margin-top value of `el-picker-panel__content` for layout purposes.

### Solution:

Replaced the margin property in `el-date-picker__header` with padding to resolve the collapsing height issue.

### Test Results:
**Before:** 
![image](https://github.com/element-plus/element-plus/assets/121680374/89dc18b8-52be-47da-b4fb-bcc286162e8c)

**After:**
![image](https://github.com/element-plus/element-plus/assets/121680374/e2d5db4b-e018-47a9-bf50-dc7c4c5b288c)

