### PR TITLE
fix(components): [tag] leave animations not working

### DIFF
--- a/packages/components/tag/src/tag.vue
+++ b/packages/components/tag/src/tag.vue
@@ -12,7 +12,12 @@
       <Close />
     </el-icon>
   </span>
-  <transition v-else :name="`${ns.namespace.value}-zoom-in-center`" appear>
+  <transition
+    v-else
+    :name="`${ns.namespace.value}-zoom-in-center`"
+    appear
+    @vnode-mounted="handleVNodeMounted"
+  >
     <span
       :class="containerKls"
       :style="{ backgroundColor: color }"
@@ -36,6 +41,7 @@ import { useNamespace } from '@element-plus/hooks'
 import { useFormSize } from '@element-plus/components/form'
 
 import { tagEmits, tagProps } from './tag'
+import type { VNode } from 'vue'
 
 defineOptions({
   name: 'ElTag',
@@ -65,5 +71,10 @@ const handleClose = (event: MouseEvent) => {
 
 const handleClick = (event: MouseEvent) => {
   emit('click', event)
+}
+
+const handleVNodeMounted = (vnode: VNode) => {
+  // @ts-ignore
+  vnode.component.subTree.component.bum = null
 }
 </script>

--- a/packages/components/tag/src/tag.vue
+++ b/packages/components/tag/src/tag.vue
@@ -16,7 +16,7 @@
     v-else
     :name="`${ns.namespace.value}-zoom-in-center`"
     appear
-    @vnode-mounted="handleVNodeMounted"
+    @vue:mounted="handleVNodeMounted"
   >
     <span
       :class="containerKls"


### PR DESCRIPTION
I filed an [issue](https://github.com/vuejs/core/issues/11703) to Vue and was aware that the problem is actually caused by a breaking change in Vue3.  I think we can either fix #17255 with monkey-patch like this PR, or remove leave animations (possibly even entire animations for consistency) to follow Transition design.