### PR TITLE
feat(components): [cascader] update cascader component to expost presentText

### DIFF
--- a/docs/en-US/component/cascader.md
+++ b/docs/en-US/component/cascader.md
@@ -188,7 +188,7 @@ cascader/panel
 | cascaderPanelRef              | cascader panel ref                                                                                                | ^[object]`ComputedRef<any>`                                     |
 | togglePopperVisible ^(2.2.31) | toggle the visible type of popper                                                                                 | ^[Function]`(visible?: boolean) => void`                        |
 | contentRef                    | cascader content ref                                                                                              | ^[object]`ComputedRef<any>`                                     |
-| presentText                   | selected content text                                                                                              | ^[object]`ComputedRef<string>`                                 |
+| presentText  ^(2.8.4)         | selected content text                                                                                              | ^[object]`ComputedRef<string>`                                 |
 
 ## CascaderPanel API
 

--- a/docs/en-US/component/cascader.md
+++ b/docs/en-US/component/cascader.md
@@ -188,7 +188,7 @@ cascader/panel
 | cascaderPanelRef              | cascader panel ref                                                                                                | ^[object]`ComputedRef<any>`                                     |
 | togglePopperVisible ^(2.2.31) | toggle the visible type of popper                                                                                 | ^[Function]`(visible?: boolean) => void`                        |
 | contentRef                    | cascader content ref                                                                                              | ^[object]`ComputedRef<any>`                                     |
-| presentText                    | selected content text                                                                                              | ^[string]                                     |
+| presentText                   | selected content text                                                                                              | ^[object]`ComputedRef<string>`                                 |
 
 ## CascaderPanel API
 

--- a/docs/en-US/component/cascader.md
+++ b/docs/en-US/component/cascader.md
@@ -188,6 +188,7 @@ cascader/panel
 | cascaderPanelRef              | cascader panel ref                                                                                                | ^[object]`ComputedRef<any>`                                     |
 | togglePopperVisible ^(2.2.31) | toggle the visible type of popper                                                                                 | ^[Function]`(visible?: boolean) => void`                        |
 | contentRef                    | cascader content ref                                                                                              | ^[object]`ComputedRef<any>`                                     |
+| presentText                    | selected content text                                                                                              | ^[string]                                     |
 
 ## CascaderPanel API
 

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -722,5 +722,9 @@ defineExpose({
    * @description cascader content ref
    */
   contentRef,
+  /**
+   * @description selected content text
+   */
+  presentText,
 })
 </script>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

This will expose `presentText`, to keep the same expose logic as Element UI2. 

So that user can access the component selected text to increase accessibility.

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
