### PR TITLE
Feat: [date-pick] support footer slot

### DIFF
--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -560,6 +560,52 @@ describe('DatePicker', () => {
     expect(!!text).toBeTruthy()
   })
 
+  it('footer slot', async () => {
+    const ParentComponent = {
+      components: {
+        'el-date-picker': DatePicker,
+      },
+      template: `
+        <el-date-picker
+          v-model="value"
+        >
+          <template #footer>
+            <div class="test-component">Test Component Content</div>
+          </template>
+        </el-date-picker>
+      `,
+      data() {
+        return { value: '' }
+      },
+    }
+
+    mount(ParentComponent)
+
+    expect(
+      document.querySelector('.el-picker-panel__footer__slot>.test-component')
+    ).toBeTruthy()
+  })
+
+  it('no footer slot', () => {
+    const ParentComponent = {
+      components: {
+        'el-date-picker': DatePicker,
+      },
+      template: `
+      <el-date-picker
+        v-model="value"
+      />
+    `,
+      data() {
+        return { value: '' }
+      },
+    }
+
+    mount(ParentComponent)
+
+    expect(document.querySelector('.el-picker-panel__footer__slot')).toBeNull()
+  })
+
   describe('value-format', () => {
     it('with literal string', async () => {
       const day = dayjs()

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -159,26 +159,36 @@
         </div>
       </div>
     </div>
-    <div v-show="footerVisible" :class="ppNs.e('footer')">
-      <el-button
-        v-show="selectionMode !== 'dates' && selectionMode !== 'years'"
-        text
-        size="small"
-        :class="ppNs.e('link-btn')"
-        :disabled="disabledNow"
-        @click="changeToNow"
-      >
-        {{ t('el.datepicker.now') }}
-      </el-button>
-      <el-button
-        plain
-        size="small"
-        :class="ppNs.e('link-btn')"
-        :disabled="disabledConfirm"
-        @click="onConfirm"
-      >
-        {{ t('el.datepicker.confirm') }}
-      </el-button>
+    <div
+      v-show="footerVisible || slots.footer"
+      :class="[
+        { [ppNs.e('footer')]: showTime && !slots.footer },
+        { [ppNs.e('footer__slot')]: slots.footer },
+      ]"
+    >
+      <slot name="footer">
+        <template v-if="footerVisible">
+          <el-button
+            v-show="selectionMode !== 'dates' && selectionMode !== 'years'"
+            text
+            size="small"
+            :class="ppNs.e('link-btn')"
+            :disabled="disabledNow"
+            @click="changeToNow"
+          >
+            {{ t('el.datepicker.now') }}
+          </el-button>
+          <el-button
+            plain
+            size="small"
+            :class="ppNs.e('link-btn')"
+            :disabled="disabledConfirm"
+            @click="onConfirm"
+          >
+            {{ t('el.datepicker.confirm') }}
+          </el-button>
+        </template>
+      </slot>
     </div>
   </div>
 </template>

--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -226,31 +226,41 @@
         </div>
       </div>
     </div>
-    <div v-if="showTime" :class="ppNs.e('footer')">
-      <el-button
-        v-if="clearable"
-        text
-        size="small"
-        :class="ppNs.e('link-btn')"
-        @click="handleClear"
-      >
-        {{ t('el.datepicker.clear') }}
-      </el-button>
-      <el-button
-        plain
-        size="small"
-        :class="ppNs.e('link-btn')"
-        :disabled="btnDisabled"
-        @click="handleRangeConfirm(false)"
-      >
-        {{ t('el.datepicker.confirm') }}
-      </el-button>
+    <div
+      v-if="showTime || slots.footer"
+      :class="[
+        { [ppNs.e('footer')]: showTime && !slots.footer },
+        { [ppNs.e('footer__slot')]: slots.footer },
+      ]"
+    >
+      <slot name="footer">
+        <template v-if="showTime">
+          <el-button
+            v-if="clearable"
+            text
+            size="small"
+            :class="ppNs.e('link-btn')"
+            @click="handleClear"
+          >
+            {{ t('el.datepicker.clear') }}
+          </el-button>
+          <el-button
+            plain
+            size="small"
+            :class="ppNs.e('link-btn')"
+            :disabled="btnDisabled"
+            @click="handleRangeConfirm(false)"
+          >
+            {{ t('el.datepicker.confirm') }}
+          </el-button>
+        </template>
+      </slot>
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, ref, toRef, unref } from 'vue'
+import { computed, inject, ref, toRef, unref, useSlots } from 'vue'
 import dayjs from 'dayjs'
 import { ClickOutside as vClickoutside } from '@element-plus/directives'
 import { isArray } from '@element-plus/utils'
@@ -300,6 +310,7 @@ const defaultValue = toRef(pickerBase.props, 'defaultValue')
 const { lang } = useLocale()
 const leftDate = ref<Dayjs>(dayjs().locale(lang.value))
 const rightDate = ref<Dayjs>(dayjs().locale(lang.value).add(1, unit))
+const slots = useSlots()
 
 const {
   minDate,

--- a/packages/components/date-picker/src/date-picker.tsx
+++ b/packages/components/date-picker/src/date-picker.tsx
@@ -81,7 +81,11 @@ export default defineComponent({
         >
           {{
             default: (scopedProps: /**FIXME: remove any type */ any) => (
-              <Component {...scopedProps} />
+              <Component {...scopedProps}>
+                {{
+                  footer: slots.footer ? slots.footer : undefined,
+                }}
+              </Component>
             ),
             'range-separator': slots['range-separator'],
           }}

--- a/packages/theme-chalk/src/date-picker/picker-panel.scss
+++ b/packages/theme-chalk/src/date-picker/picker-panel.scss
@@ -36,6 +36,13 @@
     font-size: 0;
   }
 
+  @include e(footer__slot) {
+    border-top: 1px solid getCssVar('datepicker-inner-border-color');
+    padding: 4px 12px;
+    background-color: getCssVar('bg-color', 'overlay');
+    position: relative;
+  }
+
   @include e(shortcut) {
     display: block;
     width: 100%;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

This feat is to support date-pick’s ability to customize the footer, allowing developers to completely customize the bottom area of the calendar through slots, similar to antd-vue’s date selection component.
这个功能是为了支持 date-pick 能自定义 footer，允许开发人员能通过 slot 的方式完全自定义日历最下方的区域，类似 antd-vue 的日期选择组件。

Two test cases were also written to see whether it meets expectations with or without footer slot.
编写了两个测试用例，关于有无使用 footer slot 的情况下是否符合期望。

how to use:
<img width="558" alt="image" src="https://github.com/element-plus/element-plus/assets/19322584/70b40650-8262-4e06-be0e-7f5c81de6632">

like:
![image](https://github.com/element-plus/element-plus/assets/19322584/cd1698be-0d50-425b-83b7-4eaf595d888b)

thx~

