### PR TITLE
feat(components): [popconfirm] add actions slot

### DIFF
--- a/docs/en-US/component/popconfirm.md
+++ b/docs/en-US/component/popconfirm.md
@@ -65,7 +65,7 @@ popconfirm/trigger-event
 
 ### Slots
 
-| Name      | Description                           |
-| --------- | ------------------------------------- |
-| reference | HTML element that triggers Popconfirm |
-| actions   | content of the Popconfirm footer      |
+| Name      | Description                           | Type                                                                             |
+| --------- | ------------------------------------- | -------------------------------------------------------------------------------- |
+| reference | HTML element that triggers Popconfirm | —                                                                                |
+| actions   | content of the Popconfirm footer      | ^[object]`{ confirm: (e: MouseEvent) => void, cancel: (e: MouseEvent) => void }` |

--- a/docs/en-US/component/popconfirm.md
+++ b/docs/en-US/component/popconfirm.md
@@ -68,3 +68,4 @@ popconfirm/trigger-event
 | Name      | Description                           |
 | --------- | ------------------------------------- |
 | reference | HTML element that triggers Popconfirm |
+| actions   | content of the Popconfirm footer      |

--- a/docs/en-US/component/popconfirm.md
+++ b/docs/en-US/component/popconfirm.md
@@ -65,7 +65,7 @@ popconfirm/trigger-event
 
 ### Slots
 
-| Name      | Description                           | Type                                                                             |
-| --------- | ------------------------------------- | -------------------------------------------------------------------------------- |
-| reference | HTML element that triggers Popconfirm | —                                                                                |
-| actions   | content of the Popconfirm footer      | ^[object]`{ confirm: (e: MouseEvent) => void, cancel: (e: MouseEvent) => void }` |
+| Name             | Description                           | Type                                                                             |
+| ---------------- | ------------------------------------- | -------------------------------------------------------------------------------- |
+| reference        | HTML element that triggers Popconfirm | —                                                                                |
+| actions ^(2.8.1) | content of the Popconfirm footer      | ^[object]`{ confirm: (e: MouseEvent) => void, cancel: (e: MouseEvent) => void }` |

--- a/docs/examples/popconfirm/customize.vue
+++ b/docs/examples/popconfirm/customize.vue
@@ -4,17 +4,27 @@
     :icon="InfoFilled"
     icon-color="#626AEF"
     title="Are you sure to delete this?"
+    :disabled="deleted"
+    @confirm="onConfirm"
   >
     <template #reference>
       <el-button>Delete</el-button>
     </template>
-    <template #actions>
-      <el-button size="small">No!</el-button>
-      <el-button type="danger" size="small" disabled>Yes?</el-button>
+    <template #actions="{ confirm, cancel }">
+      <el-button size="small" @click="confirm">No!</el-button>
+      <el-button type="danger" size="small" disabled @click="cancel">
+        Yes?
+      </el-button>
     </template>
   </el-popconfirm>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue'
 import { InfoFilled } from '@element-plus/icons-vue'
+
+const deleted = ref(false)
+function onConfirm() {
+  deleted.value = true
+}
 </script>

--- a/docs/examples/popconfirm/customize.vue
+++ b/docs/examples/popconfirm/customize.vue
@@ -11,7 +11,12 @@
     </template>
     <template #actions="{ confirm, cancel }">
       <el-button size="small" @click="cancel">No!</el-button>
-      <el-button type="danger" size="small" :disabled="!clicked" @click="confirm">
+      <el-button
+        type="danger"
+        size="small"
+        :disabled="!clicked"
+        @click="confirm"
+      >
         Yes?
       </el-button>
     </template>

--- a/docs/examples/popconfirm/customize.vue
+++ b/docs/examples/popconfirm/customize.vue
@@ -4,15 +4,14 @@
     :icon="InfoFilled"
     icon-color="#626AEF"
     title="Are you sure to delete this?"
-    :disabled="deleted"
-    @confirm="onConfirm"
+    @cancel="onCancel"
   >
     <template #reference>
       <el-button>Delete</el-button>
     </template>
     <template #actions="{ confirm, cancel }">
-      <el-button size="small" @click="confirm">No!</el-button>
-      <el-button type="danger" size="small" disabled @click="cancel">
+      <el-button size="small" @click="cancel">No!</el-button>
+      <el-button type="danger" size="small" :disabled="!clicked" @click="confirm">
         Yes?
       </el-button>
     </template>
