### PR TITLE
refactor(components): [date-picker] keep same slot data

### DIFF
--- a/docs/en-US/component/date-picker.md
+++ b/docs/en-US/component/date-picker.md
@@ -131,25 +131,57 @@ date-picker/custom-icon
 
 For data details, please refer:
 
+<details>
+  <summary>before <version-tag version="2.9.2" /></summary>
+
 ```ts
 interface DateCell {
   column: number
-  customClass: string
+  customClass?: string
   disabled: boolean
   end: boolean
   inRange: boolean
+  renderText?: string
   row: number
   selected: Dayjs
-  isCurrent: boolean
+  isCurrent?: boolean
+  isSelected?: boolean
+  start: boolean
+  text?: number
+  timestamp: number
+  date?: Date
+  dayjs?: Dayjs
+  type: 'normal' | 'today' | 'week' | 'next-month' | 'prev-month'
+}
+```
+
+</details>
+
+<details>
+  <summary>after <version-tag version="2.9.2" /></summary>
+
+```ts
+interface DateCell {
+  column: number
+  customClass?: string
+  disabled: boolean
+  end: boolean
+  inRange: boolean
+  //renderText?: string // merged into text
+  row: number
+  //selected: Dayjs // duplicate with dayjs
+  //isCurrent: boolean // duplicate with isSelected
   isSelected: boolean
   start: boolean
-  text: number
+  text: number | string
   timestamp: number
   date: Date
   dayjs: Dayjs
   type: 'normal' | 'today' | 'week' | 'next-month' | 'prev-month'
 }
 ```
+
+</details>
 
 ## Localization
 

