### PR TITLE
ci: remove `needs more info` label when edited

### DIFF
--- a/.github/workflows/issue-remove-inactive.yml
+++ b/.github/workflows/issue-remove-inactive.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           actions: 'remove-labels'
           issue-number: ${{ github.event.issue.number }}
-          labels: 'inactive'
+          labels: 'inactive, needs more info'


### PR DESCRIPTION
像issue 被打上needs more info 标签的时候就会被强制三天后关闭，应该在编辑后被重新关注起来。
https://github.com/element-plus/element-plus/issues/18764

测试效果
![image](https://github.com/user-attachments/assets/7e89eb16-5579-40a7-96f9-b51ca944d0cb)
