### PR TITLE
chore: change @element-plus/build-constants to workspace

### DIFF
--- a/internal/build/package.json
+++ b/internal/build/package.json
@@ -15,7 +15,7 @@
     "vue": "^3.2.25"
   },
   "dependencies": {
-    "@element-plus/build-constants": "^0.0.1",
+    "@element-plus/build-constants": "workspace:*",
     "@pnpm/find-workspace-packages": "^4.0.16",
     "@pnpm/logger": "^4.0.0",
     "@rollup/plugin-commonjs": "^22.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,7 +347,7 @@ importers:
   internal/build:
     dependencies:
       '@element-plus/build-constants':
-        specifier: ^0.0.1
+        specifier: workspace:*
         version: link:../build-constants
       '@pnpm/find-workspace-packages':
         specifier: ^4.0.16
@@ -15060,6 +15060,7 @@ packages:
 
   /workbox-google-analytics@6.6.0:
     resolution: {integrity: sha512-p4DJa6OldXWd6M9zRl0H6vB9lkrmqYFkRQ2xEiNdBFp9U0LhsGO7hsBscVEyH9H2/3eZZt8c97NB2FD9U2NJ+Q==}
+    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
     dependencies:
       workbox-background-sync: 6.6.0
       workbox-core: 6.6.0


### PR DESCRIPTION
This problem occurred when I installed dependencies on different branches.

about: https://github.com/element-plus/element-plus/pull/16794

![1715587559801](https://github.com/element-plus/element-plus/assets/45450994/d48d665d-20fb-4e04-9a89-c1d0154a42ee)
![image](https://github.com/element-plus/element-plus/assets/45450994/795be5ca-b702-4c6f-b386-e68585254832)
![image](https://github.com/element-plus/element-plus/assets/45450994/42aca31f-fe65-4848-b937-c459bb17941d)

