### PR TITLE
refactor(components): [statistics] Allows props.value to be a string.

### DIFF
--- a/docs/en-US/component/statistic.md
+++ b/docs/en-US/component/statistic.md
@@ -40,8 +40,8 @@ statistic/card
 ### Statistic Attributes
 
 | Attribute         | Description                    | Type                                                                | Default |
-| ----------------- | ------------------------------ | ------------------------------------------------------------------- | ------- |
-| value             | Numerical content              | ^[number]                                                           | 0       |
+| ----------------- |--------------------------------|---------------------------------------------------------------------| ------- |
+| value             | Basic content                  | ^[number] / ^[string] / ^[DayJs]                                    | 0       |
 | decimal-separator | Setting the decimal point      | ^[string]                                                           | .       |
 | formatter         | Custom numerical presentation  | ^[Function]`(value: number) => string \| number`                    | —       |
 | group-separator   | Sets the thousandth identifier | ^[string]                                                           | ,       |

--- a/packages/components/statistic/src/statistic.ts
+++ b/packages/components/statistic/src/statistic.ts
@@ -34,7 +34,7 @@ export const statisticProps = buildProps({
    * @description Numerical content
    */
   value: {
-    type: definePropType<number | Dayjs>([Number, Object]),
+    type: definePropType<number | string | Dayjs>([Number, String, Object]),
     default: 0,
   },
   /**

--- a/packages/components/statistic/src/statistic.vue
+++ b/packages/components/statistic/src/statistic.vue
@@ -39,9 +39,9 @@ const displayValue = computed(() => {
   const { value, formatter, precision, decimalSeparator, groupSeparator } =
     props
 
-  if (isFunction(formatter)) return formatter(value)
-
   if (!isNumber(value)) return value
+
+  if (isFunction(formatter)) return formatter(value)
 
   let [integer, decimal = ''] = String(value).split('.')
   decimal = decimal


### PR DESCRIPTION
refactor(components): [statistics] Allows props.value to be a string. Formatter will format only number. Docs now cover string and DayJs as valid props.
Actually, even before this changes, component worked with strings pretty fine, but Vue shows annoying warnings.
Also in docs allowed only number, but in code "DayJs" also allowed, so i made some changes here too.