### PR TITLE
chore(docs): switch Vue to the version used by VitePress

### DIFF
--- a/docs/.vitepress/config/index.mts
+++ b/docs/.vitepress/config/index.mts
@@ -8,8 +8,9 @@ import { nav } from './nav'
 import { mdPlugin } from './plugins'
 import { sidebars } from './sidebars'
 import { getViteConfig } from './vite'
+import { vueCompiler } from './vue-compiler'
 
-import type { UserConfigFn } from 'vitepress'
+import type { UserConfig } from 'vitepress'
 
 const buildTransformers = () => {
   const transformer = () => {
@@ -47,8 +48,8 @@ languages.forEach((lang) => {
   }
 })
 
-const setupConfig: UserConfigFn<any> = (configEnv) => {
-  const config = {
+const setupConfig = (configEnv) => {
+  const config: UserConfig<any> = {
     title: 'Element Plus',
     description: 'A Vue 3 based component library for designers and developers',
     lastUpdated: true,
@@ -78,6 +79,7 @@ const setupConfig: UserConfigFn<any> = (configEnv) => {
       config: (md) => mdPlugin(md),
     },
     vue: {
+      compiler: vueCompiler,
       template: {
         compilerOptions: {
           hoistStatic: false,

--- a/docs/.vitepress/config/vite.ts
+++ b/docs/.vitepress/config/vite.ts
@@ -1,6 +1,5 @@
 import path from 'path'
 import Inspect from 'vite-plugin-inspect'
-import VueMacros from 'unplugin-vue-macros/vite'
 import UnoCSS from 'unocss/vite'
 import mkcert from 'vite-plugin-mkcert'
 import glob from 'fast-glob'
@@ -75,16 +74,7 @@ export const getViteConfig = ({ mode }: { mode: string }): ViteConfig => {
       alias,
     },
     plugins: [
-      VueMacros({
-        setupComponent: false,
-        setupSFC: false,
-        hoistStatic: {
-          exclude: ['./**/*.vue'],
-        },
-        plugins: {
-          vueJsx: vueJsx(),
-        },
-      }),
+      vueJsx(),
 
       // https://github.com/antfu/unplugin-vue-components
       Components({

--- a/docs/.vitepress/config/vue-compiler.ts
+++ b/docs/.vitepress/config/vue-compiler.ts
@@ -1,0 +1,9 @@
+// TODO: delete this file after upgrading vue in root package.json
+import { createRequire } from 'node:module'
+
+const _require = createRequire(import.meta.url)
+const vitepressPath = _require.resolve('vitepress')
+
+export const vueCompiler = _require(
+  _require.resolve('vue/compiler-sfc', { paths: [vitepressPath] })
+)

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,8 +18,7 @@
     "clipboard-copy": "^4.0.1",
     "element-plus": "npm:element-plus@latest",
     "normalize.css": "^8.0.1",
-    "nprogress": "^0.2.0",
-    "vue": "^3.2.37"
+    "nprogress": "^0.2.0"
   },
   "devDependencies": {
     "@crowdin/cli": "^3.7.10",
@@ -39,7 +38,6 @@
     "unocss": "0.33.5",
     "unplugin-icons": "^0.14.6",
     "unplugin-vue-components": "^0.27.3",
-    "unplugin-vue-macros": "^0.11.2",
     "vite-plugin-inspect": "^0.5.0",
     "vite-plugin-mkcert": "^1.7.2",
     "vite-plugin-pwa": "^0.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,7 +238,7 @@ importers:
         version: 3.1.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@element-plus/icons-vue':
         specifier: ^2.3.1
-        version: 2.3.1(vue@3.2.37)
+        version: 2.3.1(vue@3.4.31(typescript@4.7.4))
       '@element-plus/metadata':
         specifier: workspace:*
         version: link:../internal/metadata
@@ -247,7 +247,7 @@ importers:
         version: 3.2.37
       '@vueuse/core':
         specifier: ^9.1.0
-        version: 9.1.0(vue@3.2.37)
+        version: 9.1.0(vue@3.4.31(typescript@4.7.4))
       axios:
         specifier: ^0.27.2
         version: 0.27.2
@@ -256,16 +256,13 @@ importers:
         version: 4.0.1
       element-plus:
         specifier: npm:element-plus@latest
-        version: 2.8.1(vue@3.2.37)
+        version: 2.8.1(vue@3.4.31(typescript@4.7.4))
       normalize.css:
         specifier: ^8.0.1
         version: 8.0.1
       nprogress:
         specifier: ^0.2.0
         version: 0.2.0
-      vue:
-        specifier: ^3.2.37
-        version: 3.2.37
     devDependencies:
       '@crowdin/cli':
         specifier: ^3.7.10
@@ -317,10 +314,7 @@ importers:
         version: 0.14.6(@vue/compiler-sfc@3.4.31)(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))(vue-template-compiler@2.7.16)
       unplugin-vue-components:
         specifier: ^0.27.3
-        version: 0.27.3(@babel/parser@7.24.8)(rollup@2.79.1)(vue@3.2.37)
-      unplugin-vue-macros:
-        specifier: ^0.11.2
-        version: 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))(vue@3.2.37)
+        version: 0.27.3(@babel/parser@7.24.8)(rollup@2.79.1)(vue@3.4.31(typescript@4.7.4))
       vite-plugin-inspect:
         specifier: ^0.5.0
         version: 0.5.0(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
@@ -9050,7 +9044,6 @@ packages:
 
   workbox-google-analytics@6.6.0:
     resolution: {integrity: sha512-p4DJa6OldXWd6M9zRl0H6vB9lkrmqYFkRQ2xEiNdBFp9U0LhsGO7hsBscVEyH9H2/3eZZt8c97NB2FD9U2NJ+Q==}
-    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
 
   workbox-navigation-preload@6.6.0:
     resolution: {integrity: sha512-utNEWG+uOfXdaZmvhshrh7KzhDu/1iMHyQOV6Aqup8Mm78D286ugu5k9MFD9SzBT5TcwgwSORVvInaXWbvKz9Q==}
@@ -10612,6 +10605,10 @@ snapshots:
   '@element-plus/icons-vue@2.3.1(vue@3.2.37)':
     dependencies:
       vue: 3.2.37
+
+  '@element-plus/icons-vue@2.3.1(vue@3.4.31(typescript@4.7.4))':
+    dependencies:
+      vue: 3.4.31(typescript@4.7.4)
 
   '@esbuild-kit/cjs-loader@2.2.1':
     dependencies:
@@ -12197,18 +12194,6 @@ snapshots:
       - vite
       - webpack
 
-  '@vue-macros/define-model@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))':
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      '@vue-macros/common': 0.11.2
-      ast-walker-scope: 0.2.3
-      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-
   '@vue-macros/define-models@1.2.2(@vueuse/core@9.1.0(vue@3.2.37))(vue@3.2.37)':
     dependencies:
       '@vue-macros/common': 1.10.1(vue@3.2.37)
@@ -12251,17 +12236,6 @@ snapshots:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
       unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-
-  '@vue-macros/define-render@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))':
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      '@vue-macros/common': 0.11.2
-      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -12328,17 +12302,6 @@ snapshots:
       - vite
       - webpack
 
-  '@vue-macros/hoist-static@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))':
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      '@vue-macros/common': 0.11.2
-      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-
   '@vue-macros/hoist-static@1.5.2(vue@3.2.37)':
     dependencies:
       '@vue-macros/common': 1.10.1(vue@3.2.37)
@@ -12396,17 +12359,6 @@ snapshots:
       - vite
       - webpack
 
-  '@vue-macros/setup-component@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))':
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      '@vue-macros/common': 0.11.2
-      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-
   '@vue-macros/setup-component@0.17.2(vue@3.2.37)':
     dependencies:
       '@vue-macros/common': 1.10.1(vue@3.2.37)
@@ -12420,17 +12372,6 @@ snapshots:
       '@rollup/pluginutils': 4.2.1
       '@vue-macros/common': 0.11.2
       unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-
-  '@vue-macros/setup-sfc@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))':
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      '@vue-macros/common': 0.11.2
-      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -12703,6 +12644,16 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
+  '@vueuse/core@9.1.0(vue@3.4.31(typescript@4.7.4))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.15
+      '@vueuse/metadata': 9.1.0
+      '@vueuse/shared': 9.1.0(vue@3.4.31(typescript@4.7.4))
+      vue-demi: 0.13.1(vue@3.4.31(typescript@4.7.4))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
   '@vueuse/integrations@10.11.0(async-validator@4.2.5(patch_hash=wdmp4xlpil2odxo3rasjmxbdfm))(axios@0.27.2)(focus-trap@7.5.4)(nprogress@0.2.0)(vue@3.4.31(typescript@4.7.4))':
     dependencies:
       '@vueuse/core': 10.11.0(vue@3.4.31(typescript@4.7.4))
@@ -12731,6 +12682,13 @@ snapshots:
   '@vueuse/shared@9.1.0(vue@3.2.37)':
     dependencies:
       vue-demi: 0.13.1(vue@3.2.37)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/shared@9.1.0(vue@3.4.31(typescript@4.7.4))':
+    dependencies:
+      vue-demi: 0.13.1(vue@3.4.31(typescript@4.7.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -14029,15 +13987,15 @@ snapshots:
 
   electron-to-chromium@1.4.825: {}
 
-  element-plus@2.8.1(vue@3.2.37):
+  element-plus@2.8.1(vue@3.4.31(typescript@4.7.4)):
     dependencies:
       '@ctrl/tinycolor': 3.6.1
-      '@element-plus/icons-vue': 2.3.1(vue@3.2.37)
+      '@element-plus/icons-vue': 2.3.1(vue@3.4.31(typescript@4.7.4))
       '@floating-ui/dom': 1.6.8
       '@popperjs/core': '@sxzz/popperjs-es@2.11.7'
       '@types/lodash': 4.17.7
       '@types/lodash-es': 4.17.12
-      '@vueuse/core': 9.1.0(vue@3.2.37)
+      '@vueuse/core': 9.1.0(vue@3.4.31(typescript@4.7.4))
       async-validator: 4.2.5(patch_hash=wdmp4xlpil2odxo3rasjmxbdfm)
       dayjs: 1.11.12
       escape-html: 1.0.3
@@ -14046,7 +14004,7 @@ snapshots:
       lodash-unified: 1.0.3(@types/lodash-es@4.17.12)(lodash-es@4.17.21)(lodash@4.17.21)
       memoize-one: 6.0.0
       normalize-wheel-es: 1.2.0
-      vue: 3.2.37
+      vue: 3.4.31(typescript@4.7.4)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -18509,14 +18467,6 @@ snapshots:
       rollup: 2.75.7
       vite: 5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)
 
-  unplugin-combine@0.2.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)):
-    dependencies:
-      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-    optionalDependencies:
-      esbuild: 0.21.5
-      rollup: 2.79.1
-      vite: 5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)
-
   unplugin-combine@0.8.1(esbuild@0.21.5):
     dependencies:
       '@antfu/utils': 0.7.7
@@ -18577,7 +18527,7 @@ snapshots:
       - vite
       - webpack
 
-  unplugin-vue-components@0.27.3(@babel/parser@7.24.8)(rollup@2.79.1)(vue@3.2.37):
+  unplugin-vue-components@0.27.3(@babel/parser@7.24.8)(rollup@2.79.1)(vue@3.4.31(typescript@4.7.4)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
@@ -18589,7 +18539,7 @@ snapshots:
       minimatch: 9.0.5
       mlly: 1.7.1
       unplugin: 1.12.0
-      vue: 3.2.37
+      vue: 3.4.31(typescript@4.7.4)
     optionalDependencies:
       '@babel/parser': 7.24.8
     transitivePeerDependencies:
@@ -18602,18 +18552,6 @@ snapshots:
       '@vue-macros/common': 0.11.2
       ast-walker-scope: 0.2.3
       unplugin: 0.9.5(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-
-  unplugin-vue-define-options@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)):
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      '@vue-macros/common': 0.11.2
-      ast-walker-scope: 0.2.3
-      unplugin: 0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -18641,25 +18579,6 @@ snapshots:
       local-pkg: 0.4.2
       unplugin-combine: 0.2.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
       unplugin-vue-define-options: 0.11.2(esbuild@0.14.47)(rollup@2.75.7)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-      vue: 3.2.37
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-
-  unplugin-vue-macros@0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))(vue@3.2.37):
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      '@vue-macros/common': 0.11.2
-      '@vue-macros/define-model': 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-      '@vue-macros/define-render': 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-      '@vue-macros/hoist-static': 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-      '@vue-macros/setup-component': 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-      '@vue-macros/setup-sfc': 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-      local-pkg: 0.4.2
-      unplugin-combine: 0.2.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
-      unplugin-vue-define-options: 0.11.2(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3))
       vue: 3.2.37
     transitivePeerDependencies:
       - esbuild
@@ -18745,17 +18664,6 @@ snapshots:
     optionalDependencies:
       esbuild: 0.14.47
       rollup: 2.75.7
-      vite: 5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)
-
-  unplugin@0.9.5(esbuild@0.21.5)(rollup@2.79.1)(vite@5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)):
-    dependencies:
-      acorn: 8.12.1
-      chokidar: 3.6.0
-      webpack-sources: 3.2.3
-      webpack-virtual-modules: 0.4.4
-    optionalDependencies:
-      esbuild: 0.21.5
-      rollup: 2.79.1
       vite: 5.3.3(@types/node@20.14.9)(sass@1.79.3)(terser@5.31.3)
 
   unplugin@1.10.0:
@@ -19085,6 +18993,10 @@ snapshots:
   vue-demi@0.13.1(vue@3.2.37):
     dependencies:
       vue: 3.2.37
+
+  vue-demi@0.13.1(vue@3.4.31(typescript@4.7.4)):
+    dependencies:
+      vue: 3.4.31(typescript@4.7.4)
 
   vue-demi@0.14.8(vue@3.4.31(typescript@4.7.4)):
     dependencies:


### PR DESCRIPTION
`@vitejs/plugin-vue` resolves Vue from project root by default, which means it used 3.2.x before, so I manually specified the version as 3.4.x that is used by Vitepress. 
Since `defineOptions` has been integrated into the Vue core as of version 3.3.x, we can remove `vue-macros`.