### PR TITLE
fix(docs): [image] fix `placeholder` demo

### DIFF
--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -72,6 +72,9 @@ export default defineConfig(async ({ mode }) => {
       VueMacros({
         setupComponent: false,
         setupSFC: false,
+        hoistStatic: {
+          exclude: ['./**/*.vue'],
+        },
         plugins: {
           vueJsx: vueJsx(),
         },


### PR DESCRIPTION
In lower version of `Vue Macros`, there is a bug in `hoistStatic` feature that causes the issue.

Before: 
![image](https://github.com/element-plus/element-plus/assets/93767616/d675d080-6741-41d9-9e7c-d66805557d36)

After:
![image](https://github.com/element-plus/element-plus/assets/93767616/132580c9-b133-470e-9714-c223b31072e8)


