### PR TITLE
docs(components): [tree-v2] replace mention of filter-node-method attribute with filter-method.

### DIFF
--- a/docs/en-US/component/tree-v2.md
+++ b/docs/en-US/component/tree-v2.md
@@ -61,7 +61,7 @@ tree-v2/custom-node
 
 Tree nodes can be filtered
 
-:::demo Invoke the `filter` method of the Tree instance to filter tree nodes. Its parameter is the filtering keyword. Note that for it to work, `filter-node-method` is required, and its value is the filtering method.
+:::demo Invoke the `filter` method of the Tree instance to filter tree nodes. Its parameter is the filtering keyword. Note that for it to work, `filter-method` is required, and its value is the filtering method.
 
 tree-v2/filter
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [X] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [X] Make sure you are merging your commits to `dev` branch.
- [X] Add some descriptions and refer to relative issues for your PR.

In the docs for `tree-v2`, there is a mention of the `filter-node-method` attribute which does not exist for this component. It is used instead of `filter-method`. This is a leftover from the `tree` component docs where `filter-node-method` is a valid attribute.
