### PR TITLE
fix: 内存中的游离节点, 滚动条dom节点未释放

### DIFF
--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -32,6 +32,7 @@ import {
   onActivated,
   onMounted,
   onUpdated,
+  onBeforeUnmount,
   provide,
   reactive,
   ref,
@@ -178,7 +179,12 @@ onMounted(() => {
     })
 })
 onUpdated(() => update())
-
+onBeforeUnmount(() => {
+  scrollbarRef.value = null;
+  wrapRef.value = null;
+  resizeRef.value = null;
+  barRef.value = null;
+})
 defineExpose({
   /** @description scrollbar wrap ref */
   wrapRef,


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/414fd32d-31c9-45ff-8eaa-872ad292b7a3)
轮动条销毁 的时候, 存在游离节点, 内存未释放, 如果一个项目使用过多, 会导致大量内存泄露