### PR TITLE
fix(components): [dialog] error calling `resetPostion` before dialog is rendered

### DIFF
--- a/packages/components/dialog/src/dialog.vue
+++ b/packages/components/dialog/src/dialog.vue
@@ -143,7 +143,7 @@ const overlayEvent = useSameTarget(onModalClick)
 const draggable = computed(() => props.draggable && !props.fullscreen)
 
 const resetPostion = () => {
-  dialogContentRef.value.resetPostion()
+  dialogContentRef.value?.resetPostion()
 }
 
 defineExpose({


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fix #17851