### PR TITLE
fix(components): [tabs] fix: tab remove keydown event handling

### DIFF
--- a/packages/components/tabs/src/tab-nav.tsx
+++ b/packages/components/tabs/src/tab-nav.tsx
@@ -345,6 +345,7 @@ const TabNav = defineComponent({
             onKeydown={(ev: KeyboardEvent) => {
               if (
                 closable &&
+                (ev.target as HTMLElement).getAttribute('role') === 'tab' &&
                 (ev.code === EVENT_CODE.delete ||
                   ev.code === EVENT_CODE.backspace)
               ) {

--- a/packages/components/tabs/src/tab-nav.tsx
+++ b/packages/components/tabs/src/tab-nav.tsx
@@ -345,7 +345,8 @@ const TabNav = defineComponent({
             onKeydown={(ev: KeyboardEvent) => {
               if (
                 closable &&
-                (ev.target as HTMLElement).getAttribute('role') === 'tab' &&
+                (ev.target as HTMLElement).getAttribute('id') ===
+                  `tab-${tabName}` &&
                 (ev.code === EVENT_CODE.delete ||
                   ev.code === EVENT_CODE.backspace)
               ) {


### PR DESCRIPTION
This fix prevents accidental tab closures when interacting with child elements

closed #18045

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
