### PR TITLE
fix(components): [table] compatible with window non-existence

### DIFF
--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -113,6 +113,10 @@ function useStyle<T>(
       layout.updateElsHeight()
     }
     layout.updateColumnsWidth()
+
+    // When the test case is running, the context environment simulated by jsdom may have been destroyed,
+    // and window.requestAnimationFrame does not exist at this time.
+    if (typeof window === 'undefined') return
     requestAnimationFrame(syncPosition)
   }
   onMounted(async () => {


### PR DESCRIPTION
ElTable's `doLayout()` is debounced and scheduled (relying on `setTimeout()`) which causes problems in testing(Vitest).

Sometimes the testing environment(jsdom) is destroyed before doLayout() executes which causes error due to requestAnimationFrame not existing. 

To mitigate this issue we can check if `window` is defined which is a good indication that jsdom has not been thorn down yet.

This PR is similar in spirit to https://github.com/element-plus/element-plus/pull/18445 and fixes very similar issue to the one described in https://github.com/element-plus/element-plus/issues/18433

<img width="858" alt="image" src="https://github.com/user-attachments/assets/9e40c620-488b-4b8c-8e28-a2952f65eb3d" />


Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
