### PR TITLE
feat(components): [description] export props types

### DIFF
--- a/packages/components/descriptions/src/description-item.ts
+++ b/packages/components/descriptions/src/description-item.ts
@@ -68,7 +68,7 @@ const DescriptionItem = defineComponent({
 
 export default DescriptionItem
 
-type DescriptionItemProps = ExtractPropTypes<typeof descriptionItemProps>
+export type DescriptionItemProps = ExtractPropTypes<typeof descriptionItemProps>
 export type DescriptionItemVNode = VNode & {
   children: { [name: string]: Slot } | null
   props: Partial<DescriptionItemProps> | null

--- a/packages/components/descriptions/src/description.ts
+++ b/packages/components/descriptions/src/description.ts
@@ -1,6 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 import { useSizeProp } from '@element-plus/hooks'
 
+import type { ExtractPropTypes } from 'vue'
 import type Description from './description.vue'
 
 export const descriptionProps = buildProps({
@@ -43,4 +44,5 @@ export const descriptionProps = buildProps({
   },
 } as const)
 
+export type DescriptionProps = ExtractPropTypes<typeof descriptionProps>
 export type DescriptionInstance = InstanceType<typeof Description>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

This PR adds type exports `DescriptionItemProps` and `DescriptionProps` to component **ElDescriptions**.

With context https://github.com/vuejs/core/issues/9774 it will throw when extending the type `ExtractPropTypes<typeof descriptionProps>` with `defineProps`.

Currently, I patched the package as a workaround.

It's nice to have it built-in supported since most of components's prop type are exported.
