### PR TITLE
ci: automatically comment when adding conclict label

### DIFF
--- a/.github/workflows/pr-conflict.yml
+++ b/.github/workflows/pr-conflict.yml
@@ -1,0 +1,40 @@
+name: Comment on PR with conflict Label
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for specific label
+        if: contains(github.event.pull_request.labels.*.name, 'conflict')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commentBodyConflict = "@${{ github.event.pull_request.user.login }} This PR has conflicts, please resolve them.";
+
+            const existingComments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+
+            let shouldComment = true;
+            existingComments.data.forEach(comment => {
+              if (comment.body.includes(commentBodyConflict)) {
+                shouldComment = false;
+              }
+            });
+
+            if (shouldComment) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: commentBodyConflict
+              });
+            }

--- a/.github/workflows/pr-conflict.yml
+++ b/.github/workflows/pr-conflict.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for specific label
-        if: contains(github.event.pull_request.labels.*.name, 'conflict')
+        if: contains(github.event.pull_request.labels.*.name, 'conflict pending')
         uses: actions-cool/maintain-one-comment@v3.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-conflict.yml
+++ b/.github/workflows/pr-conflict.yml
@@ -10,31 +10,11 @@ jobs:
     steps:
       - name: Check for specific label
         if: contains(github.event.pull_request.labels.*.name, 'conflict')
-        uses: actions/github-script@v7
+        uses: actions-cool/maintain-one-comment@v3.1.1
         with:
-          script: |
-            const commentBodyConflict = "@${{ github.event.pull_request.user.login }} This PR has conflicts, please resolve them.";
-
-            const existingComments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
-            });
-
-
-            let shouldComment = true;
-            existingComments.data.forEach(comment => {
-              if (comment.body.includes(commentBodyConflict)) {
-                shouldComment = false;
-              }
-            });
-
-            if (shouldComment) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: commentBodyConflict
-              });
-            }
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            @${{ github.event.pull_request.user.login }} This PR has conflicts, please resolve them.
+            <!-- ELEMENT_PLUS_CONFLICT_COMMENT -->
+          body-include: '<!-- ELEMENT_PLUS_CONFLICT_COMMENT -->'
+          number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

When the `conflict` tag is added, automatically @user handle. This makes it easier for us to review conflicting PRs without having to manually add comments repeatedly.