### PR TITLE
fix(types): [menu-item] make `index` attribute required

### DIFF
--- a/docs/en-US/component/menu.md
+++ b/docs/en-US/component/menu.md
@@ -145,11 +145,11 @@ menu/popper-offset
 
 ### Menu-Item Attributes
 
-| Name     | Description                          | Type                  | Default |
-| -------- | ------------------------------------ | --------------------- | ------- |
+| Name              | Description                          | Type                  | Default |
+| ----------------- | ------------------------------------ | --------------------- | ------- |
 | index ^(required) | unique identification                | ^[string]             | —       |
-| route    | Vue Router Route Location Parameters | ^[string] / ^[object] | —       |
-| disabled | whether disabled                     | ^[boolean]            | false   |
+| route             | Vue Router Route Location Parameters | ^[string] / ^[object] | —       |
+| disabled          | whether disabled                     | ^[boolean]            | false   |
 
 ### Menu-Item Events
 

--- a/docs/en-US/component/menu.md
+++ b/docs/en-US/component/menu.md
@@ -147,7 +147,7 @@ menu/popper-offset
 
 | Name     | Description                          | Type                  | Default |
 | -------- | ------------------------------------ | --------------------- | ------- |
-| index    | unique identification                | ^[string] / ^[null]   | null    |
+| index    | unique identification                | ^[string]             | —       |
 | route    | Vue Router Route Location Parameters | ^[string] / ^[object] | —       |
 | disabled | whether disabled                     | ^[boolean]            | false   |
 

--- a/docs/en-US/component/menu.md
+++ b/docs/en-US/component/menu.md
@@ -147,7 +147,7 @@ menu/popper-offset
 
 | Name     | Description                          | Type                  | Default |
 | -------- | ------------------------------------ | --------------------- | ------- |
-| index    | unique identification                | ^[string]             | —       |
+| index ^(required) | unique identification                | ^[string]             | —       |
 | route    | Vue Router Route Location Parameters | ^[string] / ^[object] | —       |
 | disabled | whether disabled                     | ^[boolean]            | false   |
 

