### PR TITLE
fix(components): [select] adjust width of select-dropdown

### DIFF
--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -266,7 +266,8 @@ const useSelect = (props: ISelectV2Props, emit: SelectEmitFn) => {
   )
 
   const calculatePopperSize = () => {
-    popperSize.value = selectRef.value?.offsetWidth || 200
+    // The popper has a border, so the occupied 2px should be deducted.
+    popperSize.value = (selectRef.value?.offsetWidth ?? 200) - 2
   }
 
   const getGapWidth = () => {

--- a/packages/components/select/src/select-dropdown.vue
+++ b/packages/components/select/src/select-dropdown.vue
@@ -35,7 +35,8 @@ export default defineComponent({
     const minWidth = ref('')
 
     function updateMinWidth() {
-      minWidth.value = `${select.selectRef?.offsetWidth}px`
+      // The popper has a border, so the occupied 2px should be deducted.
+      minWidth.value = `${select.selectRef?.offsetWidth - 2}px`
     }
 
     onMounted(() => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### Description
The border of the select is implemented using `box-shadow`, which does not occupy width, whereas the border of the popper is implemented using `border`. This results in the select-dropdown being 2px wider than the select.

![image](https://github.com/user-attachments/assets/db4f7096-c476-40b2-b1dd-5ee9cb234840)
