### PR TITLE
 fix(components):[loading] loading directive should dispose old instance before create a new instance

### DIFF
--- a/packages/components/loading/src/directive.ts
+++ b/packages/components/loading/src/directive.ts
@@ -54,6 +54,7 @@ const createInstance = (
     body: getBindingProp('body') ?? binding.modifiers.body,
     lock: getBindingProp('lock') ?? binding.modifiers.lock,
   }
+  el[INSTANCE_KEY]?.instance.close()
   el[INSTANCE_KEY] = {
     options,
     instance: Loading(options),


### PR DESCRIPTION
In some extreme cases, the loading component can add multiple instances of loading to a single element at the same time, overwriting the previous instances and making them inaccessible. loading directive should dispose old instance before create a new instance
