### PR TITLE
fix(components): [select] adjust input width calculation to account for cursor width

### DIFF
--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -52,6 +52,7 @@ import type ElTooltip from '@element-plus/components/tooltip'
 import type { ISelectProps, SelectOptionProxy } from './token'
 
 const MINIMUM_INPUT_WIDTH = 11
+const CURSOR_WIDTH_OFFSET = 2
 
 export const useSelect = (props: ISelectProps, emit) => {
   const { t } = useLocale()
@@ -788,7 +789,10 @@ export const useSelect = (props: ISelectProps, emit) => {
   })
 
   const inputStyle = computed(() => ({
-    width: `${Math.max(states.calculatorWidth, MINIMUM_INPUT_WIDTH)}px`,
+    width: `${
+      Math.max(states.calculatorWidth, MINIMUM_INPUT_WIDTH) +
+      CURSOR_WIDTH_OFFSET
+    }px`,
   }))
 
   useResizeObserver(selectionRef, resetSelectionWidth)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## description

When using `el-select` with `filterable`, the width of `div.el-select__selected-item.el-select__input-wrapper input.el-select__input` is by calculation. Currently, the width calculation only pays attention to the character itself. The cursor width also affects it. The cursor width in Safari is fatter than it is in Chrome.

This PR is to add the `CURSOR_WIDTH_OFFSET` into the calculation to add extra width.

## reproduction video

https://github.com/user-attachments/assets/4ff86611-8293-4863-bef9-8512db373ff0


