### PR TITLE
chore: fix type error of the tree-v2 `props.value` docs

### DIFF
--- a/docs/en-US/component/tree-v2.md
+++ b/docs/en-US/component/tree-v2.md
@@ -101,7 +101,7 @@ tree-v2/filter
 
 | Attribute      | Description                                                                          | Type                                             | Default  |
 | -------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------ | -------- |
-| value          | unique identity key name for nodes, its value should be unique across the whole tree | string,number                                    | id       |
+| value          | unique identity key name for nodes, its value should be unique across the whole tree | string                                           | id       |
 | label          | specify which key of node object is used as the node's label                         | string                                           | label    |
 | children       | specify which node object is used as the node's subtree                              | string                                           | children |
 | disabled       | specify which key of node object represents if node's checkbox is disabled           | string                                           | disabled |


### PR DESCRIPTION

<img width="649" alt="image" src="https://github.com/user-attachments/assets/a7e7c6d2-8ec5-4975-8bf3-c2fddd30406b">
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/33746aba-9f7b-476a-b834-8dbb4df19873">

should   string type