### PR TITLE
fix(components): [tag] make stubbed Transition work in tests

### DIFF
--- a/packages/components/tag/src/tag.vue
+++ b/packages/components/tag/src/tag.vue
@@ -75,6 +75,9 @@ const handleClick = (event: MouseEvent) => {
 
 const handleVNodeMounted = (vnode: VNode) => {
   // @ts-ignore
-  vnode.component.subTree.component.bum = null
+  if (vnode?.component?.subTree?.component?.bum) {
+    // @ts-ignore
+    vnode.component.subTree.component.bum = null
+  }
 }
 </script>


### PR DESCRIPTION
By default Vue Test Utils is using stubbed Transition/TransitionGroup components. In this [recent ElementPlus PR](https://github.com/element-plus/element-plus/pull/18006) we start relying on some internal logic of the Transition component which breaks existing unit tests. A potential workaround pointer by the author of the PR is [to disable the default behaviour of Vue Test Utils](https://github.com/element-plus/element-plus/pull/18006#issuecomment-2348607574) but it seems like we can avoid workarounds by protecting the code in case the Transition internals are undefined.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
