### PR TITLE
fix(theme-chalk): upgrade SASS version and fix deprecated color function

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "puppeteer": "^17.1.3",
     "resize-observer-polyfill": "^1.5.1",
     "rimraf": "^3.0.2",
-    "sass": "^1.53.0",
+    "sass": "^1.79.3",
     "tsx": "^4.7.1",
     "type-fest": "^2.14.0",
     "typescript": "^4.7.4",

--- a/packages/theme-chalk/src/color/index.scss
+++ b/packages/theme-chalk/src/color/index.scss
@@ -9,9 +9,12 @@
 @function mix-overlay-color($upper, $lower) {
   $opacity: color.alpha($upper);
 
-  $red: color.red($upper) * $opacity + color.red($lower) * (1 - $opacity);
-  $green: color.green($upper) * $opacity + color.green($lower) * (1 - $opacity);
-  $blue: color.blue($upper) * $opacity + color.blue($lower) * (1 - $opacity);
+  $red: color.channel($upper, 'red') * $opacity + color.channel($lower, 'red') *
+    (1 - $opacity);
+  $green: color.channel($upper, 'green') * $opacity +
+    color.channel($lower, 'green') * (1 - $opacity);
+  $blue: color.channel($upper, 'blue') * $opacity +
+    color.channel($lower, 'blue') * (1 - $opacity);
 
   @return rgb2hex(rgb($red, $green, $blue));
 }

--- a/packages/theme-chalk/src/mixins/_var.scss
+++ b/packages/theme-chalk/src/mixins/_var.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+@use 'sass:color';
 
 @use 'config';
 @use 'function' as *;
@@ -49,9 +50,9 @@
   $color: map.get($colors, $type, 'base');
   @include set-css-var-value(
     ('color', $type, 'rgb'),
-    #{red($color),
-    green($color),
-    blue($color)}
+    #{color.channel($color, 'red'),
+    color.channel($color, 'green'),
+    color.channel($color, 'blue')}
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,13 +124,13 @@ importers:
         version: 1.43.1
       '@vitejs/plugin-vue':
         specifier: ^2.3.3
-        version: 2.3.3(vite@2.9.15)(vue@3.2.37)
+        version: 2.3.3(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))(vue@3.2.37)
       '@vitejs/plugin-vue-jsx':
         specifier: ^1.3.10
         version: 1.3.10
       '@vitest/coverage-v8':
         specifier: ^2.0.5
-        version: 2.0.5(vitest@2.0.5)
+        version: 2.0.5(vitest@2.0.5(@types/node@18.19.25)(@vitest/ui@2.0.5)(happy-dom@14.3.3)(jsdom@16.4.0)(sass@1.79.3)(terser@5.31.3))
       '@vitest/ui':
         specifier: ^2.0.5
         version: 2.0.5(vitest@2.0.5)
@@ -201,8 +201,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       sass:
-        specifier: ^1.53.0
-        version: 1.53.0
+        specifier: ^1.79.3
+        version: 1.79.3
       tsx:
         specifier: ^4.7.1
         version: 4.7.1
@@ -214,13 +214,13 @@ importers:
         version: 4.7.4
       unplugin-element-plus:
         specifier: ^0.4.0
-        version: 0.4.0
+        version: 0.4.0(esbuild@0.21.5)
       unplugin-vue-macros:
         specifier: ^2.7.11
-        version: 2.7.11(@vueuse/core@9.1.0)(typescript@4.7.4)(vue@3.2.37)
+        version: 2.7.11(@vueuse/core@9.1.0(vue@3.2.37))(esbuild@0.21.5)(typescript@4.7.4)(vue@3.2.37)
       vitest:
         specifier: ^2.0.5
-        version: 2.0.5(@types/node@18.19.25)(@vitest/ui@2.0.5)(happy-dom@14.3.3)(jsdom@16.4.0)(sass@1.53.0)
+        version: 2.0.5(@types/node@18.19.25)(@vitest/ui@2.0.5)(happy-dom@14.3.3)(jsdom@16.4.0)(sass@1.79.3)(terser@5.31.3)
       vue:
         specifier: ^3.2.37
         version: 3.2.37
@@ -235,7 +235,7 @@ importers:
     dependencies:
       '@docsearch/js':
         specifier: ^3.1.0
-        version: 3.1.0(@types/react@18.3.3)
+        version: 3.1.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@element-plus/icons-vue':
         specifier: ^2.3.1
         version: 2.3.1(vue@3.2.37)
@@ -272,7 +272,7 @@ importers:
         version: 3.14.0
       '@docsearch/react':
         specifier: ^3.1.0
-        version: 3.1.0(@types/react@18.3.3)
+        version: 3.1.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@element-plus/build':
         specifier: workspace:*
         version: link:../internal/build
@@ -311,31 +311,31 @@ importers:
         version: 2.0.3
       unocss:
         specifier: 0.33.5
-        version: 0.33.5(vite@2.9.15)
+        version: 0.33.5(vite@2.9.15(sass@1.79.3))
       unplugin-icons:
         specifier: ^0.14.6
-        version: 0.14.6(rollup@2.79.1)(vite@2.9.15)
+        version: 0.14.6(@vue/compiler-sfc@3.4.31)(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))(vue-template-compiler@2.7.16)
       unplugin-vue-components:
         specifier: ^0.27.3
-        version: 0.27.3(rollup@2.79.1)(vue@3.2.37)
+        version: 0.27.3(@babel/parser@7.24.8)(rollup@2.79.1)(vue@3.2.37)
       unplugin-vue-macros:
         specifier: ^0.11.2
-        version: 0.11.2(rollup@2.79.1)(vite@2.9.15)(vue@3.2.37)
+        version: 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))(vue@3.2.37)
       vite:
         specifier: ^2.9.15
-        version: 2.9.15
+        version: 2.9.15(sass@1.79.3)
       vite-plugin-inspect:
         specifier: ^0.5.0
-        version: 0.5.0(vite@2.9.15)
+        version: 0.5.0(vite@2.9.15(sass@1.79.3))
       vite-plugin-mkcert:
         specifier: ^1.7.2
-        version: 1.7.2
+        version: 1.7.2(sass@1.79.3)
       vite-plugin-pwa:
         specifier: ^0.12.0
-        version: 0.12.0(vite@2.9.15)(workbox-build@6.6.0)(workbox-window@6.6.0)
+        version: 0.12.0(vite@2.9.15(sass@1.79.3))(workbox-build@6.6.0)(workbox-window@6.6.0)
       vitepress:
         specifier: ^1.2.3
-        version: 1.2.3(@algolia/client-search@4.24.0)(@types/react@18.3.3)(axios@0.27.2)(nprogress@0.2.0)(search-insights@2.15.0)
+        version: 1.2.3(@algolia/client-search@4.24.0)(@types/node@20.14.9)(@types/react@18.3.3)(async-validator@4.2.5(patch_hash=wdmp4xlpil2odxo3rasjmxbdfm))(axios@0.27.2)(nprogress@0.2.0)(postcss@8.4.39)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.79.3)(search-insights@2.15.0)(terser@5.31.3)(typescript@4.7.4)
 
   internal/build:
     dependencies:
@@ -359,7 +359,7 @@ importers:
         version: 5.0.5(rollup@2.75.7)
       '@vitejs/plugin-vue':
         specifier: ^2.3.3
-        version: 2.3.3(vite@2.9.15)(vue@3.2.37)
+        version: 2.3.3(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))(vue@3.2.37)
       '@vitejs/plugin-vue-jsx':
         specifier: ^1.3.10
         version: 1.3.10
@@ -395,7 +395,7 @@ importers:
         version: 4.9.1(esbuild@0.14.47)(rollup@2.75.7)
       unplugin-vue-macros:
         specifier: ^0.11.2
-        version: 0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vue@3.2.37)
+        version: 0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))(vue@3.2.37)
     devDependencies:
       '@esbuild-kit/cjs-loader':
         specifier: ^2.2.1
@@ -414,7 +414,7 @@ importers:
     devDependencies:
       unbuild:
         specifier: ^2.0.0
-        version: 2.0.0(sass@1.53.0)(typescript@4.7.4)(vue-tsc@1.8.27)
+        version: 2.0.0(sass@1.79.3)(typescript@4.7.4)(vue-tsc@1.8.27(typescript@4.7.4))
 
   internal/build-utils:
     dependencies:
@@ -430,13 +430,13 @@ importers:
     devDependencies:
       unbuild:
         specifier: ^2.0.0
-        version: 2.0.0(sass@1.53.0)(typescript@4.7.4)(vue-tsc@1.8.27)
+        version: 2.0.0(sass@1.79.3)(typescript@4.7.4)(vue-tsc@1.8.27(typescript@4.7.4))
 
   internal/eslint-config:
     dependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.30.0
-        version: 5.30.0(@typescript-eslint/parser@5.30.0)(eslint@8.18.0)(typescript@4.7.4)
+        version: 5.30.0(@typescript-eslint/parser@5.30.0(eslint@8.18.0)(typescript@4.7.4))(eslint@8.18.0)(typescript@4.7.4)
       '@typescript-eslint/parser':
         specifier: ^5.30.0
         version: 5.30.0(eslint@8.18.0)(typescript@4.7.4)
