### PR TITLE
fix(components): [dialog] hide the scroll bar when draggable

### DIFF
--- a/packages/components/dialog/__tests__/dialog.test.tsx
+++ b/packages/components/dialog/__tests__/dialog.test.tsx
@@ -306,6 +306,9 @@ describe('Dialog.vue', () => {
       await rAF()
       await nextTick()
       expect(wrapper.find('.is-draggable').exists()).toBe(true)
+
+      const container = wrapper.find<HTMLElement>('.el-overlay-dialog').element
+      expect(container.style.overflow).toBe('hidden')
     })
   })
 

--- a/packages/components/dialog/src/use-dialog.ts
+++ b/packages/components/dialog/src/use-dialog.ts
@@ -61,6 +61,9 @@ export const useDialog = (
     if (props.alignCenter) {
       return { display: 'flex' }
     }
+    if (props.draggable) {
+      return { overflow: 'hidden' }
+    }
     return {}
   })
 


### PR DESCRIPTION
fixed: https://github.com/element-plus/element-plus/issues/17094

### Before:

![image](https://github.com/element-plus/element-plus/assets/45450994/fcbaeab2-3621-4a37-a97a-6ed04445d03d)


### After:

![image](https://github.com/element-plus/element-plus/assets/45450994/f964bc47-647a-4d8c-9150-a4abbdc255a1)
