### PR TITLE
style(components): [table] use `--font-size-base` for default font size

### DIFF
--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -904,7 +904,7 @@ $table-font-size: () !default;
 $table-font-size: map.merge(
   (
     'large': getCssVar('font-size', 'base'),
-    'default': 14px,
+    'default': getCssVar('font-size', 'base'),
     'small': 12px,
   ),
   $table-font-size

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -905,7 +905,7 @@ $table-font-size: map.merge(
   (
     'large': getCssVar('font-size', 'base'),
     'default': getCssVar('font-size', 'base'),
-    'small': 12px,
+    'small': getCssVar('font-size', 'extra-small'),
   ),
   $table-font-size
 );

--- a/packages/theme-chalk/src/table-v2.scss
+++ b/packages/theme-chalk/src/table-v2.scss
@@ -52,7 +52,7 @@
 }
 
 @include b('table-v2') {
-  font-size: 14px;
+  font-size: getCssVar('font-size', 'base');
 
   * {
     box-sizing: border-box;

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -16,7 +16,7 @@
   width: 100%;
   max-width: 100%;
   background-color: getCssVar('table-bg-color');
-  font-size: 14px;
+  font-size: getCssVar('font-size', 'base');
   color: getCssVar('table-text-color');
 
   @include e(inner-wrapper) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### Description:

Updated the `font-size` of the table component from a static value of `14px` to the CSS variable `getCssVar('font-size', 'base')`.

This change allows for dynamic adjustments across themes, ensuring consistency with the base font size.