@@ -451,7 +451,7 @@ importers:
         version: 3.2.0(eslint@8.18.0)
       eslint-plugin-import:
         specifier: ^2.26.0
-        version: 2.26.0(@typescript-eslint/parser@5.30.0)(eslint@8.18.0)
+        version: 2.26.0(@typescript-eslint/parser@5.30.0(eslint@8.18.0)(typescript@4.7.4))(eslint@8.18.0)
       eslint-plugin-jsonc:
         specifier: ^2.3.0
         version: 2.3.0(eslint@8.18.0)
@@ -460,7 +460,7 @@ importers:
         version: 3.0.0(eslint@8.18.0)
       eslint-plugin-prettier:
         specifier: ^4.1.0
-        version: 4.1.0(eslint-config-prettier@8.5.0)(eslint@8.18.0)(prettier@2.7.1)
+        version: 4.1.0(eslint-config-prettier@8.5.0(eslint@8.18.0))(eslint@8.18.0)(prettier@2.7.1)
       eslint-plugin-unicorn:
         specifier: ^43.0.2
         version: 43.0.2(eslint@8.18.0)
@@ -627,7 +627,7 @@ importers:
         version: 6.0.5(postcss@8.4.35)
       gulp-autoprefixer:
         specifier: ^8.0.0
-        version: 8.0.0
+        version: 8.0.0(gulp@4.0.2)
       gulp-rename:
         specifier: ^2.0.0
         version: 2.0.0
@@ -655,19 +655,19 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^2.3.3
-        version: 2.3.3(vite@2.9.15)(vue@3.2.37)
+        version: 2.3.3(vite@2.9.15(sass@1.79.3))(vue@3.2.37)
       unplugin-vue-components:
         specifier: 0.21.2
-        version: 0.21.2(vite@2.9.15)(vue@3.2.37)
+        version: 0.21.2(@babel/parser@7.24.8)(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))(vue@3.2.37)
       vite:
         specifier: ^2.9.15
-        version: 2.9.15(sass@1.53.0)
+        version: 2.9.15(sass@1.79.3)
       vite-plugin-inspect:
         specifier: ^0.5.0
-        version: 0.5.0(vite@2.9.15)
+        version: 0.5.0(vite@2.9.15(sass@1.79.3))
       vite-plugin-mkcert:
         specifier: ^1.7.2
-        version: 1.7.2(sass@1.53.0)
+        version: 1.7.2(sass@1.79.3)
 
 packages:
 
@@ -1652,11 +1652,6 @@ packages:
       '@types/react': '>= 16.8.0 < 19.0.0'
       react: '>= 16.8.0 < 19.0.0'
       react-dom: '>= 16.8.0 < 19.0.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docsearch/react@3.6.0':
     resolution: {integrity: sha512-HUFut4ztcVNmqy9gp/wxNbC7pTOHhgVVkHVGCACTuLhUKUhKAF9KYHJtMiLUJxEqiFLQiuri1fWF8zqwM/cu1w==}
@@ -1984,9 +1979,11 @@ packages:
   '@humanwhocodes/config-array@0.9.5':
     resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/object-schema@1.2.1':
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@iconify-json/ri@1.1.3':
     resolution: {integrity: sha512-YQ45kQNpuHc2bso4fDGhooWou43qy7njD/I5l7vpjcujb+P/K2BfLASbWYTTUKu6lMersuFmO8F7NdGzy6eGWw==}
