### PR TITLE
style(components): [cascader] add collapse-tag margin

### DIFF
--- a/packages/theme-chalk/src/cascader.scss
+++ b/packages/theme-chalk/src/cascader.scss
@@ -181,7 +181,7 @@
     @include cascader-tag-normal(getCssVar('fill-color'));
 
     .#{$namespace}-tag {
-      margin: 2px 0 2px 6px;
+      margin: 2px 0;
     }
 
   }

--- a/packages/theme-chalk/src/cascader.scss
+++ b/packages/theme-chalk/src/cascader.scss
@@ -4,13 +4,12 @@
 @use 'mixins/var' as *;
 @use 'common/var' as *;
 
-@mixin cascader-tag-normal($background-color) {
+@mixin cascader-tag-normal() {
   .#{$namespace}-tag {
     display: inline-flex;
     align-items: center;
     max-width: 100%;
     text-overflow: ellipsis;
-    background: $background-color;
 
     &.#{$namespace}-tag--dark,
     &.#{$namespace}-tag--plain {
@@ -168,7 +167,7 @@
     line-height: normal;
     text-align: left;
     box-sizing: border-box;
-    @include cascader-tag-normal(getCssVar('cascader-tag-background'));
+    @include cascader-tag-normal();
 
     &.is-validate {
       right: 55px;
@@ -178,7 +177,10 @@
   @include e(collapse-tags) {
     white-space: normal;
     z-index: getCssVar('index-normal');
-    @include cascader-tag-normal(getCssVar('fill-color'));
+    display: flex;
+    flex-wrap: wrap;
+    gap: map.get($cascader-item-gap, 'default');
+    @include cascader-tag-normal();
   }
 
   @include e(suggestion-panel) {

--- a/packages/theme-chalk/src/cascader.scss
+++ b/packages/theme-chalk/src/cascader.scss
@@ -183,7 +183,6 @@
     .#{$namespace}-tag {
       margin: 2px 0;
     }
-
   }
 
   @include e(suggestion-panel) {

--- a/packages/theme-chalk/src/cascader.scss
+++ b/packages/theme-chalk/src/cascader.scss
@@ -4,12 +4,13 @@
 @use 'mixins/var' as *;
 @use 'common/var' as *;
 
-@mixin cascader-tag-normal() {
+@mixin cascader-tag-normal($background-color) {
   .#{$namespace}-tag {
     display: inline-flex;
     align-items: center;
     max-width: 100%;
     text-overflow: ellipsis;
+    background: $background-color;
 
     &.#{$namespace}-tag--dark,
     &.#{$namespace}-tag--plain {
@@ -167,7 +168,7 @@
     line-height: normal;
     text-align: left;
     box-sizing: border-box;
-    @include cascader-tag-normal();
+    @include cascader-tag-normal(getCssVar('cascader-tag-background'));
 
     &.is-validate {
       right: 55px;
@@ -177,10 +178,12 @@
   @include e(collapse-tags) {
     white-space: normal;
     z-index: getCssVar('index-normal');
-    display: flex;
-    flex-wrap: wrap;
-    gap: map.get($cascader-item-gap, 'default');
-    @include cascader-tag-normal();
+    @include cascader-tag-normal(getCssVar('fill-color'));
+
+    .#{$namespace}-tag {
+      margin: 2px 0 2px 6px;
+    }
+
   }
 
   @include e(suggestion-panel) {


### PR DESCRIPTION
Fix  the bug caused by #18285, where there is no gap between hidden tags when multiple selections are made.


- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
