### PR TITLE
fix(hooks): [useFormSize] priority of injection

### DIFF
--- a/packages/components/form/src/form-item.vue
+++ b/packages/components/form/src/form-item.vue
@@ -86,7 +86,7 @@ const slots = useSlots()
 const formContext = inject(formContextKey, undefined)
 const parentFormItemContext = inject(formItemContextKey, undefined)
 
-const _size = useFormSize(undefined, { formItem: false })
+const _size = useFormSize()
 const ns = useNamespace('form-item')
 
 const labelId = useId().value


### PR DESCRIPTION
Now, the data provided by the nearest ancestor component has higher priority.

fix #17636