### PR TITLE
perf(components): [image-viewer]

### DIFF
--- a/packages/components/image-viewer/__tests__/image-viewer.test.tsx
+++ b/packages/components/image-viewer/__tests__/image-viewer.test.tsx
@@ -1,7 +1,7 @@
 import { nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, test } from 'vitest'
-import { IMAGE_SUCCESS } from '@element-plus/test-utils/mock'
+import { IMAGE_FAIL, IMAGE_SUCCESS } from '@element-plus/test-utils/mock'
 import ImageViewer from '../src/image-viewer.vue'
 
 async function doubleWait() {
@@ -40,22 +40,20 @@ describe('<image-viewer />', () => {
   })
 
   test('manually switch image', async () => {
-    const wrapper = mount(
-      <ImageViewer urlList={[IMAGE_SUCCESS, IMAGE_SUCCESS]} />
-    )
+    const wrapper = mount(<ImageViewer urlList={[IMAGE_SUCCESS, IMAGE_FAIL]} />)
 
     await doubleWait()
     const viewer = wrapper.find('.el-image-viewer__wrapper')
     expect(viewer.exists()).toBe(true)
 
     const imgList = wrapper.findAll('.el-image-viewer__img')
-    expect(imgList[0].attributes('style')).not.contains('display: none;')
-    expect(imgList[1].attributes('style')).contains('display: none;')
+    expect(imgList[0].attributes('src')).toBe(IMAGE_SUCCESS)
 
     wrapper.vm.setActiveItem(1)
     await doubleWait()
-    expect(imgList[0].attributes('style')).contains('display: none;')
-    expect(imgList[1].attributes('style')).not.contains('display: none;')
+    expect(viewer.findAll('.el-image-viewer__img')[0].attributes('src')).toBe(
+      IMAGE_FAIL
+    )
     wrapper.unmount()
   })
 

--- a/packages/components/image-viewer/src/image-viewer.vue
+++ b/packages/components/image-viewer/src/image-viewer.vue
@@ -69,9 +69,9 @@
 
           <div :class="ns.e('canvas')">
             <img
-              :ref="(el) => (imgRefs[activeIndex] = el as HTMLImageElement)"
-              :key="urlList[activeIndex]"
-              :src="urlList[activeIndex]"
+              ref="imgRef"
+              :key="currentImg"
+              :src="currentImg"
               :style="imgStyle"
               :class="ns.e('img')"
               :crossorigin="crossorigin"
@@ -144,7 +144,7 @@ const { t } = useLocale()
 const ns = useNamespace('image-viewer')
 const { nextZIndex } = useZIndex()
 const wrapper = ref<HTMLDivElement>()
-const imgRefs = ref<HTMLImageElement[]>([])
+const imgRef = ref<HTMLImageElement>()
 
 const scopeEventListener = effectScope()
 
@@ -379,7 +379,7 @@ function onCloseRequested() {
 
 watch(currentImg, () => {
   nextTick(() => {
-    const $img = imgRefs.value[0]
+    const $img = imgRef.value
     if (!$img?.complete) {
       loading.value = true
     }

--- a/packages/components/image-viewer/src/image-viewer.vue
+++ b/packages/components/image-viewer/src/image-viewer.vue
@@ -17,14 +17,12 @@
         >
           <div :class="ns.e('mask')" @click.self="hideOnClickModal && hide()" />
 
-          <!-- CLOSE -->
           <span :class="[ns.e('btn'), ns.e('close')]" @click="hide">
             <el-icon>
               <Close />
             </el-icon>
           </span>
 
-          <!-- ARROW -->
           <template v-if="!isSingle">
             <span :class="arrowPrevKls" @click="prev">
               <el-icon>
@@ -46,7 +44,7 @@
               {{ progress }}
             </slot>
           </div>
-          <!-- ACTIONS -->
+
           <div :class="[ns.e('btn'), ns.e('actions')]">
             <div :class="ns.e('actions__inner')">
               <el-icon @click="handleActions('zoomOut')">
@@ -68,14 +66,12 @@
               </el-icon>
             </div>
           </div>
-          <!-- CANVAS -->
+
           <div :class="ns.e('canvas')">
             <img
-              v-for="(url, i) in urlList"
-              v-show="i === activeIndex"
-              :ref="(el) => (imgRefs[i] = el as HTMLImageElement)"
-              :key="url"
-              :src="url"
+              :ref="(el) => (imgRefs[activeIndex] = el as HTMLImageElement)"
+              :key="urlList[activeIndex]"
+              :src="urlList[activeIndex]"
               :style="imgStyle"
               :class="ns.e('img')"
               :crossorigin="crossorigin"
@@ -302,7 +298,7 @@ function reset() {
     deg: 0,
     offsetX: 0,
     offsetY: 0,
-    enableTransition: false,
+    enableTransition: true,
   }
 }
 

--- a/packages/components/image/__tests__/image.test.tsx
+++ b/packages/components/image/__tests__/image.test.tsx
@@ -120,9 +120,10 @@ describe('Image.vue', () => {
     const wrapper = mount(() => <Image {...props} />)
     await doubleWait()
     await wrapper.find('.el-image__inner').trigger('click')
-    expect(
-      wrapper.findAll('.el-image-viewer__img')[1].attributes('style')
-    ).not.toContain('display: none')
+    expect(wrapper.findAll('.el-image-viewer__img')[0].exists()).toBe(true)
+    expect(wrapper.findAll('.el-image-viewer__img')[1]?.exists()).toBe(
+      undefined
+    )
   })
 
   test('native loading attributes', async () => {
@@ -199,9 +200,10 @@ describe('Image.vue', () => {
     await doubleWait()
     wrapper.vm.$refs.imageRef.showPreview()
     await doubleWait()
-    expect(
-      wrapper.findAll('.el-image-viewer__img')[1].attributes('style')
-    ).not.toContain('display: none')
+    expect(wrapper.findAll('.el-image-viewer__img')[0].exists()).toBe(true)
+    expect(wrapper.findAll('.el-image-viewer__img')[1]?.exists()).toBe(
+      undefined
+    )
   })
   //@todo lazy image test
 })

--- a/packages/theme-chalk/src/image-viewer.scss
+++ b/packages/theme-chalk/src/image-viewer.scss
@@ -49,6 +49,10 @@
     font-size: 40px;
   }
 
+  @include e(img) {
+    cursor: pointer;
+  }
+
   @include e(canvas) {
     position: static;
     width: 100%;

--- a/packages/theme-chalk/src/image-viewer.scss
+++ b/packages/theme-chalk/src/image-viewer.scss
@@ -50,7 +50,7 @@
   }
 
   @include e(img) {
-    cursor: pointer;
+    cursor: grab;
   }
 
   @include e(canvas) {


### PR DESCRIPTION
1. only render the active image dom.
2. change`transition` is true when img reset. (There's no transition now, it looks very stiff)
3. change img cursor style. 