### PR TITLE
perf(components): [table] body render performance optimize

### DIFF
--- a/packages/components/table/src/table-body/render-helper.ts
+++ b/packages/components/table/src/table-body/render-helper.ts
@@ -6,6 +6,7 @@ import { getRowIdentity } from '../util'
 import { TABLE_INJECTION_KEY } from '../tokens'
 import useEvents from './events-helper'
 import useStyles from './styles-helper'
+import TdWrapper from './td-wrapper.vue'
 import type { TableBodyProps } from './defaults'
 import type { RenderRowData, TableProps, TreeNode } from '../table/defaults'
 
@@ -112,7 +113,6 @@ function useRender<T>(props: Partial<TableBodyProps<T>>) {
         }
         const baseKey = `${getKeyOfRow(row, $index)},${cellIndex}`
         const patchKey = columnData.columnKey || columnData.rawColumnKey || ''
-        const tdChildren = cellChildren(cellIndex, column, data)
         const mergedTooltipOptions =
           column.showOverflowTooltip &&
           merge(
@@ -123,7 +123,7 @@ function useRender<T>(props: Partial<TableBodyProps<T>>) {
             column.showOverflowTooltip
           )
         return h(
-          'td',
+          TdWrapper,
           {
             style: getCellStyle($index, cellIndex, row, column),
             class: getCellClass($index, cellIndex, row, column, colspan - 1),
@@ -134,7 +134,9 @@ function useRender<T>(props: Partial<TableBodyProps<T>>) {
               handleCellMouseEnter($event, row, mergedTooltipOptions),
             onMouseleave: handleCellMouseLeave,
           },
-          [tdChildren]
+          {
+            default: () => cellChildren(cellIndex, column, data),
+          }
         )
       })
     )

--- a/packages/components/table/src/table-body/td-wrapper.vue
+++ b/packages/components/table/src/table-body/td-wrapper.vue
@@ -1,0 +1,20 @@
+<template>
+  <td :colspan="colspan" :rowspan="rowspan"><slot /></td>
+</template>
+
+<script setup lang="ts">
+defineOptions({
+  name: 'TableTdWrapper',
+})
+
+defineProps({
+  colspan: {
+    type: Number,
+    default: 1,
+  },
+  rowspan: {
+    type: Number,
+    default: 1,
+  },
+})
+</script>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

# Description

解除 tbody 组件的 render  和  selection（row data）数据的依赖关系，使得对表格数据的修改不会触发全量的tbody render和patch，从而可以实现在 500 行乘以 20 列的情况下的可编辑表格、点击 selection  checkbox 选中行数据不卡顿，满足更多常规业务场景。

fix: #16120 #15122  #10724 