### PR TITLE
fix(components): [date-picker] resolve  v-model type inconsistency

### DIFF
--- a/packages/components/date-picker/src/date-picker.tsx
+++ b/packages/components/date-picker/src/date-picker.tsx
@@ -13,6 +13,8 @@ import {
   CommonPicker,
   DEFAULT_FORMATS_DATE,
   DEFAULT_FORMATS_DATEPICKER,
+  type DateModelType,
+  type SingleOrRange,
 } from '@element-plus/components/time-picker'
 import { ROOT_PICKER_INJECTION_KEY } from './constants'
 
@@ -61,7 +63,7 @@ export default defineComponent({
 
     expose(refProps)
 
-    const onModelValueUpdated = (val: any) => {
+    const onModelValueUpdated = (val: SingleOrRange<DateModelType> | null) => {
       emit('update:modelValue', val)
     }
 

--- a/packages/components/time-picker/__tests__/time-picker.test.tsx
+++ b/packages/components/time-picker/__tests__/time-picker.test.tsx
@@ -385,6 +385,41 @@ describe('TimePicker', () => {
     expect(value.value).toEqual('2000-01-01 09:00:00')
   })
 
+  it('when a time is input, the type of modelValue should be Date by default', async () => {
+    const value = ref('2024-11-18 12:00:00')
+    const wrapper = mount(() => <TimePicker v-model={value.value} />)
+
+    const input = wrapper.find('input')
+    input.trigger('focus')
+
+    await input.setValue('10:00:00')
+
+    input.trigger('blur')
+    expect(value.value).toBeInstanceOf(Date)
+  })
+
+  it('when a time is input, the type of modelValue should be Date by default (is-range)', async () => {
+    const value = ref([
+      new Date('2024-11-18 10:00:00'),
+      new Date('2024-11-18 12:00:00'),
+    ])
+    const wrapper = mount(() => <TimePicker v-model={value.value} is-range />)
+
+    const [startTimeInput, endTimeInput] = wrapper.findAll('input')
+
+    // Input start time
+    startTimeInput.trigger('focus')
+    await startTimeInput.setValue('10:00:10')
+    startTimeInput.trigger('blur')
+    expect(value.value[0]).toBeInstanceOf(Date)
+
+    // Input end time
+    endTimeInput.trigger('focus')
+    await endTimeInput.setValue('12:00:10')
+    endTimeInput.trigger('blur')
+    expect(value.value[1]).toBeInstanceOf(Date)
+  })
+
   it('picker-panel should not pop up when readonly', async () => {
     const wrapper = mount(() => <TimePicker readonly />)
 

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -180,7 +180,7 @@ import ElTooltip from '@element-plus/components/tooltip'
 import { NOOP, debugWarn, isArray } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import { Calendar, Clock } from '@element-plus/icons-vue'
-import { formatter, parseDate, valueEquals } from '../utils'
+import { dayOrDaysToDate, formatter, parseDate, valueEquals } from '../utils'
 import { timePickerDefaultProps } from './props'
 import PickerRangeTrigger from './picker-range-trigger.vue'
 import type { InputInstance } from '@element-plus/components/input'
@@ -190,7 +190,6 @@ import type { ComponentPublicInstance, Ref } from 'vue'
 import type { Options } from '@popperjs/core'
 import type {
   DateModelType,
-  DateOrDates,
   DayOrDays,
   PickerOptions,
   SingleOrRange,
@@ -198,8 +197,6 @@ import type {
   UserInput,
 } from './props'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
-
-// Date object and string
 
 defineOptions({
   name: 'Picker',
@@ -299,7 +296,7 @@ const emitChange = (
       formItem?.validate('change').catch((err) => debugWarn(err))
   }
 }
-const emitInput = (input: SingleOrRange<DateModelType | Dayjs> | null) => {
+const emitInput = (input: SingleOrRange<DateModelType> | null) => {
   if (!valueEquals(props.modelValue, input)) {
     let formatted
     if (isArray(input)) {
@@ -402,11 +399,7 @@ const parsedValue = computed(() => {
 
       // The result is corrected only when model-value exists
       if (!valueIsEmpty.value) {
-        emitInput(
-          (isArray(dayOrDays)
-            ? dayOrDays.map((_) => _.toDate())
-            : dayOrDays.toDate()) as SingleOrRange<Date>
-        )
+        emitInput(dayOrDaysToDate(dayOrDays))
       }
     }
   }
@@ -540,11 +533,7 @@ const handleChange = () => {
     const value = parseUserInputToDayjs(displayValue.value)
     if (value) {
       if (isValidValue(value)) {
-        emitInput(
-          (isArray(value)
-            ? value.map((_) => _.toDate())
-            : value.toDate()) as DateOrDates
-        )
+        emitInput(dayOrDaysToDate(value))
         userInput.value = null
       }
     }
@@ -664,7 +653,7 @@ const handleStartChange = () => {
     ]
     const newValue = [value, parsedVal && (parsedVal[1] || null)] as DayOrDays
     if (isValidValue(newValue)) {
-      emitInput(newValue)
+      emitInput(dayOrDaysToDate(newValue))
       userInput.value = null
     }
   }
@@ -681,7 +670,7 @@ const handleEndChange = () => {
     ]
     const newValue = [parsedVal && parsedVal[0], value] as DayOrDays
     if (isValidValue(newValue)) {
-      emitInput(newValue)
+      emitInput(dayOrDaysToDate(newValue))
       userInput.value = null
     }
   }

--- a/packages/components/time-picker/src/utils.ts
+++ b/packages/components/time-picker/src/utils.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs'
 import { isArray, isDate, isEmpty } from '@element-plus/utils'
 
 import type { Dayjs } from 'dayjs'
+import type { DateOrDates, DayOrDays } from './common/props'
 export type TimeList = [number | undefined, number, undefined | number]
 
 export const buildTimeList = (value: number, bound: number): TimeList => {
@@ -87,4 +88,10 @@ export const makeList = (total: number, method?: () => number[]) => {
     arr.push(disabledArr?.includes(i) ?? false)
   }
   return arr
+}
+
+export const dayOrDaysToDate = (dayOrDays: DayOrDays): DateOrDates => {
+  return isArray(dayOrDays)
+    ? (dayOrDays.map((d) => d.toDate()) as [Date, Date])
+    : dayOrDays.toDate()
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix: #18884

### Description

This PR addresses the issue of inconsistent value types in the `date-picker` component. Previously, the v-model value could sometimes be an internal `day.js` object instead of a native `Date` object, causing inconsistencies and potential errors. This has now been fixed by unifying values to be native Date objects.

### Preview
[PR Preview](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8cD5UcnkgdG8gZWRpdCB0aGUgdGltZSBhcyBpbnB1dDwvcD5cbiAgPGVsLWRhdGUtcGlja2VyIHYtbW9kZWw9XCJ2YWx1ZXNcIiB0eXBlPVwiZGF0ZXRpbWVyYW5nZVwiIHJhbmdlLXNlcGFyYXRvcj1cIlRvXCIgc3RhcnQtcGxhY2Vob2xkZXI9XCJTdGFydCBkYXRlXCJcbiAgICBlbmQtcGxhY2Vob2xkZXI9XCJFbmQgZGF0ZVwiIC8+XG4gIDxkaXYgc3R5bGU9XCJkaXNwbGF5OiBmbGV4OyBnYXA6IDAgMTZweFwiPlxuICAgIDxzcGFuIHYtaWY9XCJ2YWx1ZXNbMF1cIj5TdGFydCBUaW1lIGlzIERhdGU6IHt7IHZhbHVlc1swXSBpbnN0YW5jZW9mIERhdGUgfX08L3NwYW4+XG4gICAgPHNwYW4gdi1pZj1cInZhbHVlc1sxXVwiPkVuZCBUaW1lIGlzIERhdGU6IHt7IHZhbHVlc1sxXSBpbnN0YW5jZW9mIERhdGUgfX08L3NwYW4+XG4gIDwvZGl2PlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmltcG9ydCB7IHJlZiwgd2F0Y2ggfSBmcm9tICd2dWUnXG5cbmNvbnN0IHZhbHVlcyA9IHJlZjxbRGF0ZSwgRGF0ZV0+KFtcbiAgbmV3IERhdGUoMjAwMCwgMTAsIDEwLCAxMCwgMTApLFxuICBuZXcgRGF0ZSgyMDAwLCAxMCwgMTEsIDEwLCAxMCksXG5dKVxuXG53YXRjaCh2YWx1ZXMsICh2YWwpID0+IGNvbnNvbGUubG9nKHZhbCkpXG48L3NjcmlwdD5cbiIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vcHJldmlldy0xODg4OC1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcycsICdodHRwczovL3ByZXZpZXctMTg4ODgtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9pbmRleC5jc3MnXS5tYXAoKHN0eWxlKSA9PiB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgICBsaW5rLmhyZWYgPSBzdHlsZVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICAgIH0pXG4gIH0pXG4gIHJldHVybiBQcm9taXNlLmFsbFNldHRsZWQoc3R5bGVzKVxufVxuIiwidHNjb25maWcuanNvbiI6IntcbiAgXCJjb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVSZXNvbHV0aW9uXCI6IFwiQnVuZGxlclwiLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdLFxuICAgIFwiYWxsb3dJbXBvcnRpbmdUc0V4dGVuc2lvbnNcIjogdHJ1ZSxcbiAgICBcImFsbG93SnNcIjogdHJ1ZSxcbiAgICBcImNoZWNrSnNcIjogdHJ1ZVxuICB9LFxuICBcInZ1ZUNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogMy4zXG4gIH1cbn1cbiIsIlBsYXlncm91bmRNYWluLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgQXBwIGZyb20gJy4vQXBwLnZ1ZSdcbmltcG9ydCB7IHNldHVwRWxlbWVudFBsdXMgfSBmcm9tICcuL2VsZW1lbnQtcGx1cy5qcydcbnNldHVwRWxlbWVudFBsdXMoKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPEFwcCAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9ydW50aW1lLWRvbUBsYXRlc3QvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9wcmV2aWV3LTE4ODg4LWVsZW1lbnQtcGx1cy5zdXJnZS5zaC9idW5kbGUvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AZWxlbWVudC1wbHVzL2ljb25zLXZ1ZUAyL2Rpc3QvaW5kZXgubWluLmpzXCJcbiAgfSxcbiAgXCJzY29wZXNcIjoge31cbn0iLCJfbyI6eyJzaG93SGlkZGVuIjp0cnVlLCJzdHlsZVNvdXJjZSI6Imh0dHBzOi8vcHJldmlldy0xODg4OC1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2luZGV4LmNzcyJ9fQ==)