### PR TITLE
docs(components): [message] add a "Won't close automatically" example. 

### DIFF
--- a/docs/en-US/component/config-provider.md
+++ b/docs/en-US/component/config-provider.md
@@ -90,11 +90,11 @@ In this section, you can learn how to use Config Provider to provide experimenta
 
 | Attribute          | Description                                                                    | Type       | Default |
 | ------------------ | ------------------------------------------------------------------------------ | ---------- | ------- |
-| max                | the maximum number of messages that can be displayed at the same time          | ^[number]  | —       |
-| grouping ^(2.8.2)  | merge messages with the same content, type of VNode message is not supported   | ^[boolean] | —       |
-| duration ^(2.8.2)  | display duration, millisecond. If set to 0, it will not turn off automatically | ^[number]  | —       |
-| showClose ^(2.8.2) | whether to show a close button                                                 | ^[boolean] | —       |
-| offset ^(2.8.2)    | set the distance to the top of viewport                                        | ^[number]  | —       |
+| max                | the maximum number of messages that can be displayed at the same time          | ^[number]  | 3       |
+| grouping ^(2.8.2)  | merge messages with the same content, type of VNode message is not supported   | ^[boolean] | false       |
+| duration ^(2.8.2)  | display duration, millisecond. If set to 0, it will not turn off automatically | ^[number]  | 3000       |
+| showClose ^(2.8.2) | whether to show a close button                                                 | ^[boolean] | false       |
+| offset ^(2.8.2)    | set the distance to the top of viewport                                        | ^[number]  | 16       |
 
 ### Config Provider Slots
 

--- a/docs/en-US/component/config-provider.md
+++ b/docs/en-US/component/config-provider.md
@@ -90,11 +90,11 @@ In this section, you can learn how to use Config Provider to provide experimenta
 
 | Attribute          | Description                                                                    | Type       | Default |
 | ------------------ | ------------------------------------------------------------------------------ | ---------- | ------- |
-| max                | the maximum number of messages that can be displayed at the same time          | ^[number]  | 3       |
-| grouping ^(2.8.2)  | merge messages with the same content, type of VNode message is not supported   | ^[boolean] | false       |
-| duration ^(2.8.2)  | display duration, millisecond. If set to 0, it will not turn off automatically | ^[number]  | 3000       |
-| showClose ^(2.8.2) | whether to show a close button                                                 | ^[boolean] | false       |
-| offset ^(2.8.2)    | set the distance to the top of viewport                                        | ^[number]  | 16       |
+| max                | the maximum number of messages that can be displayed at the same time          | ^[number]  | —       |
+| grouping ^(2.8.2)  | merge messages with the same content, type of VNode message is not supported   | ^[boolean] | —       |
+| duration ^(2.8.2)  | display duration, millisecond. If set to 0, it will not turn off automatically | ^[number]  | —       |
+| showClose ^(2.8.2) | whether to show a close button                                                 | ^[boolean] | —       |
+| offset ^(2.8.2)    | set the distance to the top of viewport                                        | ^[number]  | —       |
 
 ### Config Provider Slots
 

--- a/docs/examples/message/closable.vue
+++ b/docs/examples/message/closable.vue
@@ -3,6 +3,7 @@
   <el-button :plain="true" @click="open2">Success</el-button>
   <el-button :plain="true" @click="open3">Warning</el-button>
   <el-button :plain="true" @click="open4">Error</el-button>
+  <el-button :plain="true" @click="open5">Won't close automatically</el-button>
 </template>
 
 <script lang="ts" setup>
@@ -33,6 +34,13 @@ const open4 = () => {
     showClose: true,
     message: 'Oops, this is a error message.',
     type: 'error',
+  })
+}
+const open5 = () => {
+  ElMessage({
+    showClose: true,
+    message: 'Oops, this is a message that does not automatically close.',
+    duration: 0,
   })
 }
 </script>


### PR DESCRIPTION
1. docs(components): [config-provider] add default values
2. docs(components): [message] add a "Won't close automatically" example. Because the "duration" attribute was mentioned above, no example was provided.