### PR TITLE
fix(components): [color-picker]

### DIFF
--- a/packages/components/color-picker/src/color-picker.ts
+++ b/packages/components/color-picker/src/color-picker.ts
@@ -86,6 +86,7 @@ export type ColorPickerInstance = InstanceType<typeof ColorPicker>
 
 export interface ColorPickerContext {
   currentColor: ComputedRef<string>
+  showAlpha: boolean
 }
 
 export const colorPickerContextKey: InjectionKey<ColorPickerContext> = Symbol(

--- a/packages/components/color-picker/src/color-picker.vue
+++ b/packages/components/color-picker/src/color-picker.vue
@@ -415,6 +415,7 @@ watch(
 
 provide(colorPickerContextKey, {
   currentColor,
+  showAlpha: props.showAlpha,
 })
 
 defineExpose({

--- a/packages/components/color-picker/src/components/predefine.vue
+++ b/packages/components/color-picker/src/components/predefine.vue
@@ -38,7 +38,7 @@ export default defineComponent({
   },
   setup(props) {
     const ns = useNamespace('color-predefine')
-    const { currentColor } = inject(colorPickerContextKey)!
+    const { currentColor, showAlpha } = inject(colorPickerContextKey)!
 
     const rgbaColors = ref(parseColors(props.colors, props.color)) as Ref<
       Color[]
@@ -68,7 +68,7 @@ export default defineComponent({
       return colors.map((value) => {
         const c = new Color()
         c.enableAlpha = true
-        c.format = 'rgba'
+        c.format = showAlpha ? 'rgba' : 'rgb'
         c.fromString(value)
         c.selected = c.value === color.value
         return c

--- a/packages/components/color-picker/src/utils/color.ts
+++ b/packages/components/color-picker/src/utils/color.ts
@@ -357,6 +357,11 @@ export default class Color {
           )}`
           break
         }
+        case 'rgb': {
+          const { r, g, b } = hsv2rgb(_hue, _saturation, _value)
+          this.value = `rgb(${r}, ${g}, ${b})`
+          break
+        }
         default: {
           const { r, g, b } = hsv2rgb(_hue, _saturation, _value)
           this.value = `rgba(${r}, ${g}, ${b}, ${this.get('alpha') / 100})`


### PR DESCRIPTION
color-picker在使用“预定义颜色”功能时，设置show-alpha=false，会使预定义颜色框没有“被选中状态”

open #17014

修改前：
不设置show-alpha，不能联动

https://github.com/element-plus/element-plus/assets/25985156/59752d50-370e-44eb-b35c-66226d162716



修改后
不设置show-alpha，可以联动。


https://github.com/element-plus/element-plus/assets/25985156/5ee75b8b-7ff4-4137-a139-8c15f5a2d20c