@@ -23,8 +22,8 @@
 import { ref } from 'vue'
 import { InfoFilled } from '@element-plus/icons-vue'
 
-const deleted = ref(false)
-function onConfirm() {
-  deleted.value = true
+const clicked = ref(false)
+function onCancel() {
+  clicked.value = true
 }
 </script>

--- a/docs/examples/popconfirm/customize.vue
+++ b/docs/examples/popconfirm/customize.vue
@@ -1,14 +1,16 @@
 <template>
   <el-popconfirm
     width="220"
-    confirm-button-text="OK"
-    cancel-button-text="No, Thanks"
     :icon="InfoFilled"
     icon-color="#626AEF"
     title="Are you sure to delete this?"
   >
     <template #reference>
       <el-button>Delete</el-button>
+    </template>
+    <template #actions>
+      <el-button size="small">No!</el-button>
+      <el-button type="danger" size="small" disabled>Yes?</el-button>
     </template>
   </el-popconfirm>
 </template>

--- a/packages/components/popconfirm/__tests__/popconfirm.test.tsx
+++ b/packages/components/popconfirm/__tests__/popconfirm.test.tsx
@@ -77,7 +77,9 @@ describe('Popconfirm.vue', () => {
       const { selector } = usePopperContainerId()
       expect(document.body.querySelector(selector.value)!.innerHTML).toBe('')
     })
+  })
 
