### PR TITLE
fix(components): [input-number] clear display content after non-numeric input

### DIFF
--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -85,7 +85,6 @@ import { vRepeatClick } from '@element-plus/directives'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import {
   debugWarn,
-  isFirefox,
   isNumber,
   isString,
   isUndefined,
@@ -294,10 +293,10 @@ const handleFocus = (event: MouseEvent | FocusEvent) => {
 
 const handleBlur = (event: MouseEvent | FocusEvent) => {
   data.userInput = null
-  // This is a Firefox-specific problem. When non-numeric content is entered into a numeric input box,
+  // When non-numeric content is entered into a numeric input box,
   // the content displayed on the page is not cleared after the value is cleared. #18533
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1398528
-  if (isFirefox() && data.currentValue === null && input.value?.input) {
+  if (data.currentValue === null && input.value?.input) {
     input.value.input.value = ''
   }
   emit('blur', event)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Related: #19018 #19044
fix: #19513 fix: https://github.com/element-plus/element-plus/issues/19514#issuecomment-257431739

### Description
The `el-input-number` component displays invalid values (such as '1++') incorrectly. The `input value` becomes an empty string, but the input field still shows the invalid value.

This should now accurately reflect that the displayed value should also be reset when an invalid value is entered. 