### PR TITLE
fix(components): [input-number] 修改组件监听wheel的方式

### DIFF
--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -54,7 +54,6 @@
       :name="name"
       :label="label"
       :validate-event="false"
-      @wheel="handleWheel"
       @keydown.up.prevent="increase"
       @keydown.down.prevent="decrease"
       @blur="handleBlur"
@@ -65,7 +64,7 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { computed, onMounted, onUpdated, reactive, ref, watch } from 'vue'
+import { computed, onMounted, onUpdated, onUnmounted, reactive, ref, watch } from 'vue'
 import { isNil } from 'lodash-unified'
 import { ElInput } from '@element-plus/components/input'
 import { ElIcon } from '@element-plus/components/icon'
@@ -294,8 +293,8 @@ const setCurrentValueToModelValue = () => {
     data.currentValue = props.modelValue
   }
 }
-const handleWheel = (e: MouseEvent) => {
-  if (document.activeElement === e.target) e.preventDefault()
+const handleWheel = (e: WheelEvent) => {
+  e.preventDefault()
 }
 
 watch(
@@ -336,10 +335,15 @@ onMounted(() => {
     }
     emit(UPDATE_MODEL_EVENT, val!)
   }
+  innerInput.addEventListener('wheel', handleWheel, { passive: false })
 })
 onUpdated(() => {
   const innerInput = input.value?.input
   innerInput?.setAttribute('aria-valuenow', `${data.currentValue ?? ''}`)
+})
+onUnmounted(() => {
+  const innerInput = input.value?.input
+  innerInput?.removeEventListener('wheel', handleWheel)
 })
 defineExpose({
   /** @description get focus the input component */


### PR DESCRIPTION
此次修改是为了消除此组件在加入了@wheel后会在谷歌浏览器控制台中发出警告：Added non-passive event listener to a scroll-blocking '<some>' event. Consider marking event handler as 'passive' to make the page more responsive. 因为使用vue中的@wheel会导致如上警告，如果是@wheel.passive会使e.preventDefault()失效导致鼠标滚轮会修改modelValue的值，所以改为了在组件加载时使用javascript中的addEventListener方法来挂载，并且使用{ passive: false }告诉浏览器此为非被动方式，以此来消除浏览器警告

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
