### PR TITLE
ci: remove `need reproduction` label

### DIFF
--- a/.github/workflows/issue-remove-inactive.yml
+++ b/.github/workflows/issue-remove-inactive.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           actions: 'remove-labels'
           issue-number: ${{ github.event.issue.number }}
-          labels: 'inactive, needs more info'
+          labels: 'inactive, needs more info, need reproduction'


### PR DESCRIPTION
#18537 

当用户编辑issue的时候也应该先移除一下，如果未给出正确的链接应该继续引导或关闭，否则一单被定时任务清除加锁定，后续用户也无法展开讨论。

![image](https://github.com/user-attachments/assets/7d9652aa-60d3-4077-b4fd-47b050ecbdd9)
