### PR TITLE
chore: stop re-exporting isVNode

### DIFF
--- a/packages/components/message-box/src/messageBox.ts
+++ b/packages/components/message-box/src/messageBox.ts
@@ -1,4 +1,4 @@
-import { createVNode, render } from 'vue'
+import { createVNode, isVNode, render } from 'vue'
 import {
   debugWarn,
   hasOwn,
@@ -8,7 +8,6 @@ import {
   isObject,
   isString,
   isUndefined,
-  isVNode,
 } from '@element-plus/utils'
 import MessageBoxConstructor from './index.vue'
 

--- a/packages/components/message/src/method.ts
+++ b/packages/components/message/src/method.ts
@@ -1,4 +1,4 @@
-import { createVNode, render } from 'vue'
+import { createVNode, isVNode, render } from 'vue'
 import {
   debugWarn,
   isBoolean,
@@ -7,7 +7,6 @@ import {
   isFunction,
   isNumber,
   isString,
-  isVNode,
 } from '@element-plus/utils'
 import { messageConfig } from '@element-plus/components/config-provider'
 import MessageConstructor from './message.vue'

--- a/packages/components/notification/src/notify.ts
+++ b/packages/components/notification/src/notify.ts
@@ -1,4 +1,4 @@
-import { createVNode, render } from 'vue'
+import { createVNode, isVNode, render } from 'vue'
 import {
   debugWarn,
   isClient,
@@ -6,7 +6,6 @@ import {
   isFunction,
   isString,
   isUndefined,
-  isVNode,
 } from '@element-plus/utils'
 import NotificationConstructor from './notification.vue'
 import { notificationTypes } from './notification'

--- a/packages/hooks/use-ordered-children/index.ts
+++ b/packages/hooks/use-ordered-children/index.ts
@@ -1,5 +1,5 @@
-import { shallowRef } from 'vue'
-import { flattedChildren, isVNode } from '@element-plus/utils'
+import { isVNode, shallowRef } from 'vue'
+import { flattedChildren } from '@element-plus/utils'
 
 import type { ComponentInternalInstance, VNode } from 'vue'
 

--- a/packages/utils/__tests__/types.test.ts
+++ b/packages/utils/__tests__/types.test.ts
@@ -1,4 +1,3 @@
-import * as vue from 'vue'
 import * as vueShared from '@vue/shared'
 import { describe, expect, it } from 'vitest'
 import {
@@ -15,7 +14,6 @@ import {
   isString,
   isSymbol,
   isUndefined,
-  isVNode,
 } from '..'
 
 describe('types', () => {
@@ -27,10 +25,6 @@ describe('types', () => {
     expect(isPromise).toBe(vueShared.isPromise)
     expect(isString).toBe(vueShared.isString)
     expect(isSymbol).toBe(vueShared.isSymbol)
-  })
-
-  it('re-export from vue', () => {
-    expect(isVNode).toBe(vue.isVNode)
   })
 
   it('isBoolean and isNumber should work', () => {

--- a/packages/utils/types.ts
+++ b/packages/utils/types.ts
@@ -11,7 +11,6 @@ export {
   isSymbol,
   isPlainObject,
 } from '@vue/shared'
-export { isVNode } from 'vue'
 
 export const isUndefined = (val: any): val is undefined => val === undefined
 export const isBoolean = (val: any): val is boolean => typeof val === 'boolean'


### PR DESCRIPTION
Since `isVNode` is a documented/public API, re-exporting it looks verbose in my mind.