### PR TITLE
fix(components): [upload]增加拖拽上传时文件类型校验 (#19880)

### DIFF
--- a/packages/components/upload/src/upload-content.vue
+++ b/packages/components/upload/src/upload-content.vue
@@ -64,6 +64,34 @@ const requests = shallowRef<Record<string, XMLHttpRequest | Promise<unknown>>>(
 )
 const inputRef = shallowRef<HTMLInputElement>()
 
+const checkFileType = (rawFile: File) => {
+  const accept = props.accept
+  if (accept === '*') {
+    return true
+  }
+
+  const acceptList = accept.split(',').map((type: string) => type.trim())
+
+  const isAccepted = acceptList.some((type: string) => {
+    if (type === '*') {
+      return true
+    } else if (type.startsWith('.')) {
+      return rawFile.name.endsWith(type)
+    } else if (type.endsWith('/*')) {
+      const prefix = type.slice(0, -1)
+      return rawFile.type.startsWith(prefix)
+    } else {
+      return rawFile.type === type
+    }
+  })
+
+  if (!isAccepted) {
+    return false
+  }
+
+  return true
+}
+
 const uploadFiles = (files: File[]) => {
   if (files.length === 0) return
 
@@ -167,7 +195,11 @@ const doUpload = async (
     props.onRemove(rawFile)
     return
   }
-
+  const isValidFileType = checkFileType(rawFile)
+  if (!isValidFileType) {
+    props.onRemove(rawFile)
+    return
+  }
   const { uid } = rawFile
   const options: UploadRequestOptions = {
     headers: headers || {},


### PR DESCRIPTION
修复拖拽上传可以绕过文件类型限制

BREAKING CHANGE :
增加拖拽上传时文件类型校验

closed #19880

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
