### PR TITLE
feat(style): support vitepress vp-code-group

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -7,6 +7,7 @@ import VPApp, { NotFound, globals } from '../vitepress'
 import { define } from '../utils/types'
 import 'uno.css'
 import './style.css'
+import 'vitepress/dist/client/theme-default/styles/components/vp-code-group.css'
 import type { Theme } from 'vitepress'
 
 export default define<Theme>({

--- a/docs/en-US/component/icon.md
+++ b/docs/en-US/component/icon.md
@@ -17,16 +17,21 @@ Element Plus provides a set of common icons.
 
 ### Using packaging manager
 
-```shell
-# Choose a package manager you like.
+Choose a package manager you like.
 
-# NPM
+::: code-group
+```NPM
 $ npm install @element-plus/icons-vue
-# Yarn
+```
+
+```Yarn
 $ yarn add @element-plus/icons-vue
-# pnpm
+```
+
+```Pnpm
 $ pnpm install @element-plus/icons-vue
 ```
+:::
 
 ### Register All Icons
 

--- a/docs/en-US/component/icon.md
+++ b/docs/en-US/component/icon.md
@@ -20,15 +20,15 @@ Element Plus provides a set of common icons.
 Choose a package manager you like.
 
 ::: code-group
-```NPM
+```shell [npm]
 $ npm install @element-plus/icons-vue
 ```
 
-```Yarn
+```shell [yarn]
 $ yarn add @element-plus/icons-vue
 ```
 
-```Pnpm
+```shell [pnpm]
 $ pnpm install @element-plus/icons-vue
 ```
 :::

--- a/docs/en-US/guide/installation.md
+++ b/docs/en-US/guide/installation.md
@@ -49,14 +49,14 @@ Choose a package manager you like.
 
 ::: code-group
 
-```NPM
+```shell [npm]
 $ npm install element-plus --save
 ```
-```Yarn
+```shell [yarn]
 $ yarn add element-plus
 ```
 
-```Pnpm
+```shell [pnpm]
 $ pnpm install element-plus
 ```
 

--- a/docs/en-US/guide/installation.md
+++ b/docs/en-US/guide/installation.md
@@ -44,18 +44,23 @@ In addition, every commit and PR on the dev branch will be published to [pkg.pr.
 so that you can utilize bundlers like [Vite](https://vitejs.dev) and
 [webpack](https://webpack.js.org/).
 
-```shell
-# Choose a package manager you like.
 
-# NPM
+Choose a package manager you like.
+
+::: code-group
+
+```NPM
 $ npm install element-plus --save
-
-# Yarn
+```
+```Yarn
 $ yarn add element-plus
+```
 
-# pnpm
+```Pnpm
 $ pnpm install element-plus
 ```
+
+:::
 
 If your network environment is not good, it is recommended to use a mirror registry [cnpm](https://github.com/cnpm/cnpm) or [npmmirror](https://npmmirror.com/).
 


### PR DESCRIPTION
对于这种安装的guide 换成vitepress的代码组的风格。
现在无论是vue还是vite都是这种风格的，可以使用vitepress内置的主题样式来实现。

![image](https://github.com/user-attachments/assets/e820d5b6-4082-4906-8a9c-3cd9593938c0)

![image](https://github.com/user-attachments/assets/9da7dc22-4035-464e-8e75-78627bef82da)

![image](https://github.com/user-attachments/assets/87f090b5-0327-4cdb-91be-f04850bafb66)

