### PR TITLE
chore: remove deprecated package @types/sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@types/gulp": "^4.0.9",
     "@types/jsdom": "^16.2.14",
     "@types/node": "^18.19.25",
-    "@types/sass": "^1.43.1",
     "@vitejs/plugin-vue": "^2.3.3",
     "@vitejs/plugin-vue-jsx": "^1.3.10",
     "@vitest/coverage-v8": "^2.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,12 +119,9 @@ importers:
       '@types/node':
         specifier: ^18.19.25
         version: 18.19.25
-      '@types/sass':
-        specifier: ^1.43.1
-        version: 1.43.1
       '@vitejs/plugin-vue':
         specifier: ^2.3.3
-        version: 2.3.3(vite@2.9.15(sass@1.79.3))(vue@3.2.37)
+        version: 2.3.3(vue@3.2.37)
       '@vitejs/plugin-vue-jsx':
         specifier: ^1.3.10
         version: 1.3.10
@@ -2676,9 +2673,6 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
-
-  '@types/sass@1.43.1':
-    resolution: {integrity: sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==}
 
   '@types/tough-cookie@4.0.2':
     resolution: {integrity: sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==}
@@ -11244,6 +11238,12 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 2.3.1
 
+  '@rollup/pluginutils@5.1.0':
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+
   '@rollup/pluginutils@5.1.0(rollup@2.75.7)':
     dependencies:
       '@types/estree': 1.0.5
@@ -11465,10 +11465,6 @@ snapshots:
       '@types/node': 20.14.9
 
   '@types/resolve@1.20.2': {}
-
-  '@types/sass@1.43.1':
-    dependencies:
-      '@types/node': 18.19.25
 
   '@types/tough-cookie@4.0.2': {}
 
@@ -11697,6 +11693,10 @@ snapshots:
       vite: 5.3.3(@types/node@22.8.6)(sass@1.79.3)(terser@5.36.0)
       vue: 3.2.37
 
+  '@vitejs/plugin-vue@2.3.3(vue@3.2.37)':
+    dependencies:
+      vue: 3.2.37
+
   '@vitejs/plugin-vue@5.0.5(vite@5.3.3(@types/node@22.8.6)(sass@1.79.3)(terser@5.36.0))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
       vite: 5.3.3(@types/node@22.8.6)(sass@1.79.3)(terser@5.36.0)
@@ -11819,7 +11819,7 @@ snapshots:
   '@vue-macros/common@1.10.1(vue@3.2.37)':
     dependencies:
       '@babel/types': 7.24.0
-      '@rollup/pluginutils': 5.1.0(rollup@2.75.7)
+      '@rollup/pluginutils': 5.1.0
       '@vue/compiler-sfc': 3.4.31
       ast-kit: 0.11.3
       local-pkg: 0.5.0
@@ -12640,7 +12640,7 @@ snapshots:
   ast-kit@0.11.3:
     dependencies:
       '@babel/parser': 7.24.7
-      '@rollup/pluginutils': 5.1.0(rollup@2.75.7)
+      '@rollup/pluginutils': 5.1.0
       pathe: 1.1.2
     transitivePeerDependencies:
       - rollup
@@ -12648,7 +12648,7 @@ snapshots:
   ast-kit@0.9.5:
     dependencies:
       '@babel/parser': 7.24.7
-      '@rollup/pluginutils': 5.1.0(rollup@2.75.7)
+      '@rollup/pluginutils': 5.1.0
       pathe: 1.1.2
     transitivePeerDependencies:
       - rollup


### PR DESCRIPTION
sass 类型已经内置了
https://www.npmjs.com/package/@types/sass

![image](https://github.com/user-attachments/assets/aabef590-7702-4cdc-8b0e-f0eab13dd10a)

![image](https://github.com/user-attachments/assets/ac35a270-48ee-4a79-a581-7680350602ca)
