### PR TITLE
docs: optimization API style

### DIFF
--- a/docs/en-US/component/anchor.md
+++ b/docs/en-US/component/anchor.md
@@ -75,7 +75,7 @@ anchor/affix
 
 ## Anchor API
 
-### Anchor Attributes
+### Attributes
 
 | Property                   | Description                                                | Type                                   | Default    |
 | -------------------------- | ---------------------------------------------------------- | -------------------------------------- | ---------- |
@@ -88,33 +88,35 @@ anchor/affix
 | direction                  | Set Anchor direction.                                      | ^[enum]`'vertical' \| 'horizontal'`    | `vertical` |
 | select-scroll-top ^(2.9.2) | scroll whether link is selected at the top                 | ^[boolean]                             | false      |
 
-### Anchor Events
+### Events
 
 | Name   | Description                                | Type                                                |
 | ------ | ------------------------------------------ | --------------------------------------------------- |
 | change | callback when the step changes             | ^[Function]`(href: string) => void`                 |
 | click  | Triggered when the user clicks on the link | ^[Function]`(e: MouseEvent, href?: string) => void` |
 
-### Anchor Methods
+### Methods
 
 | Name     | Description                               | Type                                |
 | -------- | ----------------------------------------- | ----------------------------------- |
 | scrollTo | Manually scroll to the specific position. | ^[Function]`(href: string) => void` |
 
-### Anchor Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |
 | default | AnchorLink component list |
 
-### AnchorLink Attributes
+## AnchorLink API
+
+### Attributes
 
 | Property | Description                          | Type     | Default |
 | -------- | ------------------------------------ | -------- | ------- |
 | title    | the text content of the anchor link. | `string` | —       |
 | href     | The address of the anchor link.      | `string` | —       |
 
-### AnchorLink Slots
+### Slots
 
 | Name     | Description                     |
 | -------- | ------------------------------- |

--- a/docs/en-US/component/breadcrumb.md
+++ b/docs/en-US/component/breadcrumb.md
@@ -25,14 +25,14 @@ breadcrumb/icon
 
 ## Breadcrumb API
 
-### Breadcrumb Attributes
+### Attributes
 
 | Name           | Description                      | Type                     | Default |
 | -------------- | -------------------------------- | ------------------------ | ------- |
 | separator      | separator character              | ^[string]                | /       |
 | separator-icon | icon component of icon separator | ^[string] / ^[Component] | —       |
 
-### Breadcrumb Slots
+### Slots
 
 | Name    | Description               | Subtags         |
 | ------- | ------------------------- | --------------- |
@@ -40,14 +40,14 @@ breadcrumb/icon
 
 ## BreadcrumbItem API
 
-### BreadcrumbItem Attributes
+### Attributes
 
 | Name    | Description                                               | Type                                    | Default |
 | ------- | --------------------------------------------------------- | --------------------------------------- | ------- |
 | to      | target route of the link, same as `to` of `vue-router`    | ^[string] / ^[object]`RouteLocationRaw` | ''      |
 | replace | if `true`, the navigation will not leave a history record | ^[boolean]                              | false   |
 
-### BreadcrumbItem Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |

--- a/docs/en-US/component/breadcrumb.md
+++ b/docs/en-US/component/breadcrumb.md
@@ -38,7 +38,7 @@ breadcrumb/icon
 | ------- | ------------------------- | --------------- |
 | default | customize default content | Breadcrumb Item |
 
-## BreadcrumbItem API
+## Breadcrumb-Item API
 
 ### Attributes
 

--- a/docs/en-US/component/button.md
+++ b/docs/en-US/component/button.md
@@ -135,7 +135,7 @@ button/custom
 
 ## Button API
 
-### Button Attributes
+### Attributes
 
 | Name              | Description                                                             | Type                                                                                      | Default |
 | ----------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------- |
@@ -158,7 +158,7 @@ button/custom
 | dark              | dark mode, which automatically converts `color` to dark mode colors     | ^[boolean]                                                                                | false   |
 | tag ^(2.3.4)      | custom element tag                                                      | ^[string] / ^[Component]                                                                  | button  |
 
-### Button Slots
+### Slots
 
 | Name    | Description                 |
 | ------- | --------------------------- |
@@ -166,7 +166,7 @@ button/custom
 | loading | customize loading component |
 | icon    | customize icon component    |
 
-### Button Exposes
+### Exposes
 
 | Name           | Description          | Type                                                                                                           |
 | -------------- | -------------------- | -------------------------------------------------------------------------------------------------------------- |
@@ -178,14 +178,14 @@ button/custom
 
 ## ButtonGroup API
 
-### ButtonGroup Attributes
+### Attributes
 
 | Name | Description                                      | Type                                                               | Default |
 | ---- | ------------------------------------------------ | ------------------------------------------------------------------ | ------- |
 | size | control the size of buttons in this button-group | ^[enum]`'large' \| 'default' \| 'small'`                           | —       |
 | type | control the type of buttons in this button-group | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info'` | —       |
 
-### ButtonGroup Slots
+### Slots
 
 | Name    | Description                    | Subtags |
 | ------- | ------------------------------ | ------- |

--- a/docs/en-US/component/carousel.md
+++ b/docs/en-US/component/carousel.md
@@ -77,7 +77,7 @@ carousel/vertical
 
 ## Carousel API
 
-### Carousel Attributes
+### Attributes
 
 | Name                 | Description                                           | Type                                    | Default    |
 | -------------------- | ----------------------------------------------------- | --------------------------------------- | ---------- |
@@ -95,19 +95,19 @@ carousel/vertical
 | pause-on-hover       | pause autoplay when hover                             | ^[boolean]                              | true       |
 | motion-blur ^(2.6.0) | infuse dynamism and smoothness into the carousel      | ^[boolean]                              | false      |
 
-### Carousel Events
+### Events
 
 | Name   | Description                                                                                                                                              | Type                                                    |
 | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
 | change | triggers when the active slide switches, it has two parameters, the one is the index of the new active slide, and other is index of the old active slide | ^[Function]`(current: number, prev: number) => boolean` |
 
-### Carousel Slots
+### Slots
 
 | Name    | Description               | Subtags       |
 | ------- | ------------------------- | ------------- |
 | default | customize default content | Carousel-Item |
 
-### Carousel Exposes
+### Exposes
 
 | Method               | Description                                                                                                                     | Type                                           |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
@@ -118,14 +118,14 @@ carousel/vertical
 
 ## Carousel-Item API
 
-### Carousel-Item Attributes
+### Attributes
 
 | Name  | Description                                      | Type                  | Default |
 | ----- | ------------------------------------------------ | --------------------- | ------- |
 | name  | name of the item, can be used in `setActiveItem` | ^[string]             | ''      |
 | label | text content for the corresponding indicator     | ^[string] / ^[number] | ''      |
 
-### Carousel-Item Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |

--- a/docs/en-US/component/cascader.md
+++ b/docs/en-US/component/cascader.md
@@ -129,7 +129,7 @@ cascader/panel
 
 ## Cascader API
 
-### Cascader Attributes
+### Attributes
 
 | Name                                | Description                                                                                                                                                                      | Type                                                                                                                                                                        | Default      |
 | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
