### PR TITLE
fix(components): [tour] ensure `current` prop is controlled when passed

### DIFF
--- a/packages/components/tour/__tests__/tour.test.tsx
+++ b/packages/components/tour/__tests__/tour.test.tsx
@@ -1,5 +1,5 @@
 import { defineComponent, nextTick, ref } from 'vue'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import Tour from '../src/tour.vue'
 import TourStep from '../src/step.vue'
@@ -75,6 +75,124 @@ describe('Tour.vue', () => {
     expect(document.querySelector('.el-tour__title')?.innerHTML).toEqual(
       'second'
     )
+  })
+
+  test('uncontrolled current emits update and change with the new step', async () => {
+    const onChange = vi.fn()
+    const onUpdateCurrent = vi.fn()
+    const wrapper = mount(() => (
+      <Tour
+        modelValue={true}
+        onChange={onChange}
+        onUpdate:current={onUpdateCurrent}
+      >
+        <TourStep
+          title="first"
+          description="cover description."
+          nextButtonProps={{ class: 'next-btn' }}
+        />
+        <TourStep title="second" description="cover description." />
+      </Tour>
+    ))
+
+    expect(document.querySelector('.el-tour__title')?.innerHTML).toEqual(
+      'first'
+    )
+
+    const tourStepOneComponent = wrapper.getComponent(TourStep)
+    await tourStepOneComponent.find('.next-btn').trigger('click')
+    await nextTick()
+
+    expect(document.querySelector('.el-tour__title')?.innerHTML).toEqual(
+      'second'
+    )
+    expect(onUpdateCurrent).toHaveBeenCalledTimes(1)
+    expect(onUpdateCurrent).toHaveBeenCalledWith(1)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(1)
+  })
+
+  test('controlled current emits update before change after parent syncs', async () => {
+    const current = ref(0)
+    const events: string[] = []
+    const onChange = vi.fn((value: number) => {
+      events.push(`change:${value}`)
+    })
+    const onUpdateCurrent = vi.fn((value: number) => {
+      events.push(`update:${value}`)
+      current.value = value
+    })
+    const wrapper = mount(() => (
+      <Tour
+        modelValue={true}
+        current={current.value}
+        onChange={onChange}
+        onUpdate:current={onUpdateCurrent}
+      >
+        <TourStep
+          title="first"
+          description="cover description."
+          nextButtonProps={{ class: 'next-btn' }}
+        />
+        <TourStep title="second" description="cover description." />
+      </Tour>
+    ))
+
+    const tourStepOneComponent = wrapper.getComponent(TourStep)
+    await tourStepOneComponent.find('.next-btn').trigger('click')
+    await nextTick()
+
+    expect(document.querySelector('.el-tour__title')?.innerHTML).toEqual(
+      'second'
+    )
+    expect(events).toEqual(['update:1', 'change:1'])
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(1)
+  })
+
+  test('controlled current (fixed value)', async () => {
+    const onChange = vi.fn()
+    const wrapper = mount({
+      setup() {
+        const current = ref(0)
+        const handleNext = () => {
+          Promise.resolve().then(() => {
+            current.value = 1
+          })
+        }
+        return () => (
+          <>
+            <Tour modelValue={true} current={current.value} onChange={onChange}>
+              <TourStep
+                title="first"
+                description="cover description."
+                nextButtonProps={{ onClick: handleNext, class: 'next-btn' }}
+              />
+              <TourStep title="second" description="cover description." />
+            </Tour>
+          </>
+        )
+      },
+    })
+
+    expect(document.querySelector('.el-tour__title')?.innerHTML).toEqual(
+      'first'
+    )
+    const tourStepOneComponent = wrapper.getComponent(TourStep)
+    const nextBtn = tourStepOneComponent.find('.next-btn')
+    nextBtn.trigger('click')
+    await nextTick()
+    // 'current' is set asynchronously, so it should still be in the first step at this point.
+    expect(document.querySelector('.el-tour__title')?.innerHTML).toEqual(
+      'first'
+    )
+    expect(onChange).not.toHaveBeenCalled()
+    await flushPromises()
+    expect(document.querySelector('.el-tour__title')?.innerHTML).toEqual(
+      'second'
+    )
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(1)
   })
 
   test('no mask', () => {
@@ -227,5 +345,38 @@ describe('Tour.vue', () => {
 
     expect(modelValue.value).toBeFalsy()
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  test('closing does not emit change when current resets', async () => {
+    const modelValue = ref(true)
+    const current = ref(1)
+    const onChange = vi.fn()
+
+    mount(() => (
+      <Tour
+        modelValue={modelValue.value}
+        current={current.value}
+        onChange={onChange}
+        onUpdate:modelValue={(value) => {
+          modelValue.value = value
+        }}
+        onUpdate:current={(value) => {
+          current.value = value
+        }}
+      >
+        <TourStep title="first" description="cover description." />
+        <TourStep title="second" description="cover description." />
+      </Tour>
+    ))
+
+    expect(document.querySelector('.el-tour__title')?.innerHTML).toEqual(
+      'second'
+    )
+
+    modelValue.value = false
+    await nextTick()
+
+    expect(current.value).toBe(0)
+    expect(onChange).not.toHaveBeenCalled()
   })
 })

--- a/packages/components/tour/src/helper.ts
+++ b/packages/components/tour/src/helper.ts
@@ -157,7 +157,6 @@ export interface TourContext {
   updateModelValue(modelValue: boolean): void
   onClose(): void
   onFinish(): void
-  onChange(): void
 }
 
 export const tourKey: InjectionKey<TourContext> = Symbol('ElTour')

--- a/packages/components/tour/src/step.vue
+++ b/packages/components/tour/src/step.vue
@@ -107,7 +107,6 @@ const {
   updateModelValue,
   onClose: tourOnClose,
   onFinish: tourOnFinish,
-  onChange,
 } = inject(tourKey)!
 
 watch(
@@ -135,7 +134,6 @@ const onPrev = () => {
   if (props.prevButtonProps?.onClick) {
     props.prevButtonProps?.onClick()
   }
-  onChange()
 }
 
 const onNext = () => {
@@ -147,7 +145,6 @@ const onNext = () => {
   if (props.nextButtonProps?.onClick) {
     props.nextButtonProps.onClick()
   }
-  onChange()
 }
 
 const onFinish = () => {

--- a/packages/components/tour/src/tour.ts
+++ b/packages/components/tour/src/tour.ts
@@ -90,7 +90,6 @@ export const tourProps = buildProps({
    */
   current: {
     type: Number,
-    default: 0,
   },
   /**
    * @description whether to show the arrow

--- a/packages/components/tour/src/tour.vue
+++ b/packages/components/tour/src/tour.vue
@@ -31,9 +31,8 @@
 
 <script lang="ts" setup>
 import { computed, provide, ref, toRef, useSlots, watch } from 'vue'
-import { useVModel } from '@vueuse/core'
 import { useNamespace, useZIndex } from '@element-plus/hooks'
-import { isBoolean } from '@element-plus/utils'
+import { isBoolean, isUndefined } from '@element-plus/utils'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import ElTourMask from './mask.vue'
 import ElTourContent from './content.vue'
@@ -50,7 +49,6 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<TourProps>(), {
-  current: 0,
   showArrow: true,
   showClose: true,
   placement: 'bottom',
@@ -66,9 +64,23 @@ const emit = defineEmits(tourEmits)
 const ns = useNamespace('tour')
 const total = ref(0)
 const currentStep = ref<TourStepProps>()
+const isControlled = computed(() => !isUndefined(props.current))
+const innerCurrent = ref(props.current ?? 0)
 
-const current = useVModel(props, 'current', emit, {
-  passive: true,
+const current = computed<number>({
+  get() {
+    return isUndefined(props.current) ? innerCurrent.value : props.current
+  },
+  set(newValue) {
+    const oldValue = isControlled.value ? props.current : innerCurrent.value
+    if (oldValue === newValue) return
+
+    if (!isControlled.value) {
+      innerCurrent.value = newValue
+    }
+
+    emit('update:current', newValue)
+  },
 })
 
 const currentTarget = computed(() => currentStep.value?.target)
@@ -115,9 +127,23 @@ const { mergedPosInfo: pos, triggerTarget } = useTarget(
 )
 
 watch(
+  () => props.current,
+  (val) => !isUndefined(val) && (innerCurrent.value = val)
+)
+
+watch(
+  current,
+  (newCurrent, oldCurrent) => {
+    if (!props.modelValue || newCurrent === oldCurrent) return
+    emit(CHANGE_EVENT, newCurrent)
+  },
+  { flush: 'post' }
+)
+
+watch(
   () => props.modelValue,
   (val) => {
-    if (!val) {
+    if (!val && current.value !== 0) {
       current.value = 0
     }
   }
@@ -153,9 +179,6 @@ provide(tourKey, {
   },
   onFinish() {
     emit('finish')
-  },
-  onChange() {
-    emit(CHANGE_EVENT, current.value)
   },
 })
 </script>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix: #19667
fix: #24008

### Description
Refactored the handling of the `current` prop to ensure it is controlled when passed.
> For example, if not using `v-model:current` and only passing a fixed value `:current='1'`, the tour should always stay at step 1.

### Preview
[BUG Preview](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtYnV0dG9uIHR5cGU9XCJwcmltYXJ5XCIgQGNsaWNrPVwib3BlbiA9IHRydWVcIj5CZWdpbiBUb3VyPC9lbC1idXR0b24+XG5cbiAgPGVsLWRpdmlkZXIgLz5cblxuICA8ZWwtc3BhY2U+XG4gICAgPGVsLWJ1dHRvbiBndWlkZT1cImJ0bjFcIiBAY2xpY2s9XCJuZXh0XCI+Y2xpY2sgaGVyZTwvZWwtYnV0dG9uPlxuICAgIDxlbC1kaWFsb2cgaWQ9XCJkaWFsb2dcIiB2LW1vZGVsPVwidmlzaWJsZVwiIHRpdGxlPVwidGl0bGVcIj5cbiAgICAgIDxkaXY+Y29udGVudDwvZGl2PlxuICAgIDwvZWwtZGlhbG9nPlxuICA8L2VsLXNwYWNlPlxuXG4gIDxlbC10b3VyIHYtbW9kZWw9XCJvcGVuXCIgOmN1cnJlbnQ9XCJjdXJyZW50XCIgOnotaW5kZXg9XCIzMDAwXCI+XG4gICAgPGVsLXRvdXItc3RlcCB0YXJnZXQ9XCJbZ3VpZGU9YnRuMV1cIiB0aXRsZT1cIlVwbG9hZCBGaWxlXCIgZGVzY3JpcHRpb249XCJQdXQgeW91IGZpbGVzIGhlcmUuXCJcbiAgICAgIDpuZXh0LWJ1dHRvbi1wcm9wcz1cIm5leHRCdXR0b25Qcm9wc1wiIC8+XG4gICAgPGVsLXRvdXItc3RlcCB0YXJnZXQ9XCIjZGlhbG9nXCIgdGl0bGU9XCJkaWFsb2dcIiBkZXNjcmlwdGlvbj1cInRoaXMgaXMgZGlhbG9nXCIgLz5cbiAgPC9lbC10b3VyPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3Qgb3BlbiA9IHJlZihmYWxzZSlcblxuY29uc3QgY3VycmVudCA9IHJlZigwKVxuXG5jb25zdCBuZXh0QnV0dG9uUHJvcHMgPSB7XG4gIG9uQ2xpY2s6ICgpID0+IHtcbiAgICBuZXh0KClcbiAgfVxufVxuXG5jb25zdCB2aXNpYmxlID0gcmVmKGZhbHNlKVxuXG5mdW5jdGlvbiBuZXh0KCkge1xuICB2aXNpYmxlLnZhbHVlID0gdHJ1ZVxuICBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICBjdXJyZW50LnZhbHVlID0gMVxuICB9LCAzMDApXG59XG48L3NjcmlwdD5cbiIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vZmFzdGx5LmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmNzcycsICdodHRwczovL2Zhc3RseS5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvdGhlbWUtY2hhbGsvZGFyay9jc3MtdmFycy5jc3MnXS5tYXAoKHN0eWxlKSA9PiB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgICBsaW5rLmhyZWYgPSBzdHlsZVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICAgIH0pXG4gIH0pXG4gIHJldHVybiBQcm9taXNlLmFsbFNldHRsZWQoc3R5bGVzKVxufVxuIiwidHNjb25maWcuanNvbiI6IntcbiAgXCJjb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVSZXNvbHV0aW9uXCI6IFwiQnVuZGxlclwiLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdLFxuICAgIFwiYWxsb3dJbXBvcnRpbmdUc0V4dGVuc2lvbnNcIjogdHJ1ZSxcbiAgICBcImFsbG93SnNcIjogdHJ1ZSxcbiAgICBcImNoZWNrSnNcIjogdHJ1ZVxuICB9LFxuICBcInZ1ZUNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogMy4zXG4gIH1cbn1cbiIsIlBsYXlncm91bmRNYWluLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgQXBwIGZyb20gJy4vQXBwLnZ1ZSdcbmltcG9ydCB7IHNldHVwRWxlbWVudFBsdXMgfSBmcm9tICcuL2VsZW1lbnQtcGx1cy5qcydcbnNldHVwRWxlbWVudFBsdXMoKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPEFwcCAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vZmFzdGx5LmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9ydW50aW1lLWRvbUBsYXRlc3QvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL2Zhc3RseS5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L2Rpc3QvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L1wiLFxuICAgIFwiQGVsZW1lbnQtcGx1cy9pY29ucy12dWVcIjogXCJodHRwczovL2Zhc3RseS5qc2RlbGl2ci5uZXQvbnBtL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsIl9vIjp7fX0=)

[PR Preview](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtYnV0dG9uIHR5cGU9XCJwcmltYXJ5XCIgQGNsaWNrPVwib3BlbiA9IHRydWVcIj5CZWdpbiBUb3VyPC9lbC1idXR0b24+XG5cbiAgPGVsLWRpdmlkZXIgLz5cblxuICA8ZWwtc3BhY2U+XG4gICAgPGVsLWJ1dHRvbiBndWlkZT1cImJ0bjFcIiBAY2xpY2s9XCJuZXh0XCI+Y2xpY2sgaGVyZTwvZWwtYnV0dG9uPlxuICAgIDxlbC1kaWFsb2cgaWQ9XCJkaWFsb2dcIiB2LW1vZGVsPVwidmlzaWJsZVwiIHRpdGxlPVwidGl0bGVcIj5cbiAgICAgIDxkaXY+Y29udGVudDwvZGl2PlxuICAgIDwvZWwtZGlhbG9nPlxuICA8L2VsLXNwYWNlPlxuXG4gIDxlbC10b3VyIHYtbW9kZWw9XCJvcGVuXCIgOmN1cnJlbnQ9XCJjdXJyZW50XCIgOnotaW5kZXg9XCIzMDAwXCI+XG4gICAgPGVsLXRvdXItc3RlcCB0YXJnZXQ9XCJbZ3VpZGU9YnRuMV1cIiB0aXRsZT1cIlVwbG9hZCBGaWxlXCIgZGVzY3JpcHRpb249XCJQdXQgeW91IGZpbGVzIGhlcmUuXCJcbiAgICAgIDpuZXh0LWJ1dHRvbi1wcm9wcz1cIm5leHRCdXR0b25Qcm9wc1wiIC8+XG4gICAgPGVsLXRvdXItc3RlcCB0YXJnZXQ9XCIjZGlhbG9nXCIgdGl0bGU9XCJkaWFsb2dcIiBkZXNjcmlwdGlvbj1cInRoaXMgaXMgZGlhbG9nXCIgLz5cbiAgPC9lbC10b3VyPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3Qgb3BlbiA9IHJlZihmYWxzZSlcblxuY29uc3QgY3VycmVudCA9IHJlZigwKVxuXG5jb25zdCBuZXh0QnV0dG9uUHJvcHMgPSB7XG4gIG9uQ2xpY2s6ICgpID0+IHtcbiAgICBuZXh0KClcbiAgfVxufVxuXG5jb25zdCB2aXNpYmxlID0gcmVmKGZhbHNlKVxuXG5mdW5jdGlvbiBuZXh0KCkge1xuICB2aXNpYmxlLnZhbHVlID0gdHJ1ZVxuICBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICBjdXJyZW50LnZhbHVlID0gMVxuICB9LCAzMDApXG59XG48L3NjcmlwdD5cbiIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vcHJldmlldy0xOTY3NS1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2Rpc3QvaW5kZXguY3NzJywgJ2h0dHBzOi8vcHJldmlldy0xOTY3NS1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL3RoZW1lLWNoYWxrL2RhcmsvY3NzLXZhcnMuY3NzJ10ubWFwKChzdHlsZSkgPT4ge1xuICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgICAgbGluay5ocmVmID0gc3R5bGVcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgICB9KVxuICB9KVxuICByZXR1cm4gUHJvbWlzZS5hbGxTZXR0bGVkKHN0eWxlcylcbn1cbiIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AbGF0ZXN0L2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvc2hhcmVkXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vcHJldmlldy0xOTY3NS1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2Rpc3QvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AZWxlbWVudC1wbHVzL2ljb25zLXZ1ZUAyL2Rpc3QvaW5kZXgubWluLmpzXCJcbiAgfSxcbiAgXCJzY29wZXNcIjoge31cbn0iLCJfbyI6eyJzaG93SGlkZGVuIjp0cnVlLCJzdHlsZVNvdXJjZSI6Imh0dHBzOi8vcHJldmlldy0xOTY3NS1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2Rpc3QvaW5kZXguY3NzIn19)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tour navigation now syncs current step correctly in controlled and uncontrolled modes; advancing steps emits update events in the correct order and visible step title updates reliably.
  * Closing the tour resets the current step to the first step without emitting an extra change event.

* **Tests**
  * Added async tests covering navigation, event ordering, deferred updates, and close/reset behavior.

* **Chores**
  * Removed the built-in default for the Tour's current prop so omission is treated as uncontrolled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->