### PR TITLE
docs: change some examples label to aria-label

### DIFF
--- a/docs/examples/date-picker/date-range.vue
+++ b/docs/examples/date-picker/date-range.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-radio-group v-model="size" label="size control">
+  <el-radio-group v-model="size" aria-label="size control">
     <el-radio-button value="large">large</el-radio-button>
     <el-radio-button value="default">default</el-radio-button>
     <el-radio-button value="small">small</el-radio-button>

--- a/docs/examples/date-picker/enter-date.vue
+++ b/docs/examples/date-picker/enter-date.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-radio-group v-model="size" label="size control">
+  <el-radio-group v-model="size" aria-label="size control">
     <el-radio-button value="large">large</el-radio-button>
     <el-radio-button value="default">default</el-radio-button>
     <el-radio-button value="small">small</el-radio-button>

--- a/docs/examples/form/accessibility.vue
+++ b/docs/examples/form/accessibility.vue
@@ -21,14 +21,14 @@
           <el-col :span="12">
             <el-input
               v-model="formAccessibility.firstName"
-              label="First Name"
+              aria-label="First Name"
               placeholder="First Name"
             />
           </el-col>
           <el-col :span="12">
             <el-input
               v-model="formAccessibility.lastName"
-              label="Last Name"
+              aria-label="Last Name"
               placeholder="Last Name"
             />
           </el-col>

--- a/docs/examples/form/alignment.vue
+++ b/docs/examples/form/alignment.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-radio-group v-model="labelPosition" label="label position">
+  <el-radio-group v-model="labelPosition" aria-label="label position">
     <el-radio-button value="left">Left</el-radio-button>
     <el-radio-button value="right">Right</el-radio-button>
     <el-radio-button value="top">Top</el-radio-button>

--- a/docs/examples/form/size-control.vue
+++ b/docs/examples/form/size-control.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <el-radio-group v-model="size" label="size control">
+    <el-radio-group v-model="size" aria-label="size control">
       <el-radio-button value="large">large</el-radio-button>
       <el-radio-button value="default">default</el-radio-button>
       <el-radio-button value="small">small</el-radio-button>
     </el-radio-group>
-    <el-radio-group v-model="labelPosition" label="position control">
+    <el-radio-group v-model="labelPosition" aria-label="position control">
       <el-radio-button value="left">Left</el-radio-button>
       <el-radio-button value="right">Right</el-radio-button>
       <el-radio-button value="top">Top</el-radio-button>
@@ -46,7 +46,7 @@
       <el-col :span="11">
         <el-time-picker
           v-model="sizeForm.date2"
-          label="Pick a time"
+          aria-label="Pick a time"
           placeholder="Pick a time"
           style="width: 100%"
         />

--- a/docs/examples/form/validation.vue
+++ b/docs/examples/form/validation.vue
@@ -44,7 +44,7 @@
         <el-form-item prop="date2">
           <el-time-picker
             v-model="ruleForm.date2"
-            label="Pick a time"
+            aria-label="Pick a time"
             placeholder="Pick a time"
             style="width: 100%"
           />


### PR DESCRIPTION
Should these be changed to new ones or deleted directly? I think this is an implicit attribute, and many users are still using versions before 2.7.2.

这些应该改成新的还是直接删除，我认为这是个隐式的属性，并且很多用户还在使用 2.7.2之前的版本.

https://github.com/element-plus/element-plus/pull/16598

cc: @kooriookami