### PR TITLE
fix(components): [table] summary-method return now understands HTML string.

### DIFF
--- a/packages/components/table/src/table-footer/index.ts
+++ b/packages/components/table/src/table-footer/index.ts
@@ -115,8 +115,8 @@ export default defineComponent({
                   'div',
                   {
                     class: ['cell', column.labelClassName],
+                    innerHTML: sums[cellIndex],
                   },
-                  [sums[cellIndex]]
                 ),
               ]
             )

--- a/packages/components/table/src/table-footer/index.ts
+++ b/packages/components/table/src/table-footer/index.ts
@@ -111,13 +111,10 @@ export default defineComponent({
                 style: getCellStyles(column, cellIndex),
               },
               [
-                h(
-                  'div',
-                  {
-                    class: ['cell', column.labelClassName],
-                    innerHTML: sums[cellIndex],
-                  },
-                ),
+                h('div', {
+                  class: ['cell', column.labelClassName],
+                  innerHTML: sums[cellIndex],
+                }),
               ]
             )
           ),


### PR DESCRIPTION
summary-method return now understands HTML string.

I needed to add HTML markup to the table footer cells, but the method summary didn't match the HTML markup in the row. With this modification it is possible