--- a/docs/en-US/component/date-picker.md
+++ b/docs/en-US/component/date-picker.md
@@ -147,7 +147,7 @@ interface DateCell {
   isCurrent?: boolean
   isSelected?: boolean
   start: boolean
-  text?: number
+  text: number
   timestamp: number
   date?: Date
   dayjs?: Dayjs

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -524,8 +524,8 @@ describe('DatePicker', () => {
       `<el-date-picker
         v-model="value"
         ref="input">
-        <template #default="{ isCurrent, text }">
-          <div class="el-date-table-cell__text" :class="{ current: isCurrent }">
+        <template #default="{ isSelected, text }">
+          <div class="el-date-table-cell__text" :class="{ current: isSelected }">
             <div>{{ text }}</div>
           </div>
         </template>

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -13,6 +13,7 @@ import 'dayjs/locale/zh-cn'
 import { EVENT_CODE } from '@element-plus/constants'
 import { ElFormItem } from '@element-plus/components/form'
 import DatePicker from '../src/date-picker'
+import { DateCell, IDatePickerType } from '../src/date-picker.type'
 
 const _mount = (template: string, data = () => ({}), otherObj?) =>
   mount(
@@ -682,6 +683,74 @@ describe('DatePicker', () => {
     const el = document.querySelector('td .el-date-table-cell')
     const text = el.textContent
     expect(text.includes('csw')).toBeFalsy()
+  })
+
+  it('should have always the same propreties for default slot', async () => {
+    const testCell = (cell: DateCell) => {
+      const arr: (keyof DateCell)[] = [
+        'column',
+        'type',
+        'text',
+        'start',
+        'timestamp',
+        'dayjs',
+        'date',
+        'isSelected',
+        'inRange',
+        'row',
+        'disabled',
+        'customClass',
+        'end',
+      ].sort()
+      expect(Object.keys(cell).sort()).toStrictEqual(arr)
+      for (const value of Object.values(cell)) {
+        expect(value).toBeDefined()
+      }
+    }
+    const wrapper = _mount(
+      `<el-date-picker
+        :model-value="value"
+        :type="type"
+        :cellClassName="() => 'hello'"
+        ref="input">
+        <template #default="cell">
+          <div class="el-date-table-cell" @click="testCell(cell)">
+            <div class="el-date-table-cell__text">click me</div>
+          </div>
+        </template>
+      </el-date-picker>`,
+      () => ({ value: '', type: 'date', testCell })
+    )
+    await nextTick()
+    const dateTypes: IDatePickerType[] = [
+      'year',
+      'years',
+      'month',
+      'months',
+      'date',
+      'dates',
+      'week',
+      'datetime',
+      'datetimerange',
+      'daterange',
+      //'monthrange',
+      'yearrange',
+    ]
+    for (const type of dateTypes) {
+      const input = wrapper.find('input')
+      input.trigger('blur')
+      input.trigger('focus')
+      await nextTick()
+      {
+        ;(
+          document.querySelector('td .el-date-table-cell') as HTMLElement
+        ).click()
+      }
+
+      input.trigger('focus')
+      await nextTick()
+      await wrapper.setProps({ value: '', type })
+    }
   })
 
   it('custom content for type is year', async () => {

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -13,7 +13,8 @@ import 'dayjs/locale/zh-cn'
 import { EVENT_CODE } from '@element-plus/constants'
 import { ElFormItem } from '@element-plus/components/form'
 import DatePicker from '../src/date-picker'
-import { DateCell, IDatePickerType } from '../src/date-picker.type'
+
+import type { DateCell, IDatePickerType } from '../src/date-picker.type'
 
 const _mount = (template: string, data = () => ({}), otherObj?) =>
   mount(
@@ -686,8 +687,8 @@ describe('DatePicker', () => {
   })
 
   it('should have always the same propreties for default slot', async () => {
-    const testCell = (cell: DateCell) => {
-      const arr: (keyof DateCell)[] = [
+    const testCellData = (cell: DateCell) => {
+      const cellProperties: (keyof DateCell)[] = [
         'column',
         'type',
         'text',
@@ -702,7 +703,7 @@ describe('DatePicker', () => {
         'customClass',
         'end',
       ].sort()
-      expect(Object.keys(cell).sort()).toStrictEqual(arr)
+      expect(Object.keys(cell).sort()).toStrictEqual(cellProperties)
       for (const value of Object.values(cell)) {
         expect(value).toBeDefined()
       }
@@ -714,15 +715,14 @@ describe('DatePicker', () => {
         :cellClassName="() => 'hello'"
         ref="input">
         <template #default="cell">
-          <div class="el-date-table-cell" @click="testCell(cell)">
+          <div class="el-date-table-cell" @click="testCellData(cell)">
             <div class="el-date-table-cell__text">click me</div>
           </div>
         </template>
       </el-date-picker>`,
-      () => ({ value: '', type: 'date', testCell })
+      () => ({ value: '', testCellData })
     )
-    await nextTick()
-    const dateTypes: IDatePickerType[] = [
+    const types: IDatePickerType[] = [
       'year',
       'years',
       'month',
@@ -733,23 +733,16 @@ describe('DatePicker', () => {
       'datetime',
       'datetimerange',
       'daterange',
-      //'monthrange',
+      'monthrange',
       'yearrange',
     ]
-    for (const type of dateTypes) {
-      const input = wrapper.find('input')
-      input.trigger('blur')
-      input.trigger('focus')
-      await nextTick()
+    for (const type of types) {
+      await wrapper.setProps({ type })
       {
         ;(
           document.querySelector('td .el-date-table-cell') as HTMLElement
         ).click()
       }
-
-      input.trigger('focus')
-      await nextTick()
-      await wrapper.setProps({ value: '', type })
     }
   })
 

--- a/packages/components/date-picker/src/composables/use-basic-date-table.ts
+++ b/packages/components/date-picker/src/composables/use-basic-date-table.ts
@@ -421,7 +421,6 @@ export const useBasicDateTableDOM = (
       classes.push('disabled')
     }
 
-    console.log(props.selectionMode === 'dates')
     if (props.selectionMode === 'dates' && cell.isSelected) {
       classes.push('selected')
     }

--- a/packages/components/date-picker/src/composables/use-basic-date-table.ts
+++ b/packages/components/date-picker/src/composables/use-basic-date-table.ts
@@ -136,7 +136,7 @@ export const useBasicDateTable = (
     cell.selected = _selectedDate.find((d) => d.isSame(cell.dayjs, 'day'))
     cell.isSelected = !!cell.selected
     cell.isCurrent = isCurrent(cell)
-    cell.disabled = disabledDate?.(cellDate)
+    cell.disabled = disabledDate?.(cellDate) || false
     cell.customClass = cellClassName?.(cellDate)
     return shouldIncrement
   }
@@ -164,6 +164,7 @@ export const useBasicDateTable = (
       for (let rowIndex = 0; rowIndex < 6; rowIndex++) {
         if (!rows_[rowIndex][0]) {
           rows_[rowIndex][0] = {
+            //...rows_[rowIndex][0],
             type: 'week',
             text: unref(startDate)
               .add(rowIndex * 7 + 1, dateUnit)

--- a/packages/components/date-picker/src/composables/use-basic-date-table.ts
+++ b/packages/components/date-picker/src/composables/use-basic-date-table.ts
@@ -138,7 +138,6 @@ export const useBasicDateTable = (
       for (let rowIndex = 0; rowIndex < 6; rowIndex++) {
         if (!rows_[rowIndex][0]) {
           rows_[rowIndex][0] = {
-            //...rows_[rowIndex][0],
             type: 'week',
             text: unref(startDate)
               .add(rowIndex * 7 + 1, dateUnit)

--- a/packages/components/date-picker/src/date-picker-com/basic-cell-render.tsx
+++ b/packages/components/date-picker/src/date-picker-com/basic-cell-render.tsx
@@ -14,7 +14,7 @@ export default defineComponent({
 
       return renderSlot(slots, 'default', { ...cell }, () => [
         <div class={ns.b()}>
-          <span class={ns.e('text')}>{cell?.renderText ?? cell?.text}</span>
+          <span class={ns.e('text')}>{cell?.text}</span>
         </div>,
       ])
     }

--- a/packages/components/date-picker/src/date-picker-com/basic-date-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-date-table.vue
@@ -30,11 +30,11 @@
         <td
           v-for="(cell, columnKey) in row"
           :key="`${rowKey}.${columnKey}`"
-          :ref="(el) => isSelectedCell(cell) && (currentCellRef = el as HTMLElement)"
+          :ref="(el) => cell.isSelected && (currentCellRef = el as HTMLElement)"
           :class="getCellClasses(cell)"
           :aria-current="cell.isSelected ? 'date' : undefined"
           :aria-selected="cell.isSelected"
-          :tabindex="isSelectedCell(cell) ? 0 : -1"
+          :tabindex="cell.isSelected ? 0 : -1"
           @focus="handleFocus"
         >
           <el-date-picker-cell :cell="cell" />
@@ -65,9 +65,7 @@ const {
   currentCellRef,
 
   focus,
-  isCurrent,
   isWeekActive,
-  isSelectedCell,
 
   handlePickDate,
   handleMouseUp,
@@ -77,7 +75,6 @@ const {
 } = useBasicDateTable(props, emit)
 const { tableLabel, tableKls, weekLabel, getCellClasses, getRowKls, t } =
   useBasicDateTableDOM(props, {
-    isCurrent,
     isWeekActive,
   })
 

--- a/packages/components/date-picker/src/date-picker-com/basic-date-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-date-table.vue
@@ -32,8 +32,8 @@
           :key="`${rowKey}.${columnKey}`"
           :ref="(el) => isSelectedCell(cell) && (currentCellRef = el as HTMLElement)"
           :class="getCellClasses(cell)"
-          :aria-current="cell.isCurrent ? 'date' : undefined"
-          :aria-selected="cell.isCurrent"
+          :aria-current="cell.isSelected ? 'date' : undefined"
+          :aria-selected="cell.isSelected"
           :tabindex="isSelectedCell(cell) ? 0 : -1"
           @focus="handleFocus"
         >

--- a/packages/components/date-picker/src/date-picker-com/basic-month-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-month-table.vue
@@ -154,6 +154,7 @@ const getCellStyle = (cell: MonthCell) => {
   style.disabled = props.disabledDate
     ? datesInMonth(year, month, lang.value).every(props.disabledDate)
     : false
+  style.available = !cell.disabled
   style.current = isSelectedCell(cell)
   style.today = today.getFullYear() === year && today.getMonth() === month
 

--- a/packages/components/date-picker/src/date-picker-com/basic-month-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-month-table.vue
@@ -14,7 +14,7 @@
           :ref="(el) => cell.isSelected && (currentCellRef = el as HTMLElement)"
           :class="getCellStyle(cell)"
           :aria-selected="!!cell.isSelected"
-          :aria-label="t(`el.datepicker.month${+cell.text + 1}`)"
+          :aria-label="t(`el.datepicker.month${+cell.text! + 1}`)"
           :tabindex="cell.isSelected ? 0 : -1"
           @keydown.space.prevent.stop="handleMonthTableClick"
           @keydown.enter.prevent.stop="handleMonthTableClick"
@@ -22,7 +22,7 @@
           <el-date-picker-cell
             :cell="{
               ...cell,
-              text: t('el.datepicker.months.' + months[cell.text]),
+              text: t('el.datepicker.months.' + months[cell.text as number]),
             }"
           />
         </td>
@@ -39,8 +39,23 @@ import { castArray, hasClass } from '@element-plus/utils'
 import { basicMonthTableProps } from '../props/basic-month-table'
 import { datesInMonth, getValidDateOfMonth } from '../utils'
 import ElDatePickerCell from './basic-cell-render'
+import type { Dayjs } from 'dayjs'
 
-import type { DateCell } from '../date-picker.type'
+type MonthCell = {
+  column: number
+  row: number
+  disabled: boolean
+  start: boolean
+  end: boolean
+  text: number
+  type: 'normal' | 'today'
+  inRange: boolean
+  isSelected: boolean
+  date?: Date
+  dayjs?: Dayjs
+  timestamp?: number
+  customClass?: string
+}
 
 const props = defineProps(basicMonthTableProps)
 const emit = defineEmits(['changerange', 'pick', 'select'])
@@ -57,10 +72,10 @@ const months = ref(
     .monthsShort()
     .map((_) => _.toLowerCase())
 )
-const tableRows = ref<DateCell[][]>([[], [], []])
+const tableRows = ref<MonthCell[][]>([[], [], []])
 const lastRow = ref<number>()
 const lastColumn = ref<number>()
-const rows = computed<DateCell[][]>(() => {
+const rows = computed<MonthCell[][]>(() => {
   const rows = tableRows.value
 
   const now = dayjs().locale(lang.value).startOf('month')
@@ -77,7 +92,8 @@ const rows = computed<DateCell[][]>(() => {
         end: false,
         text: -1,
         disabled: false,
-      } as DateCell)
+        isSelected: false,
+      })
 
       cell.type = 'normal'
 
@@ -123,7 +139,7 @@ const rows = computed<DateCell[][]>(() => {
       cell.customClass = props.cellClassName?.(cellDate)
       cell.dayjs = calTime
       cell.timestamp = calTime.valueOf()
-      cell.isCurrent = isCurrent(cell)
+      //cell.isCurrent = isCurrent(cell)
       cell.isSelected = isSelectedCell(cell)
       cell.disabled = props.disabledDate?.(cellDate) || false
     }
@@ -135,11 +151,11 @@ const focus = () => {
   currentCellRef.value?.focus()
 }
 
-const getCellStyle = (cell: DateCell) => {
+const getCellStyle = (cell: MonthCell) => {
   const style = {} as any
   const year = props.date.year()
   const today = new Date()
-  const month = cell.text
+  const month = cell.text as number
 
   style.disabled = props.disabledDate
     ? datesInMonth(year, month, lang.value).every(props.disabledDate)
@@ -169,7 +185,7 @@ const getCellStyle = (cell: DateCell) => {
   return style
 }
 
-const isSelectedCell = (cell: DateCell) => {
+const isSelectedCell = (cell: MonthCell) => {
   const year = cell.dayjs?.year()
   const month = cell.text
   return (
@@ -179,16 +195,16 @@ const isSelectedCell = (cell: DateCell) => {
   )
 }
 
-const isCurrent = (cell: DateCell) => {
-  const year = props.date.year()
-  const month = cell.text
-  return (
-    castArray(props.parsedValue).findIndex(
-      (date) =>
-        dayjs.isDayjs(date) && date.year() === year && date.month() === month
-    ) >= 0
-  )
-}
+//const isCurrent = (cell: DateCell) => {
+//  const year = cell.dayjs?.year()
+//  const month = cell.text
+//  return (
+//    castArray(props.parsedValue).findIndex(
+//      (date) =>
+//        dayjs.isDayjs(date) && date.year() === year && date.month() === month
+//    ) >= 0
+//  )
+//}
 
 const handleMouseMove = (event: MouseEvent) => {
   if (!props.rangeState.selecting) return

--- a/packages/components/date-picker/src/date-picker-com/basic-month-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-month-table.vue
@@ -22,7 +22,7 @@
           <el-date-picker-cell
             :cell="{
               ...cell,
-              text: t('el.datepicker.months.' + months[cell.text as number]),
+              text: t('el.datepicker.months.' + months[cell.text]),
             }"
           />
         </td>
@@ -37,7 +37,7 @@ import dayjs from 'dayjs'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { castArray, hasClass } from '@element-plus/utils'
 import { basicMonthTableProps } from '../props/basic-month-table'
-import { datesInMonth, getValidDateOfMonth } from '../utils'
+import { datesInMonth, getValidDateOfMonth, setCellMetadata } from '../utils'
 import ElDatePickerCell from './basic-cell-render'
 import type { Dayjs } from 'dayjs'
 
@@ -133,15 +133,9 @@ const rows = computed<MonthCell[][]>(() => {
         cell.type = 'today'
       }
 
-      const cellDate = calTime.toDate()
       cell.text = index
-      cell.date = cellDate
-      cell.customClass = props.cellClassName?.(cellDate)
-      cell.dayjs = calTime
-      cell.timestamp = calTime.valueOf()
-      //cell.isCurrent = isCurrent(cell)
       cell.isSelected = isSelectedCell(cell)
-      cell.disabled = props.disabledDate?.(cellDate) || false
+      setCellMetadata(cell, calTime, props)
     }
   }
   return rows
@@ -155,16 +149,12 @@ const getCellStyle = (cell: MonthCell) => {
   const style = {} as any
   const year = props.date.year()
   const today = new Date()
-  const month = cell.text as number
+  const month = cell.text
 
   style.disabled = props.disabledDate
     ? datesInMonth(year, month, lang.value).every(props.disabledDate)
     : false
-  style.current =
-    castArray(props.parsedValue).findIndex(
-      (date) =>
-        dayjs.isDayjs(date) && date.year() === year && date.month() === month
-    ) >= 0
+  style.current = isSelectedCell(cell)
   style.today = today.getFullYear() === year && today.getMonth() === month
 
   if (cell.customClass) {
@@ -194,17 +184,6 @@ const isSelectedCell = (cell: MonthCell) => {
     ) >= 0
   )
 }
-
-//const isCurrent = (cell: DateCell) => {
-//  const year = cell.dayjs?.year()
-//  const month = cell.text
-//  return (
-//    castArray(props.parsedValue).findIndex(
-//      (date) =>
-//        dayjs.isDayjs(date) && date.year() === year && date.month() === month
-//    ) >= 0
-//  )
-//}
 
 const handleMouseMove = (event: MouseEvent) => {
   if (!props.rangeState.selecting) return

--- a/packages/components/date-picker/src/date-picker-com/basic-month-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-month-table.vue
@@ -42,19 +42,6 @@ import ElDatePickerCell from './basic-cell-render'
 
 import type { DateCell } from '../date-picker.type'
 
-type MonthCell = {
-  customClass?: string
-  isSelected?: boolean
-  column: number
-  row: number
-  disabled: boolean
-  start: boolean
-  end: boolean
-  text: number
-  type: 'normal' | 'today'
-  inRange: boolean
-}
-
 const props = defineProps(basicMonthTableProps)
 const emit = defineEmits(['changerange', 'pick', 'select'])
 
@@ -70,10 +57,10 @@ const months = ref(
     .monthsShort()
     .map((_) => _.toLowerCase())
 )
-const tableRows = ref<MonthCell[][]>([[], [], []])
+const tableRows = ref<DateCell[][]>([[], [], []])
 const lastRow = ref<number>()
 const lastColumn = ref<number>()
-const rows = computed<MonthCell[][]>(() => {
+const rows = computed<DateCell[][]>(() => {
   const rows = tableRows.value
 
   const now = dayjs().locale(lang.value).startOf('month')
@@ -81,7 +68,7 @@ const rows = computed<MonthCell[][]>(() => {
   for (let i = 0; i < 3; i++) {
     const row = rows[i]
     for (let j = 0; j < 4; j++) {
-      const cell: DateCell = (row[j] ||= {
+      const cell = (row[j] ||= {
         row: i,
         column: j,
         type: 'normal',
@@ -90,7 +77,7 @@ const rows = computed<MonthCell[][]>(() => {
         end: false,
         text: -1,
         disabled: false,
-      })
+      } as DateCell)
 
       cell.type = 'normal'
 
@@ -148,7 +135,7 @@ const focus = () => {
   currentCellRef.value?.focus()
 }
 
-const getCellStyle = (cell: MonthCell) => {
+const getCellStyle = (cell: DateCell) => {
   const style = {} as any
   const year = props.date.year()
   const today = new Date()

--- a/packages/components/date-picker/src/date-picker-com/basic-month-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-month-table.vue
@@ -155,7 +155,7 @@ const getCellStyle = (cell: MonthCell) => {
     ? datesInMonth(year, month, lang.value).every(props.disabledDate)
     : false
   style.available = !cell.disabled
-  style.current = isSelectedCell(cell)
+  style.current = cell.isSelected
   style.today = today.getFullYear() === year && today.getMonth() === month
 
   if (cell.customClass) {
@@ -177,7 +177,7 @@ const getCellStyle = (cell: MonthCell) => {
 }
 
 const isSelectedCell = (cell: MonthCell) => {
-  const year = cell.dayjs?.year()
+  const year = props.date.year()
   const month = cell.text
   return (
     castArray(props.parsedValue).findIndex(

--- a/packages/components/date-picker/src/date-picker-com/basic-year-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-year-table.vue
@@ -12,7 +12,6 @@
           v-for="(cell, cellKey) in row"
           :key="`${rowKey}_${cellKey}`"
           :ref="(el) => cell.isSelected && (currentCellRef = el as HTMLElement)"
-          class="available"
           :class="getCellKls(cell)"
           :aria-selected="!!cell.isSelected"
           :aria-label="String(cell.text)"
@@ -149,15 +148,14 @@ const focus = () => {
 
 const getCellKls = (cell: YearCell) => {
   const kls: Record<string, boolean> = {}
-  const today = dayjs().locale(lang.value)
   const year = cell.text
 
   kls.disabled = props.disabledDate
     ? datesInYear(year, lang.value).every(props.disabledDate)
     : false
-
-  kls.today = today.year() === year
-  kls.current = isSelectedCell(cell)
+  kls.available = !cell.disabled
+  kls.today = cell.type === 'today' && !cell.disabled
+  kls.current = cell.isSelected
 
   if (cell.customClass) {
     kls[cell.customClass] = true
@@ -178,7 +176,7 @@ const getCellKls = (cell: YearCell) => {
 }
 
 const isSelectedCell = (cell: YearCell) => {
-  const year = cell.text
+  const year = cell.dayjs?.year()
   return castArray(props.date).findIndex((date) => date.year() === year) >= 0
 }
 

--- a/packages/components/date-picker/src/date-picker-com/basic-year-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-year-table.vue
@@ -36,8 +36,23 @@ import { castArray, hasClass } from '@element-plus/utils'
 import { basicYearTableProps } from '../props/basic-year-table'
 import { getValidDateOfYear } from '../utils'
 import ElDatePickerCell from './basic-cell-render'
+import type { Dayjs } from 'dayjs'
 
-import type { DateCell } from '../date-picker.type'
+type YearCell = {
+  column: number
+  row: number
+  disabled: boolean
+  start: boolean
+  end: boolean
+  text: number
+  type: 'normal' | 'today'
+  inRange: boolean
+  isSelected: boolean
+  date?: Date
+  dayjs?: Dayjs
+  timestamp?: number
+  customClass?: string
+}
 
 const datesInYear = (year: number, lang: string) => {
   const firstDay = dayjs(String(year)).locale(lang).startOf('year')
@@ -58,7 +73,7 @@ const startYear = computed(() => {
   return Math.floor(props.date.year() / 10) * 10
 })
 
-const tableRows = ref<DateCell[][]>([[], [], []])
+const tableRows = ref<YearCell[][]>([[], [], []])
 const lastRow = ref<number>()
 const lastColumn = ref<number>()
 const rows = computed(() => {
@@ -80,7 +95,8 @@ const rows = computed(() => {
         end: false,
         text: -1,
         disabled: false,
-      } as DateCell)
+        isSelected: false,
+      })
 
       cell.type = 'normal'
 
@@ -125,7 +141,6 @@ const rows = computed(() => {
       cell.customClass = props.cellClassName?.(cellDate)
       cell.dayjs = calTime
       cell.timestamp = calTime.valueOf()
-      cell.isCurrent = isCurrent(cell)
       cell.isSelected = isSelectedCell(cell)
       cell.disabled = props.disabledDate?.(cellDate) || false
     }
@@ -137,7 +152,7 @@ const focus = () => {
   currentCellRef.value?.focus()
 }
 
-const getCellKls = (cell: DateCell) => {
+const getCellKls = (cell: YearCell) => {
   const kls: Record<string, boolean> = {}
   const today = dayjs().locale(lang.value)
   const year = cell.text
@@ -147,7 +162,7 @@ const getCellKls = (cell: DateCell) => {
     : false
 
   kls.today = today.year() === year
-  kls.current = isCurrent(cell)
+  kls.current = isSelectedCell(cell)
 
   if (cell.customClass) {
     kls[cell.customClass] = true
@@ -167,12 +182,7 @@ const getCellKls = (cell: DateCell) => {
   return kls
 }
 
-const isCurrent = (cell: DateCell) => {
-  const year = cell.text
-  return castArray(props.parsedValue).findIndex((d) => d!.year() === year) >= 0
-}
-
-const isSelectedCell = (cell: DateCell) => {
+const isSelectedCell = (cell: YearCell) => {
   const year = cell.text
   return castArray(props.date).findIndex((date) => date.year() === year) >= 0
 }

--- a/packages/components/date-picker/src/date-picker-com/basic-year-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-year-table.vue
@@ -176,8 +176,10 @@ const getCellKls = (cell: YearCell) => {
 }
 
 const isSelectedCell = (cell: YearCell) => {
-  const year = cell.dayjs?.year()
-  return castArray(props.date).findIndex((date) => date.year() === year) >= 0
+  const year = cell.text
+  return (
+    castArray(props.parsedValue).findIndex((date) => date?.year() === year) >= 0
+  )
 }
 
 const handleYearTableClick = (event: MouseEvent | KeyboardEvent) => {

--- a/packages/components/date-picker/src/date-picker-com/basic-year-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-year-table.vue
@@ -34,7 +34,7 @@ import { useLocale, useNamespace } from '@element-plus/hooks'
 import { rangeArr } from '@element-plus/components/time-picker'
 import { castArray, hasClass } from '@element-plus/utils'
 import { basicYearTableProps } from '../props/basic-year-table'
-import { getValidDateOfYear } from '../utils'
+import { getValidDateOfYear, setCellMetadata } from '../utils'
 import ElDatePickerCell from './basic-cell-render'
 import type { Dayjs } from 'dayjs'
 
@@ -135,14 +135,9 @@ const rows = computed(() => {
       if (isToday) {
         cell.type = 'today'
       }
-      const cellDate = calTime.toDate()
       cell.text = index
-      cell.date = cellDate
-      cell.customClass = props.cellClassName?.(cellDate)
-      cell.dayjs = calTime
-      cell.timestamp = calTime.valueOf()
       cell.isSelected = isSelectedCell(cell)
-      cell.disabled = props.disabledDate?.(cellDate) || false
+      setCellMetadata(cell, calTime, props)
     }
   }
   return rows

--- a/packages/components/date-picker/src/date-picker-com/basic-year-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-year-table.vue
@@ -39,19 +39,6 @@ import ElDatePickerCell from './basic-cell-render'
 
 import type { DateCell } from '../date-picker.type'
 
-type YearCell = {
-  customClass?: string
-  isSelected?: boolean
-  column: number
-  row: number
-  disabled: boolean
-  start: boolean
-  end: boolean
-  text: number
-  type: 'normal' | 'today'
-  inRange: boolean
-}
-
 const datesInYear = (year: number, lang: string) => {
   const firstDay = dayjs(String(year)).locale(lang).startOf('year')
   const lastDay = firstDay.endOf('year')
@@ -71,7 +58,7 @@ const startYear = computed(() => {
   return Math.floor(props.date.year() / 10) * 10
 })
 
-const tableRows = ref<YearCell[][]>([[], [], []])
+const tableRows = ref<DateCell[][]>([[], [], []])
 const lastRow = ref<number>()
 const lastColumn = ref<number>()
 const rows = computed(() => {
@@ -84,7 +71,7 @@ const rows = computed(() => {
       if (i * 4 + j >= 10) {
         break
       }
-      const cell: DateCell = (row[j] ||= {
+      const cell = (row[j] ||= {
         row: i,
         column: j,
         type: 'normal',
@@ -93,7 +80,7 @@ const rows = computed(() => {
         end: false,
         text: -1,
         disabled: false,
-      })
+      } as DateCell)
 
       cell.type = 'normal'
 
@@ -150,7 +137,7 @@ const focus = () => {
   currentCellRef.value?.focus()
 }
 
-const getCellKls = (cell: YearCell) => {
+const getCellKls = (cell: DateCell) => {
   const kls: Record<string, boolean> = {}
   const today = dayjs().locale(lang.value)
   const year = cell.text

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -163,6 +163,7 @@
             :date="innerDate"
             :parsed-value="parsedValue"
             :disabled-date="disabledDate"
+            :cell-class-name="cellClassName"
             @pick="handleMonthPick"
           />
         </div>

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -154,6 +154,7 @@
             :date="innerDate"
             :disabled-date="disabledDate"
             :parsed-value="parsedValue"
+            :cell-class-name="cellClassName"
             @pick="handleYearPick"
           />
           <month-table

--- a/packages/components/date-picker/src/date-picker-com/panel-month-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-month-range.vue
@@ -58,6 +58,7 @@
             :max-date="maxDate"
             :range-state="rangeState"
             :disabled-date="disabledDate"
+            :cell-class-name="cellClassName"
             @changerange="handleChangeRange"
             @pick="handleRangePick"
             @select="onSelect"
@@ -96,6 +97,7 @@
             :max-date="maxDate"
             :range-state="rangeState"
             :disabled-date="disabledDate"
+            :cell-class-name="cellClassName"
             @changerange="handleChangeRange"
             @pick="handleRangePick"
             @select="onSelect"
@@ -134,7 +136,7 @@ const unit = 'year'
 
 const { lang } = useLocale()
 const pickerBase = inject('EP_PICKER_BASE') as any
-const { shortcuts, disabledDate } = pickerBase.props
+const { shortcuts, disabledDate, cellClassName } = pickerBase.props
 const format = toRef(pickerBase.props, 'format')
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 const leftDate = ref(dayjs().locale(lang.value))

--- a/packages/components/date-picker/src/date-picker-com/panel-year-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-year-range.vue
@@ -45,6 +45,7 @@
             :max-date="maxDate"
             :range-state="rangeState"
             :disabled-date="disabledDate"
+            :cell-class-name="cellClassName"
             @changerange="handleChangeRange"
             @pick="handleRangePick"
             @select="onSelect"
@@ -81,6 +82,7 @@
             :max-date="maxDate"
             :range-state="rangeState"
             :disabled-date="disabledDate"
+            :cell-class-name="cellClassName"
             @changerange="handleChangeRange"
             @pick="handleRangePick"
             @select="onSelect"
@@ -222,7 +224,7 @@ const onSelect = (selecting: boolean) => {
 }
 
 const pickerBase = inject('EP_PICKER_BASE') as any
-const { shortcuts, disabledDate } = pickerBase.props
+const { shortcuts, disabledDate, cellClassName } = pickerBase.props
 const format = toRef(pickerBase.props, 'format')
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 const unit = 'year'

--- a/packages/components/date-picker/src/date-picker.type.ts
+++ b/packages/components/date-picker/src/date-picker.type.ts
@@ -26,8 +26,7 @@ export interface DateCell {
   isCurrent?: boolean
   isSelected?: boolean
   start?: boolean
-  text?: number
-  renderText?: string
+  text?: number | string
   timestamp?: number
   date?: Date
   dayjs?: Dayjs

--- a/packages/components/date-picker/src/date-picker.type.ts
+++ b/packages/components/date-picker/src/date-picker.type.ts
@@ -16,22 +16,39 @@ export declare type IDatePickerType =
 
 type DateCellType = 'normal' | 'today' | 'week' | 'next-month' | 'prev-month'
 export interface DateCell {
-  column: number
+  column?: number
   customClass?: string
-  disabled: boolean
-  end: boolean
-  inRange: boolean
-  row: number
-  selected?: Dayjs
-  isCurrent: boolean
-  isSelected: boolean
-  start: boolean
-  text: number
-  timestamp: number
-  date: Date
-  dayjs: Dayjs
-  type: DateCellType
+  disabled?: boolean
+  end?: boolean
+  inRange?: boolean
+  row?: number
+  //selected?: Dayjs
+  //isCurrent?: boolean
+  isSelected?: boolean
+  start?: boolean
+  text?: number | string
+  timestamp?: number
+  date?: Date
+  dayjs?: Dayjs
+  type?: DateCellType
 }
-export type DateCellRender = Omit<DateCell, 'text'> & {
-  text: number | string
-}
+//export interface DateCell {
+//  column: number
+//  customClass?: string
+//  disabled: boolean
+//  end: boolean
+//  inRange: boolean
+//  row: number
+//  selected?: Dayjs
+//  isCurrent: boolean
+//  isSelected: boolean
+//  start: boolean
+//  text: number
+//  timestamp: number
+//  date: Date
+//  dayjs: Dayjs
+//  type: DateCellType
+//}
+//export type DateCellRender = Omit<DateCell, 'text'> & {
+//  text: number | string
+//}

--- a/packages/components/date-picker/src/date-picker.type.ts
+++ b/packages/components/date-picker/src/date-picker.type.ts
@@ -22,8 +22,6 @@ export interface DateCell {
   end?: boolean
   inRange?: boolean
   row?: number
-  //selected?: Dayjs
-  //isCurrent?: boolean
   isSelected?: boolean
   start?: boolean
   text?: number | string
@@ -32,23 +30,3 @@ export interface DateCell {
   dayjs?: Dayjs
   type?: DateCellType
 }
-//export interface DateCell {
-//  column: number
-//  customClass?: string
-//  disabled: boolean
-//  end: boolean
-//  inRange: boolean
-//  row: number
-//  selected?: Dayjs
-//  isCurrent: boolean
-//  isSelected: boolean
-//  start: boolean
-//  text: number
-//  timestamp: number
-//  date: Date
-//  dayjs: Dayjs
-//  type: DateCellType
-//}
-//export type DateCellRender = Omit<DateCell, 'text'> & {
-//  text: number | string
-//}

--- a/packages/components/date-picker/src/date-picker.type.ts
+++ b/packages/components/date-picker/src/date-picker.type.ts
@@ -16,19 +16,22 @@ export declare type IDatePickerType =
 
 type DateCellType = 'normal' | 'today' | 'week' | 'next-month' | 'prev-month'
 export interface DateCell {
-  column?: number
+  column: number
   customClass?: string
-  disabled?: boolean
-  end?: boolean
-  inRange?: boolean
-  row?: number
+  disabled: boolean
+  end: boolean
+  inRange: boolean
+  row: number
   selected?: Dayjs
-  isCurrent?: boolean
-  isSelected?: boolean
-  start?: boolean
-  text?: number | string
-  timestamp?: number
-  date?: Date
-  dayjs?: Dayjs
-  type?: DateCellType
+  isCurrent: boolean
+  isSelected: boolean
+  start: boolean
+  text: number
+  timestamp: number
+  date: Date
+  dayjs: Dayjs
+  type: DateCellType
+}
+export type DateCellRender = Omit<DateCell, 'text'> & {
+  text: number | string
 }

--- a/packages/components/date-picker/src/props/basic-cell.ts
+++ b/packages/components/date-picker/src/props/basic-cell.ts
@@ -1,11 +1,11 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
 import type { ExtractPropTypes } from 'vue'
-import type { DateCellRender } from '../date-picker.type'
+import type { DateCell } from '../date-picker.type'
 
 export const basicCellProps = buildProps({
   cell: {
-    type: definePropType<DateCellRender>(Object),
+    type: definePropType<DateCell>(Object),
   },
 } as const)
 

--- a/packages/components/date-picker/src/props/basic-cell.ts
+++ b/packages/components/date-picker/src/props/basic-cell.ts
@@ -1,11 +1,11 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
 import type { ExtractPropTypes } from 'vue'
-import type { DateCell } from '../date-picker.type'
+import type { DateCellRender } from '../date-picker.type'
 
 export const basicCellProps = buildProps({
   cell: {
-    type: definePropType<DateCell>(Object),
+    type: definePropType<DateCellRender>(Object),
   },
 } as const)
 

--- a/packages/components/date-picker/src/props/basic-date-table.ts
+++ b/packages/components/date-picker/src/props/basic-date-table.ts
@@ -1,4 +1,4 @@
-import { buildProps, definePropType } from '@element-plus/utils'
+import { buildProps } from '@element-plus/utils'
 import { datePickerSharedProps, selectionModeWithDefault } from './shared'
 
 import type { ExtractPropTypes } from 'vue'
@@ -6,9 +6,6 @@ import type { Dayjs } from 'dayjs'
 
 export const basicDateTableProps = buildProps({
   ...datePickerSharedProps,
-  cellClassName: {
-    type: definePropType<(date: Date) => string>(Function),
-  },
   showWeekNumber: Boolean,
   selectionMode: selectionModeWithDefault('date'),
 } as const)

--- a/packages/components/date-picker/src/props/shared.ts
+++ b/packages/components/date-picker/src/props/shared.ts
@@ -24,6 +24,9 @@ export type RangeState = {
 export type DisabledDateType = (date: Date) => boolean
 
 export const datePickerSharedProps = buildProps({
+  cellClassName: {
+    type: definePropType<(date: Date) => string>(Function),
+  },
   disabledDate: {
     type: definePropType<DisabledDateType>(Function),
   },

--- a/packages/components/date-picker/src/props/shared.ts
+++ b/packages/components/date-picker/src/props/shared.ts
@@ -22,10 +22,11 @@ export type RangeState = {
 }
 
 export type DisabledDateType = (date: Date) => boolean
+export type CellClassNameType = (date: Date) => string
 
 export const datePickerSharedProps = buildProps({
   cellClassName: {
-    type: definePropType<(date: Date) => string>(Function),
+    type: definePropType<CellClassNameType>(Function),
   },
   disabledDate: {
     type: definePropType<DisabledDateType>(Function),

--- a/packages/components/date-picker/src/utils.ts
+++ b/packages/components/date-picker/src/utils.ts
@@ -84,17 +84,14 @@ export const buildPickerTable = (
   for (let rowIndex = 0; rowIndex < dimension.row; rowIndex++) {
     const row = rows[rowIndex]
     for (let columnIndex = 0; columnIndex < dimension.column; columnIndex++) {
-      let cell = row[columnIndex + columnIndexOffset]
-      if (!cell) {
-        cell = {
-          row: rowIndex,
-          column: columnIndex,
-          type: 'normal',
-          inRange: false,
-          start: false,
-          end: false,
-        } as DateCell
-      }
+      const cell = (row[columnIndex + columnIndexOffset] ||= {
+        row: rowIndex,
+        column: columnIndex,
+        type: 'normal',
+        inRange: false,
+        start: false,
+        end: false,
+      })
       const index = rowIndex * dimension.column + columnIndex
       const nextStartDate = relativeDateGetter(index)
       cell.type = 'normal'

--- a/packages/components/date-picker/src/utils.ts
+++ b/packages/components/date-picker/src/utils.ts
@@ -4,7 +4,7 @@ import { rangeArr } from '@element-plus/components/time-picker'
 
 import type { Dayjs } from 'dayjs'
 import type { DateCell } from './date-picker.type'
-import type { DisabledDateType } from './props/shared'
+import type { CellClassNameType, DisabledDateType } from './props/shared'
 
 type DayRange = [Dayjs | undefined, Dayjs | undefined]
 
@@ -61,6 +61,7 @@ type BuildPickerTableMetadata = {
   relativeDateGetter: (index: number) => Dayjs
   setCellMetadata?: (
     cell: DateCell,
+    calTime: Dayjs,
     dimension: { rowIndex: number; columnIndex: number }
   ) => void
   setRowMetadata?: (row: DateCell[]) => void
@@ -96,9 +97,6 @@ export const buildPickerTable = (
       }
       const index = rowIndex * dimension.column + columnIndex
       const nextStartDate = relativeDateGetter(index)
-      cell.dayjs = nextStartDate
-      cell.date = nextStartDate.toDate()
-      cell.timestamp = nextStartDate.valueOf()
       cell.type = 'normal'
 
       cell.inRange =
@@ -128,7 +126,7 @@ export const buildPickerTable = (
       if (isToday) {
         cell.type = 'today'
       }
-      setCellMetadata?.(cell, { rowIndex, columnIndex })
+      setCellMetadata?.(cell, nextStartDate, { rowIndex, columnIndex })
       row[columnIndex + columnIndexOffset] = cell
     }
     setRowMetadata?.(row)
@@ -176,4 +174,21 @@ export const getValidDateOfYear = (
     }
   }
   return value
+}
+
+export const setCellMetadata = (
+  cell: DateCell,
+  calTime: Dayjs,
+  tableProps: {
+    cellClassName?: CellClassNameType
+    disabledDate?: DisabledDateType
+  }
+) => {
+  const { disabledDate, cellClassName } = tableProps
+  const cellDate = calTime.toDate()
+  cell.date = cellDate
+  cell.customClass = cellClassName?.(cellDate)
+  cell.dayjs = calTime
+  cell.timestamp = calTime.valueOf()
+  cell.disabled = disabledDate?.(cellDate) || false
 }

--- a/packages/components/date-picker/src/utils.ts
+++ b/packages/components/date-picker/src/utils.ts
@@ -92,7 +92,7 @@ export const buildPickerTable = (
           inRange: false,
           start: false,
           end: false,
-        }
+        } as DateCell
       }
       const index = rowIndex * dimension.column + columnIndex
       const nextStartDate = relativeDateGetter(index)


### PR DESCRIPTION
close #19260

For context the look of the current date cell look like this:
```ts
interface DateCell {
  column: number
  customClass?: string
  disabled: boolean
  end: boolean
  inRange: boolean
  renderText?: string
  row: number
  selected: Dayjs
  isCurrent?: boolean
  isSelected?: boolean
  start: boolean
  text: number
  timestamp: number
  date?: Date
  dayjs?: Dayjs
  type: 'normal' | 'today' | 'week' | 'next-month' | 'prev-month'
}
```

Initialy wanted to refact the default data slot to include `date`, `dayjs` and remove `renderText` and include it directly in `text` for any types.
Also wanted to fix that `cellCustomClass` was not applicated in all types.

After that found that we could've merge `isCurrent` into `isSelected` and remove `selected` due duplication of `dayjs`.

The new interface look like this:

```ts
interface DateCell {
  column: number
  customClass?: string
  disabled: boolean
  end: boolean
  inRange: boolean
  //renderText?: string // merged into text
  row: number
  //selected: Dayjs // duplicate with dayjs
  //isCurrent: boolean // duplicate with isSelected
  isSelected: boolean
  start: boolean
  text: number | string
  timestamp: number
  date: Date
  dayjs: Dayjs
  type: 'normal' | 'today' | 'week' | 'next-month' | 'prev-month'
}
```

I represent the change in the doc like this (80% zoomed):

![image](https://github.com/user-attachments/assets/366f1fc2-56d4-4684-97f5-2dd11e9590b7)
