### PR TITLE
docs: makeup built-in zoom-in-left transition

### DIFF
--- a/docs/en-US/guide/transitions.md
+++ b/docs/en-US/guide/transitions.md
@@ -18,7 +18,7 @@ transitions/fade
 
 ## Zoom
 
-:::demo `el-zoom-in-center`, `el-zoom-in-top` and `el-zoom-in-bottom` are provided.
+:::demo `el-zoom-in-left`, `el-zoom-in-center`, `el-zoom-in-top` and `el-zoom-in-bottom` are provided.
 
 transitions/zoom
 

--- a/docs/examples/transitions/zoom.vue
+++ b/docs/examples/transitions/zoom.vue
@@ -3,6 +3,10 @@
     <el-button @click="show = !show">Click Me</el-button>
 
     <div style="display: flex; margin-top: 20px; height: 100px">
+      <transition name="el-zoom-in-left">
+        <div v-show="show" class="transition-box">.el-zoom-in-left</div>
+      </transition>
+
       <transition name="el-zoom-in-center">
         <div v-show="show" class="transition-box">.el-zoom-in-center</div>
       </transition>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
---
As shown in the figure below, the source code contains the `zoom-in-left` transition, but the documentation is missing. I personally think it needs to be exposed to the user. What do you think?@btea @warmthsea 

![image](https://github.com/user-attachments/assets/9c81555f-d8a4-4889-918f-47c16e37d028)

### After

https://github.com/user-attachments/assets/22a8b3fc-49b9-4b65-83b9-748c1dccc9bc

