### PR TITLE
fix(components): [date-picker] delete handleMinTimePick change rightD…

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -672,7 +672,6 @@ const handleMinTimePick = (value: Dayjs, visible: boolean, first: boolean) => {
 
   if (!maxDate.value || maxDate.value.isBefore(minDate.value)) {
     maxDate.value = minDate.value
-    rightDate.value = value
   }
 }
 


### PR DESCRIPTION
…ate value

删除handleMinTimePick方法内对rightDate.value的赋值操作，这会导致在选择同一天的时候点击左侧的时分秒文本框，通过了maxDate.value.isBefore(minDate.value)的判断并将vlue值赋值给rightDate，但是value值是选中的那个日期，而rightDate是一个响应式数据，会导致右侧的日期跟左侧相同，出现了重复的时间日期面版

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
