### PR TITLE
docs(components): use `""` replace null for no icon setting

### DIFF
--- a/docs/en-US/component/page-header.md
+++ b/docs/en-US/component/page-header.md
@@ -39,7 +39,7 @@ page-header/custom-icon
 ## No icon
 
 Sometimes the page is just full of elements, and you might not want the icon to show up on the page,
-you can set the `icon` attribute to `null` to get rid of it.
+you can set the `icon` attribute to `""` to get rid of it.
 
 :::demo
 

--- a/docs/examples/page-header/additional-sections.vue
+++ b/docs/examples/page-header/additional-sections.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-page-header :icon="null">
+  <el-page-header icon="">
     <template #content>
       <div class="flex items-center">
         <el-avatar

--- a/docs/examples/page-header/no-icon.vue
+++ b/docs/examples/page-header/no-icon.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-page-header :icon="null">
+  <el-page-header icon="">
     <template #content>
       <span class="text-large font-600 mr-3"> Title </span>
     </template>


### PR DESCRIPTION
修复icon的type

![image](https://github.com/user-attachments/assets/88e941dc-083e-491d-b46d-9a311468a105)

![image](https://github.com/user-attachments/assets/fa3d4992-6073-44a1-b618-561ca326c019)
