### PR TITLE
fix(components):  [carousel] fix style when use motionBlur

### DIFF
--- a/packages/components/carousel/src/carousel.vue
+++ b/packages/components/carousel/src/carousel.vue
@@ -141,7 +141,7 @@ const carouselClasses = computed(() => {
 
 const carouselContainer = computed(() => {
   const classes = [ns.e('container')]
-  if (props.motionBlur && unref(isTransitioning)) {
+  if (props.motionBlur && unref(isTransitioning) && items.value.length > 1) {
     classes.push(
       unref(isVertical)
         ? `${ns.namespace.value}-transitioning-vertical`


### PR DESCRIPTION
fix #18328 

Do not add the transition effect when there is only one child element
