### PR TITLE
feat(components): [transfer] render costum panel body

### DIFF
--- a/packages/components/transfer/src/composables/use-check.ts
+++ b/packages/components/transfer/src/composables/use-check.ts
@@ -138,6 +138,31 @@ export const useCheck = (
     }
   )
 
+  const toggleChecked = (keys: TransferKey[], checked?: boolean) => {
+    const checkedKeys = panelState.checked.slice()
+
+    const check = (key: TransferKey) => checkedKeys.push(key)
+    const uncheck = (key: TransferKey) =>
+      checkedKeys.splice(checkedKeys.indexOf(key), 1)
+
+    const mode =
+      checked === undefined ? 'toggle' : checked ? 'check' : 'uncheck'
+
+    keys.forEach((k) => {
+      const hasChecked = checkedKeys.includes(k)
+
+      if (mode === 'toggle') {
+        hasChecked ? uncheck(k) : check(k)
+      } else if (mode === 'check' && !hasChecked) {
+        check(k)
+      } else if (mode === 'uncheck' && hasChecked) {
+        uncheck(k)
+      }
+    })
+
+    panelState.checked = checkedKeys
+  }
+
   return {
     filteredData,
     checkableData,
@@ -145,5 +170,6 @@ export const useCheck = (
     isIndeterminate,
     updateAllChecked,
     handleAllCheckedChange,
+    toggleChecked,
   }
 }

--- a/packages/components/transfer/src/transfer-panel.ts
+++ b/packages/components/transfer/src/transfer-panel.ts
@@ -28,6 +28,7 @@ export const transferPanelProps = buildProps({
   filterMethod: transferProps.filterMethod,
   defaultChecked: transferProps.leftDefaultChecked,
   props: transferProps.props,
+  remainPanelBody: Boolean,
 } as const)
 export type TransferPanelProps = ExtractPropTypes<typeof transferPanelProps>
 

--- a/packages/components/transfer/src/transfer-panel.vue
+++ b/packages/components/transfer/src/transfer-panel.vue
@@ -23,24 +23,33 @@
         clearable
         :validate-event="false"
       />
-      <el-checkbox-group
-        v-show="!hasNoMatch && !isEmpty(data)"
-        v-model="checked"
-        :validate-event="false"
+
+      <div
+        v-show="showPanelBody"
         :class="[ns.is('filterable', filterable), ns.be('panel', 'list')]"
       >
-        <el-checkbox
-          v-for="item in filteredData"
-          :key="item[propsAlias.key]"
-          :class="ns.be('panel', 'item')"
-          :value="item[propsAlias.key]"
-          :disabled="item[propsAlias.disabled]"
-          :validate-event="false"
+        <slot
+          name="body"
+          :filtered-data="filteredData"
+          :checked-keys="checked"
+          :toggle-checked="toggleChecked"
         >
-          <option-content :option="optionRender?.(item)" />
-        </el-checkbox>
-      </el-checkbox-group>
-      <p v-show="hasNoMatch || isEmpty(data)" :class="ns.be('panel', 'empty')">
+          <el-checkbox-group v-model="checked" :validate-event="false">
+            <el-checkbox
+              v-for="item in filteredData"
+              :key="item[propsAlias.key]"
+              :class="ns.be('panel', 'item')"
+              :value="item[propsAlias.key]"
+              :disabled="item[propsAlias.disabled]"
+              :validate-event="false"
+            >
+              <option-content :option="optionRender?.(item)" />
+            </el-checkbox>
+          </el-checkbox-group>
+        </slot>
+      </div>
+
+      <p v-show="showPanelEmpty" :class="ns.be('panel', 'empty')">
         {{ hasNoMatch ? t('el.transfer.noMatch') : t('el.transfer.noData') }}
       </p>
     </div>
@@ -90,6 +99,7 @@ const {
   checkedSummary,
   isIndeterminate,
   handleAllCheckedChange,
+  toggleChecked,
 } = useCheck(props, panelState, emit)
 
 const hasNoMatch = computed(
@@ -97,6 +107,14 @@ const hasNoMatch = computed(
 )
 
 const hasFooter = computed(() => !isEmpty(slots.default!()[0].children))
+
+const showPanelBody = computed(
+  () => props.remainPanelBody || (!hasNoMatch.value && !isEmpty(props.data))
+)
+
+const showPanelEmpty = computed(
+  () => !props.remainPanelBody && (hasNoMatch.value || isEmpty(props.data))
+)
 
 const { checked, allChecked, query } = toRefs(panelState)
 

--- a/packages/components/transfer/src/transfer.ts
+++ b/packages/components/transfer/src/transfer.ts
@@ -138,6 +138,14 @@ export const transferProps = buildProps({
     type: Boolean,
     default: true,
   },
+  /**
+   * @description whether to remain the left panel body when having no data or match data
+   */
+  remainLeftPanelBody: Boolean,
+  /**
+   * @description whether to remain the right panel body when having no data or match data
+   */
+  remainRightPanelBody: Boolean,
 } as const)
 export type TransferProps = ExtractPropTypes<typeof transferProps>
 

--- a/packages/components/transfer/src/transfer.vue
+++ b/packages/components/transfer/src/transfer.vue
@@ -11,8 +11,12 @@
       :filter-method="filterMethod"
       :default-checked="leftDefaultChecked"
       :props="props.props"
+      :remain-panel-body="remainLeftPanelBody"
       @checked-change="onSourceCheckedChange"
     >
+      <template #body="bodyProps">
+        <slot name="left-panel-body" v-bind="bodyProps" />
+      </template>
       <slot name="left-footer" />
     </transfer-panel>
     <div :class="ns.e('buttons')">
@@ -46,8 +50,12 @@
       :title="rightPanelTitle"
       :default-checked="rightDefaultChecked"
       :props="props.props"
+      :remain-panel-body="remainRightPanelBody"
       @checked-change="onTargetCheckedChange"
     >
+      <template #body="bodyProps">
+        <slot name="right-panel-body" v-bind="bodyProps" />
+      </template>
       <slot name="right-footer" />
     </transfer-panel>
   </div>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## description

This PR is to enhance the ElTransfer so that it can render the custom panel body. Based on this new feature, ElTransfer could work with other components such as ElTree.

Related discussion: #15762.

The TransferPanel exposes a new slot `body`, its default value is the original checkbox group. Users could use the slot `left-panel-body` and `right-panel-body` exposed on the Transfer with the props `fileredData`, `checkedKey`, and a method `toggleChecked` that are bind to the slot to render data. To get more flexibility with the original behavior of `no data` and `no match data`, there are two new props `remainLeftPanelBody` and `remainRightPanelBody`.