+  describe('actions slot', () => {
     it('should override default buttons when given actions', async () => {
       const wrapper = mount(() => (
         <>
@@ -98,6 +100,49 @@ describe('Popconfirm.vue', () => {
       const content = document.querySelector(selector)!.innerHTML
       expect(content).toContain(FUN)
       expect(content).not.toContain('.el-button')
+    })
+
+    it('should pass handlers that can emit events', async () => {
+      const wrapper = mount(() => (
+        <>
+          <Popconfirm
+            v-slots={{
+              reference: () => <div class="reference">{AXIOM}</div>,
+              actions: ({ confirm, cancel }) => (
+                <>
+                  <button class="confirm" onClick={confirm}>
+                    Confirm
+                  </button>
+                  <button class="cancel" onClick={cancel}>
+                    Cancel
+                  </button>
+                </>
+              ),
+            }}
+          />
+        </>
+      ))
+      await nextTick()
+      await wrapper.find('.reference').trigger('click')
+      await nextTick()
+      await rAF()
+
+      expect(wrapper.emitted()).not.toHaveProperty('confirm')
+      await wrapper.find('.confirm').trigger('click')
+      await nextTick()
+      await rAF()
+      expect(wrapper.emitted()).toHaveProperty('confirm')
+
+      await nextTick()
+      await wrapper.find('.reference').trigger('click')
+      await nextTick()
+      await rAF()
+
+      expect(wrapper.emitted()).not.toHaveProperty('cancel')
+      await wrapper.find('.cancel').trigger('click')
+      await nextTick()
+      await rAF()
+      expect(wrapper.emitted()).toHaveProperty('cancel')
     })
   })
 })

--- a/packages/components/popconfirm/__tests__/popconfirm.test.tsx
+++ b/packages/components/popconfirm/__tests__/popconfirm.test.tsx
@@ -1,6 +1,6 @@
 import { nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { rAF } from '@element-plus/test-utils/tick'
 import { usePopperContainerId } from '@element-plus/hooks'
 import Popconfirm from '../src/popconfirm.vue'
@@ -103,12 +103,17 @@ describe('Popconfirm.vue', () => {
     })
 
     it('should pass handlers that can emit events', async () => {
+      const confirm = vi.fn()
+      const cancel = vi.fn()
       const wrapper = mount(() => (
         <>
           <Popconfirm
+            onConfirm={confirm}
+            onCancel={cancel}
+            teleported={false}
             v-slots={{
               reference: () => <div class="reference">{AXIOM}</div>,
-              actions: ({ confirm, cancel }) => (
+              actions: ({ confirm, cancel }: { confirm: any; cancel: any }) => (
                 <>
                   <button class="confirm" onClick={confirm}>
                     Confirm
@@ -131,7 +136,7 @@ describe('Popconfirm.vue', () => {
       await wrapper.find('.confirm').trigger('click')
       await nextTick()
       await rAF()
-      expect(wrapper.emitted()).toHaveProperty('confirm')
+      expect(confirm).toHaveBeenCalled()
 
       await nextTick()
       await wrapper.find('.reference').trigger('click')
@@ -142,7 +147,7 @@ describe('Popconfirm.vue', () => {
       await wrapper.find('.cancel').trigger('click')
       await nextTick()
       await rAF()
-      expect(wrapper.emitted()).toHaveProperty('cancel')
+      expect(cancel).toHaveBeenCalled()
     })
   })
 })

--- a/packages/components/popconfirm/__tests__/popconfirm.test.tsx
+++ b/packages/components/popconfirm/__tests__/popconfirm.test.tsx
@@ -6,6 +6,7 @@ import { usePopperContainerId } from '@element-plus/hooks'
 import Popconfirm from '../src/popconfirm.vue'
 
 const AXIOM = 'rem is the best girl'
+const FUN = 'dQw4w9WgXcQ'
 const selector = '.el-popper'
 
 describe('Popconfirm.vue', () => {
@@ -75,6 +76,28 @@ describe('Popconfirm.vue', () => {
       await nextTick()
       const { selector } = usePopperContainerId()
       expect(document.body.querySelector(selector.value)!.innerHTML).toBe('')
+    })
+
+    it('should override default buttons when given actions', async () => {
+      const wrapper = mount(() => (
+        <>
+          <Popconfirm
+            v-slots={{
+              reference: () => <div class="reference">{AXIOM}</div>,
+              actions: () => <div class="actions">{FUN}</div>,
+            }}
+          />
+        </>
+      ))
+      await nextTick()
+      await wrapper.find('.reference').trigger('click')
+
+      await nextTick()
+      await rAF()
+
+      const content = document.querySelector(selector)!.innerHTML
+      expect(content).toContain(FUN)
+      expect(content).not.toContain('.el-button')
     })
   })
 })

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -24,13 +24,7 @@
           {{ title }}
         </div>
         <div :class="ns.e('action')">
-          <slot
-            v-if="$slots.actions"
-            name="actions"
-            :confirm="confirm"
-            :cancel="cancel"
-          />
-          <template v-else>
+          <slot name="actions" :confirm="confirm" :cancel="cancel">
             <el-button
               size="small"
               :type="cancelButtonType === 'text' ? '' : cancelButtonType"
@@ -47,7 +41,7 @@
             >
               {{ finalConfirmButtonText }}
             </el-button>
-          </template>
+          </slot>
         </div>
       </div>
     </template>

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -24,22 +24,25 @@
           {{ title }}
         </div>
         <div :class="ns.e('action')">
-          <el-button
-            size="small"
-            :type="cancelButtonType === 'text' ? '' : cancelButtonType"
-            :text="cancelButtonType === 'text'"
-            @click="cancel"
-          >
-            {{ finalCancelButtonText }}
-          </el-button>
-          <el-button
-            size="small"
-            :type="confirmButtonType === 'text' ? '' : confirmButtonType"
-            :text="confirmButtonType === 'text'"
-            @click="confirm"
-          >
-            {{ finalConfirmButtonText }}
-          </el-button>
+          <slot v-if="$slots.actions" name="actions" />
+          <template v-else>
+            <el-button
+              size="small"
+              :type="cancelButtonType === 'text' ? '' : cancelButtonType"
+              :text="cancelButtonType === 'text'"
+              @click="cancel"
+            >
+              {{ finalCancelButtonText }}
+            </el-button>
+            <el-button
+              size="small"
+              :type="confirmButtonType === 'text' ? '' : confirmButtonType"
+              :text="confirmButtonType === 'text'"
+              @click="confirm"
+            >
+              {{ finalConfirmButtonText }}
+            </el-button>
+          </template>
         </div>
       </div>
     </template>

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -24,7 +24,12 @@
           {{ title }}
         </div>
         <div :class="ns.e('action')">
-          <slot v-if="$slots.actions" name="actions" />
+          <slot
+            v-if="$slots.actions"
+            name="actions"
+            :confirm="confirm"
+            :cancel="cancel"
+          />
           <template v-else>
             <el-button
               size="small"


### PR DESCRIPTION
`v-slot:actions` on popconfirm will override the default buttons, allow users to customize them.

close #4733

This is my first time contributing to element-plus. I am not familiar with the naming conventions of element-plus. If there are any improvement suggestions, please point them out ❤️

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.