### PR TITLE
fix(components): [cascader-panel] update cascader's logic of check

### DIFF
--- a/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
+++ b/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
@@ -555,7 +555,7 @@ describe('CascaderPanel.vue', () => {
     vi.useRealTimers()
   })
 
-  test('no loaded nodes should not be checked', async () => {
+  test('no loaded nodes should be checked when parent is checked', async () => {
     vi.useFakeTimers()
     const props: CascaderProps = {
       multiple: true,
@@ -589,9 +589,9 @@ describe('CascaderPanel.vue', () => {
 
     const secondMenu = wrapper.findAll(MENU)[1]
     expect(secondMenu.exists()).toBe(true)
-    expect(firstMenu.find(CHECKBOX).classes('is-checked')).toBe(false)
-    expect(firstMenu.find(CHECKBOX).classes('is-indeterminate')).toBe(true)
-    expect(secondMenu.findAll(CHECKBOX)[0].classes('is-checked')).toBe(false)
+    expect(firstMenu.find(CHECKBOX).classes('is-checked')).toBe(true)
+    expect(firstMenu.find(CHECKBOX).classes('is-indeterminate')).toBe(false)
+    expect(secondMenu.findAll(CHECKBOX)[0].classes('is-checked')).toBe(true)
     expect(secondMenu.findAll(CHECKBOX)[0].classes('is-indeterminate')).toBe(
       false
     )

--- a/packages/components/cascader-panel/src/node.ts
+++ b/packages/components/cascader-panel/src/node.ts
@@ -117,6 +117,9 @@ class Node {
     this.children = (childrenData || []).map(
       (child) => new Node(child, config, this)
     )
+    if (this.parent?.checked) {
+      this.checked = true
+    }
     this.loaded = !config.lazy || this.isLeaf || !isEmpty(childrenData)
   }
 
@@ -208,13 +211,7 @@ class Node {
       const num = p.checked ? 1 : p.indeterminate ? 0.5 : 0
       return c + num
     }, 0)
-
-    this.checked =
-      this.loaded &&
-      this.children
-        .filter((child) => !child.isDisabled)
-        .every((child) => child.loaded && child.checked) &&
-      checked
+    this.checked = checked
     this.indeterminate =
       this.loaded && checkedNum !== totalNum && checkedNum > 0
   }


### PR DESCRIPTION
lazy loaded children nodes will be checked when parent node is checked

BREAKING CHANGE :
change the node's orign logic of check

closed #18288

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
