### PR TITLE
feat(components): [image] teleported is on by default when use in table

### DIFF
--- a/docs/en-US/component/table.md
+++ b/docs/en-US/component/table.md
@@ -414,6 +414,8 @@ interface TreeNode {
 
 #### How to use image preview in the table?
 
+After version ^(2.9.3), teleported by default and does not need to be set manually.
+
 ```vue{4}
 <template>
   <el-table-column width="180">

--- a/packages/components/image/src/image.ts
+++ b/packages/components/image/src/image.ts
@@ -52,7 +52,7 @@ export const imageProps = buildProps({
     default: () => mutable([] as const),
   },
   /**
-   * @description whether to append image-viewer to body. A nested parent element attribute transform should have this attribute set to `true`. Defaults to true in table.
+   * @description whether to append image-viewer to body. A nested parent element attribute transform should have this attribute set to `true`. Defaults to `true` in table.
    */
   previewTeleported: {
     type: Boolean,

--- a/packages/components/image/src/image.ts
+++ b/packages/components/image/src/image.ts
@@ -52,9 +52,12 @@ export const imageProps = buildProps({
     default: () => mutable([] as const),
   },
   /**
-   * @description whether to append image-viewer to body. A nested parent element attribute transform should have this attribute set to `true`.
+   * @description whether to append image-viewer to body. A nested parent element attribute transform should have this attribute set to `true`. Defaults to true in table.
    */
-  previewTeleported: Boolean,
+  previewTeleported: {
+    type: definePropType<boolean | undefined>([Boolean]),
+    default: undefined,
+  },
   /**
    * @description set image preview z-index.
    */

--- a/packages/components/image/src/image.ts
+++ b/packages/components/image/src/image.ts
@@ -55,7 +55,7 @@ export const imageProps = buildProps({
    * @description whether to append image-viewer to body. A nested parent element attribute transform should have this attribute set to `true`. Defaults to true in table.
    */
   previewTeleported: {
-    type: definePropType<boolean | undefined>([Boolean]),
+    type: Boolean,
     default: undefined,
   },
   /**

--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -34,7 +34,7 @@
         :url-list="previewSrcList"
         :crossorigin="crossorigin"
         :hide-on-click-modal="hideOnClickModal"
-        :teleported="previewTeleported"
+        :teleported="isTeleported"
         :close-on-press-escape="closeOnPressEscape"
         @close="closeViewer"
         @switch="switchViewer"
@@ -50,6 +50,7 @@
 <script lang="ts" setup>
 import {
   computed,
+  inject,
   nextTick,
   onMounted,
   ref,
@@ -68,8 +69,8 @@ import {
   isInContainer,
   isString,
 } from '@element-plus/utils'
+import { TABLE_INJECTION_KEY } from '@element-plus/components/table/src/tokens'
 import { imageEmits, imageProps } from './image'
-
 import type { CSSProperties } from 'vue'
 
 defineOptions({
@@ -85,6 +86,9 @@ let prevOverflow = ''
 const { t } = useLocale()
 const ns = useNamespace('image')
 const rawAttrs = useRawAttrs()
+
+const tableParent = inject(TABLE_INJECTION_KEY, undefined)
+const isTeleported = computed(() => props.previewTeleported ?? !!tableParent)
 
 const containerAttrs = computed(() => {
   return fromPairs(

--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -5,6 +5,8 @@ import ElCheckbox from '@element-plus/components/checkbox'
 import triggerEvent from '@element-plus/test-utils/trigger-event'
 import { rAF } from '@element-plus/test-utils/tick'
 import { CaretBottom, CaretTop } from '@element-plus/icons-vue'
+import ElImage from '@element-plus/components/image'
+import { IMAGE_FAIL, IMAGE_SUCCESS } from '@element-plus/test-utils/mock'
 import ElTable from '../src/table.vue'
 import ElTableColumn from '../src/table-column'
 import {
@@ -1438,6 +1440,47 @@ describe('Table.vue', () => {
     await doubleWait()
     const emptyBlockEl = wrapper.find('.el-table__empty-block')
     expect(emptyBlockEl.attributes('style')).toContain('height: 100%')
+    wrapper.unmount()
+  })
+
+  it('table use image-preview auto teleported', async () => {
+    const wrapper = mount({
+      components: {
+        ElTable,
+        ElTableColumn,
+        ElImage,
+      },
+      template: `
+      <el-table :data="testData" height="100%">
+        <el-table-column prop="name" label="片名" />
+        <el-table-column prop="release" label="发行日期" />
+        <el-table-column prop="director" label="导演" />
+        <el-table-column prop="runtime" label="时长（分）" />
+        <template #append>
+          <el-image
+            style="width: 100px; height: 100px"
+            :src="url"
+            :preview-src-list="srcList"
+            :initial-index="1"
+            fit="cover"
+          />
+        </template>
+      </el-table>
+      `,
+      data() {
+        return {
+          testData: getTestData(),
+          url: IMAGE_SUCCESS,
+          srcList: Array.from<string>({ length: 3 }).fill(IMAGE_FAIL),
+        }
+      },
+    })
+    await doubleWait()
+    await wrapper.find('.el-image__inner').trigger('click')
+    expect(wrapper.findAll('.el-image-viewer__img')).toEqual([])
+    const viewerWrapperExists =
+      document.body.querySelector('.el-image-viewer__wrapper') !== null
+    expect(viewerWrapperExists).toBe(true)
     wrapper.unmount()
   })
 


### PR DESCRIPTION
close: https://github.com/element-plus/element-plus/issues/19488

### Why?

This problem seems to be caused by the CSS positioning of the table. I think it is best to just default to the built-in processing.

#### [before](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtdGFibGUgOmRhdGE9XCJ0YWJsZURhdGFcIiA6Ym9yZGVyPVwidHJ1ZVwiIHN0eWxlPVwid2lkdGg6IDEwMCVcIiByZWY9XCJ0YWJsZVwiPlxuICAgIDxlbC10YWJsZS1jb2x1bW4gdHlwZT1cImV4cGFuZFwiPlxuICAgICAgPHRlbXBsYXRlICNkZWZhdWx0PVwicHJvcHNcIj5cbiAgICAgICAgPGVsLWltYWdlXG4gICAgICBzdHlsZT1cIndpZHRoOiAxMDBweDsgaGVpZ2h0OiAxMDBweFwiXG4gICAgICBzcmM9XCJodHRwczovL2Z1c3MxMC5lbGVtZWNkbi5jb20vYS8zZi8zMzAyZTU4ZjlhMTgxZDI1MDlmM2RjMGZhNjhiMGpwZWcuanBlZ1wiXG4gICAgICA6em9vbS1yYXRlPVwiMS4yXCJcbiAgICAgIDptYXgtc2NhbGU9XCI3XCJcbiAgICAgIDptaW4tc2NhbGU9XCIwLjJcIlxuICAgICAgOnByZXZpZXctc3JjLWxpc3Q9XCJzcmNMaXN0XCJcbiAgICAgIDppbml0aWFsLWluZGV4PVwiNFwiXG4gICAgICBmaXQ9XCJjb3ZlclwiXG4gICAgLz5cbiAgICAgIDwvdGVtcGxhdGU+XG4gICAgPC9lbC10YWJsZS1jb2x1bW4+XG4gICAgPGVsLXRhYmxlLWNvbHVtbiBsYWJlbD1cIkRhdGVcIiBwcm9wPVwiZGF0ZVwiICNkZWZhdWx0PVwie3Jvd31cIj5cbiAgICAgIDxlbC1idXR0b24gQGNsaWNrPVwiZXhwYW5kKHJvdylcIj7lsZXlvIA8L2VsLWJ1dHRvbj5cbiAgICA8L2VsLXRhYmxlLWNvbHVtbj5cbiAgPC9lbC10YWJsZT5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgbGFuZz1cInRzXCIgc2V0dXA+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5cbmxldCB0YWJsZSA9IHJlZigndGFibGUnKVxuXG5mdW5jdGlvbiBleHBhbmQocm93KSB7XG4gIHJvdy5lID0gICFyb3cuZTtcbiAgdGFibGUudmFsdWUudG9nZ2xlUm93RXhwYW5zaW9uKHJvdywgcm93LmUpO1xufVxuXG5cbmNvbnN0IHNyY0xpc3QgPSBbXG4gICdodHRwczovL2Z1c3MxMC5lbGVtZWNkbi5jb20vYS8zZi8zMzAyZTU4ZjlhMTgxZDI1MDlmM2RjMGZhNjhiMGpwZWcuanBlZycsXG4gICdodHRwczovL2Z1c3MxMC5lbGVtZWNkbi5jb20vMS8zNC8xOWFhOThiMWZjYjI3ODFjNGZiYTMzZDg1MDU0OWpwZWcuanBlZycsXG4gICdodHRwczovL2Z1c3MxMC5lbGVtZWNkbi5jb20vMC82Zi9lMzVmZjM3NTgxMmU2YjAwMjBiNmI0ZThmOTU4M2pwZWcuanBlZycsXG4gICdodHRwczovL2Z1c3MxMC5lbGVtZWNkbi5jb20vOS9iYi9lMjc4NThlOTczZjVkN2QzOTA0ODM1ZjQ2YWJiZGpwZWcuanBlZycsXG4gICdodHRwczovL2Z1c3MxMC5lbGVtZWNkbi5jb20vZC9lNi9jNGQ5M2EzODA1YjNjZTNmMzIzZjc5NzRlNmY3OGpwZWcuanBlZycsXG4gICdodHRwczovL2Z1c3MxMC5lbGVtZWNkbi5jb20vMy8yOC9iYmY4OTNmNzkyZjAzYTU0NDA4YjNiN2E3ZWJmMGpwZWcuanBlZycsXG4gICdodHRwczovL2Z1c3MxMC5lbGVtZWNkbi5jb20vMi8xMS82NTM1YmNmYjI2ZTRjNzliNDhkZGRlNDRmNGI2ZmpwZWcuanBlZycsXG5dXG5cbmNvbnN0IHRhYmxlRGF0YSA9IFtcbiAge1xuICAgIGRhdGU6ICcyMDE2LTA1LTAzJyxcbiAgICBuYW1lOiAnVG9tJyxcbiAgICBzdGF0ZTogJ0NhbGlmb3JuaWEnLFxuICAgIGNpdHk6ICdTYW4gRnJhbmNpc2NvJyxcbiAgICBhZGRyZXNzOiAnMzY1MCAyMXN0IFN0LCBTYW4gRnJhbmNpc2NvJyxcbiAgICB6aXA6ICdDQSA5NDExNCcsXG4gICAgZmFtaWx5OiBbXG4gICAgICB7XG4gICAgICAgIG5hbWU6ICdKZXJyeScsXG4gICAgICAgIHN0YXRlOiAnQ2FsaWZvcm5pYScsXG4gICAgICAgIGNpdHk6ICdTYW4gRnJhbmNpc2NvJyxcbiAgICAgICAgYWRkcmVzczogJzM2NTAgMjFzdCBTdCwgU2FuIEZyYW5jaXNjbycsXG4gICAgICAgIHppcDogJ0NBIDk0MTE0JyxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIG5hbWU6ICdTcGlrZScsXG4gICAgICAgIHN0YXRlOiAnQ2FsaWZvcm5pYScsXG4gICAgICAgIGNpdHk6ICdTYW4gRnJhbmNpc2NvJyxcbiAgICAgICAgYWRkcmVzczogJzM2NTAgMjFzdCBTdCwgU2FuIEZyYW5jaXNjbycsXG4gICAgICAgIHppcDogJ0NBIDk0MTE0JyxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIG5hbWU6ICdUeWtlJyxcbiAgICAgICAgc3RhdGU6ICdDYWxpZm9ybmlhJyxcbiAgICAgICAgY2l0eTogJ1NhbiBGcmFuY2lzY28nLFxuICAgICAgICBhZGRyZXNzOiAnMzY1MCAyMXN0IFN0LCBTYW4gRnJhbmNpc2NvJyxcbiAgICAgICAgemlwOiAnQ0EgOTQxMTQnLFxuICAgICAgfSxcbiAgICBdLFxuICB9LFxuXVxuPC9zY3JpcHQ+XG4iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgY29uc3Qgc3R5bGVzID0gWydodHRwczovL2Zhc3RseS5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvZGlzdC9pbmRleC5jc3MnLCAnaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L3RoZW1lLWNoYWxrL2RhcmsvY3NzLXZhcnMuY3NzJ10ubWFwKChzdHlsZSkgPT4ge1xuICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgICAgbGluay5ocmVmID0gc3R5bGVcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgICB9KVxuICB9KVxuICByZXR1cm4gUHJvbWlzZS5hbGxTZXR0bGVkKHN0eWxlcylcbn1cbiIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Zhc3RseS5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AbGF0ZXN0L2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvc2hhcmVkXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vZmFzdGx5LmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcImh0dHBzOi8vZmFzdGx5LmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9cIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9AZWxlbWVudC1wbHVzL2ljb25zLXZ1ZUAyL2Rpc3QvaW5kZXgubWluLmpzXCJcbiAgfSxcbiAgXCJzY29wZXNcIjoge31cbn0iLCJfbyI6e319)

![image](https://github.com/user-attachments/assets/5b515232-96c8-433b-8d89-c69fc076a572)