@@ -2526,46 +2523,55 @@ packages:
     resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.0':
     resolution: {integrity: sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.18.0':
     resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.18.0':
     resolution: {integrity: sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
     resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.0':
     resolution: {integrity: sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.18.0':
     resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.18.0':
     resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.18.0':
     resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.18.0':
     resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
@@ -2883,9 +2889,6 @@ packages:
     resolution: {integrity: sha512-q2Wc+/vCwIlarK3FfmdM3c9OwwmoiUjzMtdgK8Y6qNIq/26S7pEk5upplhswR6M9kjqjDbIQOKgaVrhQFlLeVQ==}
     peerDependencies:
       vite: ^2.9.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
 
   '@vitejs/plugin-vue-jsx@1.3.10':
     resolution: {integrity: sha512-Cf5zznh4yNMiEMBfTOztaDVDmK1XXfgxClzOSUVUc8WAmHzogrCUeM8B05ABzuGtg0D1amfng+mUmSIOFGP3Pw==}
@@ -2897,9 +2900,6 @@ packages:
     peerDependencies:
       vite: ^2.5.10
       vue: ^3.2.25
-    peerDependenciesMeta:
-      vite:
-        optional: true
 
   '@vitejs/plugin-vue@5.0.5':
     resolution: {integrity: sha512-LOjm7XeIimLBZyzinBQ6OSm3UBCNVCpLkxGC0oWmm2YPzVZoxMsdvNVimLTBzpAnR9hl/yn1SHGuRfe6/Td9rQ==}
@@ -2907,9 +2907,6 @@ packages:
     peerDependencies:
       vite: ^5.0.0
       vue: ^3.2.25
-    peerDependenciesMeta:
-      vite:
-        optional: true
 
   '@vitest/coverage-v8@2.0.5':
     resolution: {integrity: sha512-qeFcySCg5FLO2bHHSa0tAZAOnAUbp4L6/A5JDuj9+bt53JREl8hpLjLHEWF0e/gWc8INVpJaqA7+Ene2rclpZg==}
@@ -2986,6 +2983,7 @@ packages:
   '@vue-macros/define-model@0.11.2':
     resolution: {integrity: sha512-XYH1zFBWNBjJUTzVuwgGo0Yx4cCtUEDvLMcu6TKVeqq9wrcleof4pwikOc7XrLDNqN5AxPzGFQ7wPl0iUDfb7Q==}
     engines: {node: '>=14.19.0'}
+    deprecated: It has moved to @vue-macros/define-models now, and please use it instead.
 
   '@vue-macros/define-models@1.2.2':
     resolution: {integrity: sha512-dLR9pTUR/OOMwIFT5rn116meXv7fqVL5ImD0OA89JdYGxdtaxGDP8UJZV6qtIaBiAF+2KNEf6ZAF72ST250xOA==}
@@ -3300,6 +3298,7 @@ packages:
 
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
 
   acorn-globals@6.0.0:
     resolution: {integrity: sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==}
@@ -3850,6 +3849,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chokidar@4.0.1:
+    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
+    engines: {node: '>= 14.16.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -4375,6 +4378,7 @@ packages:
   domexception@2.0.1:
     resolution: {integrity: sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==}
     engines: {node: '>=8'}
+    deprecated: Use your platform's native DOMException instead
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
@@ -5252,7 +5256,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -5369,6 +5373,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -5665,10 +5670,12 @@ packages:
   is-accessor-descriptor@0.1.6:
     resolution: {integrity: sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v0.1.7
 
   is-accessor-descriptor@1.0.0:
     resolution: {integrity: sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v1.0.1
 
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
@@ -5727,10 +5734,12 @@ packages:
   is-data-descriptor@0.1.4:
     resolution: {integrity: sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v0.1.5
 
   is-data-descriptor@1.0.0:
     resolution: {integrity: sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v1.0.1
 
   is-data-view@1.0.1:
     resolution: {integrity: sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==}
@@ -6276,6 +6285,10 @@ packages:
     resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
     engines: {node: '>=10'}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   loupe@3.1.1:
     resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
 
@@ -6717,6 +6730,7 @@ packages:
 
   ohmyfetch@0.4.18:
     resolution: {integrity: sha512-MslzNrQzBLtZHmiZBI8QMOcMpdNFlK61OJ34nFNFynZ4v+4BonfCQ7VIN4EGXvGGq5zhDzgdJoY3o9S1l2T7KQ==}
+    deprecated: Package renamed to https://github.com/unjs/ofetch
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -7422,10 +7436,15 @@ packages:
   puppeteer@17.1.3:
     resolution: {integrity: sha512-tVtvNSOOqlq75rUgwLeDAEQoLIiBqmRg0/zedpI6fuqIocIkuxG23A7FIl1oVSkuSMMLgcOP5kVhNETmsmjvPw==}
     engines: {node: '>=14.1.0'}
+    deprecated: < 22.8.2 is no longer supported
 
   q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
+    deprecated: |-
+      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
+      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.5.3:
     resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
@@ -7448,6 +7467,15 @@ packages:
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   read-pkg-up@1.0.1:
     resolution: {integrity: sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==}
@@ -7483,6 +7511,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  readdirp@4.0.1:
+    resolution: {integrity: sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==}
+    engines: {node: '>= 14.16.0'}
 
   realpath-missing@1.1.0:
     resolution: {integrity: sha512-wnWtnywepjg/eHIgWR97R7UuM5i+qHLA195qdN9UPKvcMqfn60+67S8sPPW3vDlSEfYHoFkKU8IvpCNty3zQvQ==}
@@ -7664,9 +7696,11 @@ packages:
   right-pad@1.0.1:
     resolution: {integrity: sha512-bYBjgxmkvTAfgIYy328fmkwhp39v8lwVgWhhrzxPV3yHtcSqyYKe9/XOhvW48UFjATg3VuJbpsp5822ACNvkmw==}
     engines: {node: '>= 0.10'}
+    deprecated: Please use String.prototype.padEnd() over this package.
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup-plugin-dts@4.2.2:
@@ -7754,9 +7788,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sass@1.53.0:
-    resolution: {integrity: sha512-zb/oMirbKhUgRQ0/GFz8TSAwRq2IlR29vOUJZOx0l8sV+CkHUfHa4u5nqrG+1VceZp7Jfj59SVW9ogdhTvJDcQ==}
-    engines: {node: '>=12.0.0'}
+  sass@1.79.3:
+    resolution: {integrity: sha512-m7dZxh0W9EZ3cw50Me5GOuYm/tVAJAn91SUnohLRo9cXBixGUOdvmryN+dXpwR831bhoY3Zv7rEFt85PUwTmzA==}
+    engines: {node: '>=14.0.0'}
     hasBin: true
 
   sax@1.2.1:
@@ -7765,6 +7799,9 @@ packages:
   saxes@5.0.1:
     resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
     engines: {node: '>=10'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scule@0.2.1:
     resolution: {integrity: sha512-M9gnWtn3J0W+UhJOHmBxBTwv8mZCan5i1Himp60t6vvZcor0wr+IM0URKmIglsWJ7bRujNAVVN77fp+uZaWoKg==}
@@ -7776,7 +7813,7 @@ packages:
     resolution: {integrity: sha512-ch2sPCUDD4sbPQdknVl9ALSi9H7VyoeVbsxznYz6QV55jJ8CI3EtwpO1i84keN4+hF5IeHWIeGvc08530JkVXQ==}
 
   semver-greatest-satisfied-range@1.1.0:
-    resolution: {integrity: sha1-E+jCZYq5aRywzXEJMkAoDTb3els=}
+    resolution: {integrity: sha512-Ny/iyOzSSa8M5ML46IAx3iXc6tfOsYU2R4AXi2UpHk60Zrgyq6eqPj/xiOfS0rRl/iiQ/rdJkVjw/5cdUyCntQ==}
     engines: {node: '>= 0.10'}
 
   semver@5.7.2:
@@ -7801,7 +7838,7 @@ packages:
     resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
 
   set-blocking@2.0.0:
-    resolution: {integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=}
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -7932,6 +7969,7 @@ packages:
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   sparkles@1.0.1:
     resolution: {integrity: sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==}
@@ -7972,7 +8010,7 @@ packages:
     hasBin: true
 
   stack-trace@0.0.10:
-    resolution: {integrity: sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=}
+    resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -7981,14 +8019,14 @@ packages:
     resolution: {integrity: sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==}
 
   static-extend@0.1.2:
-    resolution: {integrity: sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=}
+    resolution: {integrity: sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==}
     engines: {node: '>=0.10.0'}
 
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
 
   stealthy-require@1.1.1:
-    resolution: {integrity: sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=}
+    resolution: {integrity: sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==}
     engines: {node: '>=0.10.0'}
 
   stream-exhaust@1.0.2:
@@ -8006,7 +8044,7 @@ packages:
     engines: {node: '>=10'}
 
   string-width@1.0.2:
-    resolution: {integrity: sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=}
+    resolution: {integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==}
     engines: {node: '>=0.10.0'}
 
   string-width@4.2.3:
@@ -8049,7 +8087,7 @@ packages:
     engines: {node: '>=4'}
 
   strip-ansi@3.0.1:
-    resolution: {integrity: sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=}
+    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
     engines: {node: '>=0.10.0'}
 
   strip-ansi@6.0.1:
@@ -8061,11 +8099,11 @@ packages:
     engines: {node: '>=12'}
 
   strip-bom@2.0.0:
-    resolution: {integrity: sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=}
+    resolution: {integrity: sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==}
     engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
-    resolution: {integrity: sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=}
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
   strip-bom@4.0.0:
@@ -8125,10 +8163,10 @@ packages:
     engines: {node: '>= 0.4'}
 
   sver-compat@1.5.0:
-    resolution: {integrity: sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=}
+    resolution: {integrity: sha512-aFTHfmjwizMNlNE6dsGmoAM4lHjL0CyiobWaFiXWSlD7cIxshW422Nb8KbXCmR6z+0ZEPY+daXJrDyh/vuwTyg==}
 
   svg-tags@1.0.0:
-    resolution: {integrity: sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=}
+    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
   svgo@3.3.2:
     resolution: {integrity: sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==}
@@ -8193,7 +8231,7 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   time-stamp@1.1.0:
-    resolution: {integrity: sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=}
+    resolution: {integrity: sha512-gLCeArryy2yNTRzTGKbZbloctj64jkZ57hj5zdraXue6aFgd6PmvVtEyiUU+hvU0v7q08oVv8r8ev0tRo6bvgw==}
     engines: {node: '>=0.10.0'}
 
   tinybench@2.9.0:
@@ -8212,7 +8250,7 @@ packages:
     engines: {node: '>=14.0.0'}
 
   to-absolute-glob@2.0.2:
-    resolution: {integrity: sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=}
+    resolution: {integrity: sha512-rtwLUQEwT8ZeKQbyFJyomBRYXyE16U5VKuy0ftxLMK/PZb2fkOsg5r9kHdauuVDbsNdIBoC/HCthpidamQFXYA==}
     engines: {node: '>=0.10.0'}
 
   to-fast-properties@2.0.0:
@@ -8220,11 +8258,11 @@ packages:
     engines: {node: '>=4'}
 
   to-object-path@0.3.0:
-    resolution: {integrity: sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=}
+    resolution: {integrity: sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==}
     engines: {node: '>=0.10.0'}
 
   to-regex-range@2.1.1:
-    resolution: {integrity: sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=}
+    resolution: {integrity: sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==}
     engines: {node: '>=0.10.0'}
 
   to-regex-range@5.0.1:
@@ -8236,7 +8274,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   to-through@2.0.0:
-    resolution: {integrity: sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=}
+    resolution: {integrity: sha512-+QIz37Ly7acM4EMdw2PRN389OneM5+d844tirkGp4dPKzI5OE72V9OsbFp+CIYJDahZ41ZV05hNtcPAQUAm9/Q==}
     engines: {node: '>= 0.10'}
 
   totalist@3.0.0:
@@ -8304,13 +8342,13 @@ packages:
     hasBin: true
 
   tunnel-agent@0.6.0:
-    resolution: {integrity: sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=}
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   tweetnacl@0.14.5:
-    resolution: {integrity: sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=}
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-check@0.3.2:
-    resolution: {integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=}
+    resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
     engines: {node: '>= 0.8.0'}
 
   type-check@0.4.0:
@@ -8371,7 +8409,7 @@ packages:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
   typedarray@0.0.6:
-    resolution: {integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=}
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
   typescript@4.7.3:
     resolution: {integrity: sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==}
@@ -8415,14 +8453,14 @@ packages:
     resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
   unc-path-regex@0.1.2:
-    resolution: {integrity: sha1-5z3T17DXxe2G+6xrCufYxqadUPo=}
+    resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
     engines: {node: '>=0.10.0'}
 
   unconfig@0.3.4:
     resolution: {integrity: sha512-cf39F1brwQuLSuMLTYXOdWJH0O1CJee6a4QW1nYtO7SoBUfVvQCvEel6ssTNXtPfi17kop1ADmVtmC49NlFkIQ==}
 
   undertaker-registry@1.0.1:
-    resolution: {integrity: sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=}
+    resolution: {integrity: sha512-UR1khWeAjugW3548EfQmL9Z7pGMlBgXteQpr1IZeZBtnkCJQJIJ1Scj0mb9wQaPvUZ9Q17XqW6TIaPchJkyfqw==}
     engines: {node: '>= 0.10'}
 
   undertaker@1.3.0:
@@ -8668,7 +8706,7 @@ packages:
     engines: {node: '>=14.0.0'}
 
   unset-value@1.0.0:
-    resolution: {integrity: sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=}
+    resolution: {integrity: sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==}
     engines: {node: '>=0.10.0'}
 
   untyped@0.4.4:
@@ -8692,7 +8730,7 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   urix@0.1.0:
-    resolution: {integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=}
+    resolution: {integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==}
     deprecated: Please see https://github.com/lydell/urix#deprecated
 
   url@0.10.3:
@@ -8732,11 +8770,11 @@ packages:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
   value-or-function@3.0.0:
-    resolution: {integrity: sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=}
+    resolution: {integrity: sha512-jdBB2FrWvQC/pnPtIqcLsMaQgjhdb6B7tk1MMyTKapox+tQZbdRP4uLxu/JY0t7fbfDCUMnuelzEYv5GsxHhdg==}
     engines: {node: '>= 0.10'}
 
   verror@1.10.0:
-    resolution: {integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=}
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
 
   vinyl-fs@3.0.3:
@@ -8744,11 +8782,11 @@ packages:
     engines: {node: '>= 0.10'}
 
   vinyl-sourcemap@1.1.0:
-    resolution: {integrity: sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=}
+    resolution: {integrity: sha512-NiibMgt6VJGJmyw7vtzhctDcfKch4e4n9TBeoWlirb7FMg9/1Ov9k+A5ZRAtywBpRPiyECvQRQllYM8dECegVA==}
     engines: {node: '>= 0.10'}
 
   vinyl-sourcemaps-apply@0.2.1:
-    resolution: {integrity: sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=}
+    resolution: {integrity: sha512-+oDh3KYZBoZC8hfocrbrxbLUeaYtQK7J5WU5Br9VqWqmCll3tFJqKp97GC9GmMsVIL0qnx2DgEDVxdo5EZ5sSw==}
 
   vinyl@2.2.1:
     resolution: {integrity: sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==}
@@ -8764,9 +8802,6 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       vite: ^2.9.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
 
   vite-plugin-mkcert@1.7.2:
     resolution: {integrity: sha512-YEmjMCy2mRs8SXYHQ4TcG0L7xztahnYCCaM+vMGXI9dAjHm/XUOVB9z/I0E5z5p4hraKA31oZynarE41CxoaRA==}
@@ -8778,9 +8813,6 @@ packages:
       vite: ^2.0.0
       workbox-build: ^6.4.0
       workbox-window: ^6.4.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
 
   vite@2.9.15:
     resolution: {integrity: sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==}
@@ -8918,6 +8950,7 @@ packages:
 
   w3c-hr-time@1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
+    deprecated: Use your platform's native performance.now() and performance.timeOrigin.
 
   w3c-xmlserializer@2.0.0:
     resolution: {integrity: sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==}
@@ -8985,7 +9018,7 @@ packages:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
 
   which-module@1.0.0:
-    resolution: {integrity: sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=}
+    resolution: {integrity: sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ==}
 
   which-typed-array@1.1.15:
     resolution: {integrity: sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==}
@@ -9035,6 +9068,7 @@ packages:
 
   workbox-google-analytics@6.6.0:
     resolution: {integrity: sha512-p4DJa6OldXWd6M9zRl0H6vB9lkrmqYFkRQ2xEiNdBFp9U0LhsGO7hsBscVEyH9H2/3eZZt8c97NB2FD9U2NJ+Q==}
+    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
 
   workbox-navigation-preload@6.6.0:
     resolution: {integrity: sha512-utNEWG+uOfXdaZmvhshrh7KzhDu/1iMHyQOV6Aqup8Mm78D286ugu5k9MFD9SzBT5TcwgwSORVvInaXWbvKz9Q==}
@@ -9064,7 +9098,7 @@ packages:
     resolution: {integrity: sha512-L4N9+vka17d16geaJXXRjENLFldvkWy7JyGxElRD0JvBxvFEd8LOhr+uXCcar/NzAmIBRv9EZ+M+Qr4mOoBITw==}
 
   wrap-ansi@2.1.0:
-    resolution: {integrity: sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=}
+    resolution: {integrity: sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==}
     engines: {node: '>=0.10.0'}
 
   wrap-ansi@6.2.0:
@@ -10550,18 +10584,18 @@ snapshots:
 
   '@docsearch/css@3.6.0': {}
 
-  '@docsearch/js@3.1.0(@types/react@18.3.3)':
+  '@docsearch/js@3.1.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@docsearch/react': 3.1.0(@types/react@18.3.3)
+      '@docsearch/react': 3.1.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       preact: 10.7.3
     transitivePeerDependencies:
       - '@types/react'
       - react
       - react-dom
 
-  '@docsearch/js@3.6.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(search-insights@2.15.0)':
+  '@docsearch/js@3.6.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)':
     dependencies:
-      '@docsearch/react': 3.6.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(search-insights@2.15.0)
+      '@docsearch/react': 3.6.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)
       preact: 10.22.1
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -10570,20 +10604,25 @@ snapshots:
       - react-dom
       - search-insights
 
-  '@docsearch/react@3.1.0(@types/react@18.3.3)':
+  '@docsearch/react@3.1.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@algolia/autocomplete-core': 1.6.3
       '@docsearch/css': 3.1.0
       '@types/react': 18.3.3
       algoliasearch: 4.13.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
-  '@docsearch/react@3.6.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(search-insights@2.15.0)':
+  '@docsearch/react@3.6.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)':
     dependencies:
       '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.24.0)(algoliasearch@4.24.0)(search-insights@2.15.0)
       '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.24.0)(algoliasearch@4.24.0)
       '@docsearch/css': 3.6.0
-      '@types/react': 18.3.3
       algoliasearch: 4.24.0
+    optionalDependencies:
+      '@types/react': 18.3.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       search-insights: 2.15.0
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -11421,8 +11460,9 @@ snapshots:
 
   '@rollup/plugin-alias@5.1.0(rollup@3.29.4)':
     dependencies:
-      rollup: 3.29.4
       slash: 4.0.0
+    optionalDependencies:
+      rollup: 3.29.4
 
   '@rollup/plugin-babel@5.3.1(@babel/core@7.24.9)(rollup@2.79.1)':
     dependencies:
@@ -11463,6 +11503,7 @@ snapshots:
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.30.10
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/plugin-json@4.1.0(rollup@2.75.6)':
@@ -11473,6 +11514,7 @@ snapshots:
   '@rollup/plugin-json@6.1.0(rollup@3.29.4)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/plugin-node-resolve@11.2.1(rollup@2.79.1)':
@@ -11513,6 +11555,7 @@ snapshots:
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.8
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/plugin-replace@2.4.2(rollup@2.79.1)':
@@ -11531,12 +11574,14 @@ snapshots:
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@2.75.7)
       magic-string: 0.30.8
+    optionalDependencies:
       rollup: 2.75.7
 
   '@rollup/plugin-replace@5.0.7(rollup@3.29.4)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       magic-string: 0.30.10
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/pluginutils@3.1.0(rollup@2.75.6)':
@@ -11570,6 +11615,7 @@ snapshots:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 2.75.7
 
   '@rollup/pluginutils@5.1.0(rollup@2.79.1)':
@@ -11577,6 +11623,7 @@ snapshots:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 2.79.1
 
   '@rollup/pluginutils@5.1.0(rollup@3.29.4)':
@@ -11584,6 +11631,7 @@ snapshots:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/rollup-android-arm-eabi@4.18.0':
@@ -11829,7 +11877,7 @@ snapshots:
       '@types/node': 18.19.25
     optional: true
 
-  '@typescript-eslint/eslint-plugin@5.30.0(@typescript-eslint/parser@5.30.0)(eslint@8.18.0)(typescript@4.7.4)':
+  '@typescript-eslint/eslint-plugin@5.30.0(@typescript-eslint/parser@5.30.0(eslint@8.18.0)(typescript@4.7.4))(eslint@8.18.0)(typescript@4.7.4)':
     dependencies:
       '@typescript-eslint/parser': 5.30.0(eslint@8.18.0)(typescript@4.7.4)
       '@typescript-eslint/scope-manager': 5.30.0
@@ -11842,6 +11890,7 @@ snapshots:
       regexpp: 3.2.0
       semver: 7.3.7
       tsutils: 3.21.0(typescript@4.7.4)
+    optionalDependencies:
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
@@ -11853,6 +11902,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.30.0(typescript@4.7.4)
       debug: 4.3.4
       eslint: 8.18.0
+    optionalDependencies:
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
@@ -11868,6 +11918,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.18.0
       tsutils: 3.21.0(typescript@4.7.4)
+    optionalDependencies:
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
@@ -11883,6 +11934,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.6.2
       tsutils: 3.21.0(typescript@4.7.4)
+    optionalDependencies:
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
@@ -11911,7 +11963,7 @@ snapshots:
       '@unocss/core': 0.33.5
       '@unocss/preset-uno': 0.33.5
       cac: 6.7.12
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       colorette: 2.0.17
       consola: 2.15.3
       fast-glob: 3.2.11
@@ -11983,7 +12035,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.33.5
 
-  '@unocss/vite@0.33.5(vite@2.9.15)':
+  '@unocss/vite@0.33.5(vite@2.9.15(sass@1.79.3))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@unocss/config': 0.33.5
@@ -11992,7 +12044,7 @@ snapshots:
       '@unocss/scope': 0.33.5
       '@unocss/transformer-directives': 0.33.5
       magic-string: 0.26.7
-      vite: 2.9.15
+      vite: 2.9.15(sass@1.79.3)
 
   '@vitejs/plugin-vue-jsx@1.3.10':
     dependencies:
@@ -12005,17 +12057,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@2.3.3(vite@2.9.15)(vue@3.2.37)':
+  '@vitejs/plugin-vue@2.3.3(vite@2.9.15(sass@1.79.3))(vue@3.2.37)':
     dependencies:
-      vite: 2.9.15(sass@1.53.0)
+      vite: 2.9.15(sass@1.79.3)
       vue: 3.2.37
 
-  '@vitejs/plugin-vue@5.0.5(vite@5.3.3)(vue@3.4.31)':
+  '@vitejs/plugin-vue@2.3.3(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))(vue@3.2.37)':
     dependencies:
-      vite: 5.3.3
-      vue: 3.4.31
+      vite: 5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)
+      vue: 3.2.37
 
-  '@vitest/coverage-v8@2.0.5(vitest@2.0.5)':
+  '@vitejs/plugin-vue@5.0.5(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))(vue@3.4.31(typescript@4.7.4))':
+    dependencies:
+      vite: 5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)
+      vue: 3.4.31(typescript@4.7.4)
+
+  '@vitest/coverage-v8@2.0.5(vitest@2.0.5(@types/node@18.19.25)(@vitest/ui@2.0.5)(happy-dom@14.3.3)(jsdom@16.4.0)(sass@1.79.3)(terser@5.31.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -12029,7 +12086,7 @@ snapshots:
       std-env: 3.7.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.0.5(@types/node@18.19.25)(@vitest/ui@2.0.5)(happy-dom@14.3.3)(jsdom@16.4.0)(sass@1.53.0)
+      vitest: 2.0.5(@types/node@18.19.25)(@vitest/ui@2.0.5)(happy-dom@14.3.3)(jsdom@16.4.0)(sass@1.79.3)(terser@5.31.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -12068,7 +12125,7 @@ snapshots:
       pathe: 1.1.2
       sirv: 2.0.4
       tinyrainbow: 1.2.0
-      vitest: 2.0.5(@types/node@18.19.25)(@vitest/ui@2.0.5)(happy-dom@14.3.3)(jsdom@16.4.0)(sass@1.53.0)
+      vitest: 2.0.5(@types/node@18.19.25)(@vitest/ui@2.0.5)(happy-dom@14.3.3)(jsdom@16.4.0)(sass@1.79.3)(terser@5.31.3)
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -12133,11 +12190,12 @@ snapshots:
   '@vue-macros/common@1.10.1(vue@3.2.37)':
     dependencies:
       '@babel/types': 7.24.0
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       '@vue/compiler-sfc': 3.4.31
       ast-kit: 0.11.3
       local-pkg: 0.5.0
       magic-string-ast: 0.3.0
+    optionalDependencies:
       vue: 3.2.37
     transitivePeerDependencies:
       - rollup
@@ -12151,36 +12209,37 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-model@0.11.2(esbuild@0.14.47)(rollup@2.75.7)':
+  '@vue-macros/define-model@0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
       ast-walker-scope: 0.2.3
-      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)
+      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
       - vite
       - webpack
 
-  '@vue-macros/define-model@0.11.2(rollup@2.79.1)(vite@2.9.15)':
+  '@vue-macros/define-model@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
       ast-walker-scope: 0.2.3
-      unplugin: 0.9.5(rollup@2.79.1)(vite@2.9.15)
+      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
       - vite
       - webpack
 
-  '@vue-macros/define-models@1.2.2(@vueuse/core@9.1.0)(vue@3.2.37)':
+  '@vue-macros/define-models@1.2.2(@vueuse/core@9.1.0(vue@3.2.37))(vue@3.2.37)':
     dependencies:
       '@vue-macros/common': 1.10.1(vue@3.2.37)
-      '@vueuse/core': 9.1.0(vue@3.2.37)
       ast-walker-scope: 0.5.0
       unplugin: 1.10.0
+    optionalDependencies:
+      '@vueuse/core': 9.1.0(vue@3.2.37)
     transitivePeerDependencies:
       - rollup
       - vue
@@ -12202,7 +12261,7 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-props@2.0.3(@vue-macros/reactivity-transform@0.4.3)(vue@3.2.37)':
+  '@vue-macros/define-props@2.0.3(@vue-macros/reactivity-transform@0.4.3(vue@3.2.37))(vue@3.2.37)':
     dependencies:
       '@vue-macros/common': 1.10.1(vue@3.2.37)
       '@vue-macros/reactivity-transform': 0.4.3(vue@3.2.37)
@@ -12211,22 +12270,22 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-render@0.11.2(esbuild@0.14.47)(rollup@2.75.7)':
+  '@vue-macros/define-render@0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
-      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)
+      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
       - vite
       - webpack
 
-  '@vue-macros/define-render@0.11.2(rollup@2.79.1)(vite@2.9.15)':
+  '@vue-macros/define-render@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
-      unplugin: 0.9.5(rollup@2.79.1)(vite@2.9.15)
+      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -12282,22 +12341,22 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/hoist-static@0.11.2(esbuild@0.14.47)(rollup@2.75.7)':
+  '@vue-macros/hoist-static@0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
-      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)
+      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
       - vite
       - webpack
 
-  '@vue-macros/hoist-static@0.11.2(rollup@2.79.1)(vite@2.9.15)':
+  '@vue-macros/hoist-static@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
-      unplugin: 0.9.5(rollup@2.79.1)(vite@2.9.15)
+      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -12350,22 +12409,22 @@ snapshots:
       - rollup
       - vue
 
-  '@vue-macros/setup-component@0.11.2(esbuild@0.14.47)(rollup@2.75.7)':
+  '@vue-macros/setup-component@0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
-      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)
+      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
       - vite
       - webpack
 
-  '@vue-macros/setup-component@0.11.2(rollup@2.79.1)(vite@2.9.15)':
+  '@vue-macros/setup-component@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
-      unplugin: 0.9.5(rollup@2.79.1)(vite@2.9.15)
+      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -12380,22 +12439,22 @@ snapshots:
       - rollup
       - vue
 
-  '@vue-macros/setup-sfc@0.11.2(esbuild@0.14.47)(rollup@2.75.7)':
+  '@vue-macros/setup-sfc@0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
-      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)
+      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
       - vite
       - webpack
 
-  '@vue-macros/setup-sfc@0.11.2(rollup@2.79.1)(vite@2.9.15)':
+  '@vue-macros/setup-sfc@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
-      unplugin: 0.9.5(rollup@2.79.1)(vite@2.9.15)
+      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -12571,8 +12630,9 @@ snapshots:
       minimatch: 9.0.5
       muggle-string: 0.3.1
       path-browserify: 1.0.1
-      typescript: 4.7.4
       vue-template-compiler: 2.7.16
+    optionalDependencies:
+      typescript: 4.7.4
 
   '@vue/reactivity-transform@3.2.37':
     dependencies:
@@ -12627,11 +12687,11 @@ snapshots:
       '@vue/shared': 3.2.37
       vue: 3.2.37
 
-  '@vue/server-renderer@3.4.31(vue@3.4.31)':
+  '@vue/server-renderer@3.4.31(vue@3.4.31(typescript@4.7.4))':
     dependencies:
       '@vue/compiler-ssr': 3.4.31
       '@vue/shared': 3.4.31
-      vue: 3.4.31
+      vue: 3.4.31(typescript@4.7.4)
 
   '@vue/shared@3.2.37': {}
 
@@ -12644,15 +12704,15 @@ snapshots:
       vue: 3.2.37
 
   '@vue/tsconfig@0.1.3(@types/node@18.19.25)':
-    dependencies:
+    optionalDependencies:
       '@types/node': 18.19.25
 
-  '@vueuse/core@10.11.0(vue@3.4.31)':
+  '@vueuse/core@10.11.0(vue@3.4.31(typescript@4.7.4))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.0
-      '@vueuse/shared': 10.11.0(vue@3.4.31)
-      vue-demi: 0.14.8(vue@3.4.31)
+      '@vueuse/shared': 10.11.0(vue@3.4.31(typescript@4.7.4))
+      vue-demi: 0.14.8(vue@3.4.31(typescript@4.7.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -12667,14 +12727,16 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/integrations@10.11.0(axios@0.27.2)(focus-trap@7.5.4)(nprogress@0.2.0)(vue@3.4.31)':
+  '@vueuse/integrations@10.11.0(async-validator@4.2.5(patch_hash=wdmp4xlpil2odxo3rasjmxbdfm))(axios@0.27.2)(focus-trap@7.5.4)(nprogress@0.2.0)(vue@3.4.31(typescript@4.7.4))':
     dependencies:
-      '@vueuse/core': 10.11.0(vue@3.4.31)
-      '@vueuse/shared': 10.11.0(vue@3.4.31)
+      '@vueuse/core': 10.11.0(vue@3.4.31(typescript@4.7.4))
+      '@vueuse/shared': 10.11.0(vue@3.4.31(typescript@4.7.4))
+      vue-demi: 0.14.8(vue@3.4.31(typescript@4.7.4))
+    optionalDependencies:
+      async-validator: 4.2.5(patch_hash=wdmp4xlpil2odxo3rasjmxbdfm)
       axios: 0.27.2
       focus-trap: 7.5.4
       nprogress: 0.2.0
-      vue-demi: 0.14.8(vue@3.4.31)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -12683,9 +12745,9 @@ snapshots:
 
   '@vueuse/metadata@9.1.0': {}
 
-  '@vueuse/shared@10.11.0(vue@3.4.31)':
+  '@vueuse/shared@10.11.0(vue@3.4.31(typescript@4.7.4))':
     dependencies:
-      vue-demi: 0.14.8(vue@3.4.31)
+      vue-demi: 0.14.8(vue@3.4.31(typescript@4.7.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -12961,7 +13023,7 @@ snapshots:
   ast-kit@0.11.3:
     dependencies:
       '@babel/parser': 7.24.7
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       pathe: 1.1.2
     transitivePeerDependencies:
       - rollup
@@ -12969,7 +13031,7 @@ snapshots:
   ast-kit@0.9.5:
     dependencies:
       '@babel/parser': 7.24.7
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       pathe: 1.1.2
     transitivePeerDependencies:
       - rollup
@@ -13391,6 +13453,10 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chokidar@4.0.1:
+    dependencies:
+      readdirp: 4.0.1
 
   chownr@1.1.4: {}
 
@@ -14472,12 +14538,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.30.0)(eslint-import-resolver-node@0.3.6):
+  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.30.0(eslint@8.18.0)(typescript@4.7.4))(eslint-import-resolver-node@0.3.6):
     dependencies:
-      '@typescript-eslint/parser': 5.30.0(eslint@8.18.0)(typescript@4.7.4)
       debug: 3.2.7
-      eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.30.0(eslint@8.18.0)(typescript@4.7.4)
+      eslint-import-resolver-node: 0.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -14487,16 +14554,15 @@ snapshots:
       eslint: 8.18.0
       ignore: 5.2.0
 
-  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.30.0)(eslint@8.18.0):
+  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.30.0(eslint@8.18.0)(typescript@4.7.4))(eslint@8.18.0):
     dependencies:
-      '@typescript-eslint/parser': 5.30.0(eslint@8.18.0)(typescript@4.7.4)
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.18.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.30.0)(eslint-import-resolver-node@0.3.6)
+      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.30.0(eslint@8.18.0)(typescript@4.7.4))(eslint-import-resolver-node@0.3.6)
       has: 1.0.3
       is-core-module: 2.9.0
       is-glob: 4.0.3
