### PR TITLE
fix(components): `step-strictly` is true and should keep the initial value and step matching

### DIFF
--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -594,4 +594,14 @@ describe('InputNumber.vue', () => {
     expect(increase.classes()).toContain('el-icon')
     expect(decrease.classes()).toContain('el-icon')
   })
+
+  // fix: #18275
+  test('step-strictly is true and should keep the initial value and step matching', () => {
+    const num = ref(2.6)
+    const wrapper = mount(() => (
+      <InputNumber v-model={num.value} stepStrictly step={0.5} />
+    ))
+    expect(wrapper.find('input').element.value).toBe(num.value.toString())
+    wrapper.unmount()
+  })
 })

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -228,8 +228,8 @@ const verifyValue = (
   }
   if (newVal > max || newVal < min) {
     newVal = newVal > max ? max : min
-    update && emit(UPDATE_MODEL_EVENT, newVal)
   }
+  update && emit(UPDATE_MODEL_EVENT, newVal)
   return newVal
 }
 const setCurrentValue = (

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -222,14 +222,17 @@ const verifyValue = (
   }
   if (stepStrictly) {
     newVal = toPrecision(Math.round(newVal / step) * step, precision)
+    if (newVal !== value) {
+      update && emit(UPDATE_MODEL_EVENT, newVal)
+    }
   }
   if (!isUndefined(precision)) {
     newVal = toPrecision(newVal, precision)
   }
   if (newVal > max || newVal < min) {
     newVal = newVal > max ? max : min
+    update && emit(UPDATE_MODEL_EVENT, newVal)
   }
-  update && emit(UPDATE_MODEL_EVENT, newVal)
   return newVal
 }
 const setCurrentValue = (


### PR DESCRIPTION
When step strictly is set to true, the initial rendering of component v-model differs from the value displayed in the input box。See issue # 18275 for details。

closed #18275

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
