### PR TITLE
docs: update :deep() usage in `sponsors-button`

### DIFF
--- a/docs/.vitepress/vitepress/components/doc-content/vp-table-of-content.vue
+++ b/docs/.vitepress/vitepress/components/doc-content/vp-table-of-content.vue
@@ -56,8 +56,8 @@ const sponsor = computed(() => sponsorLocale[lang.value])
   </aside>
 </template>
 <style scoped lang="scss">
-.sponsors-button:deep {
-  button {
+.sponsors-button {
+  :deep(button) {
     width: 100%;
   }
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### Update the usage of :deep() in the sponsors-button style to the correct format

### Before
```scss
.sponsors-button:deep {
  button {
    width: 100%;
  }
}
```

### After
```scss
.sponsors-button {
  :deep(button) {
    width: 100%;
  }
}
```

### Runing

![image](https://github.com/user-attachments/assets/97561f77-814b-4639-b546-fa4ea34019fe)
