### PR TITLE
chore(components): [time-picker] fix ts error

### DIFF
--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -325,7 +325,7 @@ const refInput = computed<HTMLInputElement[]>(() => {
   return []
 })
 
-// @ts-expect-error
+// @ts-ignore
 const setSelectionRange = (start: number, end: number, pos?: 'min' | 'max') => {
   const _inputs = refInput.value
   if (!_inputs.length) return
@@ -688,7 +688,7 @@ const handleEndChange = () => {
 }
 
 const pickerOptions = ref<Partial<PickerOptions>>({})
-// @ts-expect-error
+// @ts-ignore
 const onSetPickerOption = <T extends keyof PickerOptions>(
   e: [T, PickerOptions[T]]
 ) => {
@@ -696,12 +696,12 @@ const onSetPickerOption = <T extends keyof PickerOptions>(
   pickerOptions.value.panelReady = true
 }
 
-// @ts-expect-error
+// @ts-ignore
 const onCalendarChange = (e: [Date, null | Date]) => {
   emit('calendar-change', e)
 }
 
-// @ts-expect-error
+// @ts-ignore
 const onPanelChange = (
   value: [Dayjs, Dayjs],
   mode: 'month' | 'year',


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

When applying the current ts version, if you open the picker.vue file, an error warning will appear at `@ts-expect-error`. Currently temporarily changed to `@ts-ignore`.

These comments can be removed after the vue-tsc version is upgraded. For the reasons why it has not been upgraded yet, please refer to https://github.com/element-plus/element-plus/pull/18767#issuecomment-2455968294

