### PR TITLE
fix(components): [mention] ref dom array order error when list changes

### DIFF
--- a/packages/components/mention/__tests__/mention.test.tsx
+++ b/packages/components/mention/__tests__/mention.test.tsx
@@ -117,6 +117,12 @@ describe('Mention.vue', () => {
     expect(option.attributes('role')).toBe('option')
     expect(option.attributes('aria-disabled')).toBe(undefined)
     expect(option.attributes('aria-selected')).toBe('true')
+
+    const items = list.element.querySelectorAll('.el-mention-dropdown__item')
+    items.forEach((item, index) => {
+      const id = item.getAttribute('id')
+      expect(id).toBe(`${list.attributes('id')}-${index}`)
+    })
   })
 
   test('should use props of form', async () => {

--- a/packages/components/mention/__tests__/mention.test.tsx
+++ b/packages/components/mention/__tests__/mention.test.tsx
@@ -117,12 +117,6 @@ describe('Mention.vue', () => {
     expect(option.attributes('role')).toBe('option')
     expect(option.attributes('aria-disabled')).toBe(undefined)
     expect(option.attributes('aria-selected')).toBe('true')
-
-    const items = list.element.querySelectorAll('.el-mention-dropdown__item')
-    items.forEach((item, index) => {
-      const id = item.getAttribute('id')
-      expect(id).toBe(`${list.attributes('id')}-${index}`)
-    })
   })
 
   test('should use props of form', async () => {

--- a/packages/components/mention/src/mention-dropdown.vue
+++ b/packages/components/mention/src/mention-dropdown.vue
@@ -18,7 +18,7 @@
         v-for="(item, index) in options"
         :id="`${contentId}-${index}`"
         ref="optionRefs"
-        :key="item.value"
+        :key="index"
         :class="optionkls(item, index)"
         role="option"
         :aria-disabled="item.disabled || disabled || undefined"
@@ -112,21 +112,8 @@ const navigateOptions = (direction: 'next' | 'prev') => {
   nextTick(() => scrollToOption(option))
 }
 
-const sortRefDomOrder = () => {
-  return optionRefs.value
-    ?.map((item) => ({
-      item,
-      value: Number(
-        item.getAttribute('id')?.replace(`${props.contentId}-`, '')
-      ),
-    }))
-    .sort((a, b) => a.value - b.value)
-    .map(({ item }) => item)
-}
-
 const scrollToOption = (option: MentionOption) => {
   const { options } = props
-  optionRefs.value = sortRefDomOrder()
 
   const index = options.findIndex((item) => item.value === option.value)
   const target = optionRefs.value?.[index]

--- a/packages/components/mention/src/mention-dropdown.vue
+++ b/packages/components/mention/src/mention-dropdown.vue
@@ -112,8 +112,21 @@ const navigateOptions = (direction: 'next' | 'prev') => {
   nextTick(() => scrollToOption(option))
 }
 
+const sortRefDomOrder = () => {
+  return optionRefs.value
+    ?.map((item) => ({
+      item,
+      value: Number(
+        item.getAttribute('id')?.replace(`${props.contentId}-`, '')
+      ),
+    }))
+    .sort((a, b) => a.value - b.value)
+    .map(({ item }) => item)
+}
+
 const scrollToOption = (option: MentionOption) => {
   const { options } = props
+  optionRefs.value = sortRefDomOrder()
 
   const index = options.findIndex((item) => item.value === option.value)
   const target = optionRefs.value?.[index]


### PR DESCRIPTION
I found that if the option list changes, the DOM order is not consistent with the option list order. 
Causes scrolling abnormality.

```vue
ref="optionRefs"
```

```ts
const index = options.findIndex((item) => item.value === option.value)
const target = optionRefs.value?.[index]
```

#### [Before Playground Demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtbWVudGlvblxuICAgIHYtbW9kZWw9XCJ2YWx1ZVwiXG4gICAgOm9wdGlvbnM9XCJvcHRpb25zXCJcbiAgICBzdHlsZT1cIndpZHRoOiAzMjBweFwiXG4gICAgcGxhY2Vob2xkZXI9XCJQbGVhc2UgaW5wdXRcIlxuICAvPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcbmNvbnN0IHZhbHVlID0gcmVmKCdAJylcblxuY29uc3Qgb3B0aW9ucyA9IHJlZihcbiAgQXJyYXkuZnJvbSh7IGxlbmd0aDogMjAgfSkubWFwKChfLCBpbmRleCkgPT4ge1xuICAgIHJldHVybiB7XG4gICAgICBsYWJlbDogaW5kZXggKyAnJyxcbiAgICAgIHZhbHVlOiBpbmRleCxcbiAgICB9XG4gIH0pXG4pXG48L3NjcmlwdD5cbiIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vZmFzdGx5LmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmNzcycsICdodHRwczovL2Zhc3RseS5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvdGhlbWUtY2hhbGsvZGFyay9jc3MtdmFycy5jc3MnXS5tYXAoKHN0eWxlKSA9PiB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgICBsaW5rLmhyZWYgPSBzdHlsZVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICAgIH0pXG4gIH0pXG4gIHJldHVybiBQcm9taXNlLmFsbFNldHRsZWQoc3R5bGVzKVxufVxuIiwidHNjb25maWcuanNvbiI6IntcbiAgXCJjb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVSZXNvbHV0aW9uXCI6IFwiQnVuZGxlclwiLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdLFxuICAgIFwiYWxsb3dJbXBvcnRpbmdUc0V4dGVuc2lvbnNcIjogdHJ1ZSxcbiAgICBcImFsbG93SnNcIjogdHJ1ZSxcbiAgICBcImNoZWNrSnNcIjogdHJ1ZVxuICB9LFxuICBcInZ1ZUNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogMy4zXG4gIH1cbn1cbiIsIlBsYXlncm91bmRNYWluLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgQXBwIGZyb20gJy4vQXBwLnZ1ZSdcbmltcG9ydCB7IHNldHVwRWxlbWVudFBsdXMgfSBmcm9tICcuL2VsZW1lbnQtcGx1cy5qcydcbnNldHVwRWxlbWVudFBsdXMoKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPEFwcCAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vZmFzdGx5LmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9ydW50aW1lLWRvbUBsYXRlc3QvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL2Zhc3RseS5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L2Rpc3QvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L1wiLFxuICAgIFwiQGVsZW1lbnQtcGx1cy9pY29ucy12dWVcIjogXCJodHRwczovL2Zhc3RseS5qc2RlbGl2ci5uZXQvbnBtL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsIl9vIjp7fX0=)

DOM order
```
0
10
11
12
1
2
...
```

![screenshots](https://github.com/user-attachments/assets/793f38c7-10c8-4028-ab43-3f1158c1fe66)

#### [After Playground Demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtbWVudGlvblxuICAgIHYtbW9kZWw9XCJ2YWx1ZVwiXG4gICAgOm9wdGlvbnM9XCJvcHRpb25zXCJcbiAgICBzdHlsZT1cIndpZHRoOiAzMjBweFwiXG4gICAgcGxhY2Vob2xkZXI9XCJQbGVhc2UgaW5wdXRcIlxuICAvPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcbmNvbnN0IHZhbHVlID0gcmVmKCdAJylcblxuY29uc3Qgb3B0aW9ucyA9IHJlZihcbiAgQXJyYXkuZnJvbSh7IGxlbmd0aDogMjAgfSkubWFwKChfLCBpbmRleCkgPT4ge1xuICAgIHJldHVybiB7XG4gICAgICBsYWJlbDogaW5kZXggKyAnJyxcbiAgICAgIHZhbHVlOiBpbmRleCxcbiAgICB9XG4gIH0pXG4pXG48L3NjcmlwdD5cbiIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vcHJldmlldy0xODc4Ny1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcycsICdodHRwczovL3ByZXZpZXctMTg3ODctZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5jc3MnXS5tYXAoKHN0eWxlKSA9PiB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgICBsaW5rLmhyZWYgPSBzdHlsZVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICAgIH0pXG4gIH0pXG4gIHJldHVybiBQcm9taXNlLmFsbFNldHRsZWQoc3R5bGVzKVxufVxuIiwidHNjb25maWcuanNvbiI6IntcbiAgXCJjb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVSZXNvbHV0aW9uXCI6IFwiQnVuZGxlclwiLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdLFxuICAgIFwiYWxsb3dJbXBvcnRpbmdUc0V4dGVuc2lvbnNcIjogdHJ1ZSxcbiAgICBcImFsbG93SnNcIjogdHJ1ZSxcbiAgICBcImNoZWNrSnNcIjogdHJ1ZVxuICB9LFxuICBcInZ1ZUNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogMy4zXG4gIH1cbn1cbiIsIlBsYXlncm91bmRNYWluLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgQXBwIGZyb20gJy4vQXBwLnZ1ZSdcbmltcG9ydCB7IHNldHVwRWxlbWVudFBsdXMgfSBmcm9tICcuL2VsZW1lbnQtcGx1cy5qcydcbnNldHVwRWxlbWVudFBsdXMoKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPEFwcCAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vZmFzdGx5LmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9ydW50aW1lLWRvbUBsYXRlc3QvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL2Zhc3RseS5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9wcmV2aWV3LTE4Nzg3LWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9AZWxlbWVudC1wbHVzL2ljb25zLXZ1ZUAyL2Rpc3QvaW5kZXgubWluLmpzXCJcbiAgfSxcbiAgXCJzY29wZXNcIjoge31cbn0iLCJfbyI6eyJzaG93SGlkZGVuIjp0cnVlLCJzdHlsZVNvdXJjZSI6Imh0dHBzOi8vcHJldmlldy0xODc4Ny1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcyJ9fQ==)

DOM order
```
0
1
2
3
4
5
...
```

![screenshots](https://github.com/user-attachments/assets/95ed1a55-6828-44be-835f-8fcab6f33169)
