### PR TITLE
chore(vscode): set `md` defaultFormatter to prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,9 @@
     "json",
     "jsonc"
   ],
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "vite.devCommand": "pnpm run dev -- --",
   "i18n-ally.localesPaths": "packages/locale/lang",
   "i18n-ally.enabledParsers": ["ts"],


### PR DESCRIPTION
about: https://github.com/element-plus/element-plus/pull/16364

After setting, other contents do not need to be changed, because the original style is to use `prettier`.


![screenshots](https://github.com/element-plus/element-plus/assets/45450994/603c05df-c3c4-494e-9d63-302e60201e99)
