### PR TITLE
fix(components): [drawer] use dynamic zIndex from useDialog hook(#15641)

### DIFF
--- a/packages/components/drawer/src/drawer.vue
+++ b/packages/components/drawer/src/drawer.vue
@@ -128,6 +128,7 @@ const {
   rendered,
   titleId,
   bodyId,
+  zIndex,
   onModalClick,
   onOpenAutoFocus,
   onCloseAutoFocus,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

el-drawer didn't use the `zIndex` from useDialog hook, it causes the el-overlay element has no dynamic `z-index` style, it's a static value.

It's mentioned in #15641, #15660, #15856.