### PR TITLE
docs(components): [table-v2] fix dynamic-height examples error

### DIFF
--- a/docs/examples/table-v2/dynamic-height.vue
+++ b/docs/examples/table-v2/dynamic-height.vue
@@ -34,7 +34,7 @@ const textList = [shortText, midText, longText]
 let id = 0
 
 const dataGenerator = () => ({
-  id: `random:${++id}`,
+  id: `random-${++id}`,
   name: 'Tom',
   date: '2016-05-03',
   description: textList[Math.floor(Math.random() * 3)],


### PR DESCRIPTION
-  `querySelectorAll`  not support `:`, before > after, about https://github.com/element-plus/element-plus/issues/16622

![screenshots](https://github.com/element-plus/element-plus/assets/45450994/986c7ac4-c7ec-403d-aa94-862d5472ba3b)
