### PR TITLE
style(components): [table] th text can be selected

### DIFF
--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -217,7 +217,6 @@
   }
 
   th.#{$namespace}-table__cell {
-    user-select: none;
     background-color: getCssVar('table-header-bg-color');
 
     > .cell.highlight {


### PR DESCRIPTION
### motive:

Inconvenient to use

### reference:
- [Tailwindcss Table](https://tailwindcss.com/docs/border-collapse)

| UI Library | Select `th` text |
|-------|-------|
| [Material-ui](https://mui.com/material-ui/react-table/) |  ✅   |
| [AntDesign](https://ant.design/components/table-cn) | ✅ |
| [Vuestic](https://ui.vuestic.dev/ui-elements/table) | ✅ |
| [NuxtUI](https://ui.nuxt.com/components/table) | ✅  |
| [Primevue](https://primevue.org/datatable/) | ✅  |
| [ArcoDesign](https://arco.design/react/components/table) | ✅  |
| [Shadcn UI](https://ui.shadcn.com/examples/tasks) | ✅  |
| [Vuetifyjs](https://vuetifyjs.com/zh-Hans/components/data-tables/data-and-display/#item-value) | ❌(Default contains sort) |
| [Naiveui](https://www.naiveui.com/en-US/os-theme/components/data-table#border.vue) | ✅  |
| [Element UI](https://element.eleme.io/#/en-US/component/table) | ❌  |
| [Element Plus](https://element-plus.org/en-US/component/table.html) | ❌  |



