### PR TITLE
fix(hooks): cannot access 'useEmptyValuesProps' before initialization

### DIFF
--- a/packages/components/config-provider/src/hooks/use-global-config.ts
+++ b/packages/components/config-provider/src/hooks/use-global-config.ts
@@ -4,6 +4,7 @@ import {
   SIZE_INJECTION_KEY,
   defaultInitialZIndex,
   defaultNamespace,
+  emptyValuesContextKey,
   localeContextKey,
   namespaceContextKey,
   useLocale,
@@ -110,6 +111,14 @@ export const provideGlobalConfig = (
   provideFn(SIZE_INJECTION_KEY, {
     size: computed(() => context.value.size || ''),
   })
+
+  provideFn(
+    emptyValuesContextKey,
+    computed(() => ({
+      emptyValues: context.value.emptyValues,
+      valueOnClear: context.value.valueOnClear,
+    }))
+  )
 
   if (global || !globalConfig.value) {
     globalConfig.value = context.value

--- a/packages/hooks/use-empty-values/index.ts
+++ b/packages/hooks/use-empty-values/index.ts
@@ -1,9 +1,12 @@
-import { computed, ref } from 'vue'
-import { useGlobalConfig } from '@element-plus/components/config-provider'
+import { computed, getCurrentInstance, inject, ref } from 'vue'
 import { buildProps, debugWarn, isFunction } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, InjectionKey, Ref } from 'vue'
 
+type EmptyValuesContext = ExtractPropTypes<typeof useEmptyValuesProps>
+
+export const emptyValuesContextKey: InjectionKey<Ref<EmptyValuesContext>> =
+  Symbol('emptyValuesContextKey')
 export const SCOPE = 'use-empty-values'
 export const DEFAULT_EMPTY_VALUES = ['', undefined, null]
 export const DEFAULT_VALUE_ON_CLEAR = undefined
@@ -24,13 +27,12 @@ export const useEmptyValuesProps = buildProps({
 } as const)
 
 export const useEmptyValues = (
-  props: ExtractPropTypes<typeof useEmptyValuesProps>,
+  props: EmptyValuesContext,
   defaultValue?: null | undefined
 ) => {
-  let config = useGlobalConfig()
-  if (!config.value) {
-    config = ref({})
-  }
+  const config = getCurrentInstance()
+    ? inject(emptyValuesContextKey, ref<EmptyValuesContext>({}))
+    : ref<EmptyValuesContext>({})
 
   const emptyValues = computed(
     () => props.emptyValues || config.value.emptyValues || DEFAULT_EMPTY_VALUES


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


[fix #107](https://github.com/element-plus/element-plus-nuxt/issues/107)

The two files referenced each other, which caused the problem

```
config-provider-props.ts:30 Uncaught 
ReferenceError: Cannot access 'useEmptyValuesProps' before initialization
    at config-provider-props.ts:30:6
```
