### PR TITLE
docs: add guide for on-demand import with Rspack

### DIFF
--- a/docs/en-US/guide/quickstart.md
+++ b/docs/en-US/guide/quickstart.md
@@ -121,7 +121,7 @@ module.exports = {
 }
 ```
 
-For more bundlers ([Rollup](https://rollupjs.org/), [Vue CLI](https://cli.vuejs.org/), [Rsbuild](https://rsbuild.dev/)) and configs please reference [unplugin-vue-components](https://github.com/antfu/unplugin-vue-components#installation) and [unplugin-auto-import](https://github.com/antfu/unplugin-auto-import#install).
+For more bundlers ([Rollup](https://rollupjs.org/), [Vue CLI](https://cli.vuejs.org/)) and configs please reference [unplugin-vue-components](https://github.com/antfu/unplugin-vue-components#installation) and [unplugin-auto-import](https://github.com/antfu/unplugin-auto-import#install).
 
 #### Nuxt
 

--- a/docs/en-US/guide/quickstart.md
+++ b/docs/en-US/guide/quickstart.md
@@ -52,7 +52,7 @@ First you need to install `unplugin-vue-components` and `unplugin-auto-import`.
 npm install -D unplugin-vue-components unplugin-auto-import
 ```
 
-Then add the code below into your `Vite` or `Webpack` config file.
+Then add the code below into your `Vite`, `Webpack` or `Rspack` config file.
 
 ##### Vite
 
@@ -98,7 +98,30 @@ module.exports = {
 }
 ```
 
-For more bundlers ([Rollup](https://rollupjs.org/), [Vue CLI](https://cli.vuejs.org/)) and configs please reference [unplugin-vue-components](https://github.com/antfu/unplugin-vue-components#installation) and [unplugin-auto-import](https://github.com/antfu/unplugin-auto-import#install).
+##### Rspack
+
+Example of how to register these plugins in [Rspack](https://rspack.dev/):
+
+```js
+// rspack.config.js
+const AutoImport = require('unplugin-auto-import/rspack')
+const Components = require('unplugin-vue-components/rspack')
+const { ElementPlusResolver } = require('unplugin-vue-components/resolvers')
+
+module.exports = {
+  // ...
+  plugins: [
+    AutoImport({
+      resolvers: [ElementPlusResolver()],
+    }),
+    Components({
+      resolvers: [ElementPlusResolver()],
+    }),
+  ],
+}
+```
+
+For more bundlers ([Rollup](https://rollupjs.org/), [Vue CLI](https://cli.vuejs.org/), [Rsbuild](https://rsbuild.dev/)) and configs please reference [unplugin-vue-components](https://github.com/antfu/unplugin-vue-components#installation) and [unplugin-auto-import](https://github.com/antfu/unplugin-auto-import#install).
 
 #### Nuxt
 


### PR DESCRIPTION
The unplugin also supports Rspack.

This PR adds Rspack config example to the documentation to help users use Element Plus in Rspack projects.

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
