### PR TITLE
fix(components): [autocomplete] clicking inside closes popup (#17171)

### DIFF
--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -351,7 +351,10 @@ const highlight = (index: number) => {
 }
 
 onClickOutside(listboxRef, () => {
-  suggestionVisible.value && close()
+  if (suggestionVisible.value && !popperRef.value?.isFocusInsideContent()) {
+    ignoreFocusEvent = false
+    close()
+  }
 })
 
 onMounted(() => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Fixes https://github.com/element-plus/element-plus/issues/17171

**TLDR**
1. In Element Vue2 it was possible to put custom elements like buttons with custom click handlers inside autocomplete items and prevent the popup from closing on click (using @click.stop on the custom element)
2. In Element Vue3 clicking such a button automatically closes the popup which is not always the desired behavior
3. This fix brings the control of the click behaviour back and aligns the behaviour with that of Element Vue2 version

**What was the fix:**

1. Inside of the `onClickOutside` there is now additional check to see if the click was inside of the popper popup. If so ignore the click
2. Additionally if the "click outside" is confirmed, it resets the `ignoreFocusEvent` and set's it to `false` to ensure popup opens as need when input is clicked the next time. 
    - Test case here: user clicks the input to open a popup -> user clicks the custom button inside of the popup that doesn't result in the popup closure (ignoreFocusEvent is true here) -> user clicks outside of the popup to close it (ignoreFocusEvent is reset) -> user clicks the input and the popup opens as needed