### PR TITLE
chore: gen script does not support hyphens

### DIFF
--- a/scripts/gc.sh
+++ b/scripts/gc.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-NAME=$1
+NAME=$(echo $1 | sed -E 's/([A-Z])/-\1/g' | sed -E 's/^-//g' | tr 'A-Z' 'a-z')
 
 FILE_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")/../packages" && pwd)
 
@@ -25,6 +25,7 @@ for i in $(echo $NAME | sed 's/[_|-]\([a-z]\)/\ \1/;s/^\([a-z]\)/\ \1/'); do
   NORMALIZED_NAME="$NORMALIZED_NAME${C}${i:1}"
 done
 NAME=$NORMALIZED_NAME
+PROP_NAME=$(echo "${NAME:0:1}" | tr '[:upper:]' '[:lower:]')${NAME:1}
 
 mkdir -p "$DIRNAME"
 mkdir -p "$DIRNAME/src"
@@ -38,13 +39,13 @@ cat > $DIRNAME/src/$INPUT_NAME.vue <<EOF
 </template>
 
 <script lang="ts" setup>
-import { ${INPUT_NAME}Props } from './$INPUT_NAME'
+import { ${PROP_NAME}Props } from './$INPUT_NAME'
 
 defineOptions({
   name: 'El$NAME',
 })
 
-const props = defineProps(${INPUT_NAME}Props)
+const props = defineProps(${PROP_NAME}Props)
 
 // init here
 </script>
@@ -56,17 +57,21 @@ import { buildProps } from '@element-plus/utils'
 import type { ExtractPropTypes } from 'vue'
 import type $NAME from './$INPUT_NAME.vue'
 
-export const ${INPUT_NAME}Props = buildProps({})
+export const ${PROP_NAME}Props = buildProps({})
+export type ${NAME}Props = ExtractPropTypes<typeof ${PROP_NAME}Props>
 
-export type ${NAME}Props = ExtractPropTypes<typeof ${INPUT_NAME}Props>
+export const ${PROP_NAME}Emits = {}
+export type ${NAME}Emits = typeof ${PROP_NAME}Emits
+
 export type ${NAME}Instance = InstanceType<typeof $NAME>
 EOF
 
 cat <<EOF >"$DIRNAME/index.ts"
 import { withInstall } from '@element-plus/utils'
 import $NAME from './src/$INPUT_NAME.vue'
+import type { SFCWithInstall } from '@element-plus/utils'
 
-export const El$NAME = withInstall($NAME)
+export const El$NAME: SFCWithInstall<typeof $NAME> = withInstall($NAME)
 export default El$NAME
 
 export * from './src/$INPUT_NAME'

--- a/scripts/gc.sh
+++ b/scripts/gc.sh
@@ -19,7 +19,7 @@ if [ -d "$DIRNAME" ]; then
   exit 1
 fi
 
-NAME=$(echo $NAME | sed -r 's/(^|-)([a-z])/\2/g' | tr 'a-z' 'A-Z')
+NAME=$(echo $NAME | awk -F'-' '{ for(i=1; i<=NF; i++) { $i = toupper(substr($i,1,1)) tolower(substr($i,2)) } print $0 }' OFS='')
 PROP_NAME=$(echo "${NAME:0:1}" | tr '[:upper:]' '[:lower:]')${NAME:1}
 
 mkdir -p "$DIRNAME"

--- a/scripts/gc.sh
+++ b/scripts/gc.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-NAME=$(echo $1 | sed -E 's/([A-Z])/-\1/g' | sed -E 's/^-//g' | sed -E 's/_/-/g' | tr 'A-Z' 'a-z')
+NAME=$(echo $1 | sed -E "s/([A-Z])/-\1/g" | sed -E "s/^-//g" | sed -E "s/_/-/g" | tr "A-Z" "a-z")
 
 FILE_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")/../packages" && pwd)
 
@@ -24,6 +24,7 @@ PROP_NAME=$(echo "${NAME:0:1}" | tr '[:upper:]' '[:lower:]')${NAME:1}
 
 mkdir -p "$DIRNAME"
 mkdir -p "$DIRNAME/src"
+mkdir -p "$DIRNAME/style"
 mkdir -p "$DIRNAME/__tests__"
 
 cat > $DIRNAME/src/$INPUT_NAME.vue <<EOF
@@ -88,3 +89,22 @@ describe('$NAME.vue', () => {
   })
 })
 EOF
+
+cat > $DIRNAME/style/index.ts <<EOF
+import '@element-plus/components/base/style'
+import '@element-plus/theme-chalk/src/$INPUT_NAME.scss'
+EOF
+
+cat > $DIRNAME/style/css.ts <<EOF
+import '@element-plus/components/base/style/css'
+import '@element-plus/theme-chalk/el-$INPUT_NAME.css'
+EOF
+
+cat > $FILE_PATH/theme-chalk/src/$INPUT_NAME.scss <<EOF
+EOF
+
+perl -0777 -pi -e "s/\n\n/\nexport * from '.\/$INPUT_NAME'\n\n/" $FILE_PATH/components/index.ts
+
+TYPE_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")/../typings" && pwd)
+
+perl -0777 -pi -e "s/\n\s+}/\n    El$NAME: typeof import('element-plus')['El$NAME']\n  }/" $TYPE_PATH/global.d.ts

