### PR TITLE
fix(components): [tooltip]fix tooltips auto-close on contextmenu trigger

### DIFF
--- a/packages/components/tooltip/src/constants.ts
+++ b/packages/components/tooltip/src/constants.ts
@@ -17,5 +17,6 @@ export type ElTooltipInjectionContext = {
   updatePopper: () => void
 }
 
+export const TOOLTIP_CLOSE_ALL = 'tooltip.close-all'
 export const TOOLTIP_INJECTION_KEY: InjectionKey<ElTooltipInjectionContext> =
   Symbol('elTooltip')


### PR DESCRIPTION
fix issue where tooltips with trigger="contextmenu" do not auto-close other open tooltips.

closed #17246

Please make sure these boxes are checked before submitting your PR, thank you!

- [ √ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ √ ] Make sure you are merging your commits to `dev` branch.
- [ √ ] Add some descriptions and refer to relative issues for your PR.
