### PR TITLE
feat(components): [image] add empty value contral

### DIFF
--- a/packages/components/image/__tests__/image.test.tsx
+++ b/packages/components/image/__tests__/image.test.tsx
@@ -62,24 +62,6 @@ describe('Image.vue', () => {
     expect(wrapper.find('.el-image__error').exists()).toBe(true)
   })
 
-  // js user null No error message
-  test('image value is null error test', async () => {
-    const wrapper = mount(
-      <Image
-        src={null}
-        v-slots={{
-          error: () => 'error text',
-        }}
-      />
-    )
-
-    await doubleWait()
-    wrapper.emitted('error') && expect(wrapper.emitted('error')).toBeDefined()
-    expect(wrapper.find('.el-image__inner').exists()).toBe(false)
-    expect(wrapper.find('img').exists()).toBe(false)
-    expect(wrapper.text()).toContain('error text')
-  })
-
   test('image load sequence success test', async () => {
     const wrapper = mount(Image, {
       props: {

--- a/packages/components/image/__tests__/image.test.tsx
+++ b/packages/components/image/__tests__/image.test.tsx
@@ -62,6 +62,24 @@ describe('Image.vue', () => {
     expect(wrapper.find('.el-image__error').exists()).toBe(true)
   })
 
+  // js user null No error message
+  test('image value is null error test', async () => {
+    const wrapper = mount(
+      <Image
+        src={null}
+        v-slots={{
+          error: () => 'error text',
+        }}
+      />
+    )
+
+    await doubleWait()
+    wrapper.emitted('error') && expect(wrapper.emitted('error')).toBeDefined()
+    expect(wrapper.find('.el-image__inner').exists()).toBe(false)
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.text()).toContain('error text')
+  })
+
   test('image load sequence success test', async () => {
     const wrapper = mount(Image, {
       props: {

--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -135,8 +135,8 @@ const loadImage = () => {
 
   // reset status
   isLoading.value = true
-  hasLoadError.value = false
-  imageSrc.value = props.src
+  hasLoadError.value = !props.src
+  imageSrc.value = props.src || undefined
 }
 
 function handleLoad(event: Event) {

--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -5,6 +5,7 @@
     </slot>
     <template v-else>
       <img
+        v-if="imageSrc !== undefined"
         v-bind="attrs"
         :src="imageSrc"
         :loading="loading"
@@ -83,7 +84,7 @@ const ns = useNamespace('image')
 const rawAttrs = useRawAttrs()
 const attrs = useAttrs()
 
-const imageSrc = ref('')
+const imageSrc = ref<string | undefined>()
 const hasLoadError = ref(false)
 const isLoading = ref(true)
 const showViewer = ref(false)

--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -139,7 +139,9 @@ const loadImage = () => {
   hasLoadError.value = false
 
   isEmpty.value = !props.src
-  imageSrc.value = props.src
+  if (props.src) {
+    imageSrc.value = props.src
+  }
 }
 
 function handleLoad(event: Event) {

--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -5,7 +5,6 @@
     </slot>
     <template v-else>
       <img
-        v-if="imageSrc !== undefined"
         v-bind="attrs"
         :src="imageSrc"
         :loading="loading"
@@ -84,7 +83,7 @@ const ns = useNamespace('image')
 const rawAttrs = useRawAttrs()
 const attrs = useAttrs()
 
-const imageSrc = ref<string | undefined>()
+const imageSrc = ref('')
 const hasLoadError = ref(false)
 const isLoading = ref(true)
 const showViewer = ref(false)
@@ -135,8 +134,8 @@ const loadImage = () => {
 
   // reset status
   isLoading.value = true
-  hasLoadError.value = !props.src
-  imageSrc.value = props.src || undefined
+  hasLoadError.value = false
+  imageSrc.value = props.src === null ? '' : props.src
 }
 
 function handleLoad(event: Event) {

--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="container" :class="[ns.b(), $attrs.class]" :style="containerStyle">
-    <slot v-if="hasLoadError" name="error">
+    <slot v-if="hasLoadError || isEmpty" name="error">
       <div :class="ns.e('error')">{{ t('el.image.error') }}</div>
     </slot>
     <template v-else>
@@ -85,6 +85,7 @@ const rawAttrs = useRawAttrs()
 const attrs = useAttrs()
 
 const imageSrc = ref<string | undefined>()
+const isEmpty = ref(false)
 const hasLoadError = ref(false)
 const isLoading = ref(true)
 const showViewer = ref(false)
@@ -136,7 +137,9 @@ const loadImage = () => {
   // reset status
   isLoading.value = true
   hasLoadError.value = false
-  imageSrc.value = props.src === null ? '' : props.src
+
+  isEmpty.value = !props.src
+  imageSrc.value = props.src
 }
 
 function handleLoad(event: Event) {


### PR DESCRIPTION
closed https://github.com/element-plus/element-plus/issues/17059, I think this problem should be fixed, even if `img` value is `null` not trigger `@error`


TS user:

![image](https://github.com/element-plus/element-plus/assets/45450994/bce3a3ed-912d-43b8-acda-91a6aab72f88)

JS user null No error message.

<hr />

If src value is `null` `undefined`,  control the value of slot display, `hasLoadError.value` directly `true`.

before:

![image](https://github.com/element-plus/element-plus/assets/45450994/77e18e70-8b42-4331-99ab-55b66d1659de)


after:

![image](https://github.com/element-plus/element-plus/assets/45450994/3a8eaddd-52b8-4349-9904-4911025ca15d)

<hr />

😥 The newly written test case runs without errors in the old code, but the user is actually wrong.

``` vitest
test('image value is null error test', async () => {
    const src = ref(null)
    const wrapper = mount({
      setup() {
        return () => (
          <Image v-model={src.value}>{{ error: () => 'fallback' }}</Image>
        )
      },
    })
    await doubleWait()
    wrapper.emitted('error') && expect(wrapper.emitted('error')).toBeDefined()
    expect(wrapper.find('.el-image__inner').exists()).toBe(false)
    expect(wrapper.find('img').exists()).toBe(false)
    expect(wrapper.text()).toBe('fallback')
})

```

| Tew Test | Test Results | But should |
|-------|-------|-------|
| edit before |  ✅😰    | ❌↘️    |
| edit after   |  ✅    | ✅   |


before:

![image](https://github.com/element-plus/element-plus/assets/45450994/37ac4131-4be2-40f0-b436-0e38f4b5748f)

