### PR TITLE
fix(docs): overlay error caused by sidebar

### DIFF
--- a/docs/.vitepress/vitepress/styles/sidebar.scss
+++ b/docs/.vitepress/vitepress/styles/sidebar.scss
@@ -42,6 +42,7 @@
 
   @include respond-to('md') {
     width: calc(var(--vp-sidebar-width-small));
+    z-index: var(--sidebar-z-index-mobile);
   }
 
   @include respond-to('lg') {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

When at normal width, click to expand the sidebar. Overlay will cover a part of it, but expose the sidebar.
<img width="638" alt="image" src="https://github.com/element-plus/element-plus/assets/103993866/9721a294-b2c9-43bb-b882-9d094de513ad">
But if the sidebar is also covered at certain widths, it should be displayed as usual.
<img width="762" alt="image" src="https://github.com/element-plus/element-plus/assets/103993866/c3c3e271-5a0a-4b4d-affe-3b2a832c4d85">


