### PR TITLE
fix: progress bar get stuck when navigating between routes

### DIFF
--- a/docs/.vitepress/vitepress/components/vp-content.vue
+++ b/docs/.vitepress/vitepress/components/vp-content.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onUpdated, ref, watch } from 'vue'
+import { computed, nextTick, watch } from 'vue'
 import nprogress from 'nprogress'
 import { useData, useRoute } from 'vitepress'
 import { useSidebar } from '../composables/sidebar'
@@ -16,23 +16,26 @@ const { hasSidebar } = useSidebar()
 
 const props = defineProps<{ isSidebarOpen: boolean }>()
 
-const shouldUpdateProgress = ref(true)
+let shouldUpdateProgress = true
 
 watch(
   () => props.isSidebarOpen,
   (val) => {
     // delay the flag update since watch is called before onUpdated
     nextTick(() => {
-      shouldUpdateProgress.value = !val
+      shouldUpdateProgress = !val
     })
   }
 )
-
-onUpdated(() => {
-  if (shouldUpdateProgress.value) {
-    nprogress.done()
+watch(
+  () => route.path,
+  () => {
+    if (shouldUpdateProgress) nprogress.done()
+  },
+  {
+    flush: 'post',
   }
-})
+)
 </script>
 
 <template>


### PR DESCRIPTION
Vue 3.4 improved the reactivity system in https://github.com/vuejs/core/pull/5912.

> If computed new value does not change, computed, effect, watch, watchEffect, render dependencies will not be triggered

In `vp-content.vue`, running `nprogress.done()` depends on the computed value `isNotFound` which no longer triggers a re-render after the route changes.





