### PR TITLE
fix: sass declaration deprecation error

### DIFF
--- a/packages/theme-chalk/src/button-group.scss
+++ b/packages/theme-chalk/src/button-group.scss
@@ -5,9 +5,9 @@
 @use 'mixins/utils' as *;
 
 @include b(button-group) {
-  @include utils-clearfix;
   display: inline-block;
   vertical-align: middle;
+  @include utils-clearfix;
 
   & > .#{$namespace}-button {
     float: left;

--- a/packages/theme-chalk/src/button.scss
+++ b/packages/theme-chalk/src/button.scss
@@ -72,12 +72,14 @@ $button-icon-span-gap: map.merge(
     margin-left: 12px;
   }
 
-  @include button-size(
-    map.get($button-padding-vertical, 'default') - $button-border-width,
-    map.get($button-padding-horizontal, 'default') - $button-border-width,
-    map.get($button-font-size, 'default'),
-    map.get($button-border-radius, 'default')
-  );
+  & {
+    @include button-size(
+      map.get($button-padding-vertical, 'default') - $button-border-width,
+      map.get($button-padding-horizontal, 'default') - $button-border-width,
+      map.get($button-font-size, 'default'),
+      map.get($button-border-radius, 'default')
+    );
+  }
 
   &::-moz-focus-inner {
     border: 0;
@@ -284,12 +286,14 @@ $button-icon-span-gap: map.merge(
         }
       }
 
-      @include button-size(
-        map.get($button-padding-vertical, $size) - $button-border-width,
-        map.get($button-padding-horizontal, $size) - $button-border-width,
-        map.get($button-font-size, $size),
-        map.get($button-border-radius, $size)
-      );
+      & {
+        @include button-size(
+          map.get($button-padding-vertical, $size) - $button-border-width,
+          map.get($button-padding-horizontal, $size) - $button-border-width,
+          map.get($button-font-size, $size),
+          map.get($button-border-radius, $size)
+        );
+      }
 
       @include when(circle) {
         width: getCssVar('button', 'size');

--- a/packages/theme-chalk/src/col.scss
+++ b/packages/theme-chalk/src/col.scss
@@ -15,11 +15,11 @@
 @for $i from 0 through 24 {
   .#{$namespace}-col-#{$i} {
     display: if($i == 0, none, block);
+    max-width: (math.div(1, 24) * $i * 100) * 1%;
+    flex: 0 0 (math.div(1, 24) * $i * 100) * 1%;
     @include when(guttered) {
       display: if($i == 0, none, block);
     }
-    max-width: (math.div(1, 24) * $i * 100) * 1%;
-    flex: 0 0 (math.div(1, 24) * $i * 100) * 1%;
   }
 
   .#{$namespace}-col-offset-#{$i} {

--- a/packages/theme-chalk/src/input-number.scss
+++ b/packages/theme-chalk/src/input-number.scss
@@ -19,13 +19,13 @@
     &__inner {
       -webkit-appearance: none;
       -moz-appearance: textfield;
+      text-align: center;
+      line-height: 1;
       &::-webkit-inner-spin-button,
       &::-webkit-outer-spin-button {
         margin: 0;
         -webkit-appearance: none;
       }
-      text-align: center;
-      line-height: 1;
     }
   }
 

--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -60,7 +60,9 @@
   box-sizing: border-box;
 
   @include m(vertical) {
-    &:not(.#{$namespace}-menu--collapse):not(.#{$namespace}-menu--popup-container) {
+    &:not(.#{$namespace}-menu--collapse):not(
+        .#{$namespace}-menu--popup-container
+      ) {
       & .#{$namespace}-menu-item,
       & .#{$namespace}-sub-menu__title,
       & .#{$namespace}-menu-item-group__title {
@@ -80,16 +82,15 @@
   }
 
   @include m(horizontal) {
-    // reset menu-item popup height
-    &.#{$namespace}-menu--popup-container {
-      height: unset;
-    }
-
     display: flex;
     flex-wrap: nowrap;
     border-right: none;
 
     height: getCssVar('menu-horizontal-height');
+    // reset menu-item popup height
+    &.#{$namespace}-menu--popup-container {
+      height: unset;
+    }
 
     &.#{$namespace}-menu {
       border-bottom: solid 1px getCssVar('menu-border-color');

--- a/packages/theme-chalk/src/mixins/_col.scss
+++ b/packages/theme-chalk/src/mixins/_col.scss
@@ -8,11 +8,11 @@
     @for $i from 0 through 24 {
       .#{$namespace}-col-#{$size}-#{$i} {
         display: if($i == 0, none, block);
+        max-width: (math.div(1, 24) * $i * 100) * 1%;
+        flex: 0 0 (math.div(1, 24) * $i * 100) * 1%;
         @include when(guttered) {
           display: if($i == 0, none, block);
         }
-        max-width: (math.div(1, 24) * $i * 100) * 1%;
-        flex: 0 0 (math.div(1, 24) * $i * 100) * 1%;
       }
 
       .#{$namespace}-col-#{$size}-offset-#{$i} {

--- a/packages/theme-chalk/src/mixins/_var.scss
+++ b/packages/theme-chalk/src/mixins/_var.scss
@@ -9,7 +9,6 @@
 // @include set-css-var-value(('color', 'primary'), red);
 // --el-color-primary: red;
 @mixin set-css-var-value($name, $value) {
-
   // Due to https://sass-lang.com/documentation/breaking-changes/mixed-decls/
   & {
     #{joinVarName($name)}: #{$value};
@@ -28,23 +27,25 @@
   @include set-css-var-value(('color', $type), map.get($colors, $type, 'base'));
 
   @each $i in (3, 5, 7, 8, 9) {
-    @include set-css-var-value(('color', $type, 'light', $i),
-      map.get($colors, $type, 'light-#{$i}'));
+    @include set-css-var-value(
+      ('color', $type, 'light', $i),
+      map.get($colors, $type, 'light-#{$i}')
+    );
   }
 
-  @include set-css-var-value(('color', $type, 'dark-2'),
-    map.get($colors, $type, 'dark-2'));
+  @include set-css-var-value(
+    ('color', $type, 'dark-2'),
+    map.get($colors, $type, 'dark-2')
+  );
 }
 
 // set all css var for component by map
 @mixin set-component-css-var($name, $variables) {
   @each $attribute, $value in $variables {
     & {
-      @if $attribute =='default' {
+      @if $attribute == 'default' {
         #{getCssVarName($name)}: #{$value};
-      }
-
-      @else {
+      } @else {
         #{getCssVarName($name, $attribute)}: #{$value};
       }
     }
@@ -53,11 +54,12 @@
 
 @mixin set-css-color-rgb($type) {
   $color: map.get($colors, $type, 'base');
-  @include set-css-var-value(('color', $type, 'rgb'),
+  @include set-css-var-value(
+    ('color', $type, 'rgb'),
     #{red($color),
- green($color),
-    blue($color)
-  });
+    green($color),
+    blue($color)}
+  );
 }
 
 // generate css var from existing css var
@@ -65,7 +67,6 @@
 // @include css-var-from-global(('button', 'text-color'), ('color', $type))
 // --el-button-text-color: var(--el-color-#{$type});
 @mixin css-var-from-global($var, $gVar) {
-
   // Due to https://sass-lang.com/documentation/breaking-changes/mixed-decls/
   & {
     $varName: joinVarName($var);

--- a/packages/theme-chalk/src/mixins/_var.scss
+++ b/packages/theme-chalk/src/mixins/_var.scss
@@ -9,18 +9,13 @@
 // @include set-css-var-value(('color', 'primary'), red);
 // --el-color-primary: red;
 @mixin set-css-var-value($name, $value) {
-  // Due to https://sass-lang.com/documentation/breaking-changes/mixed-decls/
-  & {
-    #{joinVarName($name)}: #{$value};
-  }
+  #{joinVarName($name)}: #{$value};
 }
 
 // @include set-css-var-type('color', 'primary', $map);
 // --el-color-primary: #{map.get($map, 'primary')};
 @mixin set-css-var-type($name, $type, $variables) {
-  & {
-    #{getCssVarName($name, $type)}: #{map.get($variables, $type)};
-  }
+  #{getCssVarName($name, $type)}: #{map.get($variables, $type)};
 }
 
 @mixin set-css-color-type($colors, $type) {
@@ -42,12 +37,10 @@
 // set all css var for component by map
 @mixin set-component-css-var($name, $variables) {
   @each $attribute, $value in $variables {
-    & {
-      @if $attribute == 'default' {
-        #{getCssVarName($name)}: #{$value};
-      } @else {
-        #{getCssVarName($name, $attribute)}: #{$value};
-      }
+    @if $attribute == 'default' {
+      #{getCssVarName($name)}: #{$value};
+    } @else {
+      #{getCssVarName($name, $attribute)}: #{$value};
     }
   }
 }
@@ -67,10 +60,7 @@
 // @include css-var-from-global(('button', 'text-color'), ('color', $type))
 // --el-button-text-color: var(--el-color-#{$type});
 @mixin css-var-from-global($var, $gVar) {
-  // Due to https://sass-lang.com/documentation/breaking-changes/mixed-decls/
-  & {
-    $varName: joinVarName($var);
-    $gVarName: joinVarName($gVar);
-    #{$varName}: var(#{$gVarName});
-  }
+  $varName: joinVarName($var);
+  $gVarName: joinVarName($gVar);
+  #{$varName}: var(#{$gVarName});
 }

--- a/packages/theme-chalk/src/mixins/_var.scss
+++ b/packages/theme-chalk/src/mixins/_var.scss
@@ -9,50 +9,55 @@
 // @include set-css-var-value(('color', 'primary'), red);
 // --el-color-primary: red;
 @mixin set-css-var-value($name, $value) {
-  #{joinVarName($name)}: #{$value};
+
+  // Due to https://sass-lang.com/documentation/breaking-changes/mixed-decls/
+  & {
+    #{joinVarName($name)}: #{$value};
+  }
 }
 
 // @include set-css-var-type('color', 'primary', $map);
 // --el-color-primary: #{map.get($map, 'primary')};
 @mixin set-css-var-type($name, $type, $variables) {
-  #{getCssVarName($name, $type)}: #{map.get($variables, $type)};
+  & {
+    #{getCssVarName($name, $type)}: #{map.get($variables, $type)};
+  }
 }
 
 @mixin set-css-color-type($colors, $type) {
   @include set-css-var-value(('color', $type), map.get($colors, $type, 'base'));
 
   @each $i in (3, 5, 7, 8, 9) {
-    @include set-css-var-value(
-      ('color', $type, 'light', $i),
-      map.get($colors, $type, 'light-#{$i}')
-    );
+    @include set-css-var-value(('color', $type, 'light', $i),
+      map.get($colors, $type, 'light-#{$i}'));
   }
 
-  @include set-css-var-value(
-    ('color', $type, 'dark-2'),
-    map.get($colors, $type, 'dark-2')
-  );
+  @include set-css-var-value(('color', $type, 'dark-2'),
+    map.get($colors, $type, 'dark-2'));
 }
 
 // set all css var for component by map
 @mixin set-component-css-var($name, $variables) {
   @each $attribute, $value in $variables {
-    @if $attribute == 'default' {
-      #{getCssVarName($name)}: #{$value};
-    } @else {
-      #{getCssVarName($name, $attribute)}: #{$value};
+    & {
+      @if $attribute =='default' {
+        #{getCssVarName($name)}: #{$value};
+      }
+
+      @else {
+        #{getCssVarName($name, $attribute)}: #{$value};
+      }
     }
   }
 }
 
 @mixin set-css-color-rgb($type) {
   $color: map.get($colors, $type, 'base');
-  @include set-css-var-value(
-    ('color', $type, 'rgb'),
+  @include set-css-var-value(('color', $type, 'rgb'),
     #{red($color),
-    green($color),
-    blue($color)}
-  );
+ green($color),
+    blue($color)
+  });
 }
 
 // generate css var from existing css var
@@ -60,7 +65,11 @@
 // @include css-var-from-global(('button', 'text-color'), ('color', $type))
 // --el-button-text-color: var(--el-color-#{$type});
 @mixin css-var-from-global($var, $gVar) {
-  $varName: joinVarName($var);
-  $gVarName: joinVarName($gVar);
-  #{$varName}: var(#{$gVarName});
+
+  // Due to https://sass-lang.com/documentation/breaking-changes/mixed-decls/
+  & {
+    $varName: joinVarName($var);
+    $gVarName: joinVarName($gVar);
+    #{$varName}: var(#{$gVarName});
+  }
 }

--- a/packages/theme-chalk/src/overlay.scss
+++ b/packages/theme-chalk/src/overlay.scss
@@ -2,9 +2,6 @@
 @use 'common/var' as *;
 
 @include b(overlay) {
-  #{& + '-root'} {
-    height: 0;
-  }
   position: fixed;
   top: 0;
   right: 0;
@@ -14,4 +11,7 @@
   height: 100%;
   background-color: getCssVar('overlay-color', 'lighter');
   overflow: auto;
+  #{& + '-root'} {
+    height: 0;
+  }
 }

--- a/packages/theme-chalk/src/switch.scss
+++ b/packages/theme-chalk/src/switch.scss
@@ -171,6 +171,10 @@ $switch-content-padding: map.merge(
       justify-content: center;
       align-items: center;
       overflow: hidden;
+      padding: 0 #{map.get($switch-content-padding, 'default')} 0 calc(#{map.get(
+              $switch-button-size,
+              'default'
+            )} + 2px);
 
       .is-icon,
       .is-text {
@@ -179,10 +183,6 @@ $switch-content-padding: map.merge(
         user-select: none;
         @include utils-ellipsis;
       }
-      padding: 0 #{map.get($switch-content-padding, 'default')} 0 calc(#{map.get(
-              $switch-button-size,
-              'default'
-            )} + 2px);
     }
 
     .#{$namespace}-switch__action {