@@ -161,7 +161,7 @@ cascader/panel
 | placement ^(2.8.1)                  | position of dropdown                                                                                                                                                             | ^[enum]`'top' \| 'top-start' \| 'top-end' \| 'bottom' \| 'bottom-start' \| 'bottom-end' \| 'left' \| 'left-start' \| 'left-end' \| 'right' \| 'right-start' \| 'right-end'` | bottom-start |
 | popper-append-to-body ^(deprecated) | whether to append the popper menu to body. If the positioning of the popper is wrong, you can try to set this prop to false                                                      | ^[boolean]                                                                                                                                                                  | true         |
 
-### Cascader Events
+### Events
 
 | Name           | Description                                                   | Type                                                        |
 | -------------- | ------------------------------------------------------------- | ----------------------------------------------------------- |
@@ -173,7 +173,7 @@ cascader/panel
 | visible-change | triggers when the dropdown appears/disappears                 | ^[Function]`(value: boolean) => void`                       |
 | remove-tag     | triggers when remove tag in multiple selection mode           | ^[Function]`(value: CascaderNode['valueByOption']) => void` |
 
-### Cascader Slots
+### Slots
 
 | Name            | Description                                                                                    | Scope                               |
 | --------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------- |
@@ -181,7 +181,7 @@ cascader/panel
 | empty           | content when there is no matched options.                                                      | —                                   |
 | prefix ^(2.9.4) | content as Input prefix                                                                        | —                                   |
 
-### Cascader Exposes
+### Exposes
 
 | Name                          | Description                                                                                                       | Type                                                            |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
@@ -193,7 +193,7 @@ cascader/panel
 
 ## CascaderPanel API
 
-### CascaderPanel Attributes
+### Attributes
 
 | Name                  | Description                                                                              | Type                                                       | Default |
 | --------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------- |
@@ -201,7 +201,7 @@ cascader/panel
 | options               | data of the options, the key of `value` and `label` can be customize by `CascaderProps`. | ^[object]`Record<string, unknown>[]`                       | —       |
 | props                 | configuration options, see the following `CascaderProps` table.                          | ^[object]`CascaderProps`                                   | —       |
 
-### CascaderPanel Events
+### Events
 
 | Name          | Description                                                             | Type                                                |
 | ------------- | ----------------------------------------------------------------------- | --------------------------------------------------- |
@@ -209,14 +209,14 @@ cascader/panel
 | expand-change | triggers when expand option changes                                     | ^[Function]`(value: CascaderNodePathValue) => void` |
 | close         | close panel event, provided to Cascader to put away the panel judgment. | ^[Function]`() => void`                             |
 
-### CascaderPanel Slots
+### Slots
 
 | Name           | Description                                                                                    | Scope                               |
 | -------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------- |
 | default        | the custom content of cascader node, which are current Node object and node data respectively. | ^[object]`{ node: any, data: any }` |
 | empty ^(2.8.3) | the content of the panel when there is no data.                                                | —                                   |
 
-### CascaderPanel Exposes
+### Exposes
 
 | Name              | Description                                                                                                       | Type                                                            |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |

--- a/docs/en-US/component/checkbox.md
+++ b/docs/en-US/component/checkbox.md
@@ -101,7 +101,7 @@ checkbox/with-border
 
 ## Checkbox API
 
-### Checkbox Attributes
+### Attributes
 
 | Name                           | Description                                                                                                                                                    | Type                                           | Default |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ------- |
@@ -124,13 +124,13 @@ checkbox/with-border
 | false-label ^(deprecated)      | value of the Checkbox if it's not checked                                                                                                                      | ^[string] / ^[number]                          | —       |
 | controls ^(a11y) ^(deprecated) | same as [aria-controls](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls), takes effect when `indeterminate` is `true` | ^[string]                                      | —       |
 
-### Checkbox Events
+### Events
 
 | Name   | Description                             | Type                                                      |
 | ------ | --------------------------------------- | --------------------------------------------------------- |
 | change | triggers when the binding value changes | ^[Function]`(value: string \| number \| boolean) => void` |
 
-### Checkbox Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |
@@ -138,7 +138,7 @@ checkbox/with-border
 
 ## CheckboxGroup API
 
-### CheckboxGroup Attributes
+### Attributes
 
 | Name                        | Description                                       | Type                                     | Default |
 | --------------------------- | ------------------------------------------------- | ---------------------------------------- | ------- |
@@ -154,13 +154,13 @@ checkbox/with-border
 | validate-event              | whether to trigger form validation                | ^[boolean]                               | true    |
 | label ^(a11y) ^(deprecated) | native `aria-label` attribute                     | ^[string]                                | —       |
 
-### CheckboxGroup Events
+### Events
 
 | Name   | Description                             | Type                                               |
 | ------ | --------------------------------------- | -------------------------------------------------- |
 | change | triggers when the binding value changes | ^[Function]`(value: string[] \| number[]) => void` |
 
-### CheckboxGroup Slots
+### Slots
 
 | Name    | Description               | Subtags                    |
 | ------- | ------------------------- | -------------------------- |
@@ -168,7 +168,7 @@ checkbox/with-border
 
 ## CheckboxButton API
 
-### CheckboxButton Attributes
+### Attributes
 
 | Name                      | Description                                                                                                 | Type                                           | Default |
 | ------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ------- |
@@ -182,7 +182,7 @@ checkbox/with-border
 | true-label ^(deprecated)  | value of the checkbox if it's checked                                                                       | ^[string] / ^[number]                          | —       |
 | false-label ^(deprecated) | value of the checkbox if it's not checked                                                                   | ^[string] / ^[number]                          | —       |
 
-### CheckboxButton Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |

--- a/docs/en-US/component/collapse.md
+++ b/docs/en-US/component/collapse.md
@@ -49,20 +49,20 @@ collapse/custom-icon
 
 ## Collapse API
 
-### Collapse Attributes
+### Attributes
 
 | Name                  | Description                                                                             | Type                 | Default |
 | --------------------- | --------------------------------------------------------------------------------------- | -------------------- | ------- |
 | model-value / v-model | currently active panel, the type is `string` in accordion mode, otherwise it is `array` | ^[string] / ^[array] | []      |
 | accordion             | whether to activate accordion mode                                                      | ^[boolean]           | false   |
 
-### Collapse Events
+### Events
 
 | Name   | Description                                                                                                   | Type                                                |
 | ------ | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
 | change | triggers when active panels change, the parameter type is `string` in accordion mode, otherwise it is `array` | ^[Function]`(activeNames: array \| string) => void` |
 
-### Collapse Slots
+### Slots
 
 | Name    | Description               | Subtags       |
 | ------- | ------------------------- | ------------- |
@@ -70,7 +70,7 @@ collapse/custom-icon
 
 ## Collapse Item API
 
-### Collapse Item Attributes
+### Attributes
 
 | Name          | Description                        | Type                     | Default    |
 | ------------- | ---------------------------------- | ------------------------ | ---------- |
@@ -79,7 +79,7 @@ collapse/custom-icon
 | icon ^(2.8.3) | icon of the collapse item          | ^[string] / ^[Component] | ArrowRight |
 | disabled      | disable the collapse item          | ^[boolean]               | false      |
 
-### Collapse Item Slot
+### Slot
 
 | Name          | Description                    | Type                             |
 | ------------- | ------------------------------ | -------------------------------- |

--- a/docs/en-US/component/container.md
+++ b/docs/en-US/component/container.md
@@ -81,13 +81,13 @@ container/example
 
 ## Container API
 
