### PR TITLE
fix(components): [time-picker] fix click outside, mishandles handleOpen

### DIFF
--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -417,7 +417,6 @@ const handleBlurInput = (e?: FocusEvent) => {
           }).length === 0
         ) {
           handleChange()
-          pickerVisible.value = false
           emit('blur', e)
           props.validateEvent &&
             formItem?.validate('blur').catch((err) => debugWarn(err))


### PR DESCRIPTION
修复 time-picker 通过点击空白处确认修改时 handleOpen 执行时机问题
Fixes: https://github.com/element-plus/element-plus/issues/17237

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

修复前：
![bef](https://github.com/element-plus/element-plus/assets/81006731/1c83836d-8aa7-49c4-beaf-ece227001958)


修复后：
![aft](https://github.com/element-plus/element-plus/assets/81006731/10ed6048-b2fa-480d-b9e4-28b67fe207ca)

