### PR TITLE
fix(components): [skeleton] `throttle` property not working

### DIFF
--- a/packages/components/skeleton/src/skeleton.vue
+++ b/packages/components/skeleton/src/skeleton.vue
@@ -2,7 +2,7 @@
   <template v-if="uiLoading">
     <div :class="[ns.b(), ns.is('animated', animated)]" v-bind="$attrs">
       <template v-for="i in count" :key="i">
-        <slot v-if="loading" :key="i" name="template">
+        <slot v-if="uiLoading" :key="i" name="template">
           <el-skeleton-item :class="ns.is('first')" variant="p" />
           <el-skeleton-item
             v-for="item in rows"

--- a/packages/hooks/use-throttle-render/index.ts
+++ b/packages/hooks/use-throttle-render/index.ts
@@ -4,7 +4,7 @@ import type { Ref } from 'vue'
 
 export const useThrottleRender = (loading: Ref<boolean>, throttle = 0) => {
   if (throttle === 0) return loading
-  const throttled = ref(false)
+  const throttled = ref(loading.value)
   let timeoutHandle = 0
 
   const dispatchThrottling = () => {
@@ -15,16 +15,11 @@ export const useThrottleRender = (loading: Ref<boolean>, throttle = 0) => {
       throttled.value = loading.value
     }, throttle)
   }
-  onMounted(dispatchThrottling)
 
   watch(
     () => loading.value,
-    (val) => {
-      if (val) {
-        dispatchThrottling()
-      } else {
-        throttled.value = val
-      }
+    () => {
+      dispatchThrottling()
     }
   )
   return throttled

--- a/packages/hooks/use-throttle-render/index.ts
+++ b/packages/hooks/use-throttle-render/index.ts
@@ -1,4 +1,4 @@
-import { onMounted, ref, watch } from 'vue'
+import { ref, watch } from 'vue'
 
 import type { Ref } from 'vue'
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix bug #4804 

Additional Information: This PR fixes the issue where the skeleton screen flashes when the throttled property is set and the loading changes quickly.

