### PR TITLE
fix(components): [popper] remove unnecessary conditional judgment

### DIFF
--- a/packages/components/popper/src/content.vue
+++ b/packages/components/popper/src/content.vue
@@ -93,10 +93,7 @@ provide(POPPER_CONTENT_INJECTION_KEY, {
   arrowOffset,
 })
 
-if (
-  formItemContext &&
-  (formItemContext.addInputId || formItemContext.removeInputId)
-) {
+if (formItemContext) {
   // disallow auto-id from inside popper content
   provide(formItemContextKey, {
     ...formItemContext,


### PR DESCRIPTION
`()=> void` always `true`
about: https://github.com/element-plus/element-plus/pull/7790/files

![20240511173740](https://github.com/warmthsea/element-plus/assets/45450994/7b2c8b26-ae7e-498e-b9b4-1fb6c4e8b44d)
