### PR TITLE
docs: remove tip about client-only

### DIFF
--- a/docs/en-US/component/autocomplete.md
+++ b/docs/en-US/component/autocomplete.md
@@ -7,12 +7,6 @@ lang: en-US
 
 Get some recommended tips based on the current input.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic Usage
 
 Autocomplete component provides input suggestions.
@@ -66,7 +60,7 @@ autocomplete/custom-loading
 | value-key                           | key name of the input suggestion object for display                                                                        | ^[string]                                                                                 | value        |
 | debounce                            | debounce delay when typing, in milliseconds                                                                                | ^[number]                                                                                 | 300          |
 | placement                           | placement of the popup menu                                                                                                | ^[enum]`'top' \| 'top- start' \| 'top-end' \| 'bottom' \| 'bottom-start' \| 'bottom-end'` | bottom-start |
-| fetch-suggestions                   | a method to fetch input suggestions. When suggestions are ready, invoke `callback(data:[])` to return them to Autocomplete | ^[Array] / ^[Function]`(queryString: string, callback: callbackfn) => void`                          | —            |
+| fetch-suggestions                   | a method to fetch input suggestions. When suggestions are ready, invoke `callback(data:[])` to return them to Autocomplete | ^[Array] / ^[Function]`(queryString: string, callback: callbackfn) => void`               | —            |
 | trigger-on-focus                    | whether show suggestions when input focus                                                                                  | ^[boolean]                                                                                | true         |
 | select-when-unmatched               | whether to emit a `select` event on enter when there is no autocomplete match                                              | ^[boolean]                                                                                | false        |
 | name                                | same as `name` in native input                                                                                             | ^[string]                                                                                 | —            |
@@ -80,14 +74,14 @@ autocomplete/custom-loading
 
 ### Events
 
-| Name   | Description                                      | Type                                                  |
-| ------ | ------------------------------------------------ | ----------------------------------------------------- |
-| blur   | triggers when Input blurs                                       | ^[Function]`(event: FocusEvent) => void`       |
-| focus  | triggers when Input focuses                                     | ^[Function]`(event: FocusEvent) => void`       |
-| input  | triggers when the Input value change                            | ^[Function]`(value: string \| number) => void` |
-| clear  | triggers when the Input is cleared by clicking the clear button | ^[Function]`() => void`                        |
-| select | triggers when a suggestion is clicked            | ^[Function]`(item: typeof modelValue \| any) => void` |
-| change | triggers when the icon inside Input value change | ^[Function]`(value: string \| number) => void`        |
+| Name   | Description                                                     | Type                                                  |
+| ------ | --------------------------------------------------------------- | ----------------------------------------------------- |
+| blur   | triggers when Input blurs                                       | ^[Function]`(event: FocusEvent) => void`              |
+| focus  | triggers when Input focuses                                     | ^[Function]`(event: FocusEvent) => void`              |
+| input  | triggers when the Input value change                            | ^[Function]`(value: string \| number) => void`        |
+| clear  | triggers when the Input is cleared by clicking the clear button | ^[Function]`() => void`                               |
+| select | triggers when a suggestion is clicked                           | ^[Function]`(item: typeof modelValue \| any) => void` |
+| change | triggers when the icon inside Input value change                | ^[Function]`(value: string \| number) => void`        |
 
 ### Slots
 

--- a/docs/en-US/component/cascader.md
+++ b/docs/en-US/component/cascader.md
@@ -7,12 +7,6 @@ lang: en-US
 
 If the options have a clear hierarchical structure, Cascader can be used to view and select them.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic usage
 
 There are two ways to expand child option items.

--- a/docs/en-US/component/color-picker.md
+++ b/docs/en-US/component/color-picker.md
@@ -7,12 +7,6 @@ lang: en-US
 
 ColorPicker is a color selector supporting multiple color formats.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic usage
 
 :::demo ColorPicker requires a string typed variable to be bound to v-model.

--- a/docs/en-US/component/date-picker.md
+++ b/docs/en-US/component/date-picker.md
@@ -7,12 +7,6 @@ lang: en-US
 
 Use Date Picker for date input.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Enter Date
 
 Basic date picker measured by 'day'.

