### PR TITLE
fix(components): [el-table] fix table broken

### DIFF
--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -62,7 +62,8 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
         }
       },
       childrenColumnName.value,
-      lazyColumnIdentifier.value
+      lazyColumnIdentifier.value,
+      lazy.value
     )
     return res
   }

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -299,14 +299,15 @@ export function walkTreeNode(
   root,
   cb,
   childrenKey = 'children',
-  lazyKey = 'hasChildren'
+  lazyKey = 'hasChildren',
+  isLazy = false
 ) {
   const isNil = (array) => !(Array.isArray(array) && array.length)
 
   function _walker(parent, children, level) {
     cb(parent, children, level)
     children.forEach((item) => {
-      if (item[lazyKey]) {
+      if (isLazy && item[lazyKey]) {
         cb(item, null, level + 1)
         return
       }
@@ -318,7 +319,7 @@ export function walkTreeNode(
   }
 
   root.forEach((item) => {
-    if (item[lazyKey]) {
+    if (isLazy && item[lazyKey]) {
       cb(item, null, 0)
       return
     }


### PR DESCRIPTION
fix table broken when `hasChildren` and `children` mixed.

PR related to issues #12656, #8370, and #13213.

Add a new parameter `isLazy` for `walkTreeNode` to determine whether lazy loading is enabled. Default value is `false` (same as the document).

- [X] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [X] Make sure you are merging your commits to `dev` branch.
- [X] Add some descriptions and refer to relative issues for your PR.
