### PR TITLE
Revert "docs: add guide for on-demand import with Rspack"

### DIFF
--- a/docs/en-US/guide/quickstart.md
+++ b/docs/en-US/guide/quickstart.md
@@ -52,7 +52,7 @@ First you need to install `unplugin-vue-components` and `unplugin-auto-import`.
 npm install -D unplugin-vue-components unplugin-auto-import
 ```
 
-Then add the code below into your `Vite`, `Webpack` or `Rspack` config file.
+Then add the code below into your `Vite` or `Webpack` config file.
 
 ##### Vite
 
@@ -83,29 +83,6 @@ export default defineConfig({
 // webpack.config.js
 const AutoImport = require('unplugin-auto-import/webpack')
 const Components = require('unplugin-vue-components/webpack')
-const { ElementPlusResolver } = require('unplugin-vue-components/resolvers')
-
-module.exports = {
-  // ...
-  plugins: [
-    AutoImport({
-      resolvers: [ElementPlusResolver()],
-    }),
-    Components({
-      resolvers: [ElementPlusResolver()],
-    }),
-  ],
-}
-```
-
-##### Rspack
-
-Example of how to register these plugins in [Rspack](https://rspack.dev/):
-
-```js
-// rspack.config.js
-const AutoImport = require('unplugin-auto-import/rspack')
-const Components = require('unplugin-vue-components/rspack')
 const { ElementPlusResolver } = require('unplugin-vue-components/resolvers')
 
 module.exports = {


### PR DESCRIPTION
Reverts element-plus/element-plus#16841

It will be better to focus on Vite and Webpack in the docs and leave the rest to our users to explore.