--- a/docs/en-US/component/datetime-picker.md
+++ b/docs/en-US/component/datetime-picker.md
@@ -13,12 +13,6 @@ DateTimePicker is derived from DatePicker and TimePicker. For a more detailed ex
 
 :::
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Date and time
 
 :::demo You can select date and time in one picker at the same time by setting `type` to `datetime`. The way to use shortcuts is the same as Date Picker.

--- a/docs/en-US/component/dialog.md
+++ b/docs/en-US/component/dialog.md
@@ -7,12 +7,6 @@ lang: en-US
 
 Informs users while preserving the current page state.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic usage
 
 Dialog pops up a dialog box, and it's quite customizable.

--- a/docs/en-US/component/drawer.md
+++ b/docs/en-US/component/drawer.md
@@ -13,12 +13,6 @@ Since v-model is natively supported for all components, `visible.sync` has been 
 
 :::
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic Usage
 
 Callout a temporary drawer, from multiple direction

--- a/docs/en-US/component/dropdown.md
+++ b/docs/en-US/component/dropdown.md
@@ -7,12 +7,6 @@ lang: en-US
 
 Toggleable menu for displaying lists of links and actions.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic usage
 
 Hover on the dropdown menu to unfold it for more actions.
@@ -124,11 +118,11 @@ dropdown/sizes
 
 ### Dropdown Events
 
-| Name           | Description                                                                                               | Type                                                  |
-| -------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| click          | if `split-button` is `true`, triggers when left button is clicked                                         | ^[Function]`(e: MouseEvent) => void`                  |
-| command        | triggers when a dropdown item is clicked, the parameters is the command dispatched from the dropdown item | ^[Function]`(...args: any[]) => void`                 |
-| visible-change | triggers when the dropdown appears/disappears, the param is true when it appears, and false otherwise     | ^[Function]`(val: boolean) => void`                   |
+| Name           | Description                                                                                               | Type                                  |
+| -------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| click          | if `split-button` is `true`, triggers when left button is clicked                                         | ^[Function]`(e: MouseEvent) => void`  |
+| command        | triggers when a dropdown item is clicked, the parameters is the command dispatched from the dropdown item | ^[Function]`(...args: any[]) => void` |
+| visible-change | triggers when the dropdown appears/disappears, the param is true when it appears, and false otherwise     | ^[Function]`(val: boolean) => void`   |
 
 ### Dropdown Exposes
 

--- a/docs/en-US/component/menu.md
+++ b/docs/en-US/component/menu.md
@@ -7,12 +7,6 @@ lang: en-US
 
 Menu that provides navigation for your website.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Top bar
 
 Top bar Menu can be used in a variety of scenarios.
@@ -103,28 +97,28 @@ menu/popper-offset
 
 ### Menu Exposes
 
-| Name         | Description                                                            | Type                                 |
-| ------------ | ---------------------------------------------------------------------- | ------------------------------------ |
-| open         | open a specific sub-menu, the param is index of the sub-menu to open   | ^[Function]`(index: string) => void` |
-| close        | close a specific sub-menu, the param is index of the sub-menu to close | ^[Function]`(index: string) => void` |
+| Name  | Description                                                            | Type                                 |
+| ----- | ---------------------------------------------------------------------- | ------------------------------------ |
+| open  | open a specific sub-menu, the param is index of the sub-menu to open   | ^[Function]`(index: string) => void` |
+| close | close a specific sub-menu, the param is index of the sub-menu to close | ^[Function]`(index: string) => void` |
 
 ## SubMenu API
 
 ### SubMenu Attributes
 
