### PR TITLE
fix(components): [tree-v2] setCheckdKeys check-change not triggered

### DIFF
--- a/packages/components/tree-v2/src/composables/useCheck.ts
+++ b/packages/components/tree-v2/src/composables/useCheck.ts
@@ -101,20 +101,24 @@ export function useCheck(props: TreeProps, tree: Ref<Tree | undefined>) {
     if (immediateUpdate) {
       updateCheckedKeys()
     }
-    if (nodeClick) {
-      afterNodeCheck(node, isChecked)
-    }
+    afterNodeCheck(node, isChecked, nodeClick)
   }
 
-  const afterNodeCheck = (node: TreeNode, checked: CheckboxValueType) => {
+  const afterNodeCheck = (
+    node: TreeNode,
+    checked: CheckboxValueType,
+    nodeClick: boolean
+  ) => {
     const { checkedNodes, checkedKeys } = getChecked()
     const { halfCheckedNodes, halfCheckedKeys } = getHalfChecked()
-    emit(NODE_CHECK, node.data, {
-      checkedKeys,
-      checkedNodes,
-      halfCheckedKeys,
-      halfCheckedNodes,
-    })
+    if (nodeClick) {
+      emit(NODE_CHECK, node.data, {
+        checkedKeys,
+        checkedNodes,
+        halfCheckedKeys,
+        halfCheckedNodes,
+      })
+    }
     emit(NODE_CHECK_CHANGE, node.data, checked)
   }
 


### PR DESCRIPTION
When using setChecked and setCheckedKeys, the check-change event is not triggered as expected.

This behavior does not align with the documentation, which states that the check-change event should be triggered when the selected nodes change.

Furthermore, this behavior is inconsistent with the el-tree component

[Element Plus Playground example](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZGl2Pnt7aXNWMiA/ICdlbC10cmVlLXYyJyA6ICdlbC10cmVlJ319PC9kaXY+XG4gIDxlbC1idXR0b24gQGNsaWNrPVwiaXNWMj0haXNWMlwiPuWIh+aNoueJiOacrDwvZWwtYnV0dG9uPlxuICA8ZWwtdHJlZS12MlxuICAgIHYtaWY9XCJpc1YyXCJcbiAgICBzdHlsZT1cIm1heC13aWR0aDogNjAwcHhcIlxuICAgIDpkYXRhPVwiZGF0YVwiXG4gICAgOnByb3BzPVwicHJvcHNcIlxuICAgIHNob3ctY2hlY2tib3hcbiAgICBAY2hlY2stY2hhbmdlPVwiaGFuZGxlQ2hlY2tDaGFuZ2VcIlxuICAgIEBjaGVjaz1cImhhbmRsZUNoZWNrXCJcbiAgICByZWY9XCJ0cmVlUmVmXCJcbiAgICBub2RlLWtleT1cImlkXCJcbiAgICBAY3VycmVudC1jaGFuZ2U9XCJoYW5kbGVDaGFuZ2VcIlxuICAvPlxuICAgIDxlbC10cmVlXG4gICAgdi1lbHNlXG4gICAgc3R5bGU9XCJtYXgtd2lkdGg6IDYwMHB4XCJcbiAgICA6ZGF0YT1cImRhdGFcIlxuICAgIDpwcm9wcz1cInByb3BzXCJcbiAgICBzaG93LWNoZWNrYm94XG4gICAgQGNoZWNrLWNoYW5nZT1cImhhbmRsZUNoZWNrQ2hhbmdlXCJcbiAgICBAY2hlY2s9XCJoYW5kbGVDaGVja1wiXG4gICAgcmVmPVwidHJlZVJlZlwiXG4gICAgbm9kZS1rZXk9XCJpZFwiXG4gICAgQGN1cnJlbnQtY2hhbmdlPVwiaGFuZGxlQ2hhbmdlXCJcbiAgLz5cbiAgPGRpdj7pgInkuK17e2NoZWNrZHMubGVuZ3RofX3kuKo8L2Rpdj5cbiAgPGVsLWJ1dHRvbiBAY2xpY2s9XCJjYW5jZWxDaGVja2VkXCI+5Y+W5raI6YCJ5LitPC9lbC1idXR0b24+XG4gIDxlbC1idXR0b24gQGNsaWNrPVwidXBkYXRlQ2hlY2tkXCI+6YCJ5LitPC9lbC1idXR0b24+XG48L3RlbXBsYXRlPlxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmltcG9ydCB7IG5leHRUaWNrIH0gZnJvbSBcInZ1ZVwiXG5pbXBvcnQge3JlZn0gZnJvbSBcInZ1ZVwiXG5pbnRlcmZhY2UgVHJlZSB7XG4gIGlkOiBzdHJpbmdcbiAgbGFiZWw6IHN0cmluZ1xuICBjaGlsZHJlbj86IFRyZWVbXVxufVxuXG5jb25zdCBpc1YyID0gcmVmKHRydWUpXG5jb25zdCBjaGVja2RzID0gcmVmKFtcbl0pXG5jb25zdCB0cmVlUmVmID0gcmVmKClcbmNvbnN0IGtleSA9IFsnbm9kZS00J11cblxuXG5jb25zdCBoYW5kbGVDaGVja0NoYW5nZSA9IChkYXRhLGluZm8pID0+e1xuICBjb25zb2xlLmxvZyhcImhhbmRsZUNoZWNrQ2hhbmdlXCIsZGF0YSxpbmZvKVxuICAvL2NoZWNrZHMudmFsdWUgPSBpbmZvLmNoZWNrZWRLZXlzXG4gIGNvbnN0IHJlcyA9IHRyZWVSZWYudmFsdWUuZ2V0Q2hlY2tlZEtleXMoKVxuICBjaGVja2RzLnZhbHVlID0gcmVzXG59XG5cbmNvbnN0IGhhbmRsZUNoZWNrID0oZGF0YSxpbmZvKT0+e1xuICAgY29uc29sZS5sb2coXCJoYW5kbGVDaGVja1wiLGRhdGEpXG4gIGNvbnNvbGUubG9nKFwiaGFuZGxlQ2hlY2tcIixpbmZvKVxufVxuXG5jb25zdCBjYW5jZWxDaGVja2VkID0gKCkgPT57XG4gIGNvbnN0IGNoZWNrZWRLZXlzID0gdHJlZVJlZi52YWx1ZS5nZXRDaGVja2VkS2V5cygpXG4gIGNoZWNrZWRLZXlzLmZvckVhY2goKGtleSk9PntcbiAgICB0cmVlUmVmLnZhbHVlLnNldENoZWNrZWQoa2V5LGZhbHNlKVxuICB9KVxuICBuZXh0VGljaygoKT0+e1xuICAgIGNoZWNrZHMudmFsdWUgPSBbXVxuICB9KVxuICAvL3RyZWVSZWYudmFsdWUuc2V0Q2hlY2tlZEtleXMoY2hlY2tkcy52YWx1ZSlcbn1cblxuY29uc3QgdXBkYXRlQ2hlY2tkID0gKCkgPT57XG4gIHRyZWVSZWYudmFsdWUuc2V0Q2hlY2tlZEtleXMoa2V5KVxuICBuZXh0VGljaygoKT0+e1xuICAgIGNvbnN0IHJlcyA9IHRyZWVSZWYudmFsdWUuZ2V0Q2hlY2tlZEtleXMoKVxuICAgIGNoZWNrZHMudmFsdWUgPSByZXNcbiAgfSlcbn1cblxuY29uc3QgaGFuZGxlQ2hhbmdlID0gKGRhdGEpID0+e1xuICBjb25zb2xlLmxvZyhcImhhbmRsZUNoYW5nZVwiLGRhdGEpXG59XG5cbmNvbnN0IGdldEtleSA9IChwcmVmaXg6IHN0cmluZywgaWQ6IG51bWJlcikgPT4ge1xuICByZXR1cm4gYCR7cHJlZml4fS0ke2lkfWBcbn1cblxuY29uc3QgY3JlYXRlRGF0YSA9IChcbiAgbWF4RGVlcDogbnVtYmVyLFxuICBtYXhDaGlsZHJlbjogbnVtYmVyLFxuICBtaW5Ob2Rlc051bWJlcjogbnVtYmVyLFxuICBkZWVwID0gMSxcbiAga2V5ID0gJ25vZGUnXG4pOiBUcmVlW10gPT4ge1xuICBsZXQgaWQgPSAwXG4gIHJldHVybiBBcnJheS5mcm9tKHsgbGVuZ3RoOiBtaW5Ob2Rlc051bWJlciB9KVxuICAgIC5maWxsKGRlZXApXG4gICAgLm1hcCgoKSA9PiB7XG4gICAgICBjb25zdCBjaGlsZHJlbk51bWJlciA9XG4gICAgICAgIGRlZXAgPT09IG1heERlZXAgPyAwIDogTWF0aC5yb3VuZChNYXRoLnJhbmRvbSgpICogbWF4Q2hpbGRyZW4pXG4gICAgICBjb25zdCBub2RlS2V5ID0gZ2V0S2V5KGtleSwgKytpZClcbiAgICAgIHJldHVybiB7XG4gICAgICAgIGlkOiBub2RlS2V5LFxuICAgICAgICBsYWJlbDogbm9kZUtleSxcbiAgICAgICAgY2hpbGRyZW46IGNoaWxkcmVuTnVtYmVyXG4gICAgICAgICAgPyBjcmVhdGVEYXRhKG1heERlZXAsIG1heENoaWxkcmVuLCBjaGlsZHJlbk51bWJlciwgZGVlcCArIDEsIG5vZGVLZXkpXG4gICAgICAgICAgOiB1bmRlZmluZWQsXG4gICAgICB9XG4gICAgfSlcbn1cblxuY29uc3QgcHJvcHMgPSB7XG4gIHZhbHVlOiAnaWQnLFxuICBsYWJlbDogJ2xhYmVsJyxcbiAgY2hpbGRyZW46ICdjaGlsZHJlbicsXG59XG5jb25zdCBkYXRhID0gY3JlYXRlRGF0YSg0LCA1LCA1KVxuPC9zY3JpcHQ+XG4iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgY29uc3Qgc3R5bGVzID0gWydodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvZGlzdC9pbmRleC5jc3MnLCAnaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L3RoZW1lLWNoYWxrL2RhcmsvY3NzLXZhcnMuY3NzJ10ubWFwKChzdHlsZSkgPT4ge1xuICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgICAgbGluay5ocmVmID0gc3R5bGVcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgICB9KVxuICB9KVxuICByZXR1cm4gUHJvbWlzZS5hbGxTZXR0bGVkKHN0eWxlcylcbn1cbiIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AbGF0ZXN0L2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvc2hhcmVkXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9cIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AZWxlbWVudC1wbHVzL2ljb25zLXZ1ZUAyL2Rpc3QvaW5kZXgubWluLmpzXCJcbiAgfSxcbiAgXCJzY29wZXNcIjoge31cbn0iLCJfbyI6e319)

BREAKING CHANGE :
no

closed #15520

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
