### PR TITLE
fix(components): fix type warnings caused by the effect in the Tooltip

### DIFF
--- a/packages/components/popper/src/popper.ts
+++ b/packages/components/popper/src/popper.ts
@@ -5,12 +5,13 @@ import { buildProps } from '@element-plus/utils'
 import type { ExtractPropTypes } from 'vue'
 import type Popper from './popper.vue'
 
-const effects = ['light', 'dark'] as const
+const effects = ['light', 'dark', 'customized'] as const
 const triggers = ['click', 'contextmenu', 'hover', 'focus'] as const
 
 export const Effect = {
   LIGHT: 'light',
   DARK: 'dark',
+  CUSTOMIZED: 'customized',
 } as const
 
 export const roleTypes = [


### PR DESCRIPTION
fix: #19516 
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
![image](https://github.com/user-attachments/assets/6ebdae1f-08c5-4548-9f80-04dfd3c56de2)

添加类型后，webstorm相关类型警告已消失。
