### PR TITLE
docs: delete select-option attributes-value:object

### DIFF
--- a/docs/en-US/component/select.md
+++ b/docs/en-US/component/select.md
@@ -281,11 +281,11 @@ select/empty-values
 
 ### Option Attributes
 
-| Name     | Description                                 | Type                                           | Default |
-|----------|---------------------------------------------|------------------------------------------------|---------|
-| value    | value of option                             | ^[string] / ^[number] / ^[boolean] / ^[object] | —       |
-| label    | label of option, same as `value` if omitted | ^[string] / ^[number]                          | —       |
-| disabled | whether option is disabled                  | ^[boolean]                                     | false   |
+| Name     | Description                                 | Type                                 | Default |
+|----------|---------------------------------------------|--------------------------------------|---------|
+| value    | value of option                             | ^[string] / ^[number] / ^[boolean]   | —       |
+| label    | label of option, same as `value` if omitted | ^[string] / ^[number]                | —       |
+| disabled | whether option is disabled                  | ^[boolean]                           | false   |
 
 ### Option Slots
 


### PR DESCRIPTION
el-select-option value not support `object` . about https://github.com/element-plus/element-plus/issues/16642
