### PR TITLE
chore(dev): add unocss and delete vite vscode config

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
     "vue.volar",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "antfu.vite",
+    "antfu.unocss",
     "lokalise.i18n-ally"
   ]
 }


### PR DESCRIPTION
This project uses unocss, but vite vscode plugin is of no use.