### PR TITLE
fix(components): [Input] input's row props that are not declared in the typefile and  fix return value Many<T>[] not matching the type of T[]

### DIFF
--- a/packages/components/input/src/input.ts
+++ b/packages/components/input/src/input.ts
@@ -58,13 +58,13 @@ export const inputProps = buildProps({
     type: String,
     default: 'text',
   },
-  // /**
-  //  * @description rows of input
-  //  */
-  // rows: {
-  //   type: Number,
-  //   default: 1,
-  // },
+  /**
+   * @description rows of input
+   */
+  rows: {
+    type: Number,
+    default: 1,
+  },
   /**
    * @description control the resizability
    */

--- a/packages/components/input/src/input.ts
+++ b/packages/components/input/src/input.ts
@@ -58,6 +58,13 @@ export const inputProps = buildProps({
     type: String,
     default: 'text',
   },
+  // /**
+  //  * @description rows of input
+  //  */
+  // rows: {
+  //   type: Number,
+  //   default: 1,
+  // },
   /**
    * @description control the resizability
    */

--- a/packages/utils/arrays.ts
+++ b/packages/utils/arrays.ts
@@ -5,7 +5,7 @@ type Many<T> = T | ReadonlyArray<T>
 /** like `_.castArray`, except falsy value returns empty array. */
 export const castArray = <T>(arr: Many<T>): T[] => {
   if (!arr && (arr as any) !== 0) return []
-  return Array.isArray(arr) ? arr : [arr]
+  return Array.isArray(arr) ? (arr as T[]) : [arr as T]
 }
 
 // TODO: remove import alias


### PR DESCRIPTION
quewtions no1:
![SF1H8_B{8SH9OCLV5I`U84Q](https://github.com/element-plus/element-plus/assets/48849602/70dd0bb5-f270-46ba-bbe3-1cf4866998cf)
question no2:
Explain problem: 不能将类型“(T & any[]) | Many<T>[]”分配给类型“T[]”。 不能将类型“Many<T>[]”分配给类型“T[]”。 不能将类型“Many<T>”分配给类型“T”。 “T”可以使用与“Many<T>”无关的任意类型进行实例化。