### PR TITLE
docs: improve language matching logic

### DIFF
--- a/docs/.vitepress/lang.js
+++ b/docs/.vitepress/lang.js
@@ -2,18 +2,15 @@
   const supportedLangs = window.supportedLangs
   const cacheKey = 'preferred_lang'
   const defaultLang = 'en-US'
-  // docs supported languages
-  const langAlias = {
-    en: 'en-US',
-    fr: 'fr-FR',
-    es: 'es-ES',
+  const handleNavigatorLang = (navLang) => {
+    const { language, region } = new Intl.Locale(navLang).maximize()
+    return `${language}-${region}`
   }
-  let userPreferredLang = localStorage.getItem(cacheKey) || navigator.language
-  const language =
-    langAlias[userPreferredLang] ||
-    (supportedLangs.includes(userPreferredLang)
-      ? userPreferredLang
-      : defaultLang)
+  let userPreferredLang =
+    localStorage.getItem(cacheKey) || handleNavigatorLang(navigator.language)
+  const language = supportedLangs.includes(userPreferredLang)
+    ? userPreferredLang
+    : defaultLang
   localStorage.setItem(cacheKey, language)
   userPreferredLang = language
   if (!location.pathname.startsWith(`/${userPreferredLang}`)) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### Description

This PR addresses an issue with the language preference handling in the documentation. Specifically, it resolves the problem where `navigator.language` does not match variations of the Chinese language code (e.g., 'zh' not matching 'zh-CN').

### Problem Illustration
![image](https://github.com/user-attachments/assets/e614563a-c2dd-4c03-a8ab-fbfff7e3df78)
