### PR TITLE
test(components): [select-v2]  backspace should not delete disabled tag

### DIFF
--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -1661,4 +1661,45 @@ describe('Select', () => {
     await nextTick()
     expect(selectVm.filteredOptions.length).toBe(3)
   })
+
+  it('backspace key should delete selected tag but should not delete disabled options', async () => {
+    const wrapper = createSelect({
+      data() {
+        return {
+          multiple: true,
+          filterable: true,
+          options: [
+            {
+              value: 'Option1',
+              label: 'option 1',
+              disabled: true,
+            },
+            {
+              value: 'Option2',
+              label: 'option 2',
+              disabled: false,
+            },
+          ],
+          value: ['Option2', 'Option1'],
+        }
+      },
+    })
+    await nextTick()
+    const selectInput = wrapper.find('.el-select__input')
+    expect(wrapper.findAll('.el-tag').length).toBe(2)
+    // after deletion, an el-tag will be deleted
+    await selectInput.trigger('keydown', {
+      code: EVENT_CODE.backspace,
+      key: EVENT_CODE.backspace,
+    })
+    await nextTick()
+    expect(wrapper.findAll('.el-tag').length).toBe(1)
+    await selectInput.trigger('keydown', {
+      code: EVENT_CODE.backspace,
+      key: EVENT_CODE.backspace,
+    })
+    await nextTick()
+    // after deletion, an el-tag still exist
+    expect(wrapper.findAll('.el-tag').length).toBe(1)
+  })
 })


### PR DESCRIPTION
select-v2 behaves consistently with select, supplement with test cases.

The case same as #15551 

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
