### PR TITLE
chore(vscode): fix `unocss` highlighting on `windows` caused by node path diff

### DIFF
--- a/docs/unocss.config.ts
+++ b/docs/unocss.config.ts
@@ -2,11 +2,8 @@ import { defineConfig, presetAttributify, presetIcons, presetUno } from 'unocss'
 
 export default defineConfig({
   presets: [presetUno(), presetAttributify(), presetIcons()],
-  include: [`${__dirname}/**/*`],
-  exclude: [
-    `${__dirname}/node_modules/**/*`,
-    `${__dirname}/.vitepress/cache/**/*`,
-  ],
+  include: [`./**/*`],
+  exclude: [`./node_modules/**/*`, `./.vitepress/cache/**/*`],
   theme: {
     breakpoints: {
       sm: '640px',


### PR DESCRIPTION
about: https://github.com/unocss/unocss/issues/3972

- windows

Before: 

![image](https://github.com/user-attachments/assets/fe291d32-8ec8-42e1-8e3d-299c36ecea85)


After:

![image](https://github.com/user-attachments/assets/77854c7b-1e2e-4970-adfa-fdb488ab74f2)
