### PR TITLE
fix(components): [el-cascader] fix loading when setting lazy and v-model

### DIFF
--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -230,7 +230,10 @@ export default defineComponent({
 
         if (nodes.length) {
           nodes.forEach((node) => {
-            lazyLoad(node, () => syncCheckedValue(false, forced))
+            lazyLoad(node, () => {
+              expandNode(node)
+              syncCheckedValue(false, forced)
+            })
           })
         } else {
           syncCheckedValue(true, forced)


### PR DESCRIPTION
When using lazyLoad,

after setting the default value with v-model to load the child nodes of the corresponding node,

even after loading is complete, the loading icon does not disappear.

The loading icon only disappears when the node is clicked to expand.

BREAKING CHANGE :
There are no breaking changes introduced by this fix

closed Fixes #17655

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
