### PR TITLE
fix(theme-chalk): [tabs] padding is incorrect while hovering on `border-card`-shaped tab

### DIFF
--- a/packages/theme-chalk/src/tabs.scss
+++ b/packages/theme-chalk/src/tabs.scss
@@ -177,6 +177,28 @@
     overflow: hidden;
     position: relative;
   }
+  @include m((top, bottom)) {
+    > .#{$namespace}-tabs__header {
+      .#{$namespace}-tabs__item:nth-child(2) {
+        padding-left: 0;
+      }
+      .#{$namespace}-tabs__item:last-child {
+        padding-right: 0;
+      }
+    }
+
+    &.#{$namespace}-tabs--border-card,
+    &.#{$namespace}-tabs--card {
+      > .#{$namespace}-tabs__header {
+        .#{$namespace}-tabs__item:nth-child(2) {
+          padding-left: 20px;
+        }
+        .#{$namespace}-tabs__item:last-child {
+          padding-right: 20px;
+        }
+      }
+    }
+  }
   @include m(card) {
     > .#{$namespace}-tabs__header {
       border-bottom: 1px solid getCssVar('border-color-light');
@@ -290,39 +312,6 @@
       .is-scrollable
       .#{$namespace}-tabs__item:first-child {
       margin-left: 0;
-    }
-  }
-  @include m((top, bottom)) {
-    .#{$namespace}-tabs__item.is-top:nth-child(2),
-    .#{$namespace}-tabs__item.is-bottom:nth-child(2) {
-      padding-left: 0;
-    }
-    .#{$namespace}-tabs__item.is-top:last-child,
-    .#{$namespace}-tabs__item.is-bottom:last-child {
-      padding-right: 0;
-    }
-
-    &.#{$namespace}-tabs--border-card,
-    &.#{$namespace}-tabs--card,
-    .#{$namespace}-tabs--left,
-    .#{$namespace}-tabs--right {
-      > .#{$namespace}-tabs__header {
-        .#{$namespace}-tabs__item:nth-child(2) {
-          padding-left: 20px;
-
-          &:not(.is-active).is-closable:hover {
-            padding-left: 13px;
-          }
-        }
-
-        .#{$namespace}-tabs__item:last-child {
-          padding-right: 20px;
-
-          &:not(.is-active).is-closable:hover {
-            padding-right: 13px;
-          }
-        }
-      }
     }
   }
   @include m(bottom) {


### PR DESCRIPTION
The issue was introduced by #11283.

fix #13934, close #13966