### PR TITLE
fix(components): [tooltip] hide tooltip after click iframe

### DIFF
--- a/packages/components/tooltip/src/tooltip.vue
+++ b/packages/components/tooltip/src/tooltip.vue
@@ -51,6 +51,7 @@
 import {
   computed,
   onDeactivated,
+  onMounted,
   provide,
   readonly,
   ref,
@@ -106,6 +107,14 @@ const { onOpen, onClose } = useDelayedToggle({
   autoClose: toRef(props, 'autoClose'),
   open: show,
   close: hide,
+})
+
+onMounted(() => {
+  window.addEventListener('blur', () => {
+    if (document.activeElement?.tagName === 'IFRAME') {
+      hide()
+    }
+  })
 })
 
 const controlled = computed(


### PR DESCRIPTION
Wanna reset focus on `<el-select>` after hiding it make some tests before set the PR ready

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
