### PR TITLE
feat(components): [input] show pwd visible icon when the input is readonly

### DIFF
--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -305,7 +305,6 @@ const showPwdVisible = computed(
   () =>
     props.showPassword &&
     !inputDisabled.value &&
-    !props.readonly &&
     !!nativeInputValue.value &&
     (!!nativeInputValue.value || isFocused.value)
 )


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## description

This PR is to show the password visible icon when the input is readonly.

Users could get a better experience if they are able to toggle the visibility of the password input when it is readonly.