### PR TITLE
fix(components): [segmented] unSelected style for vertical direction

### DIFF
--- a/docs/examples/segmented/custom-direction.vue
+++ b/docs/examples/segmented/custom-direction.vue
@@ -6,6 +6,7 @@
       style="margin-bottom: 1rem"
     />
     <br />
+    <el-button @click="value = null">clear</el-button>
     <el-segmented
       v-model="direction"
       :options="directionOptions"

--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -108,16 +108,22 @@ const getItemCls = (item: Option) => {
   ]
 }
 
+const getSelectedElements = () => {
+  const selectedItem = segmentedRef.value?.querySelector(
+    '.is-selected'
+  ) as HTMLElement | null
+  const selectedItemInput = segmentedRef.value?.querySelector(
+    '.is-selected input'
+  ) as HTMLElement | null
+  return { selectedItem, selectedItemInput }
+}
+
 const updateSelect = () => {
   if (!segmentedRef.value) return
-  const selectedItem = segmentedRef.value.querySelector(
-    '.is-selected'
-  ) as HTMLElement
-  const selectedItemInput = segmentedRef.value.querySelector(
-    '.is-selected input'
-  ) as HTMLElement
+  const { selectedItem, selectedItemInput } = getSelectedElements()
   if (!selectedItem || !selectedItemInput) {
     state.width = 0
+    state.height = 0
     state.translateX = 0
     state.translateY = 0
     state.focusVisible = false
@@ -144,15 +150,19 @@ const segmentedCls = computed(() => [
   ns.is('block', props.block),
 ])
 
-const selectedStyle = computed(() => ({
-  width: props.direction === 'vertical' ? '100%' : `${state.width}px`,
-  height: props.direction === 'vertical' ? `${state.height}px` : '100%',
-  transform:
-    props.direction === 'vertical'
-      ? `translateY(${state.translateY}px)`
-      : `translateX(${state.translateX}px)`,
-  display: state.isInit ? 'block' : 'none',
-}))
+const selectedStyle = computed(() => {
+  const { selectedItem } = getSelectedElements()
+  const verticalWidth = selectedItem ? '100%' : 0
+  return {
+    width: props.direction === 'vertical' ? verticalWidth : `${state.width}px`,
+    height: props.direction === 'vertical' ? `${state.height}px` : '100%',
+    transform:
+      props.direction === 'vertical'
+        ? `translateY(${state.translateY}px)`
+        : `translateX(${state.translateX}px)`,
+    display: state.isInit ? 'block' : 'none',
+  }
+})
 
 const selectedCls = computed(() => [
   ns.e('item-selected'),

--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -108,19 +108,14 @@ const getItemCls = (item: Option) => {
   ]
 }
 
-const getSelectedElements = () => {
-  const selectedItem = segmentedRef.value?.querySelector(
-    '.is-selected'
-  ) as HTMLElement | null
-  const selectedItemInput = segmentedRef.value?.querySelector(
-    '.is-selected input'
-  ) as HTMLElement | null
-  return { selectedItem, selectedItemInput }
-}
-
 const updateSelect = () => {
   if (!segmentedRef.value) return
-  const { selectedItem, selectedItemInput } = getSelectedElements()
+  const selectedItem = segmentedRef.value.querySelector(
+    '.is-selected'
+  ) as HTMLElement
+  const selectedItemInput = segmentedRef.value.querySelector(
+    '.is-selected input'
+  ) as HTMLElement
   if (!selectedItem || !selectedItemInput) {
     state.width = 0
     state.height = 0
@@ -150,19 +145,15 @@ const segmentedCls = computed(() => [
   ns.is('block', props.block),
 ])
 
-const selectedStyle = computed(() => {
-  const { selectedItem } = getSelectedElements()
-  const verticalWidth = selectedItem ? '100%' : 0
-  return {
-    width: props.direction === 'vertical' ? verticalWidth : `${state.width}px`,
-    height: props.direction === 'vertical' ? `${state.height}px` : '100%',
-    transform:
-      props.direction === 'vertical'
-        ? `translateY(${state.translateY}px)`
-        : `translateX(${state.translateX}px)`,
-    display: state.isInit ? 'block' : 'none',
-  }
-})
+const selectedStyle = computed(() => ({
+  width: props.direction === 'vertical' ? '100%' : `${state.width}px`,
+  height: props.direction === 'vertical' ? `${state.height}px` : '100%',
+  transform:
+    props.direction === 'vertical'
+      ? `translateY(${state.translateY}px)`
+      : `translateX(${state.translateX}px)`,
+  display: state.isInit ? 'block' : 'none',
+}))
 
 const selectedCls = computed(() => [
   ns.e('item-selected'),


### PR DESCRIPTION
https://github.com/element-plus/element-plus/discussions/18803

问题出在selectedItem不存在的时候忘记清空height了，会导致没有value绑定的时候，还显示着选中背景色。
![image](https://github.com/user-attachments/assets/2b837faa-8686-4463-a982-08856062a61e)

![image](https://github.com/user-attachments/assets/0e3298ed-d107-477e-b074-9f5978f16f5b)
