### PR TITLE
chore: optimize docs style

### DIFF
--- a/docs/.vitepress/vitepress/components/doc-content/vp-table-of-content.vue
+++ b/docs/.vitepress/vitepress/components/doc-content/vp-table-of-content.vue
@@ -19,8 +19,8 @@ const removeTag = (str: string) => str.replace(/<span.*<\/span>/g, '')
 <template>
   <aside ref="container" class="toc-wrapper">
     <nav class="toc-content">
-      <h3 class="toc-content__heading">Contents</h3>
-      <el-scrollbar max-height="calc(100vh - 110px)">
+      <el-scrollbar max-height="calc(100vh - var(--header-height) - 55px)">
+        <h3 class="toc-content__heading">Contents</h3>
         <el-anchor :offset="70" :bound="120" type="underline">
           <el-anchor-link
             v-for="{ link, text, children } in headers"
@@ -64,5 +64,8 @@ const removeTag = (str: string) => str.replace(/<span.*<\/span>/g, '')
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+}
+:deep(.el-scrollbar__bar.is-vertical) {
+  display: none;
 }
 </style>

--- a/docs/.vitepress/vitepress/components/doc-content/vp-table-of-content.vue
+++ b/docs/.vitepress/vitepress/components/doc-content/vp-table-of-content.vue
@@ -20,30 +20,28 @@ const removeTag = (str: string) => str.replace(/<span.*<\/span>/g, '')
   <aside ref="container" class="toc-wrapper">
     <nav class="toc-content">
       <h3 class="toc-content__heading">Contents</h3>
-      <el-anchor :offset="70" :bound="120">
-        <el-anchor-link
-          v-for="{ link, text, children } in headers"
-          :key="link"
-          :href="link"
-          :title="text"
-        >
-          <div :title="removeTag(text)" v-html="text" />
-          <template v-if="children" #sub-link>
-            <el-anchor-link
-              v-for="{ link: childLink, text: childText } in children"
-              :key="childLink"
-              :href="childLink"
-              :title="text"
-            >
-              <div :title="removeTag(childText)" v-html="childText" />
-            </el-anchor-link>
-          </template>
-        </el-anchor-link>
-      </el-anchor>
-      <!-- <SponsorLarge
-        class="mt-8 toc-ads flex flex-col"
-        item-style="width: 180px; height: 55px;"
-      /> -->
+      <el-scrollbar max-height="calc(100vh - 110px)">
+        <el-anchor :offset="70" :bound="120" type="underline">
+          <el-anchor-link
+            v-for="{ link, text, children } in headers"
+            :key="link"
+            :href="link"
+            :title="text"
+          >
+            <div :title="removeTag(text)" v-html="text" />
+            <template v-if="children" #sub-link>
+              <el-anchor-link
+                v-for="{ link: childLink, text: childText } in children"
+                :key="childLink"
+                :href="childLink"
+                :title="text"
+              >
+                <div :title="removeTag(childText)" v-html="childText" />
+              </el-anchor-link>
+            </template>
+          </el-anchor-link>
+        </el-anchor>
+      </el-scrollbar>
       <p class="text-14px font-300 color-$text-color-secondary">
         {{ sponsor.sponsoredBy }}
       </p>

--- a/docs/.vitepress/vitepress/styles/content/doc-content.scss
+++ b/docs/.vitepress/vitepress/styles/content/doc-content.scss
@@ -21,7 +21,7 @@
     padding: 48px 32px;
   }
   @include respond-to('lg') {
-    padding: 0 32px 48px 32px;
+    padding: 0 32px 48px;
   }
   @include respond-to('xxl') {
     padding: 0 0 48px 64px;

--- a/docs/.vitepress/vitepress/styles/content/doc-content.scss
+++ b/docs/.vitepress/vitepress/styles/content/doc-content.scss
@@ -21,14 +21,14 @@
     padding: 48px 32px;
   }
   @include respond-to('lg') {
-    padding: 48px 32px;
+    padding: 0 32px 48px 32px;
   }
   @include respond-to('xxl') {
-    padding: 64px 0 48px 64px;
+    padding: 0 0 48px 64px;
     display: flex;
   }
   @include respond-to('max') {
-    padding: 64px 0 48px 64px;
+    padding: 0 0 48px 64px;
     display: flex;
   }
 }

--- a/docs/.vitepress/vitepress/styles/content/table-of-content.scss
+++ b/docs/.vitepress/vitepress/styles/content/table-of-content.scss
@@ -10,10 +10,7 @@
   }
 
   @include respond-to('max') {
-    padding-right: 32px;
-  }
-
-  @include respond-to('max') {
+    display: block;
     padding-right: 48px;
   }
 

--- a/docs/.vitepress/vitepress/styles/content/table-of-content.scss
+++ b/docs/.vitepress/vitepress/styles/content/table-of-content.scss
@@ -6,20 +6,10 @@
 
   @include respond-to('xxl') {
     display: block;
-    padding-right: 32px;
-  }
-
-  @include respond-to('max') {
-    padding-right: 48px;
   }
 
   @include respond-to('xxl') {
     display: block;
-    padding-right: 32px;
-  }
-
-  @include respond-to('max') {
-    padding-right: 48px;
   }
 
   .toc-content {

--- a/docs/.vitepress/vitepress/styles/content/table-of-content.scss
+++ b/docs/.vitepress/vitepress/styles/content/table-of-content.scss
@@ -6,10 +6,15 @@
 
   @include respond-to('xxl') {
     display: block;
+    padding-right: 32px;
   }
 
-  @include respond-to('xxl') {
-    display: block;
+  @include respond-to('max') {
+    padding-right: 32px;
+  }
+
+  @include respond-to('max') {
+    padding-right: 48px;
   }
 
   .toc-content {
@@ -28,6 +33,7 @@
       text-transform: uppercase;
       margin-top: 0;
     }
+
     p {
       text-overflow: ellipsis;
       overflow: hidden;


### PR DESCRIPTION
1. Remove this blank area to make the content appear more compact 

before:
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/ebedf617-2242-4f10-b1c7-734b1c82ce51">
after:
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/736ca691-502a-434d-9e51-be516f115a71">

2. Make the directory area scrollable, allowing developers to quickly find the APIs they want

before:
<img width="1498" alt="image" src="https://github.com/user-attachments/assets/83e4e5e6-b105-481a-b2e1-b55d0b13ddf6">

after:
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/3103fa1b-3574-41c1-b710-4294343568d5">
