### PR TITLE
fix(components): [color-picker/tree-v2] build error typechecking fails with error TS2300

### DIFF
--- a/packages/components/color-picker/src/color-picker.ts
+++ b/packages/components/color-picker/src/color-picker.ts
@@ -76,8 +76,8 @@ export const colorPickerEmits = {
   [UPDATE_MODEL_EVENT]: (val: string | null) => isString(val) || isNil(val),
   [CHANGE_EVENT]: (val: string | null) => isString(val) || isNil(val),
   activeChange: (val: string | null) => isString(val) || isNil(val),
-  focus: (event: FocusEvent) => event instanceof FocusEvent,
-  blur: (event: FocusEvent) => event instanceof FocusEvent,
+  focus: (evt: FocusEvent) => evt instanceof FocusEvent,
+  blur: (evt: FocusEvent) => evt instanceof FocusEvent,
 }
 
 export type ColorPickerProps = ExtractPropTypes<typeof colorPickerProps>

--- a/packages/components/tree-v2/src/virtual-tree.ts
+++ b/packages/components/tree-v2/src/virtual-tree.ts
@@ -184,8 +184,8 @@ export const treeEmits = {
     data && checkedInfo,
   [NODE_CHECK_CHANGE]: (data: TreeNodeData, checked: boolean) =>
     data && typeof checked === 'boolean',
-  [NODE_CONTEXTMENU]: (event: Event, data: TreeNodeData, node: TreeNode) =>
-    event && data && node,
+  [NODE_CONTEXTMENU]: (evt: Event, data: TreeNodeData, node: TreeNode) =>
+    evt && data && node,
 }
 
 export const treeNodeEmits = {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix: #17513, fix: #13177 

after the build, an error occurs in color-picker and tree-v2 due to the use of the same parameter name: error TS2300: Duplicate identifier 'event'.

![image](https://github.com/user-attachments/assets/1eeecce8-86c3-4612-a27d-f13d60376e0a)

rename one of the parameters in the method to evt to prevent the error by ensuring the parameter names are different.

![image](https://github.com/user-attachments/assets/ef8125e9-5e2f-4054-a4b2-394654408acd)
![image](https://github.com/user-attachments/assets/9e5edd43-1d15-4427-9186-f43a391656a8)
