### PR TITLE
fix(components): [upload] drag use before-upload to intercepting files

### DIFF
--- a/packages/components/upload/src/upload-dragger.vue
+++ b/packages/components/upload/src/upload-dragger.vue
@@ -44,35 +44,7 @@ const onDrop = (e: DragEvent) => {
   e.stopPropagation()
 
   const files = Array.from(e.dataTransfer!.files)
-  const accept = uploaderContext.accept.value
-  if (!accept) {
-    emit('file', files)
-    return
-  }
-
-  const filesFiltered = files.filter((file) => {
-    const { type, name } = file
-    const extension = name.includes('.') ? `.${name.split('.').pop()}` : ''
-    const baseType = type.replace(/\/.*$/, '')
-    return accept
-      .split(',')
-      .map((type) => type.trim())
-      .filter((type) => type)
-      .some((acceptedType) => {
-        if (acceptedType.startsWith('.')) {
-          return extension === acceptedType
-        }
-        if (/\/\*$/.test(acceptedType)) {
-          return baseType === acceptedType.replace(/\/\*$/, '')
-        }
-        if (/^[^/]+\/[^/]+$/.test(acceptedType)) {
-          return type === acceptedType
-        }
-        return false
-      })
-  })
-
-  emit('file', filesFiltered)
+  emit('file', files)
 }
 
 const onDragover = () => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix https://github.com/element-plus/element-plus/issues/15740
去除在拖拽上传时通过accept校验, 让拖拽和点击上传保持一致, 通过before-upload进行上传前的校验等操作

![1708242599013](https://github.com/element-plus/element-plus/assets/10903843/6466db8f-3b93-492c-a738-24a23383d904)
