### PR TITLE
fix(components): [segmented] fire change event if option not checked

### DIFF
--- a/packages/components/segmented/__tests__/segmented.test.tsx
+++ b/packages/components/segmented/__tests__/segmented.test.tsx
@@ -1,6 +1,6 @@
 import { nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import Segmented from '../src/segmented.vue'
 
 describe('Segmented.vue', () => {
@@ -208,5 +208,28 @@ describe('Segmented.vue', () => {
         .classes()
         .includes('is-disabled')
     ).toBeTruthy()
+  })
+
+  test('should fire the change event until it is equal to model-value', async () => {
+    const value = ref('Mon')
+    const options = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+    const onChange = vi.fn()
+    const wrapper = mount(() => (
+      <Segmented
+        modelValue={value.value}
+        options={options}
+        onChange={onChange}
+      />
+    ))
+    expect(wrapper.find('.is-selected').text()).toEqual('Mon')
+    const secondOption = wrapper.findAll('.el-segmented__item')[1]
+    await secondOption.trigger('click')
+    expect(onChange).toHaveBeenCalledTimes(1)
+    await secondOption.trigger('click')
+    expect(onChange).toHaveBeenCalledTimes(2)
+    value.value = 'Tue'
+    await nextTick()
+    await secondOption.trigger('click')
+    expect(onChange).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -80,16 +80,7 @@ const handleChange = (item: Option, evt: Event) => {
   emit(UPDATE_MODEL_EVENT, value)
   emit(CHANGE_EVENT, value)
 
-  if (!getSelected(item)) {
-    evt.target && ((evt.target as HTMLInputElement).checked = false)
-    if (!segmentedRef.value) return
-    const selectedItemInput = segmentedRef.value.querySelector(
-      '.is-selected input'
-    ) as HTMLInputElement
-    if (selectedItemInput) {
-      selectedItemInput.checked = true
-    }
-  }
+  ;(evt.target as HTMLInputElement).checked = value === props.modelValue
 }
 
 const aliasProps = computed(() => ({ ...defaultProps, ...props.props }))

--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -75,7 +75,7 @@ const state = reactive({
   focusVisible: false,
 })
 
-const handleChange = (item: Option, evt: Event) => {
+const handleChange = (evt: Event, item: Option) => {
   const value = getValue(item)
   emit(UPDATE_MODEL_EVENT, value)
   emit(CHANGE_EVENT, value)

--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -21,7 +21,7 @@
           :name="name"
           :disabled="getDisabled(item)"
           :checked="getSelected(item)"
-          @change="handleChange(item)"
+          @change="handleChange(item, $event)"
         />
         <div :class="ns.e('item-label')">
           <slot :item="intoAny(item)">{{ getLabel(item) }}</slot>
@@ -75,10 +75,21 @@ const state = reactive({
   focusVisible: false,
 })
 
-const handleChange = (item: Option) => {
+const handleChange = (item: Option, evt: Event) => {
   const value = getValue(item)
   emit(UPDATE_MODEL_EVENT, value)
   emit(CHANGE_EVENT, value)
+
+  if (!getSelected(item)) {
+    evt.target && ((evt.target as HTMLInputElement).checked = false)
+    if (!segmentedRef.value) return
+    const selectedItemInput = segmentedRef.value.querySelector(
+      '.is-selected input'
+    ) as HTMLInputElement
+    if (selectedItemInput) {
+      selectedItemInput.checked = true
+    }
+  }
 }
 
 const aliasProps = computed(() => ({ ...defaultProps, ...props.props }))

--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -79,7 +79,6 @@ const handleChange = (evt: Event, item: Option) => {
   const value = getValue(item)
   emit(UPDATE_MODEL_EVENT, value)
   emit(CHANGE_EVENT, value)
-
   ;(evt.target as HTMLInputElement).checked = value === props.modelValue
 }
 

--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -21,7 +21,7 @@
           :name="name"
           :disabled="getDisabled(item)"
           :checked="getSelected(item)"
-          @change="handleChange(item, $event)"
+          @change="handleChange($event, item)"
         />
         <div :class="ns.e('item-label')">
           <slot :item="intoAny(item)">{{ getLabel(item) }}</slot>


### PR DESCRIPTION
fix: #19684 
fix: #16497

After selecting input, which triggers the change event, I do something: 
1. Determine whether the value bound by the current modelValue is the currently selected value (use getSelect) 
2. If no, cancel the check status of the current item first. 
3. Select the input corresponding to modelValue.

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