-| Name                                | Description                                                                                                                                                                               | Type                     | Default   |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | --------- |
-| index ^(required)                   | unique identification                                                                                                                                                                     | ^[string]                | —         |
-| popper-class                        | custom class name for the popup menu                                                                                                                                                      | ^[string]                | —         |
-| show-timeout                        | timeout before showing a sub-menu(inherit `show-timeout` of the menu by default.)                                                                                                         | ^[number]                | —         |
-| hide-timeout                        | timeout before hiding a sub-menu(inherit `hide-timeout` of the menu by default.)                                                                                                          | ^[number]                | —         |
-| disabled                            | whether the sub-menu is disabled                                                                                                                                                          | ^[boolean]               | false     |
-| teleported                          | whether popup menu is teleported to the body, the default is true for the level one SubMenu, false for other SubMenus                                                                     | ^[boolean]               | undefined |
-| popper-offset                       | offset of the popper (overrides the `popper` of menu)                                                                                                                                     | ^[number]                | —         |
-| expand-close-icon                   | Icon when menu are expanded and submenu are closed, `expand-close-icon` and `expand-open-icon` need to be passed together to take effect                                                  | ^[string] / ^[Component] | —         |
-| expand-open-icon                    | Icon when menu are expanded and submenu are opened, `expand-open-icon` and `expand-close-icon` need to be passed together to take effect                                                  | ^[string] / ^[Component] | —         |
-| collapse-close-icon                 | Icon when menu are collapsed and submenu are closed, `collapse-close-icon` and `collapse-open-icon` need to be passed together to take effect                                             | ^[string] / ^[Component] | —         |
-| collapse-open-icon                  | Icon when menu are collapsed and submenu are opened, `collapse-open-icon` and `collapse-close-icon` need to be passed together to take effect                                             | ^[string] / ^[Component] | —         |
+| Name                | Description                                                                                                                                   | Type                     | Default   |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | --------- |
+| index ^(required)   | unique identification                                                                                                                         | ^[string]                | —         |
+| popper-class        | custom class name for the popup menu                                                                                                          | ^[string]                | —         |
+| show-timeout        | timeout before showing a sub-menu(inherit `show-timeout` of the menu by default.)                                                             | ^[number]                | —         |
+| hide-timeout        | timeout before hiding a sub-menu(inherit `hide-timeout` of the menu by default.)                                                              | ^[number]                | —         |
+| disabled            | whether the sub-menu is disabled                                                                                                              | ^[boolean]               | false     |
+| teleported          | whether popup menu is teleported to the body, the default is true for the level one SubMenu, false for other SubMenus                         | ^[boolean]               | undefined |
+| popper-offset       | offset of the popper (overrides the `popper` of menu)                                                                                         | ^[number]                | —         |
+| expand-close-icon   | Icon when menu are expanded and submenu are closed, `expand-close-icon` and `expand-open-icon` need to be passed together to take effect      | ^[string] / ^[Component] | —         |
+| expand-open-icon    | Icon when menu are expanded and submenu are opened, `expand-open-icon` and `expand-close-icon` need to be passed together to take effect      | ^[string] / ^[Component] | —         |
+| collapse-close-icon | Icon when menu are collapsed and submenu are closed, `collapse-close-icon` and `collapse-open-icon` need to be passed together to take effect | ^[string] / ^[Component] | —         |
+| collapse-open-icon  | Icon when menu are collapsed and submenu are opened, `collapse-open-icon` and `collapse-close-icon` need to be passed together to take effect | ^[string] / ^[Component] | —         |
 
 ### SubMenu Slots
 
