### PR TITLE
fix(components): [tree] check isLeaf using lazy and default-expand-all

### DIFF
--- a/packages/components/tree/src/model/node.ts
+++ b/packages/components/tree/src/model/node.ts
@@ -145,7 +145,12 @@ class Node {
         this.expanded = true
         this.canFocus = true
       }
-    } else if (this.level > 0 && store.lazy && store.defaultExpandAll) {
+    } else if (
+      this.level > 0 &&
+      store.lazy &&
+      store.defaultExpandAll &&
+      !this.isLeafByUser
+    ) {
       this.expand()
     }
     if (!Array.isArray(this.data)) {


### PR DESCRIPTION
Fixes the issue where the isLeaf parameter was not checked when using lazy and default-expand-all.

In the current implementation, when default-expand-all is set to true and lazy loading is enabled, the ElTree component expands nodes without considering the isLeaf parameter. This can lead to unnecessary loading of leaf nodes.

This fix adds a check for the isLeaf parameter to prevent loading children for nodes marked as leaf nodes.

This fix improves performance and avoids unnecessary network requests or data processing for nodes already known to be leaf nodes.

BREAKING CHANGE :
There are no breaking changes introduced by this fix.

closed None.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
