### PR TITLE
docs(examples): [table] column width shows full

### DIFF
--- a/docs/examples/table/fixed-column-and-group-header.vue
+++ b/docs/examples/table/fixed-column-and-group-header.vue
@@ -1,12 +1,12 @@
 <template>
   <el-table :data="tableData" style="width: 100%" height="250">
-    <el-table-column prop="date" label="Date" width="150" />
-    <el-table-column prop="name" label="Name" width="150" />
-    <el-table-column prop="zip" label="Zip" width="150" />
+    <el-table-column prop="date" label="Date" />
+    <el-table-column prop="name" label="Name" />
+    <el-table-column prop="zip" label="Zip" />
     <el-table-column label="Address Info" fixed="right">
-      <el-table-column prop="state" label="State" width="100" />
-      <el-table-column prop="city" label="City" width="120" />
-      <el-table-column prop="address" label="Address" width="250" />
+      <el-table-column prop="state" label="State" />
+      <el-table-column prop="city" label="City" />
+      <el-table-column prop="address" label="Address" min-width="200" />
     </el-table-column>
   </el-table>
 </template>

--- a/docs/examples/table/fixed-column-and-header.vue
+++ b/docs/examples/table/fixed-column-and-header.vue
@@ -5,7 +5,7 @@
     <el-table-column prop="state" label="State" width="120" />
     <el-table-column prop="city" label="City" width="320" />
     <el-table-column prop="address" label="Address" width="600" />
-    <el-table-column prop="zip" label="Zip" width="120" />
+    <el-table-column prop="zip" label="Zip" />
   </el-table>
 </template>
 

--- a/docs/examples/table/fixed-column.vue
+++ b/docs/examples/table/fixed-column.vue
@@ -6,7 +6,7 @@
     <el-table-column prop="city" label="City" width="120" />
     <el-table-column prop="address" label="Address" width="600" />
     <el-table-column prop="zip" label="Zip" width="120" />
-    <el-table-column fixed="right" label="Operations" width="120">
+    <el-table-column fixed="right" label="Operations" min-width="120">
       <template #default>
         <el-button link type="primary" size="small" @click="handleClick">
           Detail

--- a/docs/examples/table/fixed-header-with-fluid-header.vue
+++ b/docs/examples/table/fixed-header-with-fluid-header.vue
@@ -6,7 +6,7 @@
     <el-table-column prop="city" label="City" width="120" />
     <el-table-column prop="address" label="Address" width="600" />
     <el-table-column prop="zip" label="Zip" width="120" />
-    <el-table-column fixed="right" label="Operations" width="120">
+    <el-table-column fixed="right" label="Operations" min-width="120">
       <template #default="scope">
         <el-button
           link


### PR DESCRIPTION
fixed: https://github.com/element-plus/element-plus/issues/17110

## Beford:

![image](https://github.com/element-plus/element-plus/assets/45450994/c7e5bd36-0afc-4bc5-b4d7-fb232f714ef4)

## After:

![image](https://github.com/element-plus/element-plus/assets/45450994/c04c4fb2-5e77-4df7-82c0-55864c878b7a)


## The original effect remains normal

![image](https://github.com/element-plus/element-plus/assets/45450994/0d51cd8a-dfd1-44ac-b01d-a000d5e7422f)
