### PR TITLE
fixed(component): [table] Customizing the row height causes the table height to exceed 1px

### DIFF
--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -330,7 +330,7 @@
               position: absolute;
               top: 0px;
               width: 10px;
-              bottom: -1px;
+              bottom: 0px;
               overflow-x: hidden;
               overflow-y: hidden;
               box-shadow: none;


### PR DESCRIPTION
Customizing the row height causes the table height to exceed 1px, and there is always have a y scroll bar

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
