### PR TITLE
fix(components): [page-header] use `$slots` instead of `useSlots`

### DIFF
--- a/packages/components/page-header/__tests__/page-header.test.tsx
+++ b/packages/components/page-header/__tests__/page-header.test.tsx
@@ -94,6 +94,44 @@ describe('PageHeader.vue', () => {
     expect(wrapper.find('.el-page-header__title').text()).toEqual(AXIOM)
   })
 
+  test('conditional slots rendering', async () => {
+    const wrapper = mount(
+      (props: {
+        showDefault: boolean
+        showBreadcrumb: boolean
+        showExtra: boolean
+      }) => (
+        <PageHeader
+          v-slots={{
+            default: props.showDefault ? () => AXIOM : undefined,
+            breadcrumb: props.showBreadcrumb ? () => AXIOM : undefined,
+            extra: props.showExtra ? () => AXIOM : undefined,
+          }}
+        />
+      ),
+      {
+        props: {
+          showDefault: false,
+          showBreadcrumb: false,
+          showExtra: false,
+        },
+      }
+    )
+    expect(wrapper.classes()).not.toContain('is-contentful')
+    expect(wrapper.classes()).not.toContain('el-page-header--has-breadcrumb')
+    expect(wrapper.classes()).not.toContain('el-page-header--has-extra')
+
+    await wrapper.setProps({
+      showDefault: true,
+      showBreadcrumb: true,
+      showExtra: true,
+    })
+
+    expect(wrapper.classes()).toContain('is-contentful')
+    expect(wrapper.classes()).toContain('el-page-header--has-breadcrumb')
+    expect(wrapper.classes()).toContain('el-page-header--has-extra')
+  })
+
   test('event back', async () => {
     const wrapper = mount(() => <PageHeader content={AXIOM} />)
     const pageHeader = wrapper.findComponent(PageHeader)

--- a/packages/components/page-header/src/page-header.vue
+++ b/packages/components/page-header/src/page-header.vue
@@ -1,5 +1,14 @@
 <template>
-  <div :class="kls">
+  <div
+    :class="[
+      ns.b(),
+      {
+        [ns.m('has-breadcrumb')]: !!$slots.breadcrumb,
+        [ns.m('has-extra')]: !!$slots.extra,
+        [ns.is('contentful')]: !!$slots.default,
+      },
+    ]"
+  >
     <div v-if="$slots.breadcrumb" :class="ns.e('breadcrumb')">
       <slot name="breadcrumb" />
     </div>
@@ -43,7 +52,6 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { computed, useSlots } from 'vue'
 import { ElIcon } from '@element-plus/components/icon'
 import { ElDivider } from '@element-plus/components/divider'
 
@@ -56,20 +64,9 @@ defineOptions({
 
 defineProps(pageHeaderProps)
 const emit = defineEmits(pageHeaderEmits)
-const slots = useSlots()
 
 const { t } = useLocale()
 const ns = useNamespace('page-header')
-const kls = computed(() => {
-  return [
-    ns.b(),
-    {
-      [ns.m('has-breadcrumb')]: !!slots.breadcrumb,
-      [ns.m('has-extra')]: !!slots.extra,
-      [ns.is('contentful')]: !!slots.default,
-    },
-  ]
-})
 
 function handleClick() {
   emit('back')


### PR DESCRIPTION
closed #19453

`useSlots` isnt reactive on slots change

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