@@ -14504,6 +14570,8 @@ snapshots:
       object.values: 1.1.5
       resolve: 1.22.0
       tsconfig-paths: 3.14.1
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.30.0(eslint@8.18.0)(typescript@4.7.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -14523,12 +14591,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-prettier@4.1.0(eslint-config-prettier@8.5.0)(eslint@8.18.0)(prettier@2.7.1):
+  eslint-plugin-prettier@4.1.0(eslint-config-prettier@8.5.0(eslint@8.18.0))(eslint@8.18.0)(prettier@2.7.1):
     dependencies:
       eslint: 8.18.0
-      eslint-config-prettier: 8.5.0(eslint@8.18.0)
       prettier: 2.7.1
       prettier-linter-helpers: 1.0.0
+    optionalDependencies:
+      eslint-config-prettier: 8.5.0(eslint@8.18.0)
 
   eslint-plugin-unicorn@43.0.2(eslint@8.18.0):
     dependencies:
@@ -14891,7 +14960,7 @@ snapshots:
       tabbable: 6.2.0
 
   follow-redirects@1.15.1(debug@4.3.4):
-    dependencies:
+    optionalDependencies:
       debug: 4.3.4
 
   for-each@0.3.3:
@@ -15199,7 +15268,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  gulp-autoprefixer@8.0.0:
+  gulp-autoprefixer@8.0.0(gulp@4.0.2):
     dependencies:
       autoprefixer: 10.4.7(postcss@8.4.35)
       fancy-log: 1.3.3
@@ -15207,6 +15276,8 @@ snapshots:
       postcss: 8.4.35
       through2: 4.0.2
       vinyl-sourcemaps-apply: 0.2.1
+    optionalDependencies:
+      gulp: 4.0.2
 
   gulp-cli@2.3.0:
     dependencies:
@@ -15711,7 +15782,7 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 20.14.9
+      '@types/node': 18.19.25
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
@@ -16043,6 +16114,10 @@ snapshots:
       slice-ansi: 4.0.0
       wrap-ansi: 6.2.0
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.1.1:
     dependencies:
       get-func-name: 2.0.2
@@ -16295,9 +16370,10 @@ snapshots:
       jiti: 1.13.0
       mri: 1.2.0
       pathe: 0.2.0
+    optionalDependencies:
       typescript: 4.7.3
 
-  mkdist@1.5.3(sass@1.53.0)(typescript@4.7.4)(vue-tsc@1.8.27):
+  mkdist@1.5.3(sass@1.79.3)(typescript@4.7.4)(vue-tsc@1.8.27(typescript@4.7.4)):
     dependencies:
       autoprefixer: 10.4.19(postcss@8.4.39)
       citty: 0.1.6
@@ -16313,8 +16389,9 @@ snapshots:
       pkg-types: 1.1.3
       postcss: 8.4.39
       postcss-nested: 6.0.1(postcss@8.4.39)
-      sass: 1.53.0
       semver: 7.6.2
+    optionalDependencies:
+      sass: 1.79.3
       typescript: 4.7.4
       vue-tsc: 1.8.27(typescript@4.7.4)
 
@@ -17200,6 +17277,16 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
   read-pkg-up@1.0.1:
     dependencies:
       find-up: 1.1.2
@@ -17256,6 +17343,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  readdirp@4.0.1: {}
 
   realpath-missing@1.1.0: {}
 
@@ -17572,11 +17661,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass@1.53.0:
+  sass@1.79.3:
     dependencies:
-      chokidar: 3.5.3
+      chokidar: 4.0.1
       immutable: 4.1.0
-      source-map-js: 1.0.2
+      source-map-js: 1.2.0
 
   sax@1.2.1:
     optional: true
@@ -17584,6 +17673,10 @@ snapshots:
   saxes@5.0.1:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scule@0.2.1: {}
 
@@ -18298,7 +18391,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  unbuild@2.0.0(sass@1.53.0)(typescript@4.7.4)(vue-tsc@1.8.27):
+  unbuild@2.0.0(sass@1.79.3)(typescript@4.7.4)(vue-tsc@1.8.27(typescript@4.7.4)):
     dependencies:
       '@rollup/plugin-alias': 5.1.0(rollup@3.29.4)
       '@rollup/plugin-commonjs': 25.0.8(rollup@3.29.4)
@@ -18315,7 +18408,7 @@ snapshots:
       hookable: 5.5.3
       jiti: 1.21.6
       magic-string: 0.30.10
-      mkdist: 1.5.3(sass@1.53.0)(typescript@4.7.4)(vue-tsc@1.8.27)
+      mkdist: 1.5.3(sass@1.79.3)(typescript@4.7.4)(vue-tsc@1.8.27(typescript@4.7.4))
       mlly: 1.7.1
       pathe: 1.1.2
       pkg-types: 1.1.3
@@ -18323,8 +18416,9 @@ snapshots:
       rollup: 3.29.4
       rollup-plugin-dts: 6.1.1(rollup@3.29.4)(typescript@4.7.4)
       scule: 1.3.0
-      typescript: 4.7.4
       untyped: 1.4.2
+    optionalDependencies:
+      typescript: 4.7.4
     transitivePeerDependencies:
       - sass
       - supports-color
@@ -18411,7 +18505,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unocss@0.33.5(vite@2.9.15):
+  unocss@0.33.5(vite@2.9.15(sass@1.79.3)):
     dependencies:
       '@unocss/cli': 0.33.5
       '@unocss/core': 0.33.5
@@ -18426,41 +18520,47 @@ snapshots:
       '@unocss/transformer-compile-class': 0.33.5
       '@unocss/transformer-directives': 0.33.5
       '@unocss/transformer-variant-group': 0.33.5
-      '@unocss/vite': 0.33.5(vite@2.9.15)
+      '@unocss/vite': 0.33.5(vite@2.9.15(sass@1.79.3))
     transitivePeerDependencies:
       - supports-color
       - vite
 
-  unplugin-combine@0.2.2(esbuild@0.14.47)(rollup@2.75.7):
+  unplugin-combine@0.2.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)):
     dependencies:
