### PR TITLE
refactor(components): [select] simplify code

### DIFF
--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -425,7 +425,6 @@ export const useSelect = (props: ISelectProps, emit) => {
   const getOption = (value) => {
     let option
     const isObjectValue = isPlainObject(value)
-    const isNullish = value === null || value === undefined
 
     for (let i = states.cachedOptions.size - 1; i >= 0; i--) {
       const cachedOption = cachedOptionsArray.value[i]
@@ -444,7 +443,7 @@ export const useSelect = (props: ISelectProps, emit) => {
       }
     }
     if (option) return option
-    const label = isObjectValue ? value.label : !isNullish ? value : ''
+    const label = isObjectValue ? value.label : value ?? ''
     const newOption = {
       value,
       currentLabel: label,

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -25,9 +25,9 @@ import {
   isIOS,
   isNumber,
   isObject,
+  isPlainObject,
   isUndefined,
   scrollIntoView,
-  toRawType,
 } from '@element-plus/utils'
 import {
   CHANGE_EVENT,
@@ -424,9 +424,8 @@ export const useSelect = (props: ISelectProps, emit) => {
 
   const getOption = (value) => {
     let option
-    const isObjectValue = toRawType(value).toLowerCase() === 'object'
-    const isNull = toRawType(value).toLowerCase() === 'null'
-    const isUndefined = toRawType(value).toLowerCase() === 'undefined'
+    const isObjectValue = isPlainObject(value)
+    const isNullish = value === null || value === undefined
 
     for (let i = states.cachedOptions.size - 1; i >= 0; i--) {
       const cachedOption = cachedOptionsArray.value[i]
@@ -445,11 +444,7 @@ export const useSelect = (props: ISelectProps, emit) => {
       }
     }
     if (option) return option
-    const label = isObjectValue
-      ? value.label
-      : !isNull && !isUndefined
-      ? value
-      : ''
+    const label = isObjectValue ? value.label : !isNullish ? value : ''
     const newOption = {
       value,
       currentLabel: label,


### PR DESCRIPTION
These changes make the code more concise and TypeScript-friendly, allowing type narrowing to work as expected.

And there is the implementation of `toRawType` and `isPlainObject` for anyone wanna do a quick check if the code is equivalent to what was before.
```js
const objectToString = Object.prototype.toString;
const toTypeString = (value) => objectToString.call(value);

const toRawType = (value) => {
    // extract "RawType" from strings like "[object RawType]"
    return toTypeString(value).slice(8, -1);
};
const isPlainObject = (val) => toTypeString(val) === '[object Object]';
```