### PR TITLE
docs: improve mirror registry

### DIFF
--- a/docs/en-US/guide/installation.md
+++ b/docs/en-US/guide/installation.md
@@ -57,7 +57,11 @@ $ yarn add element-plus
 $ pnpm install element-plus
 ```
 
-If your network environment is not good, it is recommended to use a mirror registry [cnpm](https://github.com/cnpm/cnpm) or [Alibaba](https://registry.npmmirror.com/).
+If your network environment is not good, it is recommended to use a mirror registry [cnpm](https://github.com/cnpm/cnpm) or [npmmirror](https://npmmirror.com/).
+
+```shell
+npm config set registry https://registry.npmmirror.com
+```
 
 ## Import in Browser
 


### PR DESCRIPTION
原本的文档会跳转到https://registry.npmmirror.com/ 返回的是一串json格式，是实际要注册的镜像源，但是对新手不是很友好。

现在拆解为跳转到npm镜像源官网，那边是教程指引，将注册命令直接拆解可以复制shell 开箱即用。

![image](https://github.com/user-attachments/assets/060c7b11-34f2-45b6-862c-01c3c8a1a022)
![image](https://github.com/user-attachments/assets/d1699e9f-78ae-40bd-a128-d02424f3ca4b)
![image](https://github.com/user-attachments/assets/2937728b-3bf3-4c70-a745-19b0c39e5824)
