### PR TITLE
fix(components): [table-v2] sass declaration deprecation error

### DIFF
--- a/packages/theme-chalk/src/table-v2.scss
+++ b/packages/theme-chalk/src/table-v2.scss
@@ -85,8 +85,8 @@
     @include table-root;
     left: 0;
     box-shadow: 2px 0 4px 0 rgb(0 0 0 / 6%);
-    @include hidden-scrollbar;
     z-index: 1;
+    @include hidden-scrollbar;
   }
 
   @include e('right') {


### PR DESCRIPTION
```
Deprecation Warning: Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
44  │ ┌   .#{$namespace}-vl__vertical,
45  │ │   .#{$namespace}-vl__horizontal {
46  │ │     z-index: -1;
47  │ │   }
    │ └─── nested rule
... │
89  │       z-index: 1;
    │       ^^^^^^^^^^ declaration
    ╵
    ..\..\node_modules\.pnpm\element-plus@2.8.2_vue@3.5.3_typescript@5.4.5_\node_modules\element-plus\theme-chalk\src\table-v2.scss 89:5       @content

.........

```

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