@@ -214,4 +208,5 @@ interface MenuItemClicked {
   route?: RouteLocationRaw
 }
 ```
+
 </details>

--- a/docs/en-US/component/popconfirm.md
+++ b/docs/en-US/component/popconfirm.md
@@ -7,12 +7,6 @@ lang: en-US
 
 A simple confirmation dialog of an element click action.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic usage
 
 Popconfirm is similar to Popover. So for some duplicated attributes, please refer to the documentation of Popover.

--- a/docs/en-US/component/popover.md
+++ b/docs/en-US/component/popover.md
@@ -5,12 +5,6 @@ lang: en-US
 
 # Popover
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic usage
 
 Popover is built with `ElTooltip`. So for some duplicated attributes, please refer to the documentation of Tooltip.
@@ -115,6 +109,6 @@ popover/directive-usage
 
 ### Exposes
 
-| Name         | Description  | Type                    |
-| ------------ | ------------ | ----------------------- |
-| hide         | hide popover | ^[Function]`() => void` |
+| Name | Description  | Type                    |
+| ---- | ------------ | ----------------------- |
+| hide | hide popover | ^[Function]`() => void` |

--- a/docs/en-US/component/select-v2.md
+++ b/docs/en-US/component/select-v2.md
@@ -11,12 +11,6 @@ This component is still under testing, if you found any bug or issue please repo
 
 :::
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Background
 
 In some use-cases, a single selector may end up loading tens of thousands of rows of data.
@@ -265,7 +259,7 @@ select-v2/custom-label
 | collapse-tags-tooltip ^(2.3.0)      | whether show all selected tags when mouse hover text of collapse-tags. To use this, `collapse-tags` must be true                         | ^[boolean]                                                                                                                                                                  | false                                          |
 | max-collapse-tags ^(2.3.0)          | The max tags number to be shown. To use this, `collapse-tags` must be true                                                               | ^[number]                                                                                                                                                                   | 1                                              |
 | tag-type ^(2.5.0)                   | tag type                                                                                                                                 | ^[enum]`'' \| 'success' \| 'info' \| 'warning' \| 'danger'`                                                                                                                 | info                                           |
-| tag-effect ^(2.7.7)                        | tag effect                                                                                                              | ^[enum]`'' \| 'light' \| 'dark' \| 'plain'`                                                                                                                 | light                                           |
+| tag-effect ^(2.7.7)                 | tag effect                                                                                                                               | ^[enum]`'' \| 'light' \| 'dark' \| 'plain'`                                                                                                                                 | light                                          |
 | aria-label ^(a11y) ^(2.5.0)         | same as `aria-label` in native input                                                                                                     | ^[string]                                                                                                                                                                   | —                                              |
 | empty-values ^(2.7.0)               | empty values of component, [see config-provider](/en-US/component/config-provider#empty-values-configurations)                           | ^[array]                                                                                                                                                                    | —                                              |
 | value-on-clear ^(2.7.0)             | clear return value, [see config-provider](/en-US/component/config-provider#empty-values-configurations)                                  | ^[string] / ^[number] / ^[boolean] / ^[Function]                                                                                                                            | —                                              |

--- a/docs/en-US/component/select.md
+++ b/docs/en-US/component/select.md
@@ -15,12 +15,6 @@ After version ^(2.8.0), the component will no longer forcibly convert the incomi
 
 :::
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic usage
 
 :::demo `v-model` is the value of `el-option` that is currently selected.

--- a/docs/en-US/component/slider.md
+++ b/docs/en-US/component/slider.md
@@ -7,12 +7,6 @@ lang: en-US
 
 Drag the slider within a fixed range.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic usage
 
 The current value is displayed when the slider is being dragged.

--- a/docs/en-US/component/table-v2.md
+++ b/docs/en-US/component/table-v2.md
@@ -18,12 +18,6 @@ fully developed yet, which is why they are not mentioned here.
 
 :::
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic usage
 
 Let's demonstrate the performance of the Virtualized Table by rendering a basic example with 10 columns and 1000 rows.

--- a/docs/en-US/component/table.md
+++ b/docs/en-US/component/table.md
@@ -7,12 +7,6 @@ lang: en-US
 
 Display multiple data with similar format. You can sort, filter, compare your data in a table.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic table
 
 Basic table is just for data display.

--- a/docs/en-US/component/time-picker.md
+++ b/docs/en-US/component/time-picker.md
@@ -7,12 +7,6 @@ lang: en-US
 
 Use Time Picker for time input.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Arbitrary time picker
 
 Can pick an arbitrary time.
@@ -81,13 +75,13 @@ time-picker/range
 
 ### Events
 
-| Name           | Description                                                | Type                                                                                                         |
-| -------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| change         | triggers when user confirms the value                      | ^[Function]`(val: number \| string \| Date \| [number, number] \| [string, string] \| [Date, Date]) => void` |
-| blur           | triggers when Input blurs                                  | ^[Function]`(e: FocusEvent) => void`                                                                         |
-| focus          | triggers when Input focuses                                | ^[Function]`(e: FocusEvent) => void`                                                                         |
-| clear ^(2.7.7) | triggers when the clear icon is clicked in a clearable TimePicker | ^[Function]`() => void`                                                                               |
-| visible-change | triggers when the TimePicker's dropdown appears/disappears | ^[Function]`(visibility: boolean) => void`                                                                   |
+| Name           | Description                                                       | Type                                                                                                         |
+| -------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| change         | triggers when user confirms the value                             | ^[Function]`(val: number \| string \| Date \| [number, number] \| [string, string] \| [Date, Date]) => void` |
+| blur           | triggers when Input blurs                                         | ^[Function]`(e: FocusEvent) => void`                                                                         |
+| focus          | triggers when Input focuses                                       | ^[Function]`(e: FocusEvent) => void`                                                                         |
+| clear ^(2.7.7) | triggers when the clear icon is clicked in a clearable TimePicker | ^[Function]`() => void`                                                                                      |
+| visible-change | triggers when the TimePicker's dropdown appears/disappears        | ^[Function]`(visibility: boolean) => void`                                                                   |
 
 ### Exposes
 

--- a/docs/en-US/component/time-select.md
+++ b/docs/en-US/component/time-select.md
@@ -9,12 +9,6 @@ Use Time Select for time input.
 
 The available time range is 00:00 to 23:59
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Fixed time picker
 
 Provide a list of fixed time for users to choose.
@@ -80,12 +74,12 @@ time-select/time-range
 
 ### Events
 
-| Name   | Description                           | Type                                     |
-| ------ | ------------------------------------- | ---------------------------------------- |
-| change | triggers when user confirms the value | ^[Function]`(value: string) => void`     |
-| blur   | triggers when Input blurs             | ^[Function]`(event: FocusEvent) => void` |
-| focus  | triggers when Input focuses           | ^[Function]`(event: FocusEvent) => void` |
-| clear ^(2.7.7) | triggers when the clear icon is clicked in a clearable TimeSelect | ^[Function]`() => void` |
+| Name           | Description                                                       | Type                                     |
+| -------------- | ----------------------------------------------------------------- | ---------------------------------------- |
+| change         | triggers when user confirms the value                             | ^[Function]`(value: string) => void`     |
+| blur           | triggers when Input blurs                                         | ^[Function]`(event: FocusEvent) => void` |
+| focus          | triggers when Input focuses                                       | ^[Function]`(event: FocusEvent) => void` |
+| clear ^(2.7.7) | triggers when the clear icon is clicked in a clearable TimeSelect | ^[Function]`() => void`                  |
 
 ### Exposes
 

--- a/docs/en-US/component/tooltip-v2.md
+++ b/docs/en-US/component/tooltip-v2.md
@@ -7,12 +7,6 @@ lang: en-US
 
 For the existing tooltip, it has too many APIs which is not very intuitive and accessible, so we created this much simpler tooltip, which does only one simple thing - showing tooltip. The structure of having a tooltip is kind of the same, but the API is different. In this version we have provided the components individually, you can compose your own tooltip by using the components.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic usage
 
 **Hover** or **tab** on the icon to see the tooltip.

--- a/docs/en-US/component/tooltip.md
+++ b/docs/en-US/component/tooltip.md
@@ -7,12 +7,6 @@ lang: en-US
 
 Display prompt information for mouse hover.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic usage
 
 Tooltip has 9 placements.

--- a/docs/en-US/component/tree-select.md
+++ b/docs/en-US/component/tree-select.md
@@ -8,12 +8,6 @@ lang: en-US
 The tree selector of the dropdown menu,
 it combines the functions of components `el-tree` and `el-select`.
 
-:::tip
-
-This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).
-
-:::
-
 ## Basic usage
 
 Selector for tree structures.

--- a/docs/en-US/guide/ssr.md
+++ b/docs/en-US/guide/ssr.md
@@ -87,16 +87,6 @@ onMounted(() => {
 
 Another way is to inject the teleport markup into the correct location in your final page HTML.
 
-:::warning
-
-There may be some [SSR problems with teleport](https://github.com/vuejs/core/issues?q=is%3Aissue+is%3Aopen+ssr+teleport+), so you should pay attention to the following precautions.
-
-1. The `teleported` attribute in all components based on ElTooltip should be consistent, it is recommended to use the default value.
-2. The `append-to-body` attribute value of ElDialog and ElDrawer should be consistent, it is recommended to enable the `append-to-body`.
-3. When the ElSubMenu component has a multi-layer popup, It is recommended to enable the `teleported`
-
-:::
-
 You need to inject the teleport markup close to the `<body>` tag.
 
 ```html


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

remove

```md
:::tip

This component requires the `<client-only></client-only>` wrap when used in SSR (eg: [Nuxt](https://nuxt.com/v3)) and SSG (eg: [VitePress](https://vitepress.vuejs.org/)).

:::
```

Users can refer to [SSR](https://element-plus.org/en-US/guide/ssr.html) usage to avoid hydration errors instead of blindly using client-only.