### PR TITLE
fix(components): [autocomplete] Query string convert problem (#15723)

### DIFF
--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -244,9 +244,9 @@ const handleFocus = (evt: FocusEvent) => {
   if (!ignoreFocusEvent) {
     activated.value = true
     emit('focus', evt)
-
     if (props.triggerOnFocus && !readonly) {
-      debouncedGetData(String(props.modelValue))
+      const queryString = props.modelValue ?? ''
+      debouncedGetData(String(queryString))
     }
   } else {
     ignoreFocusEvent = false


### PR DESCRIPTION
Closed #15723.When `query string` is null or undefined,use `String()` will tranform it to `'null'` or `'undefined'`.Which is will lead to searching errors.

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
