### PR TITLE
fix(components): [date-picker] clear button repeatedly triggers `update:model-value`

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -681,10 +681,7 @@ const handleClear = () => {
   rightDate.value = leftDate.value.add(1, 'month')
   maxDate.value = undefined
   minDate.value = undefined
-
-  if (props.type === 'datetimerange') {
-    emit('pick', null)
-  }
+  emit('pick', null)
 }
 
 const formatToString = (value: Dayjs | Dayjs[]) => {

--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -681,7 +681,10 @@ const handleClear = () => {
   rightDate.value = leftDate.value.add(1, 'month')
   maxDate.value = undefined
   minDate.value = undefined
-  emit('pick', null)
+
+  if (props.type === 'datetimerange') {
+    emit('pick', null)
+  }
 }
 
 const formatToString = (value: Dayjs | Dayjs[]) => {

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -508,11 +508,16 @@ const onClearIconClick = (event: MouseEvent) => {
   if (showClose.value) {
     event.stopPropagation()
     focusOnInputBox()
-    emitInput(valueOnClear.value)
+    // When the handleClear Function was provided, emit null will be executed inside it
+    // There is no need for us to execute emit null twice. #14752
+    if (pickerOptions.value.handleClear) {
+      pickerOptions.value.handleClear()
+    } else {
+      emitInput(valueOnClear.value)
+    }
     emitChange(valueOnClear.value, true)
     showClose.value = false
     pickerVisible.value = false
-    pickerOptions.value.handleClear && pickerOptions.value.handleClear()
   }
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [X] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [X] Make sure you are merging your commits to `dev` branch.
- [X] Add some descriptions and refer to relative issues for your PR.

## Description
Component: date-picker
type: daterange

In most case (except when type is datetimerange), when click clear icon, there has a repeat operation(emit('pick', null)).


In picker.vue, function onClickIconClick do that;
In panel-date-range.vue, function handleClear do that again.

So we see when we click clear icon, @update:model-value will trigger twice.
The emit('pick', null) in function handleClear only be need when type is datetimerange, so I add a type contition for that.


## Related Issue
Fixes https://github.com/element-plus/element-plus/issues/14752

## Explanation of Changes
Component: date-picker
type: daterange

In most case (except when type is datetimerange), when click clear icon, there has a repeat operation(emit('pick', null)).


In picker.vue, function onClickIconClick do that;
In panel-date-range.vue, function handleClear do that again.

So we see when we click clear icon, @update:model-value will trigger twice.
The emit('pick', null) in function handleClear only be need when type is datetimerange, so I add a type contition for that.
