### PR TITLE
chore: remove redundant code

### DIFF
--- a/packages/components/select-v2/src/token.ts
+++ b/packages/components/select-v2/src/token.ts
@@ -7,7 +7,7 @@ export interface SelectV2Context {
   props: ExtractPropTypes<typeof SelectProps>
   expanded: boolean
   tooltipRef: Ref<TooltipInstance>
-  onSelect: (option: Option, index: number, byClick?: boolean) => void
+  onSelect: (option: Option) => void
   onHover: (idx: number) => void
   onKeyboardNavigate: (direction: 'forward' | 'backward') => void
   onKeyboardSelect: () => void

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -78,7 +78,6 @@ const useSelect = (props: ISelectV2Props, emit) => {
   })
 
   // data refs
-  const selectedIndex = ref(-1)
   const popperSize = ref(-1)
 
   // DOM & Component refs
@@ -518,7 +517,6 @@ const useSelect = (props: ISelectV2Props, emit) => {
         states.inputValue = ''
       }
     } else {
-      selectedIndex.value = idx
       states.selectedLabel = getLabel(option)
       update(getValue(option))
       expanded.value = false

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -489,7 +489,7 @@ const useSelect = (props: ISelectV2Props, emit) => {
     tagTooltipRef.value?.updatePopper?.()
   }
 
-  const onSelect = (option: Option, idx: number) => {
+  const onSelect = (option: Option) => {
     if (props.multiple) {
       let selectedOptions = (props.modelValue as any[]).slice()
 
@@ -659,10 +659,7 @@ const useSelect = (props: ISelectV2Props, emit) => {
       ~states.hoveringIndex &&
       filteredOptions.value[states.hoveringIndex]
     ) {
-      onSelect(
-        filteredOptions.value[states.hoveringIndex],
-        states.hoveringIndex
-      )
+      onSelect(filteredOptions.value[states.hoveringIndex])
     }
   }
 


### PR DESCRIPTION
![image](https://github.com/element-plus/element-plus/assets/93767616/5192f213-ddfd-4924-965a-da1fbbd263d5)
As the variable `selectedIndex` only appears in the two lines, it should be redundant.