### PR TITLE
fix(components): [descriptions] fix slot parsing for description-items

### DIFF
--- a/packages/components/descriptions/src/description.vue
+++ b/packages/components/descriptions/src/description.vue
@@ -26,7 +26,7 @@
 
 <script lang="ts" setup>
 import { computed, provide, useSlots } from 'vue'
-import { isArray, isObject } from '@element-plus/utils'
+import { isObject } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { useFormSize } from '@element-plus/components/form'
 import ElDescriptionsRow from './descriptions-row.vue'


### PR DESCRIPTION
closed #18452

The original implementation used `flattedChildren(slots.default()).filter(...)` to extract `<el-descriptions-item>` nodes, which did not account for nested or deeply embedded child nodes within custom components. This caused scenarios where descriptions items nested in other components were not being parsed correctly, resulting in incomplete or missing content in the final layout. 

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
