### PR TITLE
fix(components): [table] fix cell tooltip display error

### DIFF
--- a/packages/components/table/src/table-body/events-helper.ts
+++ b/packages/components/table/src/table-body/events-helper.ts
@@ -134,6 +134,7 @@ function useEvents<T>(props: Partial<TableBodyProps<T>>) {
     let rangeWidth = range.getBoundingClientRect().width
     let rangeHeight = range.getBoundingClientRect().height
     const offsetWidth = rangeWidth - Math.floor(rangeWidth)
+    let {width:cellChildWidth,height:cellChildHeight} = cellChild.getBoundingClientRect()
     if (offsetWidth < 0.001) {
       rangeWidth = Math.floor(rangeWidth)
     }
@@ -146,9 +147,9 @@ function useEvents<T>(props: Partial<TableBodyProps<T>>) {
     const horizontalPadding = left + right
     const verticalPadding = top + bottom
     if (
-      rangeWidth + horizontalPadding > cellChild.offsetWidth ||
-      rangeHeight + verticalPadding > cellChild.offsetHeight ||
-      cellChild.scrollWidth > cellChild.offsetWidth
+      rangeWidth + horizontalPadding > cellChildWidth ||
+      rangeHeight + verticalPadding > cellChildHeight ||
+      cellChild.scrollWidth > cellChildWidth
     ) {
       createTablePopper(
         tooltipOptions,

--- a/packages/components/table/src/table-body/events-helper.ts
+++ b/packages/components/table/src/table-body/events-helper.ts
@@ -134,7 +134,7 @@ function useEvents<T>(props: Partial<TableBodyProps<T>>) {
     let rangeWidth = range.getBoundingClientRect().width
     let rangeHeight = range.getBoundingClientRect().height
     const offsetWidth = rangeWidth - Math.floor(rangeWidth)
-    let {width:cellChildWidth,height:cellChildHeight} = cellChild.getBoundingClientRect()
+    const { width: cellChildWidth, height: cellChildHeight } = cellChild.getBoundingClientRect()
     if (offsetWidth < 0.001) {
       rangeWidth = Math.floor(rangeWidth)
     }

--- a/packages/components/table/src/table-body/events-helper.ts
+++ b/packages/components/table/src/table-body/events-helper.ts
@@ -134,7 +134,8 @@ function useEvents<T>(props: Partial<TableBodyProps<T>>) {
     let rangeWidth = range.getBoundingClientRect().width
     let rangeHeight = range.getBoundingClientRect().height
     const offsetWidth = rangeWidth - Math.floor(rangeWidth)
-    const { width: cellChildWidth, height: cellChildHeight } = cellChild.getBoundingClientRect()
+    const { width: cellChildWidth, height: cellChildHeight } =
+      cellChild.getBoundingClientRect()
     if (offsetWidth < 0.001) {
       rangeWidth = Math.floor(rangeWidth)
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ x] Make sure you are merging your commits to `dev` branch.
- [ x] Add some descriptions and refer to relative issues for your PR.

fix #15004

修复trigger 到 table cell 的触发方式，原来的代码中 cellChild 的计算方式是通过 offsetWidth 和 offsetHeight(render前的元素)，但是在后面根据条件触发是用 getComputeStyle 和 getBoundingClientRect 这个api(render后的元素)和render前的cellChild进行比较 。这会导致下面链接呈现的情况

- https://codesandbox.io/p/sandbox/element-plus-vue3-yzcky9?file=%2Fsrc%2FApp.vue%3A13%2C23   (设置了show-overflow-tooltip的情况下，在数据量不多的时候,例如hover链接里面的N，仍然能够触发tooltip)

solution: 用 getBoundingClientRect 替代 offsetwidth/height




