### PR TITLE
docs: [tree-v2] fix props.class type in zh-CN

### DIFF
--- a/docs/en-US/component/tree-v2.md
+++ b/docs/en-US/component/tree-v2.md
@@ -99,13 +99,13 @@ tree-v2/filter
 
 ## props
 
-| Attribute      | Description                                                                          | Type                                             | Default  |
-| -------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------ | -------- |
-| value          | unique identity key name for nodes, its value should be unique across the whole tree | string                                           | id       |
-| label          | specify which key of node object is used as the node's label                         | string                                           | label    |
-| children       | specify which node object is used as the node's subtree                              | string                                           | children |
-| disabled       | specify which key of node object represents if node's checkbox is disabled           | string                                           | disabled |
-| class ^(2.9.0) | custom node class name                                                               | ^[string] \| ^[Function]`(data, node) => string` | —        |
+| Attribute      | Description                                                                          | Type                                            | Default  |
+| -------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------- | -------- |
+| value          | unique identity key name for nodes, its value should be unique across the whole tree | string                                          | id       |
+| label          | specify which key of node object is used as the node's label                         | string                                          | label    |
+| children       | specify which node object is used as the node's subtree                              | string                                          | children |
+| disabled       | specify which key of node object represents if node's checkbox is disabled           | string                                          | disabled |
+| class ^(2.9.0) | custom node class name                                                               | ^[string] / ^[Function]`(data, node) => string` | —        |
 
 ## TreeV2 Method
 


### PR DESCRIPTION
tree-v2 props.class 中文翻译类型错位
<img width="1148" alt="image" src="https://github.com/user-attachments/assets/a18c3e84-0c1d-46ac-a30f-dd25641a4ecf">

将分割符号改为 /
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/eb4a43fc-d340-4394-85ae-0753dc0c642b">
