### PR TITLE
only ts in script tag not tsx

### DIFF
--- a/docs/examples/table-v2/cell-templating.vue
+++ b/docs/examples/table-v2/cell-templating.vue
@@ -8,7 +8,7 @@
   />
 </template>
 
-<script lang="tsx" setup>
+<script lang="ts" setup>
 import { ref } from 'vue'
 import dayjs from 'dayjs'
 import {


### PR DESCRIPTION
Element Plus Playground only lang="ts" is supported for <script> blocks.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
