### PR TITLE
fix(components): [select-v2] cannot find name `handleBlur`

### DIFF
--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -105,7 +105,7 @@ const useSelect = (props: ISelectV2Props, emit) => {
     afterComposition: (e) => onInput(e),
   })
 
-  const { wrapperRef, isFocused } = useFocusController(inputRef, {
+  const { wrapperRef, isFocused, handleBlur } = useFocusController(inputRef, {
     beforeFocus() {
       return selectDisabled.value
     },


### PR DESCRIPTION
In #16746, the CI report indicates an error: `Cannot find name 'handleBlur'`. The error seems to be unintentionally introduced due to `// @tsnocheck`