### PR TITLE
fix(components): [select-v2] group label overflow hidden

### DIFF
--- a/packages/theme-chalk/src/option-group.scss
+++ b/packages/theme-chalk/src/option-group.scss
@@ -17,10 +17,14 @@
   }
 
   @include e(title) {
-    padding-left: $gap;
+    box-sizing: border-box;
+    padding: 0 $gap;
     font-size: map.get($select-group, 'font-size');
     color: map.get($select-group, 'text-color');
     line-height: map.get($select-group, 'height');
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   & .#{$namespace}-select-dropdown__item {


### PR DESCRIPTION
fix: [18548](https://github.com/element-plus/element-plus/issues/18548)

before:

<img width="343" alt="image" src="https://github.com/user-attachments/assets/2fa22f30-052e-4dde-babc-803f6088659c">

after:

<img width="302" alt="image" src="https://github.com/user-attachments/assets/7edebbd5-b70f-4f4a-a76e-85ca39b4fc04">
