### PR TITLE
style(components): [popper] fix arrow style

### DIFF
--- a/packages/theme-chalk/src/popper.scss
+++ b/packages/theme-chalk/src/popper.scss
@@ -24,7 +24,7 @@
     background: getCssVar('text-color', 'primary');
     border: 1px solid getCssVar('text-color', 'primary');
 
-    #{$arrow-selector}::before {
+    > #{$arrow-selector}::before {
       border: 1px solid getCssVar('text-color', 'primary');
       background: getCssVar('text-color', 'primary');
       right: 0;
@@ -35,7 +35,7 @@
     background: getCssVar('bg-color', 'overlay');
     border: 1px solid getCssVar('border-color', 'light');
 
-    #{$arrow-selector}::before {
+    > #{$arrow-selector}::before {
       border: 1px solid getCssVar('border-color', 'light');
       background: getCssVar('bg-color', 'overlay');
       right: 0;


### PR DESCRIPTION
fix #17823 

With descendant selectors, there is an issue of style overlay conflicts when nesting occurs.
The arrow style applies only to child elements, make the style only apply inside the current component

