### PR TITLE
fix(components): [steps] update border-color to support safari

### DIFF
--- a/packages/theme-chalk/src/step.scss
+++ b/packages/theme-chalk/src/step.scss
@@ -68,7 +68,7 @@
     @include when(text) {
       border-radius: 50%;
       border: 2px solid;
-      border-color: inherit;
+      border-color: currentColor;
     }
 
     @include when(icon) {
@@ -97,7 +97,7 @@
 
   @include e(line) {
     position: absolute;
-    border-color: inherit;
+    border-color: currentColor;
     background-color: getCssVar('text-color', 'placeholder');
   }
 
@@ -105,7 +105,7 @@
     display: block;
     border-width: 1px;
     border-style: solid;
-    border-color: inherit;
+    border-color: currentColor;
     transition: 0.15s ease-out;
     box-sizing: border-box;
     width: 0;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## description

Try to close #14654.

The main issue is the style error of the `border-color` on Safari.

Because the `color` is always rendered correctly, and the `border-color` is the same as the `color` under the current design. So I think setting the `border-color` to the `currentColor` may be a solution.