### PR TITLE
docs: Add an example of the tooltip component using the append-to API

### DIFF
--- a/docs/en-US/component/tooltip.md
+++ b/docs/en-US/component/tooltip.md
@@ -146,6 +146,16 @@ tooltip/animations
 
 :::
 
+## Use the `append-to`
+
+You must wait for the DOM to be mounted before using `targetElement`.
+
+:::demo
+
+tooltip/append-to
+
+:::
+
 ## API
 
 ### Attributes

--- a/docs/examples/tooltip/append-to.vue
+++ b/docs/examples/tooltip/append-to.vue
@@ -1,0 +1,23 @@
+<template>
+  <el-tooltip
+    :append-to="targetElement"
+    trigger="click"
+    content="Append to .target"
+    placement="top"
+  >
+    <el-button class="target">Click to open tooltip</el-button>
+  </el-tooltip>
+</template>
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+
+const targetElement = ref<string>('')
+onMounted(() => {
+  targetElement.value = '.target'
+})
+</script>
+<style scoped>
+.target {
+  position: relative;
+}
+</style>


### PR DESCRIPTION
docs: Add an example of the tooltip component using the append-to API .
docs: 为Tooltip 组件添加 append-to API使用的示例。