### PR TITLE
fix(components): [date-picker] clear event penalty panel flashes

### DIFF
--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -263,8 +263,15 @@ const _ref = computed(() => input.value || textarea.value)
 const { wrapperRef, isFocused, handleFocus, handleBlur } = useFocusController(
   _ref,
   {
-    beforeFocus() {
-      return inputDisabled.value
+    beforeFocus(event: FocusEvent) {
+      if (inputDisabled.value) {
+        return true
+      }
+      const el = event.target as HTMLElement
+      if (el.className.includes('input__wrapper')) {
+        return true
+      }
+      return false
     },
     afterBlur() {
       if (props.validateEvent) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fix #18161  rel #17719

This is because we modified the binding method of the focus event in #17719. Therefore, when clear is clicked in this scenario, the focus event will be triggered first, causing the panel to be displayed. I haven't thought of a particularly good way yet. Do you have any suggestions? @tolking