### PR TITLE
style(components): prevent Dialog width from over the screen

### DIFF
--- a/packages/theme-chalk/src/dialog.scss
+++ b/packages/theme-chalk/src/dialog.scss
@@ -17,6 +17,7 @@
   box-sizing: border-box;
   padding: getCssVar('dialog', 'padding-primary');
   width: var(#{getCssVarName('dialog-width')}, 50%);
+  max-width: 100vw;
   overflow-wrap: break-word;
 
   &:focus {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

---

When the screen width is smaller than the width of the Dialog (common in mobile phones), the Dialog will exceed the screen, causing the close button in the upper right corner and the action button in the lower right corner to be not directly visible.
I added the max-width: 100vw; property to prevent the Dialog width from exceeding the viewport width.
