### PR TITLE
fix(components): [time-picker] fix the default time error after 11pm

### DIFF
--- a/packages/components/time-picker/src/time-picker-com/panel-time-range.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-range.vue
@@ -214,6 +214,11 @@ const disabledHours_ = (role: string, compare?: Dayjs) => {
   const isStart = role === 'start'
   const compareDate = compare || (isStart ? endTime.value : startTime.value)
   const compareHour = compareDate.hour()
+  // fix the time-picker show error time between 11:00 to 12:00 pm.
+  if ((isStart && compareHour === 0) || (!isStart && compareHour === 23)) {
+    return union(defaultDisable)
+  }
+
   const nextDisable = isStart
     ? makeSelectRange(compareHour + 1, 23)
     : makeSelectRange(0, compareHour - 1)

--- a/packages/components/time-picker/src/time-picker-com/panel-time-range.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-range.vue
@@ -216,7 +216,7 @@ const disabledHours_ = (role: string, compare?: Dayjs) => {
   const compareHour = compareDate.hour()
   // fix the time-picker show error time between 11:00 to 12:00 pm.
   if ((isStart && compareHour === 0) || (!isStart && compareHour === 23)) {
-    return union(defaultDisable)
+    return union(defaultDisable, [])
   }
 
   const nextDisable = isStart


### PR DESCRIPTION
Close #15708, #15821.

I fixed this by adding some additional logic to the `disabledHour` function,which can fix this edge case.

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.