+      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
+    optionalDependencies:
       esbuild: 0.14.47
       rollup: 2.75.7
-      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)
+      vite: 5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)
 
-  unplugin-combine@0.2.2(rollup@2.79.1)(vite@2.9.15):
+  unplugin-combine@0.2.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3)):
     dependencies:
+      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
+    optionalDependencies:
+      esbuild: 0.21.5
       rollup: 2.79.1
-      unplugin: 0.9.5(rollup@2.79.1)(vite@2.9.15)
-      vite: 2.9.15
+      vite: 2.9.15(sass@1.79.3)
 
-  unplugin-combine@0.8.1:
+  unplugin-combine@0.8.1(esbuild@0.21.5):
     dependencies:
       '@antfu/utils': 0.7.7
       unplugin: 1.10.0
+    optionalDependencies:
+      esbuild: 0.21.5
 
-  unplugin-element-plus@0.4.0:
+  unplugin-element-plus@0.4.0(esbuild@0.21.5):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       es-module-lexer: 0.10.5
       magic-string: 0.26.2
-      unplugin: 0.6.3
+      unplugin: 0.6.3(esbuild@0.21.5)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - vite
       - webpack
 
-  unplugin-icons@0.14.6(rollup@2.79.1)(vite@2.9.15):
+  unplugin-icons@0.14.6(@vue/compiler-sfc@3.4.31)(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))(vue-template-compiler@2.7.16):
     dependencies:
       '@antfu/install-pkg': 0.1.0
       '@antfu/utils': 0.5.2
