### PR TITLE
fix(components): [input] unify `async-validator` string length calc

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,9 @@
         "react",
         "react-dom"
       ]
+    },
+    "patchedDependencies": {
+      "async-validator@4.2.5": "patches/async-validator@4.2.5.patch"
     }
   },
   "lint-staged": {

--- a/patches/async-validator@4.2.5.patch
+++ b/patches/async-validator@4.2.5.patch
@@ -1,0 +1,28 @@
+diff --git a/dist-node/index.js b/dist-node/index.js
+index 563b966fe2b4dce9583c6d90ceb996215c1104bc..f81c89359f4566b7a1e7b6228227fc858e026670 100644
+--- a/dist-node/index.js
++++ b/dist-node/index.js
+@@ -564,7 +564,8 @@ var range = function range(rule, value, source, errors, options) {
+ 
+   if (str) {
+     // 处理码点大于U+010000的文字length属性不准确的bug，如"𠮷𠮷𠮷".lenght !== 3
+-    val = value.replace(spRegexp, '_').length;
++    // val = value.replace(spRegexp, '_').length;
++    val = value.length;
+   }
+ 
+   if (len) {
+diff --git a/dist-web/index.js b/dist-web/index.js
+index 3bdcb3926b75854c4a9203281400376aa7ea246b..4c4e10a409d007280e6991a0021c6874e9e2a1c3 100644
+--- a/dist-web/index.js
++++ b/dist-web/index.js
+@@ -560,7 +560,8 @@ var range = function range(rule, value, source, errors, options) {
+ 
+   if (str) {
+     // 处理码点大于U+010000的文字length属性不准确的bug，如"𠮷𠮷𠮷".lenght !== 3
+-    val = value.replace(spRegexp, '_').length;
++    // val = value.replace(spRegexp, '_').length;
++    val = value.length;
+   }
+ 
+   if (len) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  async-validator@4.2.5:
+    hash: wdmp4xlpil2odxo3rasjmxbdfm
+    path: patches/async-validator@4.2.5.patch
+
 importers:
 
   .:
@@ -52,7 +57,7 @@ importers:
         version: 9.1.0(vue@3.2.37)
       async-validator:
         specifier: ^4.2.5
-        version: 4.2.5
+        version: 4.2.5(patch_hash=wdmp4xlpil2odxo3rasjmxbdfm)
       dayjs:
         specifier: ^1.11.3
         version: 1.11.3
@@ -566,7 +571,7 @@ importers:
         version: 9.1.0(vue@3.2.37)
       async-validator:
         specifier: ^4.2.5
-        version: 4.2.5
+        version: 4.2.5(patch_hash=wdmp4xlpil2odxo3rasjmxbdfm)
       dayjs:
         specifier: ^1.11.3
         version: 1.11.3
@@ -5804,9 +5809,10 @@ packages:
       async-done: 1.3.2
     dev: false
 
-  /async-validator@4.2.5:
+  /async-validator@4.2.5(patch_hash=wdmp4xlpil2odxo3rasjmxbdfm):
     resolution: {integrity: sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==}
     dev: false
+    patched: true
 
   /async@3.2.5:
     resolution: {integrity: sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==}
@@ -7263,7 +7269,7 @@ packages:
       '@types/lodash': 4.14.184
       '@types/lodash-es': 4.17.6
       '@vueuse/core': 9.1.0(vue@3.2.37)
-      async-validator: 4.2.5
+      async-validator: 4.2.5(patch_hash=wdmp4xlpil2odxo3rasjmxbdfm)
       dayjs: 1.11.5
       escape-html: 1.0.3
       lodash: 4.17.21


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fix #16756

The internal string length calculation method of `async-validator` is inconsistent with input. In order to keep the results consistent, the calculation methods of the two are unified.

Since `async-validator` has not been updated for two years, the fastest, most efficient and controllable way is to generate patch file modifications, so I made this modification.