### PR TITLE
fix(components): [form] not use status-icon and use slot icon style error

### DIFF
--- a/packages/components/image/__tests__/image.test.tsx
+++ b/packages/components/image/__tests__/image.test.tsx
@@ -44,7 +44,6 @@ describe('Image.vue', () => {
     await doubleWait()
     expect(wrapper.find('.el-image__inner').exists()).toBe(true)
     expect(wrapper.find('img').exists()).toBe(true)
-    await nextTick()
     expect(wrapper.find('.el-image__placeholder').exists()).toBe(false)
     expect(wrapper.find('.el-image__error').exists()).toBe(false)
   })

--- a/packages/components/image/__tests__/image.test.tsx
+++ b/packages/components/image/__tests__/image.test.tsx
@@ -44,6 +44,7 @@ describe('Image.vue', () => {
     await doubleWait()
     expect(wrapper.find('.el-image__inner').exists()).toBe(true)
     expect(wrapper.find('img').exists()).toBe(true)
+    await nextTick()
     expect(wrapper.find('.el-image__placeholder').exists()).toBe(false)
     expect(wrapper.find('.el-image__error').exists()).toBe(false)
   })

--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -117,7 +117,7 @@ $form-item-label-top-margin-bottom: map.merge(
   }
 
   .#{$namespace}-input__validateIcon {
-    display: none !important;
+    display: none;
   }
 
   @each $size in (large, default, small) {
@@ -230,6 +230,10 @@ $form-item-label-top-margin-bottom: map.merge(
     .#{$namespace}-input-group__prepend {
       .#{$namespace}-input__wrapper {
         box-shadow: 0 0 0 1px transparent inset;
+      }
+
+      .#{$namespace}-input__validateIcon {
+        display: none;
       }
     }
     .#{$namespace}-input__validateIcon {

--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -117,7 +117,7 @@ $form-item-label-top-margin-bottom: map.merge(
   }
 
   .#{$namespace}-input__validateIcon {
-    display: none;
+    display: none !important;
   }
 
   @each $size in (large, default, small) {


### PR DESCRIPTION
fix: https://github.com/element-plus/element-plus/issues/16846

## Before:
### use status-icon
![screenshots](https://github.com/element-plus/element-plus/assets/45450994/fd7a4d10-29b6-4c81-9d70-723db37af2a1)
### not use status-icon
![screenshots](https://github.com/element-plus/element-plus/assets/45450994/264f12db-8ca5-410e-aca5-1326b55ab894)


## After:
### use status-icon
![screenshots](https://github.com/element-plus/element-plus/assets/45450994/8e0ad854-bd0f-4116-b942-8296dbd26d43)
### not use status-icon
![screenshots](https://github.com/element-plus/element-plus/assets/45450994/9b158d9a-c5f2-49b2-973a-210258787cba)

