### PR TITLE
docs: add Playground link in navbar

### DIFF
--- a/docs/.vitepress/config/nav.ts
+++ b/docs/.vitepress/config/nav.ts
@@ -1,3 +1,4 @@
+import { isExternal } from 'vitepress/dist/client/shared'
 import { ensureLang } from '../utils/lang'
 import navLocale from '../i18n/pages/sidebar.json'
 
@@ -12,7 +13,7 @@ function getNav() {
         activeMatch?: string
       }[] = Object.values(locales).map((item) => ({
         ...item,
-        link: `${ensureLang(lang)}${item.link}`,
+        link: `${isExternal(item.link) ? '' : ensureLang(lang)}${item.link}`,
       }))
 
       return [lang, item]

--- a/docs/.vitepress/crowdin/en-US/pages/sidebar.json
+++ b/docs/.vitepress/crowdin/en-US/pages/sidebar.json
@@ -13,5 +13,9 @@
     "text": "Resource",
     "link": "/resource/index",
     "activeMatch": "/resource/"
+  },
+  {
+    "text": "Playground",
+    "link": "https://element-plus.run"
   }
 ]


### PR DESCRIPTION
I think it would be useful to have an Playground link in the navbar.

![image](https://github.com/user-attachments/assets/46ddbf31-2cf1-49aa-aad1-c620e982c096)

Edit: I dont know how can i test the chinese doc version and if someone can translate "Playground" into chinese it would be great ! Thanks 😀