--- a/packages/theme-chalk/src/table-v2.scss
+++ b/packages/theme-chalk/src/table-v2.scss
@@ -20,6 +20,7 @@
     justify-content: center;
     text-align: center;
   }
+
   @include when('align-right') {
     justify-content: flex-end;
     text-align: right;
@@ -39,6 +40,7 @@
   .#{$namespace}-virtual-scrollbar {
     opacity: 0;
   }
+
   .#{$namespace}-vl__vertical,
   .#{$namespace}-vl__horizontal {
     z-index: -1;
@@ -51,6 +53,7 @@
 
 @include b('table-v2') {
   font-size: 14px;
+
   * {
     box-sizing: border-box;
   }
@@ -136,15 +139,15 @@
     border-bottom: getCssVar('table', 'border');
 
     @include e('header-cell') {
-      @include center-flex;
-      @include cell-padding;
-      @include cell-alignment;
       height: 100%;
       user-select: none;
       overflow: hidden;
       background-color: getCssVar('table-header', 'bg-color');
       color: getCssVar('table-header', 'text-color');
       font-weight: bold;
+      @include center-flex;
+      @include cell-padding;
+      @include cell-alignment;
 
       @include when(sortable) {
         cursor: pointer;
@@ -220,6 +223,7 @@
     @include e('row') {
       overflow: hidden;
       align-items: stretch;
+
       @include e('row-cell') {
         overflow-wrap: break-word;
       }

--- a/packages/theme-chalk/src/tag.scss
+++ b/packages/theme-chalk/src/tag.scss
@@ -10,49 +10,55 @@
 
 $tag-border-width: 1px;
 
-$tag-icon-span-gap: (
-  ) !default;
-$tag-icon-span-gap: map.merge(('large': 8px,
-      'default': 6px,
-      'small': 4px,
-    ),
-    $tag-icon-span-gap
+$tag-icon-span-gap: () !default;
+$tag-icon-span-gap: map.merge(
+  (
+    'large': 8px,
+    'default': 6px,
+    'small': 4px,
+  ),
+  $tag-icon-span-gap
 );
 
 @function returnVarList($var, $type: 'primary') {
-  $list: (
-    'fill-color',
-    'blank'
-  );
+  $list: ('fill-color', 'blank');
 
-@if $var !=false {
-  $list: (
-    'color',
-    $type,
-    $var
-  );
-}
+  @if $var !=false {
+    $list: ('color', $type, $var);
+  }
 
-@return $list;
+  @return $list;
 }
 
 // false mean --el-color-white
 @mixin genTheme($backgroundColorWeight, $borderColorWeight, $hoverColorWeight) {
-  @include css-var-from-global(('tag', 'bg-color'),
-    returnVarList($backgroundColorWeight));
-  @include css-var-from-global(('tag', 'border-color'),
-    returnVarList($borderColorWeight));
-  @include css-var-from-global(('tag', 'hover-color'),
-    returnVarList($hoverColorWeight));
+  @include css-var-from-global(
+    ('tag', 'bg-color'),
+    returnVarList($backgroundColorWeight)
+  );
+  @include css-var-from-global(
+    ('tag', 'border-color'),
+    returnVarList($borderColorWeight)
+  );
+  @include css-var-from-global(
+    ('tag', 'hover-color'),
+    returnVarList($hoverColorWeight)
+  );
 
   @each $type in $types {
     &.#{bem('tag', '', $type)} {
-      @include css-var-from-global(('tag', 'bg-color'),
-        returnVarList($backgroundColorWeight, $type));
-      @include css-var-from-global(('tag', 'border-color'),
-        returnVarList($borderColorWeight, $type));
-      @include css-var-from-global(('tag', 'hover-color'),
-        returnVarList($hoverColorWeight, $type));
+      @include css-var-from-global(
+        ('tag', 'bg-color'),
+        returnVarList($backgroundColorWeight, $type)
+      );
+      @include css-var-from-global(
+        ('tag', 'border-color'),
+        returnVarList($borderColorWeight, $type)
+      );
+      @include css-var-from-global(
+        ('tag', 'hover-color'),
+        returnVarList($hoverColorWeight, $type)
+      );
     }
   }
 }
@@ -147,8 +153,10 @@ $tag-icon-span-gap: map.merge(('large': 8px,
       padding: 0 map.get($tag-padding, $size) - $tag-border-width;
       height: map.get($tag-height, $size);
 
-      @include set-css-var-value('icon-size',
-        #{map.get($tag-icon-size, $size)});
+      @include set-css-var-value(
+        'icon-size',
+        #{map.get($tag-icon-size, $size)}
+      );
 
       .#{$namespace}-tag__close {
         margin-left: map.get($tag-icon-span-gap, $size);

--- a/packages/theme-chalk/src/tag.scss
+++ b/packages/theme-chalk/src/tag.scss
@@ -64,13 +64,27 @@ $tag-icon-span-gap: map.merge(
 }
 
 @include b(tag) {
-  @include genTheme('light-9', 'light-8', '');
+  background-color: getCssVar('tag-bg-color');
+  border-color: getCssVar('tag-border-color');
+  color: getCssVar('tag-text-color');
 
-  @each $type in $types {
-    &.#{bem('tag', '', $type)} {
-      @include css-var-from-global(('tag', 'text-color'), ('color', $type));
-    }
-  }
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  vertical-align: middle;
+  height: map.get($tag-height, 'default');
+  padding: 0 map.get($tag-padding, 'default') - $border-width;
+
+  font-size: getCssVar('tag-font-size');
+  line-height: 1;
+  border-width: $tag-border-width;
+  border-style: solid;
+  border-radius: getCssVar('tag-border-radius');
+  box-sizing: border-box;
+  white-space: nowrap;
+
+  @include set-css-var-value('icon-size', 14px);
+  @include genTheme('light-9', 'light-8', '');
 
   @include when(hit) {
     border-color: getCssVar('color', 'primary');
@@ -90,28 +104,11 @@ $tag-icon-span-gap: map.merge(
     }
   }
 
-  & {
-    background-color: getCssVar('tag-bg-color');
-    border-color: getCssVar('tag-border-color');
-    color: getCssVar('tag-text-color');
-
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    vertical-align: middle;
-    height: map.get($tag-height, 'default');
-    padding: 0 map.get($tag-padding, 'default') - $border-width;
-
-    font-size: getCssVar('tag-font-size');
-    line-height: 1;
-    border-width: $tag-border-width;
-    border-style: solid;
-    border-radius: getCssVar('tag-border-radius');
-    box-sizing: border-box;
-    white-space: nowrap;
+  @each $type in $types {
+    &.#{bem('tag', '', $type)} {
+      @include css-var-from-global(('tag', 'text-color'), ('color', $type));
+    }
   }
-
-  @include set-css-var-value('icon-size', 14px);
 
   $svg-margin-size: 1px;
 
@@ -129,8 +126,8 @@ $tag-icon-span-gap: map.merge(
   }
 
   @include m(dark) {
-    @include genTheme('', '', 'light-3');
     @include css-var-from-global(('tag', 'text-color'), ('color', 'white'));
+    @include genTheme('', '', 'light-3');
 
     @each $type in $types {
       &.#{bem('tag', '', $type)} {
@@ -140,8 +137,8 @@ $tag-icon-span-gap: map.merge(
   }
 
   @include m(plain) {
-    @include genTheme(false, 'light-5', '');
     @include css-var-from-global(('tag', 'bg-color'), ('fill-color', 'blank'));
+    @include genTheme(false, 'light-5', '');
   }
 
   &.is-closable {

--- a/packages/theme-chalk/src/tag.scss
+++ b/packages/theme-chalk/src/tag.scss
@@ -10,55 +10,49 @@
 
 $tag-border-width: 1px;
 
-$tag-icon-span-gap: () !default;
-$tag-icon-span-gap: map.merge(
-  (
-    'large': 8px,
-    'default': 6px,
-    'small': 4px,
-  ),
-  $tag-icon-span-gap
+$tag-icon-span-gap: (
+  ) !default;
+$tag-icon-span-gap: map.merge(('large': 8px,
+      'default': 6px,
+      'small': 4px,
+    ),
+    $tag-icon-span-gap
 );
 
 @function returnVarList($var, $type: 'primary') {
-  $list: ('fill-color', 'blank');
+  $list: (
+    'fill-color',
+    'blank'
+  );
 
-  @if $var !=false {
-    $list: ('color', $type, $var);
-  }
+@if $var !=false {
+  $list: (
+    'color',
+    $type,
+    $var
+  );
+}
 
-  @return $list;
+@return $list;
 }
 
 // false mean --el-color-white
 @mixin genTheme($backgroundColorWeight, $borderColorWeight, $hoverColorWeight) {
-  @include css-var-from-global(
-    ('tag', 'bg-color'),
-    returnVarList($backgroundColorWeight)
-  );
-  @include css-var-from-global(
-    ('tag', 'border-color'),
-    returnVarList($borderColorWeight)
-  );
-  @include css-var-from-global(
-    ('tag', 'hover-color'),
-    returnVarList($hoverColorWeight)
-  );
+  @include css-var-from-global(('tag', 'bg-color'),
+    returnVarList($backgroundColorWeight));
+  @include css-var-from-global(('tag', 'border-color'),
+    returnVarList($borderColorWeight));
+  @include css-var-from-global(('tag', 'hover-color'),
+    returnVarList($hoverColorWeight));
 
   @each $type in $types {
     &.#{bem('tag', '', $type)} {
-      @include css-var-from-global(
-        ('tag', 'bg-color'),
-        returnVarList($backgroundColorWeight, $type)
-      );
-      @include css-var-from-global(
-        ('tag', 'border-color'),
-        returnVarList($borderColorWeight, $type)
-      );
-      @include css-var-from-global(
-        ('tag', 'hover-color'),
-        returnVarList($hoverColorWeight, $type)
-      );
+      @include css-var-from-global(('tag', 'bg-color'),
+        returnVarList($backgroundColorWeight, $type));
+      @include css-var-from-global(('tag', 'border-color'),
+        returnVarList($borderColorWeight, $type));
+      @include css-var-from-global(('tag', 'hover-color'),
+        returnVarList($hoverColorWeight, $type));
     }
   }
 }
@@ -90,24 +84,26 @@ $tag-icon-span-gap: map.merge(
     }
   }
 
-  background-color: getCssVar('tag-bg-color');
-  border-color: getCssVar('tag-border-color');
-  color: getCssVar('tag-text-color');
+  & {
+    background-color: getCssVar('tag-bg-color');
+    border-color: getCssVar('tag-border-color');
+    color: getCssVar('tag-text-color');
 
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  vertical-align: middle;
-  height: map.get($tag-height, 'default');
-  padding: 0 map.get($tag-padding, 'default') - $border-width;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    vertical-align: middle;
+    height: map.get($tag-height, 'default');
+    padding: 0 map.get($tag-padding, 'default') - $border-width;
 
-  font-size: getCssVar('tag-font-size');
-  line-height: 1;
-  border-width: $tag-border-width;
-  border-style: solid;
-  border-radius: getCssVar('tag-border-radius');
-  box-sizing: border-box;
-  white-space: nowrap;
+    font-size: getCssVar('tag-font-size');
+    line-height: 1;
+    border-width: $tag-border-width;
+    border-style: solid;
+    border-radius: getCssVar('tag-border-radius');
+    box-sizing: border-box;
+    white-space: nowrap;
+  }
 
   @include set-css-var-value('icon-size', 14px);
 
@@ -151,10 +147,8 @@ $tag-icon-span-gap: map.merge(
       padding: 0 map.get($tag-padding, $size) - $tag-border-width;
       height: map.get($tag-height, $size);
 
-      @include set-css-var-value(
-        'icon-size',
-        #{map.get($tag-icon-size, $size)}
-      );
+      @include set-css-var-value('icon-size',
+        #{map.get($tag-icon-size, $size)});
 
       .#{$namespace}-tag__close {
         margin-left: map.get($tag-icon-span-gap, $size);

--- a/packages/theme-chalk/src/upload.scss
+++ b/packages/theme-chalk/src/upload.scss
@@ -28,6 +28,7 @@
 
   cursor: pointer;
   outline: none;
+
   @include e(input) {
     display: none;
   }
@@ -144,6 +145,7 @@
   padding: 0;
   list-style: none;
   position: relative;
+
   @include e(item) {
     transition: all 0.5s cubic-bezier(0.55, 0, 0.1, 1);
     font-size: 14px;
@@ -246,6 +248,7 @@
       &:active {
         /* click时 */
         outline-width: 0;
+
         .#{bem('icon', '', 'close-tip')} {
           display: none;
         }
@@ -340,6 +343,7 @@
       .#{bem('icon', '', 'close')} {
         display: none;
       }
+
       &:hover {
         .#{bem('upload-list', 'item-status-label')} {
           opacity: 0;
@@ -404,6 +408,7 @@
 
       &:hover {
         opacity: 1;
+
         span {
           display: inline-flex;
         }


### PR DESCRIPTION
Based on the major breaking change of Sass: https://sass-lang.com/documentation/breaking-changes/mixed-decls/

* Add `&{}` for wrapping nested css blocks.
* Update files with warnings by applying the `&{}` block and repositioning.

### Screenshot after fixed

![CleanShot 2024-07-17 at 09 50 02@2x](https://github.com/user-attachments/assets/e8c5d5e3-d88b-4c76-8bb5-c2e72a4d531d)


Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
