### PR TITLE
Update render-helper.ts 解决树形表格多级的level错误的问题，level会被当做字符串，导致多级后缩进太大

### DIFF
--- a/packages/components/table/src/table-body/render-helper.ts
+++ b/packages/components/table/src/table-body/render-helper.ts
@@ -218,7 +218,7 @@ function useRender<T>(props: Partial<TableBodyProps<T>>) {
             // 父节点的 display 状态影响子节点的显示状态
             const innerTreeRowData = {
               display: parent.display && parent.expanded,
-              level: parent.level + 1,
+              level: +parent.level + 1,
               expanded: false,
               noLazyChildren: false,
               loading: false,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
