### PR TITLE
fix(theme-chalk): [input-tag] correct input-tag placeholder color

### DIFF
--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -924,6 +924,7 @@ $input-tag: () !default;
 $input-tag: map.merge(
   (
     'border-color-hover': getCssVar('border-color-hover'),
+    'placeholder-color': getCssVar('text-color-placeholder'),
     'disabled-color': getCssVar('disabled-text-color'),
     'disabled-border': getCssVar('disabled-border-color'),
     'font-size': getCssVar('font-size-base'),

--- a/packages/theme-chalk/src/input-tag.scss
+++ b/packages/theme-chalk/src/input-tag.scss
@@ -169,6 +169,10 @@
     appearance: none;
     width: 100%;
     background-color: transparent;
+
+    &::placeholder {
+      color: getCssVar('input-tag-placeholder-color');
+    }
   }
 
   @include e(input-calculator) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### Description
The current placeholder color setting is missing.

#### Before
![fQ2cCt94Cr](https://github.com/user-attachments/assets/77378a06-90ef-445b-801b-cda128332122)

#### After
![image](https://github.com/user-attachments/assets/6b3a1198-78d2-4d94-96a2-22865178824b)
