### PR TITLE
fix(build-utils): ignore the effects of directories when exclude files

### DIFF
--- a/internal/build-utils/src/pkg.ts
+++ b/internal/build-utils/src/pkg.ts
@@ -31,7 +31,8 @@ export const getPackageDependencies = (
 
 export const excludeFiles = (files: string[]) => {
   const excludes = ['node_modules', 'test', 'mock', 'gulpfile', 'dist']
-  return files.filter(
-    (path) => !excludes.some((exclude) => path.includes(exclude))
-  )
+  return files.filter((path) => {
+    const position = path.startsWith(projRoot) ? projRoot.length : 0
+    return !excludes.some((exclude) => path.includes(exclude, position))
+  })
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

Build error when `['node_modules', 'test', 'mock', 'gulpfile', 'dist']` is included in the project directory.