@@ -18468,7 +18568,10 @@ snapshots:
       debug: 4.3.4
       kolorist: 1.5.1
       local-pkg: 0.4.1
-      unplugin: 0.7.0(rollup@2.79.1)(vite@2.9.15)
+      unplugin: 0.7.0(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.4.31
+      vue-template-compiler: 2.7.16
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -18476,7 +18579,7 @@ snapshots:
       - vite
       - webpack
 
-  unplugin-vue-components@0.21.2(vite@2.9.15)(vue@3.2.37):
+  unplugin-vue-components@0.21.2(@babel/parser@7.24.8)(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))(vue@3.2.37):
     dependencies:
       '@antfu/utils': 0.5.2
       '@rollup/pluginutils': 4.2.1
@@ -18487,8 +18590,10 @@ snapshots:
       magic-string: 0.26.3
       minimatch: 5.1.0
       resolve: 1.22.1
-      unplugin: 0.7.2(vite@2.9.15)
+      unplugin: 0.7.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
       vue: 3.2.37
+    optionalDependencies:
+      '@babel/parser': 7.24.8
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -18496,7 +18601,7 @@ snapshots:
       - vite
       - webpack
 
-  unplugin-vue-components@0.27.3(rollup@2.79.1)(vue@3.2.37):
+  unplugin-vue-components@0.27.3(@babel/parser@7.24.8)(rollup@2.79.1)(vue@3.2.37):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
@@ -18509,28 +18614,30 @@ snapshots:
       mlly: 1.7.1
       unplugin: 1.12.0
       vue: 3.2.37
