### PR TITLE
docs: add single closed tag tip for using CDN in `HTML`

### DIFF
--- a/docs/en-US/guide/installation.md
+++ b/docs/en-US/guide/installation.md
@@ -89,12 +89,13 @@ on the link address, so as not to be affected by incompatible updates when Eleme
 is upgraded in the future. Please check [unpkg.com](https://unpkg.com) for
 the method to lock the version.
 
-When directly quoting in an HTML file, due to the limitations of native HTML parsing behavior, please use a complete end tag, [reference](https://vuejs.org/guide/essentials/component-basics.html#in-dom-template-parsing-caveats)
+Due to the limitations of native HTML parsing behavior, single-closed tags may cause some exceptions, so please use double-closed tags, [reference](https://vuejs.org/guide/essentials/component-basics.html#in-dom-template-parsing-caveats)
 
-```
+```html
+<!-- examples -->
 <el-table>
-    <el-table-column></el-table-column>
-    <el-table-column></el-table-column>
+  <el-table-column></el-table-column>
+  <el-table-column></el-table-column>
 </el-table>
 ```
 

--- a/docs/en-US/guide/installation.md
+++ b/docs/en-US/guide/installation.md
@@ -89,6 +89,15 @@ on the link address, so as not to be affected by incompatible updates when Eleme
 is upgraded in the future. Please check [unpkg.com](https://unpkg.com) for
 the method to lock the version.
 
+When directly quoting in an HTML file, due to the limitations of native HTML parsing behavior, please use a complete end tag, [reference](https://vuejs.org/guide/essentials/component-basics.html#in-dom-template-parsing-caveats)
+
+```
+<el-table>
+    <el-table-column></el-table-column>
+    <el-table-column></el-table-column>
+</el-table>
+```
+
 :::
 
 ## Hello World


### PR DESCRIPTION
https://github.com/element-plus/element-plus/issues/17083
https://github.com/element-plus/element-plus/issues?q=is%3Aissue+cdn+table



![image](https://github.com/element-plus/element-plus/assets/45450994/4fda042c-1397-48d2-91b9-f43465e4e467)

Although `el-table` has a record (new issues still appear dozens of times), other components using single closing tags also have this problem, so I think it is better to add a reminder here.

### Add

![image](https://github.com/element-plus/element-plus/assets/45450994/2ba38d50-7969-4486-afa0-436893e91718)
