### PR TITLE
style(components): [select] add a unique class name for the clear icon

### DIFF
--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -218,7 +218,11 @@
             </el-icon>
             <el-icon
               v-if="showClearBtn && clearIcon"
-              :class="[nsSelect.e('caret'), nsInput.e('icon')]"
+              :class="[
+                nsSelect.e('caret'),
+                nsInput.e('icon'),
+                nsSelect.e('clear'),
+              ]"
               @click.prevent.stop="handleClear"
             >
               <component :is="clearIcon" />

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -218,7 +218,11 @@
             </el-icon>
             <el-icon
               v-if="showClose && clearIcon"
-              :class="[nsSelect.e('caret'), nsSelect.e('icon')]"
+              :class="[
+                nsSelect.e('caret'),
+                nsSelect.e('icon'),
+                nsSelect.e('clear'),
+              ]"
               @click="handleClearClick"
             >
               <component :is="clearIcon" />


### PR DESCRIPTION
- [✔] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [✔] Make sure you are merging your commits to `dev` branch.
- [✔] Add some descriptions and refer to relative issues for your PR.

There is a configuration item for 'clear-icon' in the select component, but if users globally modify it through CSS, they cannot determine which one is clearing the image. Therefore, it is recommended to add a class to the clearing icon to identify it.
```scss
.el-select__wrapper {
  &.is-hovering {
    // TODO issue: Unable to confirm which one is clearing the image. will change the dropdown icons together [7/17 24]
    .el-select__caret {
      position: relative;
      >svg{
        display: none;
      }
    }
    .el-select__caret::after {
      background: url('@/assets/icons/close.png') 100%/100%;
      position: absolute;
      content:' ';
      display: block;
      width: 14px;
      height: 14px;
    }
  }
}
```