+    optionalDependencies:
+      '@babel/parser': 7.24.8
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  unplugin-vue-define-options@0.11.2(esbuild@0.14.47)(rollup@2.75.7):
+  unplugin-vue-define-options@0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
       ast-walker-scope: 0.2.3
-      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)
+      unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
       - vite
       - webpack
 
-  unplugin-vue-define-options@0.11.2(rollup@2.79.1)(vite@2.9.15):
+  unplugin-vue-define-options@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3)):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
       ast-walker-scope: 0.2.3
-      unplugin: 0.9.5(rollup@2.79.1)(vite@2.9.15)
+      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -18546,18 +18653,18 @@ snapshots:
       - rollup
       - vue
 
-  unplugin-vue-macros@0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vue@3.2.37):
+  unplugin-vue-macros@0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))(vue@3.2.37):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
-      '@vue-macros/define-model': 0.11.2(esbuild@0.14.47)(rollup@2.75.7)
-      '@vue-macros/define-render': 0.11.2(esbuild@0.14.47)(rollup@2.75.7)
-      '@vue-macros/hoist-static': 0.11.2(esbuild@0.14.47)(rollup@2.75.7)
-      '@vue-macros/setup-component': 0.11.2(esbuild@0.14.47)(rollup@2.75.7)
-      '@vue-macros/setup-sfc': 0.11.2(esbuild@0.14.47)(rollup@2.75.7)
+      '@vue-macros/define-model': 0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
+      '@vue-macros/define-render': 0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
+      '@vue-macros/hoist-static': 0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
+      '@vue-macros/setup-component': 0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
+      '@vue-macros/setup-sfc': 0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
       local-pkg: 0.4.2
-      unplugin-combine: 0.2.2(esbuild@0.14.47)(rollup@2.75.7)
-      unplugin-vue-define-options: 0.11.2(esbuild@0.14.47)(rollup@2.75.7)
+      unplugin-combine: 0.2.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
+      unplugin-vue-define-options: 0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
       vue: 3.2.37
     transitivePeerDependencies:
       - esbuild
@@ -18565,18 +18672,18 @@ snapshots:
       - vite
       - webpack
 
-  unplugin-vue-macros@0.11.2(rollup@2.79.1)(vite@2.9.15)(vue@3.2.37):
+  unplugin-vue-macros@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))(vue@3.2.37):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
-      '@vue-macros/define-model': 0.11.2(rollup@2.79.1)(vite@2.9.15)
-      '@vue-macros/define-render': 0.11.2(rollup@2.79.1)(vite@2.9.15)
-      '@vue-macros/hoist-static': 0.11.2(rollup@2.79.1)(vite@2.9.15)
-      '@vue-macros/setup-component': 0.11.2(rollup@2.79.1)(vite@2.9.15)
-      '@vue-macros/setup-sfc': 0.11.2(rollup@2.79.1)(vite@2.9.15)
+      '@vue-macros/define-model': 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
+      '@vue-macros/define-render': 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
+      '@vue-macros/hoist-static': 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
+      '@vue-macros/setup-component': 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
+      '@vue-macros/setup-sfc': 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
       local-pkg: 0.4.2
-      unplugin-combine: 0.2.2(rollup@2.79.1)(vite@2.9.15)
-      unplugin-vue-define-options: 0.11.2(rollup@2.79.1)(vite@2.9.15)
+      unplugin-combine: 0.2.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
+      unplugin-vue-define-options: 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3))
       vue: 3.2.37
     transitivePeerDependencies:
       - esbuild
@@ -18584,16 +18691,16 @@ snapshots:
       - vite
       - webpack
 
-  unplugin-vue-macros@2.7.11(@vueuse/core@9.1.0)(typescript@4.7.4)(vue@3.2.37):
+  unplugin-vue-macros@2.7.11(@vueuse/core@9.1.0(vue@3.2.37))(esbuild@0.21.5)(typescript@4.7.4)(vue@3.2.37):
     dependencies:
       '@vue-macros/better-define': 1.7.3(vue@3.2.37)
       '@vue-macros/boolean-prop': 0.3.2(vue@3.2.37)
       '@vue-macros/chain-call': 0.2.2(vue@3.2.37)
       '@vue-macros/common': 1.10.1(vue@3.2.37)
       '@vue-macros/define-emit': 0.2.3(vue@3.2.37)
-      '@vue-macros/define-models': 1.2.2(@vueuse/core@9.1.0)(vue@3.2.37)
+      '@vue-macros/define-models': 1.2.2(@vueuse/core@9.1.0(vue@3.2.37))(vue@3.2.37)
       '@vue-macros/define-prop': 0.3.3(vue@3.2.37)
-      '@vue-macros/define-props': 2.0.3(@vue-macros/reactivity-transform@0.4.3)(vue@3.2.37)
+      '@vue-macros/define-props': 2.0.3(@vue-macros/reactivity-transform@0.4.3(vue@3.2.37))(vue@3.2.37)
       '@vue-macros/define-props-refs': 1.2.2(vue@3.2.37)
       '@vue-macros/define-render': 1.5.2(vue@3.2.37)
       '@vue-macros/define-slots': 1.1.2(vue@3.2.37)
@@ -18612,7 +18719,7 @@ snapshots:
       '@vue-macros/short-emits': 1.5.2(vue@3.2.37)
       '@vue-macros/short-vmodel': 1.4.2(vue@3.2.37)
       unplugin: 1.10.0
-      unplugin-combine: 0.8.1
+      unplugin-combine: 0.8.1(esbuild@0.21.5)
       unplugin-vue-define-options: 1.4.2(vue@3.2.37)
       vue: 3.2.37
     transitivePeerDependencies:
@@ -18623,46 +18730,57 @@ snapshots:
       - vite
       - webpack
 
-  unplugin@0.6.3:
+  unplugin@0.6.3(esbuild@0.21.5):
     dependencies:
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.4.3
+    optionalDependencies:
+      esbuild: 0.21.5
 
-  unplugin@0.7.0(rollup@2.79.1)(vite@2.9.15):
-    dependencies:
-      acorn: 8.12.1
-      chokidar: 3.5.3
-      rollup: 2.79.1
-      vite: 2.9.15
-      webpack-sources: 3.2.3
-      webpack-virtual-modules: 0.4.3
-
-  unplugin@0.7.2(vite@2.9.15):
-    dependencies:
-      acorn: 8.12.1
-      chokidar: 3.5.3
-      vite: 2.9.15(sass@1.53.0)
-      webpack-sources: 3.2.3
-      webpack-virtual-modules: 0.4.4
-
-  unplugin@0.9.5(esbuild@0.14.47)(rollup@2.75.7):
+  unplugin@0.7.0(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3)):
     dependencies:
       acorn: 8.12.1
       chokidar: 3.6.0
+      webpack-sources: 3.2.3
+      webpack-virtual-modules: 0.4.3
+    optionalDependencies:
+      esbuild: 0.21.5
+      rollup: 2.79.1
+      vite: 2.9.15(sass@1.79.3)
+
+  unplugin@0.7.2(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3)):
+    dependencies:
+      acorn: 8.12.1
+      chokidar: 3.6.0
+      webpack-sources: 3.2.3
+      webpack-virtual-modules: 0.4.4
+    optionalDependencies:
+      esbuild: 0.21.5
+      rollup: 2.79.1
+      vite: 2.9.15(sass@1.79.3)
+
+  unplugin@0.9.5(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)):
+    dependencies:
+      acorn: 8.12.1
+      chokidar: 3.6.0
+      webpack-sources: 3.2.3
+      webpack-virtual-modules: 0.4.4
+    optionalDependencies:
       esbuild: 0.14.47
       rollup: 2.75.7
-      webpack-sources: 3.2.3
-      webpack-virtual-modules: 0.4.4
+      vite: 5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)
 
-  unplugin@0.9.5(rollup@2.79.1)(vite@2.9.15):
+  unplugin@0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@2.9.15(sass@1.79.3)):
     dependencies:
       acorn: 8.12.1
       chokidar: 3.6.0
-      rollup: 2.79.1
-      vite: 2.9.15
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.4.4
+    optionalDependencies:
+      esbuild: 0.21.5
+      rollup: 2.79.1
+      vite: 2.9.15(sass@1.79.3)
 
   unplugin@1.10.0:
     dependencies:
@@ -18809,13 +18927,13 @@ snapshots:
       remove-trailing-separator: 1.1.0
       replace-ext: 1.0.1
 
