### PR TITLE
fix(components): [select] fix The width of the input box is too small

### DIFF
--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -859,7 +859,7 @@ export const useSelect: useSelectType = (props: ISelectProps, emit) => {
   })
 
   const inputStyle = computed(() => ({
-    width: `${Math.max(states.calculatorWidth, MINIMUM_INPUT_WIDTH)}px`,
+    width: `${Math.max(states.selectionWidth, MINIMUM_INPUT_WIDTH)}px`,
   }))
 
   useResizeObserver(selectionRef, resetSelectionWidth)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #19452
Although the issue was explained in #15834, I don't think there's any problem with solving it this way. The width is normal
<img width="408" alt="image" src="https://github.com/user-attachments/assets/a0e0201a-817c-4335-95af-f4efb0978e5a" />
