### PR TITLE
fix(components): [el-slider] fix v-model value is out of range

### DIFF
--- a/packages/components/slider/src/composables/use-lifecycle.ts
+++ b/packages/components/slider/src/composables/use-lifecycle.ts
@@ -5,7 +5,8 @@ import type { SliderInitData, SliderProps } from '../slider'
 export const useLifecycle = (
   props: SliderProps,
   initData: SliderInitData,
-  resetSize: () => void
+  resetSize: () => void,
+  setFirstValue: (val: number) => void
 ) => {
   const sliderWrapper = ref<HTMLElement>()
 
@@ -24,13 +25,19 @@ export const useLifecycle = (
         typeof props.modelValue !== 'number' ||
         Number.isNaN(props.modelValue)
       ) {
-        initData.firstValue = props.min
+        setFirstValue(props.min)
       } else {
-        initData.firstValue = Math.min(
+        const clampedValue = Math.min(
           props.max,
           Math.max(props.min, props.modelValue)
         )
+        if (clampedValue !== props.modelValue) {
+          setFirstValue(clampedValue)
+        } else {
+          initData.firstValue = clampedValue
+        }
       }
+
       initData.oldValue = initData.firstValue
     }
 

--- a/packages/components/slider/src/slider.vue
+++ b/packages/components/slider/src/slider.vue
@@ -227,7 +227,12 @@ const precision = computed(() => {
   return Math.max.apply(null, precisions)
 })
 
-const { sliderWrapper } = useLifecycle(props, initData, resetSize)
+const { sliderWrapper } = useLifecycle(
+  props,
+  initData,
+  resetSize,
+  setFirstValue
+)
 
 const { firstValue, secondValue, sliderSize } = toRefs(initData)
 


### PR DESCRIPTION
When the default v-model value is out of the range defined by the minimum and maximum values, the UI will only display the nearest valid maximum or minimum value.

However, the v-model itself is not updated, which leads to inconsistencies between the UI and the data,

potentially causing confusion.

BREAKING CHANGE :
There are no breaking changes introduced by this fix.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