--- a/scripts/gc.sh
+++ b/scripts/gc.sh
@@ -1,13 +1,13 @@
 #! /bin/bash
 
-NAME=$(echo $1 | sed -E 's/([A-Z])/-\1/g' | sed -E 's/^-//g' | tr 'A-Z' 'a-z')
+NAME=$(echo $1 | sed -E 's/([A-Z])/-\1/g' | sed -E 's/^-//g' | sed -E 's/_/-/g' | tr 'A-Z' 'a-z')
 
 FILE_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")/../packages" && pwd)
 
 re="[[:space:]]+"
 
 if [ "$#" -ne 1 ] || [[ $NAME =~ $re ]] || [ "$NAME" == "" ]; then
-  echo "Usage: pnpm gc \${name} with no space"
+  echo "Usage: pnpm gen \${name} with no space"
   exit 1
 fi
 
@@ -19,12 +19,7 @@ if [ -d "$DIRNAME" ]; then
   exit 1
 fi
 
-NORMALIZED_NAME=""
-for i in $(echo $NAME | sed 's/[_|-]\([a-z]\)/\ \1/;s/^\([a-z]\)/\ \1/'); do
-  C=$(echo "${i:0:1}" | tr "[:lower:]" "[:upper:]")
-  NORMALIZED_NAME="$NORMALIZED_NAME${C}${i:1}"
-done
-NAME=$NORMALIZED_NAME
+NAME=$(echo $NAME | sed -r 's/(^|-)([a-z])/\2/g' | tr 'a-z' 'A-Z')
 PROP_NAME=$(echo "${NAME:0:1}" | tr '[:upper:]' '[:lower:]')${NAME:1}
 
 mkdir -p "$DIRNAME"

--- a/scripts/gc.sh
+++ b/scripts/gc.sh
@@ -35,7 +35,7 @@ cat > $DIRNAME/src/$INPUT_NAME.vue <<EOF
 </template>
 
 <script lang="ts" setup>
-import { ${PROP_NAME}Props, ${PROP_NAME}Emits } from './$INPUT_NAME'
+import { ${PROP_NAME}Emits, ${PROP_NAME}Props } from './$INPUT_NAME'
 
 defineOptions({
   name: 'El$NAME',
@@ -52,13 +52,16 @@ cat > $DIRNAME/src/$INPUT_NAME.ts <<EOF
 import { buildProps } from '@element-plus/utils'
 
 import type { ExtractPropTypes } from 'vue'
-import type $NAME from './$INPUT_NAME.vue'
 
 export const ${PROP_NAME}Props = buildProps({} as const)
 export type ${NAME}Props = ExtractPropTypes<typeof ${PROP_NAME}Props>
 
 export const ${PROP_NAME}Emits = {}
 export type ${NAME}Emits = typeof ${PROP_NAME}Emits
+EOF
+
+cat > $DIRNAME/src/instance.ts <<EOF
+import type $NAME from './$INPUT_NAME.vue'
 
 export type ${NAME}Instance = InstanceType<typeof $NAME>
 EOF
@@ -72,6 +75,7 @@ export const El$NAME: SFCWithInstall<typeof $NAME> = withInstall($NAME)
 export default El$NAME
 
 export * from './src/$INPUT_NAME'
+export type { ${NAME}Instance } from './src/instance'
 EOF
 
 cat > $DIRNAME/__tests__/$INPUT_NAME.test.tsx <<EOF

--- a/scripts/gc.sh
+++ b/scripts/gc.sh
@@ -34,13 +34,14 @@ cat > $DIRNAME/src/$INPUT_NAME.vue <<EOF
 </template>
 
 <script lang="ts" setup>
-import { ${PROP_NAME}Props } from './$INPUT_NAME'
+import { ${PROP_NAME}Props, ${PROP_NAME}Emits } from './$INPUT_NAME'
 
 defineOptions({
   name: 'El$NAME',
 })
 
 const props = defineProps(${PROP_NAME}Props)
+const emit = defineEmits(${PROP_NAME}Emits)
 
 // init here
 </script>
@@ -52,7 +53,7 @@ import { buildProps } from '@element-plus/utils'
 import type { ExtractPropTypes } from 'vue'
 import type $NAME from './$INPUT_NAME.vue'
 
-export const ${PROP_NAME}Props = buildProps({})
+export const ${PROP_NAME}Props = buildProps({} as const)
 export type ${NAME}Props = ExtractPropTypes<typeof ${PROP_NAME}Props>
 
 export const ${PROP_NAME}Emits = {}


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

1. fix the gen script does not support hyphens

```sh
pnpm gen input-tag
```

before

```vue
<script lang="ts" setup>
import { input-tagProps } from './input-tag'

defineOptions({
  name: 'ElInputTag',
})

const props = defineProps(input-tagProps)

// init here
</script>

```

after

```vue
<script lang="ts" setup>
import { inputTagProps } from './input-tag'

defineOptions({
  name: 'ElInputTag',
})

const props = defineProps(inputTagProps)

// init here
</script>

```

---

2. updated the generated content
3. generate style files
4. the component name support inputting camel-case strings

```sh
pnpm gen input-tag
pnpm gen inputTag
pnpm gen InputTag
pnpm gen input_tag
```

They will all generate `input-tag` directory