### PR TITLE
fix(theme-chalk):  sass `!global assignments` deprecation warning

### DIFF
--- a/packages/theme-chalk/src/mixins/mixins.scss
+++ b/packages/theme-chalk/src/mixins/mixins.scss
@@ -6,7 +6,10 @@
 @forward '_var';
 @use 'config' as *;
 @use 'sass:string';
-@use "sass:map";
+@use 'sass:map';
+
+$B: null;
+$E: null;
 
 // Break-points
 @mixin res($key, $map: $breakpoints) {


### PR DESCRIPTION
In sass 1.80.5, will receive a deprecation warning  、
fix: 
#18708 
https://github.com/element-plus/element-plus/issues/18759 
https://github.com/element-plus/element-plus/issues/18732#issuecomment-2450604214


![image](https://github.com/user-attachments/assets/8d967aa0-95f6-4cab-9ed9-b17935189940)
![image](https://github.com/user-attachments/assets/7e42ab6f-f9fc-4bfd-b369-aee7e9f56c34)
