### PR TITLE
chore(utils): improve setTimeout type

### DIFF
--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -18,7 +18,7 @@ import type { UseNamespaceReturn } from '@element-plus/hooks'
 import type { LoadingOptionsResolved } from './types'
 
 export function createLoadingComponent(options: LoadingOptionsResolved) {
-  let afterLeaveTimer: number
+  let afterLeaveTimer: ReturnType<typeof setTimeout>
   // IMPORTANT NOTE: this is only a hacking way to expose the injections on an
   // instance, DO NOT FOLLOW this pattern in your own code.
   const afterLeaveFlag = ref(false)
@@ -60,7 +60,7 @@ export function createLoadingComponent(options: LoadingOptionsResolved) {
     afterLeaveFlag.value = true
     clearTimeout(afterLeaveTimer)
 
-    afterLeaveTimer = window.setTimeout(handleAfterLeave, 400)
+    afterLeaveTimer = setTimeout(handleAfterLeave, 400)
     data.visible = false
 
     options.closed?.()

--- a/packages/hooks/use-throttle-render/index.ts
+++ b/packages/hooks/use-throttle-render/index.ts
@@ -5,13 +5,13 @@ import type { Ref } from 'vue'
 export const useThrottleRender = (loading: Ref<boolean>, throttle = 0) => {
   if (throttle === 0) return loading
   const throttled = ref(false)
-  let timeoutHandle = 0
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null
 
   const dispatchThrottling = () => {
     if (timeoutHandle) {
       clearTimeout(timeoutHandle)
     }
-    timeoutHandle = window.setTimeout(() => {
+    timeoutHandle = setTimeout(() => {
       throttled.value = loading.value
     }, throttle)
   }

--- a/packages/utils/raf.ts
+++ b/packages/utils/raf.ts
@@ -1,9 +1,7 @@
 import { isClient } from './browser'
 
 export const rAF = (fn: () => void) =>
-  isClient
-    ? window.requestAnimationFrame(fn)
-    : (setTimeout(fn, 16) as unknown as number)
+  isClient ? window.requestAnimationFrame(fn) : setTimeout(fn, 16)
 
 export const cAF = (handle: number) =>
   isClient ? window.cancelAnimationFrame(handle) : clearTimeout(handle)

--- a/packages/utils/raf.ts
+++ b/packages/utils/raf.ts
@@ -1,7 +1,9 @@
 import { isClient } from './browser'
 
 export const rAF = (fn: () => void) =>
-  isClient ? window.requestAnimationFrame(fn) : setTimeout(fn, 16)
+  isClient
+    ? window.requestAnimationFrame(fn)
+    : (setTimeout(fn, 16) as unknown as number)
 
 export const cAF = (handle: number) =>
   isClient ? window.cancelAnimationFrame(handle) : clearTimeout(handle)


### PR DESCRIPTION
统一使用ReturnType<typeof setTimeout>来作为timer的类型推导，比起number更为严格和具体，更合适