-### Container Attributes
+### Attributes
 
 | Name      | Description                         | Type                                | Default                                                                    |
 | --------- | ----------------------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
 | direction | layout direction for child elements | ^[enum]`'horizontal' \| 'vertical'` | vertical when nested with `el-header` or `el-footer`; horizontal otherwise |
 
-### Container Slots
+### Slots
 
 | Name    | Description               | Subtags                                    |
 | ------- | ------------------------- | ------------------------------------------ |
@@ -95,13 +95,13 @@ container/example
 
 ## Header API
 
-### Header Attributes
+### Attributes
 
 | Name   | Description          | Type      | Default |
 | ------ | -------------------- | --------- | ------- |
 | height | height of the header | ^[string] | 60px    |
 
-### Header Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |
@@ -109,13 +109,13 @@ container/example
 
 ## Aside API
 
-### Aside Attributes
+### Attributes
 
 | Name  | Description               | Type      | Default |
 | ----- | ------------------------- | --------- | ------- |
 | width | width of the side section | ^[string] | 300px   |
 
-### Aside Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |
@@ -123,7 +123,7 @@ container/example
 
 ## Main API
 
-### Main Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |
@@ -131,13 +131,13 @@ container/example
 
 ## Footer API
 
-### Footer Attributes
+### Attributes
 
 | Name   | Description          | Type      | Default |
 | ------ | -------------------- | --------- | ------- |
 | height | height of the footer | ^[string] | 60px    |
 
-### Footer Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |

--- a/docs/en-US/component/datetime-picker.md
+++ b/docs/en-US/component/datetime-picker.md
@@ -77,7 +77,9 @@ datetime-picker/custom-icon
 
 :::
 
-## Attributes
+## API
+
+### Attributes
 
 | Name                    | Description                                                                                                    | Type                                                                                           | Default             |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------- |