-  vite-node@2.0.5(@types/node@18.19.25)(sass@1.53.0):
+  vite-node@2.0.5(@types/node@18.19.25)(sass@1.79.3)(terser@5.31.3):
     dependencies:
       cac: 6.7.14
       debug: 4.3.5
       pathe: 1.1.2
       tinyrainbow: 1.2.0
-      vite: 5.3.3(@types/node@18.19.25)(sass@1.53.0)
+      vite: 5.3.3(@types/node@18.19.25)(sass@1.79.3)(terser@5.31.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18826,24 +18944,24 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-inspect@0.5.0(vite@2.9.15):
+  vite-plugin-inspect@0.5.0(vite@2.9.15(sass@1.79.3)):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       debug: 4.3.4
       kolorist: 1.5.1
       sirv: 2.0.2
       ufo: 0.8.4
-      vite: 2.9.15
+      vite: 2.9.15(sass@1.79.3)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-mkcert@1.7.2:
+  vite-plugin-mkcert@1.7.2(sass@1.79.3):
     dependencies:
       '@octokit/rest': 18.12.0
       axios: 0.21.4(debug@4.3.4)
       debug: 4.3.4
       picocolors: 1.0.0
-      vite: 2.9.15
+      vite: 2.9.15(sass@1.79.3)
     transitivePeerDependencies:
       - encoding
       - less
@@ -18851,33 +18969,19 @@ snapshots:
       - stylus
       - supports-color
 
-  vite-plugin-mkcert@1.7.2(sass@1.53.0):
-    dependencies:
-      '@octokit/rest': 18.12.0
-      axios: 0.21.4(debug@4.3.4)
-      debug: 4.3.4
-      picocolors: 1.0.0
-      vite: 2.9.15(sass@1.53.0)
-    transitivePeerDependencies:
-      - encoding
-      - less
-      - sass
-      - stylus
-      - supports-color
-
-  vite-plugin-pwa@0.12.0(vite@2.9.15)(workbox-build@6.6.0)(workbox-window@6.6.0):
+  vite-plugin-pwa@0.12.0(vite@2.9.15(sass@1.79.3))(workbox-build@6.6.0)(workbox-window@6.6.0):
     dependencies:
       debug: 4.3.4
       fast-glob: 3.2.11
       pretty-bytes: 6.0.0
       rollup: 2.75.6
-      vite: 2.9.15
+      vite: 2.9.15(sass@1.79.3)
       workbox-build: 6.6.0
       workbox-window: 6.6.0
     transitivePeerDependencies:
       - supports-color
 
-  vite@2.9.15:
+  vite@2.9.15(sass@1.79.3):
     dependencies:
       esbuild: 0.14.47
       postcss: 8.4.14
@@ -18885,53 +18989,50 @@ snapshots:
       rollup: 2.75.7
     optionalDependencies:
       fsevents: 2.3.3
+      sass: 1.79.3
 
-  vite@2.9.15(sass@1.53.0):
-    dependencies:
-      esbuild: 0.14.47
-      postcss: 8.4.14
-      resolve: 1.22.1
-      rollup: 2.75.7
-      sass: 1.53.0
-    optionalDependencies:
-      fsevents: 2.3.3
-
-  vite@5.3.3:
+  vite@5.3.3(@types/node@18.19.25)(sass@1.79.3)(terser@5.31.3):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.39
       rollup: 4.18.0
     optionalDependencies:
-      fsevents: 2.3.3
-
-  vite@5.3.3(@types/node@18.19.25)(sass@1.53.0):
-    dependencies:
       '@types/node': 18.19.25
+      fsevents: 2.3.3
+      sass: 1.79.3
+      terser: 5.31.3
+
+  vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3):
+    dependencies:
       esbuild: 0.21.5
       postcss: 8.4.39
       rollup: 4.18.0
-      sass: 1.53.0
     optionalDependencies:
+      '@types/node': 20.14.9
       fsevents: 2.3.3
+      sass: 1.79.3
+      terser: 5.31.3
 
-  vitepress@1.2.3(@algolia/client-search@4.24.0)(@types/react@18.3.3)(axios@0.27.2)(nprogress@0.2.0)(search-insights@2.15.0):
+  vitepress@1.2.3(@algolia/client-search@4.24.0)(@types/node@20.14.9)(@types/react@18.3.3)(async-validator@4.2.5(patch_hash=wdmp4xlpil2odxo3rasjmxbdfm))(axios@0.27.2)(nprogress@0.2.0)(postcss@8.4.39)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.79.3)(search-insights@2.15.0)(terser@5.31.3)(typescript@4.7.4):
     dependencies:
       '@docsearch/css': 3.6.0
-      '@docsearch/js': 3.6.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(search-insights@2.15.0)
+      '@docsearch/js': 3.6.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)
       '@shikijs/core': 1.10.1
       '@shikijs/transformers': 1.10.1
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.0.5(vite@5.3.3)(vue@3.4.31)
+      '@vitejs/plugin-vue': 5.0.5(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))(vue@3.4.31(typescript@4.7.4))
       '@vue/devtools-api': 7.3.5
       '@vue/shared': 3.4.31
-      '@vueuse/core': 10.11.0(vue@3.4.31)
-      '@vueuse/integrations': 10.11.0(axios@0.27.2)(focus-trap@7.5.4)(nprogress@0.2.0)(vue@3.4.31)
+      '@vueuse/core': 10.11.0(vue@3.4.31(typescript@4.7.4))
+      '@vueuse/integrations': 10.11.0(async-validator@4.2.5(patch_hash=wdmp4xlpil2odxo3rasjmxbdfm))(axios@0.27.2)(focus-trap@7.5.4)(nprogress@0.2.0)(vue@3.4.31(typescript@4.7.4))
       focus-trap: 7.5.4
       mark.js: 8.11.1
       minisearch: 6.3.0
       shiki: 1.10.1
-      vite: 5.3.3
-      vue: 3.4.31
+      vite: 5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)
+      vue: 3.4.31(typescript@4.7.4)
+    optionalDependencies:
+      postcss: 8.4.39
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'
@@ -18959,31 +19060,32 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@2.0.5(@types/node@18.19.25)(@vitest/ui@2.0.5)(happy-dom@14.3.3)(jsdom@16.4.0)(sass@1.53.0):
+  vitest@2.0.5(@types/node@18.19.25)(@vitest/ui@2.0.5)(happy-dom@14.3.3)(jsdom@16.4.0)(sass@1.79.3)(terser@5.31.3):
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@types/node': 18.19.25
       '@vitest/expect': 2.0.5
       '@vitest/pretty-format': 2.0.5
       '@vitest/runner': 2.0.5
       '@vitest/snapshot': 2.0.5
       '@vitest/spy': 2.0.5
-      '@vitest/ui': 2.0.5(vitest@2.0.5)
       '@vitest/utils': 2.0.5
       chai: 5.1.1
       debug: 4.3.5
       execa: 8.0.1
-      happy-dom: 14.3.3
-      jsdom: 16.4.0
       magic-string: 0.30.10
       pathe: 1.1.2
       std-env: 3.7.0
       tinybench: 2.9.0
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.3.3(@types/node@18.19.25)(sass@1.53.0)
-      vite-node: 2.0.5(@types/node@18.19.25)(sass@1.53.0)
+      vite: 5.3.3(@types/node@18.19.25)(sass@1.79.3)(terser@5.31.3)
+      vite-node: 2.0.5(@types/node@18.19.25)(sass@1.79.3)(terser@5.31.3)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 18.19.25
+      '@vitest/ui': 2.0.5(vitest@2.0.5)
+      happy-dom: 14.3.3
+      jsdom: 16.4.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -18997,9 +19099,9 @@ snapshots:
     dependencies:
       vue: 3.2.37
 
-  vue-demi@0.14.8(vue@3.4.31):
+  vue-demi@0.14.8(vue@3.4.31(typescript@4.7.4)):
     dependencies:
-      vue: 3.4.31
+      vue: 3.4.31(typescript@4.7.4)
 
   vue-eslint-parser@9.0.2(eslint@8.18.0):
     dependencies:
@@ -19039,21 +19141,14 @@ snapshots:
       '@vue/server-renderer': 3.2.37(vue@3.2.37)
       '@vue/shared': 3.2.37
 
-  vue@3.4.31:
-    dependencies:
-      '@vue/compiler-dom': 3.4.31
-      '@vue/compiler-sfc': 3.4.31
-      '@vue/runtime-dom': 3.4.31
-      '@vue/server-renderer': 3.4.31(vue@3.4.31)
-      '@vue/shared': 3.4.31
-
   vue@3.4.31(typescript@4.7.4):
     dependencies:
       '@vue/compiler-dom': 3.4.31
       '@vue/compiler-sfc': 3.4.31
       '@vue/runtime-dom': 3.4.31
-      '@vue/server-renderer': 3.4.31(vue@3.4.31)
+      '@vue/server-renderer': 3.4.31(vue@3.4.31(typescript@4.7.4))
       '@vue/shared': 3.4.31
+    optionalDependencies:
       typescript: 4.7.4
 
   w3c-hr-time@1.0.2:


### PR DESCRIPTION
Upgrade SASS version to 1.79.3
fix code from #18300
I did not fix the deprecated warning for the SASS Legacy JS API because I do not know where to make the change

closed #18306, #18301, #18300

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
