### PR TITLE
fix(components): fix iOS select click event listening

### DIFF
--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -3,7 +3,7 @@
     ref="selectRef"
     v-click-outside:[popperRef]="handleClickOutside"
     :class="[nsSelect.b(), nsSelect.m(selectSize)]"
-    @mouseenter="states.inputHovering = true"
+    @[mouseEnterEventName]="states.inputHovering = true"
     @mouseleave="states.inputHovering = false"
     @click.prevent.stop="toggleMenu"
   >

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -28,6 +28,7 @@ import {
   debugWarn,
   isClient,
   isFunction,
+  isIOS,
   isNumber,
   isUndefined,
   scrollIntoView,
@@ -252,6 +253,12 @@ export const useSelect = (props: ISelectProps, emit) => {
       ? _placeholder
       : states.selectedLabel
   })
+
+  // iOS Safari does not handle click events when a mouseenter event is registered and a DOM-change happens in a child
+  // We use a Vue custom event binding to only register the event on non-iOS devices
+  // ref.: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html
+  // Github Issue: https://github.com/vuejs/vue/issues/9859
+  const mouseEnterEventName = computed(() => (isIOS ? null : 'mouseenter'))
 
   watch(
     () => props.modelValue,
@@ -670,6 +677,10 @@ export const useSelect = (props: ISelectProps, emit) => {
   const toggleMenu = () => {
     if (selectDisabled.value) return
 
+    // We only set the inputHovering state to true on mouseenter event on iOS devices
+    // To keep the state updated we set it here to true
+    if (isIOS) states.inputHovering = true
+
     if (states.menuVisibleOnFocus) {
       // controlled by automaticDropdown
       states.menuVisibleOnFocus = false
@@ -814,6 +825,7 @@ export const useSelect = (props: ISelectProps, emit) => {
     hasModelValue,
     shouldShowPlaceholder,
     currentPlaceholder,
+    mouseEnterEventName,
     showClose,
     iconComponent,
     iconReverse,


### PR DESCRIPTION
## Problem / fix
iOS Safari does not handle click events when a mouseenter event is registered and a DOM-change happens in a child.
We use a Vue custom event binding to only register the event on non-iOS devices.

The inputHovering state gets updated now on iOS-devices on click. This is needed as the mouseenter event normally does this.

Apple Developer Documentation: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html
Vue Issue: https://github.com/vuejs/vue/issues/9859


## Here are some test-case recordings
### Before changes
https://github.com/element-plus/element-plus/assets/48283236/c644f302-8764-413b-b975-b2ca758be154

### After changes
https://github.com/element-plus/element-plus/assets/48283236/7f8c5132-9493-49be-833d-5f0db09fc779


closed #5210
