### PR TITLE
fix(components): [tabs] lssues(#16835)

### DIFF
--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -155,7 +155,12 @@ const Tabs = defineComponent({
       const newButton =
         props.editable || props.addable ? (
           <span
-            class={ns.e('new-tab')}
+            class={[
+              ns.e('new-tab'),
+              ns.e(
+                props.tabPosition == 'left' ? 'new-tab-left' : 'new-tab-right'
+              ),
+            ]}
             tabindex="0"
             onClick={handleTabAdd}
             onKeydown={(ev: KeyboardEvent) => {

--- a/packages/theme-chalk/src/tabs.scss
+++ b/packages/theme-chalk/src/tabs.scss
@@ -26,7 +26,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    float: right;
     border: 1px solid getCssVar('border-color');
     height: 20px;
     width: 20px;
@@ -52,6 +51,12 @@
     &:hover {
       color: getCssVar('color-primary');
     }
+  }
+  @include e(new-tab-left) {
+    float: left;
+  }
+  @include e(new-tab-right) {
+    float: right;
   }
   @include e(nav-wrap) {
     overflow: hidden;


### PR DESCRIPTION
[Component] [tabs] when addable is enabled and tab-position is set to left, the position of the add icon is wrong. #16835