### PR TITLE
feat(components): [input] remove extra size classname on the textarea

### DIFF
--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -141,6 +141,11 @@ describe('Input.vue', () => {
     expect(wrapper.classes('el-input--large')).toBe(true)
   })
 
+  test('textarea size', () => {
+    const wrapper = mount(() => <Input type="textarea" size="large" />)
+    expect(wrapper.classes('el-input--large')).not.toBe(true)
+  })
+
   test('type', () => {
     const wrapper = mount(() => <Input type="textarea" />)
     expect(wrapper.classes('el-textarea')).toBe(true)

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -215,7 +215,7 @@ const containerAttrs = computed(() => {
 
 const containerKls = computed(() => [
   props.type === 'textarea' ? nsTextarea.b() : nsInput.b(),
-  nsInput.m(inputSize.value),
+  props.type !== 'textarea' && nsInput.m(inputSize.value),
   nsInput.is('disabled', inputDisabled.value),
   nsInput.is('exceed', inputExceed.value),
   {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## description

The prop `size` will work when the `type` is not `textarea`.

![image](https://github.com/user-attachments/assets/089d9f64-7a00-4a3d-a1e0-96406efd7900)

However, when using textarea like `<el-input type="textarea" size="large" />`, currently it will add an extra class name `el-input--large`.

![image](https://github.com/user-attachments/assets/56bdd2f4-f62a-4e97-9672-a5ef375223ee)

This PR is to conditionally add the size classname when the type of the input is not `textarea`.