### PR TITLE
ci: the node version supported by action is consistent with GitHub

### DIFF
--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/pr-docs-build.yml
+++ b/.github/workflows/pr-docs-build.yml
@@ -13,13 +13,11 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [20]
         os: [ubuntu-latest, windows-latest]
         include:
-          - node-version: 18
+          - node-version: 20
             node-name: LTS
-          # - node-version: 18
-          #   node-name: Current
 
       fail-fast: false
 

--- a/.github/workflows/publish-build-product.yml
+++ b/.github/workflows/publish-build-product.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/publish-docs-deploy-manual.yml
+++ b/.github/workflows/publish-docs-deploy-manual.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/publish-docs-deploy.yml
+++ b/.github/workflows/publish-docs-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/publish-npm-nightly.yml
+++ b/.github/workflows/publish-npm-nightly.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: 20
           registry-url: https://registry.npmjs.com/
 
       - name: Setup pnpm

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           registry-url: https://registry.npmjs.com/
 
       - name: Get pnpm store directory
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           registry-url: https://registry.npmjs.com/
 
       - name: Setup pnpm

--- a/.github/workflows/publish-pr-commit-pkg.yml
+++ b/.github/workflows/publish-pr-commit-pkg.yml
@@ -21,7 +21,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
 
       - name: Setup pnpm

--- a/.github/workflows/publish-size-report.yml
+++ b/.github/workflows/publish-size-report.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/staging-docs.yml
+++ b/.github/workflows/staging-docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/test-ssr.yml
+++ b/.github/workflows/test-ssr.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -57,12 +57,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22]
         include:
-          - node-version: 18
-            node-name: LTS
           - node-version: 20
-            node-name: LTS-20
+            node-name: LTS
+          - node-version: 22
+            node-name: Current
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

![image](https://github.com/user-attachments/assets/343b8757-6ec2-418c-a74e-0c055a859cc7)

