### PR TITLE
fix(components): [statistic] fix excessive decimals when value is NAN

### DIFF
--- a/packages/components/statistic/src/statistic.vue
+++ b/packages/components/statistic/src/statistic.vue
@@ -41,7 +41,8 @@ const displayValue = computed(() => {
 
   if (isFunction(formatter)) return formatter(value)
 
-  if (!isNumber(value)) return value
+  // https://github.com/element-plus/element-plus/issues/17784
+  if (!isNumber(value) || Number.isNaN(value)) return value
 
   let [integer, decimal = ''] = String(value).split('.')
   decimal = decimal


### PR DESCRIPTION
When the value is NAN, correct the display issue that shows unnecessary decimal points.

closed #17784

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
