### PR TITLE
feat(components): [dropdown] icon slot

### DIFF
--- a/docs/en-US/component/dropdown.md
+++ b/docs/en-US/component/dropdown.md
@@ -83,6 +83,16 @@ dropdown/sizes
 
 :::
 
+## dropdown-item icon slot
+
+Use `icon` slot to customize the icon of the dropdown item.
+
+:::demo
+
+dropdown/icon-slot
+
+:::
+
 ## Dropdown Attributes
 
 | Name                 | Description                                                                                                           | Type            | Accepted Values                                          | Default                                                                    |
@@ -145,3 +155,4 @@ dropdown/sizes
 | Name | Description                |
 | ---- | -------------------------- |
 | —    | customize of Dropdown Item |
+| icon | custom icon                |

--- a/docs/examples/dropdown/icon-slot.vue
+++ b/docs/examples/dropdown/icon-slot.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <el-dropdown>
+      <el-button type="primary">
+        Dropdown List <el-icon class="el-icon--right"><arrow-down /></el-icon>
+      </el-button>
+      <template #dropdown>
+        <el-dropdown-menu>
+          <el-dropdown-item>
+            <template #icon>
+              <el-icon>
+                <plus />
+              </el-icon>
+            </template>
+            Action 1
+          </el-dropdown-item>
+        </el-dropdown-menu>
+      </template>
+    </el-dropdown>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ArrowDown, Plus } from '@element-plus/icons-vue'
+</script>

--- a/packages/components/dropdown/__tests__/dropdown.test.ts
+++ b/packages/components/dropdown/__tests__/dropdown.test.ts
@@ -815,4 +815,35 @@ describe('Dropdown', () => {
       expect(document.body.querySelector(selector.value).innerHTML).toBe('')
     })
   })
+
+  test('use icon slot in dropdown item', async () => {
+    const wrapper = _mount(
+      `
+      <el-dropdown>
+        <span class="el-dropdown-link">
+          Dropdown List
+        </span>
+        <template #dropdown>
+          <el-dropdown-menu>
+            <el-dropdown-item>
+              <template #icon>
+                <i class="el-icon-plus"></i>
+              </template>
+              dropdown item
+            </el-dropdown-item>
+          </el-dropdown-menu>
+        </template>
+      </el-dropdown>
+      `,
+      () => ({})
+    )
+    await nextTick()
+
+    // 查找并验证dropdown-item中的自定义icon是否存在
+    const iconElement = wrapper
+      .findComponent({ name: 'DropdownItemImpl' })
+      .find('.el-icon-plus')
+
+    expect(iconElement.exists()).toBe(true)
+  })
 })

--- a/packages/components/dropdown/src/dropdown-item-impl.vue
+++ b/packages/components/dropdown/src/dropdown-item-impl.vue
@@ -19,9 +19,11 @@
     @pointermove="(e) => $emit('pointermove', e)"
     @pointerleave="(e) => $emit('pointerleave', e)"
   >
-    <el-icon v-if="icon">
-      <component :is="icon" />
-    </el-icon>
+    <slot name="icon">
+      <el-icon v-if="icon">
+        <component :is="icon" />
+      </el-icon>
+    </slot>
     <slot />
   </li>
 </template>

--- a/packages/components/dropdown/src/dropdown-item.vue
+++ b/packages/components/dropdown/src/dropdown-item.vue
@@ -10,6 +10,7 @@
         @pointermove="handlePointerMove"
         @clickimpl="handleClick"
       >
+        <slot name="icon" />
         <slot />
       </el-dropdown-item-impl>
     </el-roving-focus-item>


### PR DESCRIPTION
在 `dropdown-item` 中新增一个 `icon` slot， 在使用 `iconify` 图标是动态的，仅仅通过导入图标名称可能达不到预取的效果，因此 `slot` 很方便引入组件