@@ -113,7 +115,7 @@ datetime-picker/custom-icon
 | value-on-clear ^(2.7.0) | clear return value, [see config-provider](/en-US/component/config-provider#empty-values-configurations)        | ^[string] / ^[number] / ^[boolean] / ^[Function]                                               | —                   |
 | show-now ^(2.8.7)       | whether to show the now button                                                                                 | ^[boolean]                                                                                     | true                |
 
-## Events
+### Events
 
 | Name            | Description                                                                   | Parameters                                |
 | --------------- | ----------------------------------------------------------------------------- | ----------------------------------------- |
@@ -124,7 +126,7 @@ datetime-picker/custom-icon
 | calendar-change | triggers when the calendar selected date is changed. Only for `datetimerange` | [Date, Date]                              |
 | visible-change  | triggers when the DateTimePicker's dropdown appears/disappears                | true when it appears, and false otherwise |
 
-## Slots
+### Slots
 
 | Name                | Description                    |
 | ------------------- | ------------------------------ |
@@ -135,7 +137,7 @@ datetime-picker/custom-icon
 | prev-year ^(2.8.0)  | prev year icon                 |
 | next-year ^(2.8.0)  | next year icon                 |
 
-## Exposes
+### Exposes
 
 | Method        | Description                    | Type                    |
 | ------------- | ------------------------------ | ----------------------- |

--- a/docs/en-US/component/descriptions.md
+++ b/docs/en-US/component/descriptions.md
@@ -49,7 +49,7 @@ descriptions/customized-style
 
 ## Descriptions API
 
-### Descriptions Attributes
+### Attributes
 
 | Name                 | Description                                | Type                                           | Default    |
 | -------------------- | ------------------------------------------ | ---------------------------------------------- | ---------- |
@@ -61,7 +61,7 @@ descriptions/customized-style
 | extra                | extra text, display on the top right       | ^[string]                                      | ''         |
 | label-width ^(2.8.8) | label width of every column                | ^[string] / ^[number]                          | ''         |
 
-### Descriptions Slots
+### Slots
 
 | Name    | Description                                 | Subtags           |
 | ------- | ------------------------------------------- | ----------------- |
@@ -71,7 +71,7 @@ descriptions/customized-style
 
 ## DescriptionsItem API
 
-### DescriptionsItem Attributes
+### Attributes
 
 | Name                 | Description                                                                                                                                                                                  | Type                                   | Default |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------- |
@@ -86,7 +86,7 @@ descriptions/customized-style
 | class-name           | column content custom class name                                                                                                                                                             | ^[string]                              | ''      |
 | label-class-name     | column label custom class name                                                                                                                                                               | ^[string]                              | ''      |
 
-### DescriptionsItem Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |

--- a/docs/en-US/component/dropdown.md
+++ b/docs/en-US/component/dropdown.md
@@ -89,7 +89,7 @@ dropdown/sizes
 
 ## Dropdown API
 
-### Dropdown Attributes
+### Attributes
 
 | Name                 | Description                                                                                                           | Type                                                                                                         | Default                                                                    |
 | -------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
@@ -111,14 +111,14 @@ dropdown/sizes
 | popper-options       | [popper.js](https://popper.js.org/docs/v2/) parameters                                                                | ^[object]                                                                                                    | `{modifiers: [{name: 'computeStyles',options: {gpuAcceleration: false}}]}` |
 | teleported ^(2.2.20) | whether the dropdown popup is teleported to the body                                                                  | ^[boolean]                                                                                                   | true                                                                       |
 
-### Dropdown Slots
+### Slots
 
 | Name     | Description                                                                                                                                   | Subtags       |
 | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | default  | content of Dropdown. Notice: Must be a valid html dom element (ex. `<span>, <button> etc.`) or `el-component`, to attach the trigger listener | —             |
 | dropdown | content of the Dropdown Menu, usually a `<el-dropdown-menu>` element                                                                          | Dropdown-Menu |
 
-### Dropdown Events
+### Events
 
 | Name           | Description                                                                                               | Type                                  |
 | -------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------- |
@@ -126,7 +126,7 @@ dropdown/sizes
 | command        | triggers when a dropdown item is clicked, the parameters is the command dispatched from the dropdown item | ^[Function]`(...args: any[]) => void` |
 | visible-change | triggers when the dropdown appears/disappears, the param is true when it appears, and false otherwise     | ^[Function]`(val: boolean) => void`   |
 
-### Dropdown Exposes
+### Exposes
 
 | Method      | Description             | Type                    |
 | ----------- | ----------------------- | ----------------------- |
@@ -135,7 +135,7 @@ dropdown/sizes
 
 ## Dropdown-Menu API
 
-### Dropdown-Menu Slots
+### Slots
 
 | Name    | Description              | Subtags       |
 | ------- | ------------------------ | ------------- |
@@ -143,7 +143,7 @@ dropdown/sizes
 
 ## Dropdown-Item API
 
-### Dropdown-Item Attributes
+### Attributes
 
 | Name     | Description                                                 | Type                              | Default |
 | -------- | ----------------------------------------------------------- | --------------------------------- | ------- |
@@ -152,7 +152,7 @@ dropdown/sizes
 | divided  | whether a divider is displayed                              | ^[boolean]                        | false   |
 | icon     | custom icon                                                 | ^[string] / ^[Component]          | —       |
 
-### Dropdown-Item Slots
+### Slots
 
 | Name    | Description                |
 | ------- | -------------------------- |

--- a/docs/en-US/component/form.md
+++ b/docs/en-US/component/form.md
@@ -125,7 +125,7 @@ form/accessibility
 
 ## Form API
 
-### Form Attributes
+### Attributes
 
 | Name                              | Description                                                                                                                                                                              | Type                                           | Default |
 | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ------- |
@@ -146,19 +146,19 @@ form/accessibility
 | scroll-to-error                   | When validation fails, scroll to the first error form entry.                                                                                                                             | ^[boolean]                                     | false   |
 | scroll-into-view-options ^(2.3.2) | When validation fails, it scrolls to the first error item based on the scrollIntoView option. [scrollIntoView](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView). | ^[object]`Record<string, any>` / ^[boolean]    | —       |
 
-### Form Events
+### Events
 
 | Name     | Description                             | Type                                                                         |
 | -------- | --------------------------------------- | ---------------------------------------------------------------------------- |
 | validate | triggers after a form item is validated | ^[Function]`(prop: FormItemProp, isValid: boolean, message: string) => void` |
 
-### Form Slots
+### Slots
 
 | Name    | Description               | Subtags  |
 | ------- | ------------------------- | -------- |
 | default | customize default content | FormItem |
 
-### Form Exposes
+### Exposes
 
 | Name            | Description                                                        | Type                                                                                                                              |
 | --------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
@@ -171,7 +171,7 @@ form/accessibility
 
 ## FormItem API
 
-### FormItem Attributes
+### Attributes
 
 | Name                    | Description                                                                                                                                                            | Type                                                | Default |
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ------- |
@@ -200,7 +200,7 @@ If you don't want to trigger the validator based on input events, set the `valid
 
 :::
 
-### FormItem Slots
+### Slots
 
 | Name    | Description                                   | Type                         |
 | ------- | --------------------------------------------- | ---------------------------- |
@@ -208,7 +208,7 @@ If you don't want to trigger the validator based on input events, set the `valid
 | label   | Custom content to display on label.           | ^[object]`{ label: string }` |
 | error   | Custom content to display validation message. | ^[object]`{ error: string }` |
 
-### FormItem Exposes
+### Exposes
 
 | Name            | Description                                       | Type                                                                                                 |
 | --------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |

--- a/docs/en-US/component/image.md
+++ b/docs/en-US/component/image.md
@@ -73,7 +73,7 @@ image/custom-toolbar
 
 ## Image API
 
-### Image Attributes
+### Attributes
 
 | Name                  | Description                                                                                                                                       | Type                                                                    | Default |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------- |
@@ -96,7 +96,7 @@ image/custom-toolbar
 | min-scale ^(2.4.0)    | the min scale of the image viewer zoom event.                                                                                                     | ^[number]                                                               | 0.2     |
 | max-scale ^(2.4.0)    | the max scale of the image viewer zoom event.                                                                                                     | ^[number]                                                               | 7       |
 
-### Image Events
+### Events
 
 | Name   | Description                                                                                       | Type                                 |
 | ------ | ------------------------------------------------------------------------------------------------- | ------------------------------------ |
@@ -106,7 +106,7 @@ image/custom-toolbar
 | close  | trigger when clicking on close button or when `hide-on-click-modal` enabled clicking on backdrop. | ^[Function]`() => void`              |
 | show   | trigger when the viewer displays                                                                  | ^[Function]`() => void`              |
 
-### Image Slots
+### Slots
 
 | Name              | Description                                              | Type                                                                                                                                                                      |
 | ----------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -116,7 +116,7 @@ image/custom-toolbar
 | progress ^(2.9.4) | custom progress content when image preview.              | ^[object]`{ activeIndex: number, total: number }`                                                                                                                         |
 | toolbar ^(2.9.4)  | custom toolbar content when image preview.               | ^[object]`{actions: (action: ImageViewerAction, options?: ImageViewerActionOptions ) => void, prev: ()=> void, next: () => void,reset: () => void, activeIndex: number }` |
 
-### Image Exposes
+### Exposes
 
 | Name                 | Description                     | Type                    |
 | -------------------- | ------------------------------- | ----------------------- |
@@ -124,7 +124,7 @@ image/custom-toolbar
 
 ## Image Viewer API
 
-### Image Viewer Attributes
+### Attributes
 
 | Name                   | Description                                                                                                                   | Type                  | Default |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------- | ------- |
@@ -140,7 +140,7 @@ image/custom-toolbar
 | close-on-press-escape  | whether the image-viewer can be closed by pressing ESC.                                                                       | ^[boolean]            | true    |
 | show-progress ^(2.9.4) | whether to display the preview image progress content                                                                         | ^[boolean]            | false   |
 
-### Image Viewer Events
+### Events
 
 | Name             | Description                                                                                       | Type                                 |
 | ---------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------ |
@@ -148,7 +148,7 @@ image/custom-toolbar
 | switch           | trigger when switching images.                                                                    | ^[Function]`(index: number) => void` |
 | rotate ^(2.3.13) | trigger when rotating images.                                                                     | ^[Function]`(deg: number) => void`   |
 
-### Image Viewer Exposes
+### Exposes
 
 | Name          | Description           | Type                                 |
 | ------------- | --------------------- | ------------------------------------ |

--- a/docs/en-US/component/layout.md
+++ b/docs/en-US/component/layout.md
@@ -105,7 +105,7 @@ The classes are:
 
 ## Row API
 
-### Row Attributes
+### Attributes
 
 | Name    | Description                         | Type                                                                                         | Default |
 | ------- | ----------------------------------- | -------------------------------------------------------------------------------------------- | ------- |
@@ -114,7 +114,7 @@ The classes are:
 | align   | vertical alignment of flex layout   | ^[enum]`'top' \| 'middle' \| 'bottom'`                                                       | —       |
 | tag     | custom element tag                  | ^[string]                                                                                    | div     |
 
-### Row Slots
+### Slots
 
 | Name    | Description               | Subtags |
 | ------- | ------------------------- | ------- |
@@ -122,7 +122,7 @@ The classes are:
 
 ## Col API
 
-### Col Attributes
+### Attributes
 
 | Name   | Description                                         | Type                                                                                  | Default |
 | ------ | --------------------------------------------------- | ------------------------------------------------------------------------------------- | ------- |
@@ -137,7 +137,7 @@ The classes are:
 | xl     | `≥1920px` Responsive columns or column props object | ^[number] / ^[object]`{span?: number, offset?: number, pull?: number, push?: number}` | —       |
 | tag    | custom element tag                                  | ^[string]                                                                             | div     |
 
-### Col Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |

--- a/docs/en-US/component/menu.md
+++ b/docs/en-US/component/menu.md
@@ -69,7 +69,7 @@ menu/popper-offset
 
 ## Menu API
 
-### Menu Attributes
+### Attributes
 
 | Name                            | Description                                                                                                                                                           | Type                                   | Default  |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | -------- |
@@ -93,7 +93,7 @@ menu/popper-offset
 | text-color ^(deprecated)        | text color of Menu (hex format) ( use `--el-menu-text-color` in a style class instead)                                                                                | ^[string]                              | #303133  |
 | active-text-color ^(deprecated) | text color of currently active menu item (hex format) ( use `--el-menu-active-color` in a style class instead)                                                        | ^[string]                              | #409eff  |
 
-### Menu Events
+### Events
 
 | Name   | Description                               | Type                         |
 | ------ | ----------------------------------------- | ---------------------------- |
@@ -101,13 +101,13 @@ menu/popper-offset
 | open   | callback function when sub-menu expands   | ^[Function]`MenuOpenEvent`   |
 | close  | callback function when sub-menu collapses | ^[Function]`MenuCloseEvent`  |
 
-### Menu Slots
+### Slots
 
 | Name    | Description               | Subtags                               |
 | ------- | ------------------------- | ------------------------------------- |
 | default | customize default content | SubMenu / Menu-Item / Menu-Item-Group |
 
-### Menu Exposes
+### Exposes
 
 | Name  | Description                                                            | Type                                 |
 | ----- | ---------------------------------------------------------------------- | ------------------------------------ |
@@ -116,7 +116,7 @@ menu/popper-offset
 
 ## SubMenu API
 
-### SubMenu Attributes
+### Attributes
 
 | Name                | Description                                                                                                                                   | Type                     | Default   |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | --------- |
@@ -132,7 +132,7 @@ menu/popper-offset
 | collapse-close-icon | Icon when menu are collapsed and submenu are closed, `collapse-close-icon` and `collapse-open-icon` need to be passed together to take effect | ^[string] / ^[Component] | —         |
 | collapse-open-icon  | Icon when menu are collapsed and submenu are opened, `collapse-open-icon` and `collapse-close-icon` need to be passed together to take effect | ^[string] / ^[Component] | —         |
 
-### SubMenu Slots
+### Slots
 
 | Name    | Description               | Subtags                               |
 | ------- | ------------------------- | ------------------------------------- |
@@ -141,7 +141,7 @@ menu/popper-offset
 
 ## Menu-Item API
 
-### Menu-Item Attributes
+### Attributes
 
 | Name     | Description                          | Type                  | Default |
 | -------- | ------------------------------------ | --------------------- | ------- |
@@ -149,13 +149,13 @@ menu/popper-offset
 | route    | Vue Router Route Location Parameters | ^[string] / ^[object] | —       |
 | disabled | whether disabled                     | ^[boolean]            | false   |
 
-### Menu-Item Events
+### Events
 
 | Name  | Description                                                                  | Type                                            |
 | ----- | ---------------------------------------------------------------------------- | ----------------------------------------------- |
 | click | callback function when menu-item is clicked, the param is menu-item instance | ^[Function]`(item: MenuItemRegistered) => void` |
 
-### Menu-Item Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |
@@ -164,13 +164,13 @@ menu/popper-offset
 
 ## Menu-Item-Group API
 
-### Menu-Item-Group Attributes
+### Attributes
 
 | Name  | Description | Type      | Default |
 | ----- | ----------- | --------- | ------- |
 | title | group title | ^[string] | —       |
 
-### Menu-Item-Group Slots
+### Slots
 
 | Name    | Description               | Subtags   |
 | ------- | ------------------------- | --------- |

--- a/docs/en-US/component/radio.md
+++ b/docs/en-US/component/radio.md
@@ -81,7 +81,7 @@ radio/with-borders
 
 ## Radio API
 
-### Radio Attributes
+### Attributes
 
 | Name                  | Description                                                            | Type                                     | Default |
 | --------------------- | ---------------------------------------------------------------------- | ---------------------------------------- | ------- |
@@ -93,13 +93,13 @@ radio/with-borders
 | size                  | size of the Radio                                                      | ^[enum]`'large' \| 'default' \| 'small'` | —       |
 | name                  | native `name` attribute                                                | ^[string]                                | —       |
 
-### Radio Events
+### Events
 
 | Name   | Description                           | Type                                                      |
 | ------ | ------------------------------------- | --------------------------------------------------------- |
 | change | triggers when the bound value changes | ^[Function]`(value: string \| number \| boolean) => void` |
 
-### Radio Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |
@@ -107,7 +107,7 @@ radio/with-borders
 
 ## RadioGroup API
 
-### RadioGroup Attributes
+### Attributes
 
 | Name                        | Description                                       | Type                               | Default |
 | --------------------------- | ------------------------------------------------- | ---------------------------------- | ------- |
@@ -122,13 +122,13 @@ radio/with-borders
 | id                          | native `id` attribute                             | ^[string]                          | —       |
 | label ^(a11y) ^(deprecated) | same as `aria-label` in RadioGroup                | ^[string]                          | —       |
 
-### RadioGroup Events
+### Events
 
 | Name   | Description                           | Type                                                      |
 | ------ | ------------------------------------- | --------------------------------------------------------- |
 | change | triggers when the bound value changes | ^[Function]`(value: string \| number \| boolean) => void` |
 
-### RadioGroup Slots
+### Slots
 
 | Name    | Description               | Subtags             |
 | ------- | ------------------------- | ------------------- |
@@ -136,7 +136,7 @@ radio/with-borders
 
 ## RadioButton API
 
-### RadioButton Attributes
+### Attributes
 
 | Name           | Description                                                            | Type                               | Default |
 | -------------- | ---------------------------------------------------------------------- | ---------------------------------- | ------- |
@@ -145,7 +145,7 @@ radio/with-borders
 | disabled       | whether Radio is disabled                                              | ^[boolean]                         | false   |
 | name           | native 'name' attribute                                                | ^[string]                          | —       |
 
-### RadioButton Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |

--- a/docs/en-US/component/select.md
+++ b/docs/en-US/component/select.md
@@ -183,7 +183,7 @@ select/custom-label
 
 ## Select API
 
-### Select Attributes
+### Attributes
 
 | Name                            | Description                                                                                                           | Type                                                                                                                                                                        | Default                                        |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
@@ -241,7 +241,7 @@ select/custom-label
 
 :::
 
-### Select Events
+### Events
 
 | Name                  | Description                                                   | Type                                                                |
 | --------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------- |
@@ -253,7 +253,7 @@ select/custom-label
 | focus                 | triggers when Input focuses                                   | ^[Function]`(event: FocusEvent) => void`                            |
 | popup-scroll ^(2.9.4) | triggers when dropdown scrolls                                | ^[Function]`(data:{scrollTop: number, scrollLeft: number}) => void` |
 
-### Select Slots
+### Slots
 
 | Name             | Description                           | Subtags               |
 | ---------------- | ------------------------------------- | --------------------- |
@@ -266,7 +266,7 @@ select/custom-label
 | loading ^(2.5.2) | content as Select loading             | —                     |
 | label ^(2.7.4)   | content as Select label               | —                     |
 
-### Select Exposes
+### Exposes
 
 | Name                   | Description                                     | Type                                       |
 | ---------------------- | ----------------------------------------------- | ------------------------------------------ |
@@ -276,14 +276,14 @@ select/custom-label
 
 ## Option Group API
 
-### Option Group Attributes
+### Attributes
 
 | Name     | Description                                  | Type       | Default |
 | -------- | -------------------------------------------- | ---------- | ------- |
 | label    | name of the group                            | ^[string]  | —       |
 | disabled | whether to disable all options in this group | ^[boolean] | false   |
 
-### Option Group Slots
+### Slots
 
 | Name    | Description               | Subtags |
 | ------- | ------------------------- | ------- |
@@ -291,7 +291,7 @@ select/custom-label
 
 ## Option API
 
-### Option Attributes
+### Attributes
 
 | Name     | Description                                 | Type                                           | Default |
 | -------- | ------------------------------------------- | ---------------------------------------------- | ------- |
@@ -299,7 +299,7 @@ select/custom-label
 | label    | label of option, same as `value` if omitted | ^[string] / ^[number]                          | —       |
 | disabled | whether option is disabled                  | ^[boolean]                                     | false   |
 
-### Option Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |

--- a/docs/en-US/component/skeleton.md
+++ b/docs/en-US/component/skeleton.md
@@ -117,11 +117,9 @@ skeleton/leading-trailing-without-bouncing
 
 :::
 
-##
-
 ## Skeleton API
 
-### Skeleton Attributes
+### Attributes
 
 | Name     | Description                                                                                                                                                                                                                                 | Type                                                                              | Default |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------- |
@@ -131,7 +129,7 @@ skeleton/leading-trailing-without-bouncing
 | rows     | numbers of the row, only useful when no template slot were given                                                                                                                                                                            | ^[number]                                                                         | 3       |
 | throttle | rendering delay in milliseconds. Numbers represent delayed display, and can also be set to delay hide, for example `{ leading: 500, trailing: 500 }`. When needing to control the initial value of loading, you can set `{ initVal: true }` | ^[number] / ^[object]`{ leading?: number, trailing?: number, initVal?: boolean }` | 0       |
 
-### Skeleton Slots
+### Slots
 
 | Name     | Description                            | Scope                      |
 | -------- | -------------------------------------- | -------------------------- |
@@ -140,7 +138,7 @@ skeleton/leading-trailing-without-bouncing
 
 ## SkeletonItem API
 
-### SkeletonItem Attributes
+### Attributes
 
 | Name    | Description                         | Type                                                                                             | Default |
 | ------- | ----------------------------------- | ------------------------------------------------------------------------------------------------ | ------- |

--- a/docs/en-US/component/statistic.md
+++ b/docs/en-US/component/statistic.md
@@ -37,7 +37,7 @@ statistic/card
 
 ## Statistic API
 
-### Statistic Attributes
+### Attributes
 
 | Attribute         | Description                    | Type                                                                | Default |
 | ----------------- | ------------------------------ | ------------------------------------------------------------------- | ------- |
@@ -51,7 +51,7 @@ statistic/card
 | title             | Numeric titles                 | ^[string]                                                           | —       |
 | value-style       | Styles numeric values          | ^[string] / ^[object]`CSSProperties \| CSSProperties[] \| string[]` | —       |
 
-### Statistic Slots
+### Slots
 
 | Name   | Description                 |
 | ------ | --------------------------- |
@@ -59,7 +59,7 @@ statistic/card
 | suffix | Suffixes for numeric values |
 | title  | Numeric titles              |
 
-### Statistic Exposes
+### Exposes
 
 | Name         | Description           | Type                             |
 | ------------ | --------------------- | -------------------------------- |
@@ -67,7 +67,7 @@ statistic/card
 
 ## Countdown API
 
-### Countdown Attributes
+### Attributes
 
 | Attribute   | Description                      | Type                                                                | Default  |
 | ----------- | -------------------------------- | ------------------------------------------------------------------- | -------- |
@@ -78,14 +78,14 @@ statistic/card
 | title       | countdown titles                 | ^[string]                                                           | —        |
 | value-style | Styles countdown values          | ^[string] / ^[object]`CSSProperties \| CSSProperties[] \| string[]` | —        |
 
-### Countdown Events
+### Events
 
 | Method | Description                  | Type                                 |
 | ------ | ---------------------------- | ------------------------------------ |
 | change | Time difference change event | ^[Function]`(value: number) => void` |
 | finish | countdown end event          | ^[Function]`() => void`              |
 
-### Countdown Slots
+### Slots
 
 | Name   | Description            |
 | ------ | ---------------------- |
@@ -93,7 +93,7 @@ statistic/card
 | suffix | countdown value suffix |
 | title  | countdown title        |
 
-### Countdown Exposes
+### Exposes
 
 | Name         | Description           | Type                   |
 | ------------ | --------------------- | ---------------------- |

--- a/docs/en-US/component/steps.md
+++ b/docs/en-US/component/steps.md
@@ -79,7 +79,7 @@ steps/simple
 
 ## Steps API
 
-### Steps Attributes
+### Attributes
 
 | Name           | Description                                                                   | Type                                                             | Default    |
 | -------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------- | ---------- |
@@ -91,7 +91,7 @@ steps/simple
 | align-center   | center title and description                                                  | ^[boolean]                                                       | —          |
 | simple         | whether to apply simple theme                                                 | ^[boolean]                                                       | —          |
 
-### Steps Slots
+### Slots
 
 | Name    | Description               | Subtags |
 | ------- | ------------------------- | ------- |
@@ -99,7 +99,7 @@ steps/simple
 
 ## Step API
 
-### Step Attributes
+### Attributes
 
 | Name        | Description                                                              | Type                                                                   | Default |
 | ----------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------- | ------- |
@@ -108,7 +108,7 @@ steps/simple
 | icon        | step custom icon. Icons can be passed via named slot as well             | ^[string] / ^[Component]                                               | —       |
 | status      | current status. It will be automatically set by Steps if not configured. | ^[enum]`'' \| 'wait' \| 'process' \| 'finish' \| 'error' \| 'success'` | ''      |
 
-### Step Slots
+### Slots
 
 | Name        | Description      |
 | ----------- | ---------------- |

--- a/docs/en-US/component/switch.md
+++ b/docs/en-US/component/switch.md
@@ -132,7 +132,7 @@ switch/custom-action-slot
 | ------ | --------------------------- | ------------------------------------------------------- |
 | change | triggers when value changes | ^[Function]`(val: boolean \| string \| number) => void` |
 
-### Switch Slots
+### Slots
 
 | Name                     | Description               |
 | ------------------------ | ------------------------- |

--- a/docs/en-US/component/table-v2.md
+++ b/docs/en-US/component/table-v2.md
@@ -293,7 +293,9 @@ table-v2/manual-scroll
 
 :::
 
-## TableV2 Attributes
+## TableV2 API
+
+### Attributes
 
 | Name                      | Description                                                                                                                | Type                                                   | Default   |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | --------- |
@@ -328,7 +330,7 @@ table-v2/manual-scroll
 | sort-by                   | Sort indicator                                                                                                             | `object`\<[SortBy](#typings)\>                         | {}        |
 | sort-state                | Multiple sort indicator                                                                                                    | `object`\<[SortState](#typings)\>                      | undefined |
 
-## TableV2 Slots
+### Slots
 
 | Name        | Params                                      |
 | ----------- | ------------------------------------------- |
@@ -340,7 +342,7 @@ table-v2/manual-scroll
 | empty       | —                                           |
 | overlay     | —                                           |
 
-## TableV2 Events
+### Events
 
 | Name                 | Description                                                           | Parameters                                 |
 | -------------------- | --------------------------------------------------------------------- | ------------------------------------------ |
@@ -352,7 +354,7 @@ table-v2/manual-scroll
 | row-expand           | Invoked when expand/collapse the tree node by clicking the arrow icon | `object`\<[RowExpandParams](#typings)\>    |
 | row-event-handlers   | A collection of handlers attached to each row                         | `object`\<[RowEventHandlers](#typings)\>   |
 
-## TableV2 Methods
+### Methods
 
 | Event Name   | Description                                          | Parameters                                                                             |
 | ------------ | ---------------------------------------------------- | -------------------------------------------------------------------------------------- |
@@ -367,7 +369,9 @@ Note that these are `JavaScript` Objects, so you **CANNOT USE** kebab-case for t
 
 :::
 
-## Column Attribute
+## Column API
+
+### Attribute
 
 | Name               | Description                                                           | Type                                                                                                                                                                 | Default |
 | ------------------ | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
@@ -389,7 +393,7 @@ Note that these are `JavaScript` Objects, so you **CANNOT USE** kebab-case for t
 | cellRenderer       | Customized Cell renderer                                              | `VueComponent` / (props: [CellRenderProps](#typings)) => VNode                                                                                                       | —       |
 | headerCellRenderer | Customized Header renderer                                            | `VueComponent` / (props: [HeaderRenderProps](#typings)) => VNode                                                                                                     | —       |
 
-## Typings{#typings}
+## Type Declarations
 
 <details>
 <summary>Show Type Declarations</summary>

--- a/docs/en-US/component/tabs.md
+++ b/docs/en-US/component/tabs.md
@@ -85,7 +85,7 @@ tabs/customized-trigger
 
 ## Tabs API
 
-### Tabs Attributes
+### Attributes
 
 | Name                  | Description                                                                                                                             | Type                                                                                             | Default    |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ---------- |
@@ -98,7 +98,7 @@ tabs/customized-trigger
 | stretch               | whether width of tab automatically fits its container                                                                                   | ^[boolean]                                                                                       | false      |
 | before-leave          | hook function before switching tab. If `false` is returned or a `Promise` is returned and then is rejected, switching will be prevented | ^[Function]`(activeName: TabPaneName, oldActiveName: TabPaneName) => Awaitable<void \| boolean>` | () => true |
 
-### Tabs Events
+### Events
 
 | Name       | Description                                           | Parameters                                                                           |
 | ---------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------ |
@@ -108,7 +108,7 @@ tabs/customized-trigger
 | tab-add    | triggers when tab-add button is clicked               | ^[Function]`() => void`                                                              |
 | edit       | triggers when tab-add button or tab-remove is clicked | ^[Function]`(paneName: TabPaneName \| undefined, action: 'remove' \| 'add') => void` |
 
-### Tabs Slots
+### Slots
 
 | Name                           | Description               | Subtags  |
 | ------------------------------ | ------------------------- | -------- |
@@ -118,7 +118,7 @@ tabs/customized-trigger
 
 ## Tab-pane API
 
-### Tab-pane Attributes
+### Attributes
 
 | Name     | Description                                                                                                                                                                         | Type                  | Default |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ------- |
@@ -128,7 +128,7 @@ tabs/customized-trigger
 | closable | whether Tab is closable                                                                                                                                                             | ^[boolean]            | false   |
 | lazy     | whether Tab is lazily rendered                                                                                                                                                      | ^[boolean]            | false   |
 
-### Tab-pane Slots
+### Slots
 
 | Name    | Description        |
 | ------- | ------------------ |

--- a/docs/en-US/component/tag.md
+++ b/docs/en-US/component/tag.md
@@ -75,7 +75,7 @@ tag/checkable
 
 ## Tag API
 
-### Tag Attributes
+### Attributes
 
 | Name                | Description                          | Type                                                               | Default |
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------ | ------- |
@@ -88,14 +88,14 @@ tag/checkable
 | effect              | theme of Tag                         | ^[enum]`'dark' \| 'light' \| 'plain'`                              | light   |
 | round               | whether Tag is rounded               | ^[boolean]                                                         | false   |
 
-### Tag Events
+### Events
 
 | Name  | Description                  | Type                                   |
 | ----- | ---------------------------- | -------------------------------------- |
 | click | triggers when Tag is clicked | ^[Function]`(evt: MouseEvent) => void` |
 | close | triggers when Tag is removed | ^[Function]`(evt: MouseEvent) => void` |
 
-### Tag Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |
@@ -103,7 +103,7 @@ tag/checkable
 
 ## CheckTag API
 
-### CheckTag Attributes
+### Attributes
 
 | Name                      | Description                       | Type                                                               | Default |
 | ------------------------- | --------------------------------- | ------------------------------------------------------------------ | ------- |
@@ -111,13 +111,13 @@ tag/checkable
 | disabled ^(2.8.2)         | whether the check-tag is disabled | ^[boolean]                                                         | false   |
 | type ^(2.5.4)             | type of CheckTag                  | ^[enum]`'primary' \| 'success' \| 'info' \| 'warning' \| 'danger'` | primary |
 
-### CheckTag Events
+### Events
 
 | Name   | Description                        | Type                                  |
 | ------ | ---------------------------------- | ------------------------------------- |
 | change | triggers when Check Tag is clicked | ^[Function]`(value: boolean) => void` |
 
-### CheckTag Slots
+### Slots
 
 | Name    | Description               |
 | ------- | ------------------------- |

--- a/docs/en-US/component/timeline.md
+++ b/docs/en-US/component/timeline.md
@@ -49,7 +49,7 @@ timeline/center
 
 ## Timeline API
 
-### Timeline Slots
+### Slots
 
 | Name    | Description                            | Subtags       |
 | ------- | -------------------------------------- | ------------- |
@@ -57,7 +57,7 @@ timeline/center
 
 ## Timeline-Item API
 
-### Timeline-Item Attributes
+### Attributes
 
 | Name           | Description                 | Type                                                               | Default |
 | -------------- | --------------------------- | ------------------------------------------------------------------ | ------- |
@@ -71,7 +71,7 @@ timeline/center
 | icon           | icon component              | ^[string] / ^[Component]                                           | —       |
 | hollow         | icon is hollow              | ^[boolean]                                                         | false   |
 
-### Timeline-Item Slots
+### Slots
 
 | Name    | Description                                 |
 | ------- | ------------------------------------------- |

--- a/docs/en-US/component/tour.md
+++ b/docs/en-US/component/tour.md
@@ -73,7 +73,7 @@ tour/target
 tour-step component configuration with the same name has higher priority
 :::
 
-### Tour Attributes
+### Attributes
 
 | Property                  | Description                                                                      | Type                                                                                                                                                                        | Default                        |
 | ------------------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
@@ -91,14 +91,14 @@ tour-step component configuration with the same name has higher priority
 | close-on-press-escape     | whether the Dialog can be closed by pressing ESC                                 | `boolean`                                                                                                                                                                   | `true`                         |
 | target-area-clickable     | whether the target element can be clickable, when using mask                     | `boolean`                                                                                                                                                                   | `true`                         |
 
-### Tour slots
+### slots
 
 | Name       | Description                                                   |
 | ---------- | ------------------------------------------------------------- |
 | default    | tourStep component list                                       |
 | indicators | custom indicator, The scope parameter is `{ current, total }` |
 
-### Tour events
+### events
 
 | Name   | Description                    | Type                                   |
 | ------ | ------------------------------ | -------------------------------------- |
@@ -106,7 +106,9 @@ tour-step component configuration with the same name has higher priority
 | finish | callback function on finished  | ^[Function]`() => void`                |
 | change | callback when the step changes | ^[Function]`(current: number) => void` |
 
-### TourStep Attributes
+## TourStep API
+
+### Attributes
 
 | Property                 | Description                                                                                                                                                                                            | Type                                                                                                                                                                        | Default   |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
@@ -124,14 +126,14 @@ tour-step component configuration with the same name has higher priority
 | show-close               | whether to show a close button                                                                                                                                                                         | `boolean`                                                                                                                                                                   | `true`    |
 | close-icon               | custom close icon, default is Close                                                                                                                                                                    | `string` \| `Component`                                                                                                                                                     | —         |
 
-### TourStep slots
+### slots
 
 | Name    | Description |
 | ------- | ----------- |
 | default | description |
 | header  | header      |
 
-### TourStep events
+### events
 
 | Name  | Description                   | Arguments               |
 | ----- | ----------------------------- | ----------------------- |

--- a/docs/en-US/component/transfer.md
+++ b/docs/en-US/component/transfer.md
@@ -55,7 +55,7 @@ transfer/prop-alias
 
 ## Transfer API
 
-### Transfer Attributes
+### Attributes
 
 | Name                  | Description                                                                                                                                                                                                                                                                        | Type                                                               | Default  |
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------- |
@@ -74,7 +74,7 @@ transfer/prop-alias
 | right-default-checked | key array of initially checked data items of the right list                                                                                                                                                                                                                        | ^[object]`Array<string \| number>`                                 | []       |
 | validate-event        | whether to trigger form validation                                                                                                                                                                                                                                                 | ^[boolean]                                                         | true     |
 
-### Transfer Events
+### Events
 
 | Name               | Description                                                                         | Type                                                                                                |
 | ------------------ | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
@@ -82,7 +82,7 @@ transfer/prop-alias
 | left-check-change  | triggers when end user changes the checked state of any data item in the left list  | ^[Function]`(value: TransferKey[], movedKeys?: TransferKey[]) => void`                              |
 | right-check-change | triggers when end user changes the checked state of any data item in the right list | ^[Function]`(value: TransferKey[], movedKeys?: TransferKey[]) => void`                              |
 
-### Transfer Slots
+### Slots
 
 | Name                 | Description                                                          |
 | -------------------- | -------------------------------------------------------------------- |
@@ -92,7 +92,7 @@ transfer/prop-alias
 | left-empty ^(2.9.0)  | content when left panel is empty or when no data matches the filter  |
 | right-empty ^(2.9.0) | content when right panel is empty or when no data matches the filter |
 
-### Transfer Exposes
+### Exposes
 
 | Name       | Description                                 | Type                                            |
 | ---------- | ------------------------------------------- | ----------------------------------------------- |
@@ -102,7 +102,7 @@ transfer/prop-alias
 
 ## Transfer Panel API
 
-### Transfer Panel Exposes
+### Exposes
 
 | Name  | Description    | Type      |
 | ----- | -------------- | --------- |

--- a/docs/en-US/component/tree-v2.md
+++ b/docs/en-US/component/tree-v2.md
@@ -78,7 +78,9 @@ tree-v2/filter
 
 :::
 
-## TreeV2 Attributes
+## API
+
+### Attributes
 
 | Name                  | Description                                                                                                                                  | Type                        | Default |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- | ------- |
@@ -98,7 +100,7 @@ tree-v2/filter
 | icon                  | custom tree node icon                                                                                                                        | `string \| Component`       | —       |
 | item-size ^(2.2.33)   | custom tree node height                                                                                                                      | number                      | 26      |
 
-## props
+### props
 
 | Attribute      | Description                                                                          | Type                                            | Default  |
 | -------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------- | -------- |
@@ -108,7 +110,7 @@ tree-v2/filter
 | disabled       | specify which key of node object represents if node's checkbox is disabled           | string                                          | disabled |
 | class ^(2.9.0) | custom node class name                                                               | ^[string] / ^[Function]`(data, node) => string` | —        |
 
-## TreeV2 Method
+### Method
 
 `Tree` has the following method, which returns the currently selected array of nodes.
 | Method | Description | Parameters |
@@ -131,7 +133,7 @@ tree-v2/filter
 | scrollTo ^(2.8.0) | scroll to a given position | `(offset: number)` |
 | scrollToNode ^(2.8.0) | scroll to a given tree key with specified scroll strategy | `(key: TreeKey, strategy?: auto \| smart \| center \| start \| end)` |
 
-## TreeV2 Events
+### Events
 
 | Name               | Description                                          | Parameters                                                                                                                              |
 | ------------------ | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
@@ -144,7 +146,7 @@ tree-v2/filter
 | node-expand        | triggers when current node open                      | `(data: TreeNodeData, node: TreeNode)`                                                                                                  |
 | node-collapse      | triggers when current node close                     | `(data: TreeNodeData, node: TreeNode)`                                                                                                  |
 
-## TreeV2 Slots
+### Slots
 
 | Name           | Description                                                                                    |
 | -------------- | ---------------------------------------------------------------------------------------------- |

--- a/docs/en-US/component/tree.md
+++ b/docs/en-US/component/tree.md
@@ -121,7 +121,9 @@ tree/draggable
 
 :::
 
-## Attributes
+## API
+
+### Attributes
 
 | Name                  | Description                                                                                                                                                                                                                                                                                                                                                                 | Type                                                   | Default |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------- |
@@ -151,7 +153,7 @@ tree/draggable
 | allow-drag            | this function will be executed before dragging a node. If `false` is returned, the node can not be dragged                                                                                                                                                                                                                                                                  | ^[Function]`(node) => boolean`                         | —       |
 | allow-drop            | this function will be executed before the dragging node is dropped. If `false` is returned, the dragging node can not be dropped at the target node. `type` has three possible values: 'prev' (inserting the dragging node before the target node), 'inner' (inserting the dragging node to the target node) and 'next' (inserting the dragging node after the target node) | ^[Function]`(draggingNode, dropNode, type) => boolean` | —       |
 
-## props
+### props
 
 | Attribute | Description                                                                   | Type                                             | Default |
 | --------- | ----------------------------------------------------------------------------- | ------------------------------------------------ | ------- |
@@ -161,7 +163,7 @@ tree/draggable
 | isLeaf    | specify whether the node is a leaf node, only works when lazy load is enabled | ^[string] / ^[Function]`(data, node) => boolean` | —       |
 | class     | custom node class name                                                        | ^[string] / ^[Function]`(data, node) => string`  | —       |
 
-## Method
+### Method
 
 `Tree` has the following method, which returns the currently selected array of nodes.
 | Method | Description | Parameters |
@@ -185,7 +187,7 @@ tree/draggable
 | insertBefore | insert a node before a given node in the tree | (data, refNode) 1. node's data to be inserted 2. reference node's data, key or node |
 | insertAfter | insert a node after a given node in the tree | (data, refNode) 1. node's data to be inserted 2. reference node's data, key or node |
 
-## Events
+### Events
 
 | Name             | Description                                               | Parameters                                                                                                                                                                                       |
 | ---------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -203,7 +205,7 @@ tree/draggable
 | node-drag-end    | triggers when dragging ends                               | four parameters: node object corresponding to the dragging node, node object corresponding to the dragging end node (may be `undefined`), node drop type (before / after / inner), event.        |
 | node-drop        | triggers after the dragging node is dropped               | four parameters: node object corresponding to the dragging node, node object corresponding to the dropped node, node drop type (before / after / inner), event.                                  |
 
-## Slots
+### Slots
 
 | Name           | Description                                                            |
 | -------------- | ---------------------------------------------------------------------- |


### PR DESCRIPTION
将右侧 `API` 样式统一
单个的:
<img width="262" alt="image" src="https://github.com/user-attachments/assets/2495d5f5-bcaa-42dc-a62c-3b2fc9f528c8" />
多个的:
<img width="214" alt="image" src="https://github.com/user-attachments/assets/856e4634-8435-4d1d-8d96-ebcec2cb5138" />
