### PR TITLE
fix(hooks): rendering multiple popper container DOM in SSR/SSG

### DIFF
--- a/packages/hooks/use-popper-container/index.ts
+++ b/packages/hooks/use-popper-container/index.ts
@@ -3,8 +3,6 @@ import { isClient } from '@element-plus/utils'
 import { useGetDerivedNamespace } from '../use-namespace'
 import { useIdInjection } from '../use-id'
 
-let cachedContainer: HTMLElement
-
 export const usePopperContainerId = () => {
   const namespace = useGetDerivedNamespace()
   const idInjection = useIdInjection()
@@ -37,10 +35,9 @@ export const usePopperContainer = () => {
     // for this we need to disable the caching since it's not really needed
     if (
       process.env.NODE_ENV === 'test' ||
-      !cachedContainer ||
       !document.body.querySelector(selector.value)
     ) {
-      cachedContainer = createContainer(id.value)
+      createContainer(id.value)
     }
   })
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

By viewing the [document](https://element-plus.org/zh-CN/component/overview.html), it can be found that there are two `<div id="el-popper-container-1024">` appearing in the DOM.