--- a/packages/components/menu/src/menu-item.ts
+++ b/packages/components/menu/src/menu-item.ts
@@ -15,7 +15,8 @@ export const menuItemProps = buildProps({
    */
   index: {
     type: definePropType<string | null>([String, null]),
-    required: true,
+    // will be required in the next major version
+    // required: true,
   },
   /**
    * @description Vue Router object

--- a/packages/components/menu/src/menu-item.ts
+++ b/packages/components/menu/src/menu-item.ts
@@ -15,7 +15,7 @@ export const menuItemProps = buildProps({
    */
   index: {
     type: definePropType<string | null>([String, null]),
-    default: null,
+    required: true,
   },
   /**
    * @description Vue Router object

--- a/packages/components/menu/src/menu-item.ts
+++ b/packages/components/menu/src/menu-item.ts
@@ -17,6 +17,7 @@ export const menuItemProps = buildProps({
     type: definePropType<string | null>([String, null]),
     // will be required in the next major version
     // required: true,
+    default: null,
   },
   /**
    * @description Vue Router object

--- a/packages/components/menu/src/menu-item.vue
+++ b/packages/components/menu/src/menu-item.vue
@@ -46,7 +46,7 @@ import {
   toRef,
 } from 'vue'
 import ElTooltip from '@element-plus/components/tooltip'
-import { throwError } from '@element-plus/utils'
+import { debugWarn, isPropAbsent, throwError } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import useMenu from './use-menu'
 import { menuItemEmits, menuItemProps } from './menu-item'
@@ -59,6 +59,12 @@ defineOptions({
 })
 const props = defineProps(menuItemProps)
 const emit = defineEmits(menuItemEmits)
+
+isPropAbsent(props.index) &&
+  debugWarn(
+    COMPONENT_NAME,
+    "The 'index' prop will be required in the next major version"
+  )
 
 const instance = getCurrentInstance()!
 const rootMenu = inject<MenuProvider>('rootMenu')

--- a/packages/components/menu/src/menu-item.vue
+++ b/packages/components/menu/src/menu-item.vue
@@ -61,10 +61,7 @@ const props = defineProps(menuItemProps)
 const emit = defineEmits(menuItemEmits)
 
 isPropAbsent(props.index) &&
-  debugWarn(
-    COMPONENT_NAME,
-    "The 'index' prop will be required in the next major version"
-  )
+  debugWarn(COMPONENT_NAME, 'Missing required prop: "index"')
 
 const instance = getCurrentInstance()!
 const rootMenu = inject<MenuProvider>('rootMenu')


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

about: #19004

### Description

When `ElMenuItem` is used without specifying the `index` attribute, `ElMenu` becomes [unusable](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICAgICAgICA8c3Ryb25nPkVsTWVudUl0ZW0gd2l0aG91dCAnaW5kZXgnIGF0dHI8L3N0cm9uZz5cbiAgICAgICAgPGVsLW1lbnUgbW9kZT1cImhvcml6b250YWxcIiA6ZWxsaXBzaXM9XCJmYWxzZVwiPlxuICAgICAgICAgICAgICAgIDxlbC1tZW51LWl0ZW0+YzE8L2VsLW1lbnUtaXRlbT5cbiAgICAgICAgICAgICAgICA8ZWwtbWVudS1pdGVtPmMyPC9lbC1tZW51LWl0ZW0+XG4gICAgICAgIDwvZWwtbWVudT5cbiAgICAgICAgPHN0cm9uZz5FbE1lbnVJdGVtIHdpdGggJ2luZGV4JyBhdHRyPC9zdHJvbmc+XG4gICAgICAgIDxlbC1tZW51IG1vZGU9XCJob3Jpem9udGFsXCIgOmVsbGlwc2lzPVwiZmFsc2VcIj5cbiAgICAgICAgICAgICAgICA8ZWwtbWVudS1pdGVtIGluZGV4PVwiYzFcIj5jMTwvZWwtbWVudS1pdGVtPlxuICAgICAgICAgICAgICAgIDxlbC1tZW51LWl0ZW0gaW5kZXg9XCJjMlwiPmMyPC9lbC1tZW51LWl0ZW0+XG4gICAgICAgIDwvZWwtbWVudT5cbjwvdGVtcGxhdGU+XG4iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgY29uc3Qgc3R5bGVzID0gWydodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvZGlzdC9pbmRleC5jc3MnLCAnaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L3RoZW1lLWNoYWxrL2RhcmsvY3NzLXZhcnMuY3NzJ10ubWFwKChzdHlsZSkgPT4ge1xuICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgICAgbGluay5ocmVmID0gc3R5bGVcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgICB9KVxuICB9KVxuICByZXR1cm4gUHJvbWlzZS5hbGxTZXR0bGVkKHN0eWxlcylcbn1cbiIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AbGF0ZXN0L2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvc2hhcmVkXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9cIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AZWxlbWVudC1wbHVzL2ljb25zLXZ1ZUAyL2Rpc3QvaW5kZXgubWluLmpzXCJcbiAgfSxcbiAgXCJzY29wZXNcIjoge31cbn0iLCJDb21wLnZ1ZSI6Ijx0ZW1wbGF0ZT5cclxuICA8ZGl2PlxyXG4gICAgYzFcclxuICA8L2Rpdj5cclxuPC90ZW1wbGF0ZT5cclxuXHJcbjxzY3JpcHQgc2V0dXAgbGFuZz1cInRzXCI+XHJcblxyXG48L3NjcmlwdD5cclxuXHJcbjxzdHlsZSBzY29wZWQ+XHJcblxyXG48L3N0eWxlPiIsIkNvbXAxLnZ1ZSI6Ijx0ZW1wbGF0ZT5cclxuICA8ZGl2PlxyXG4gICAgYzJcclxuICA8L2Rpdj5cclxuPC90ZW1wbGF0ZT5cclxuXHJcbjxzY3JpcHQgc2V0dXAgbGFuZz1cInRzXCI+XHJcblxyXG48L3NjcmlwdD5cclxuXHJcbjxzdHlsZSBzY29wZWQ+XHJcblxyXG48L3N0eWxlPiIsIl9vIjp7fX0=). Therefore, this PR makes the `index` attribute required.