### PR TITLE
fix: component [radio] disabled radio label should not be colored as placeholder

### DIFF
--- a/packages/theme-chalk/src/radio.scss
+++ b/packages/theme-chalk/src/radio.scss
@@ -114,7 +114,7 @@ $radio-font-size: map.merge(
         }
       }
       & + span.#{$namespace}-radio__label {
-        color: getCssVar('text-color', 'placeholder');
+        color: getCssVar('disabled-text-color');
         cursor: not-allowed;
       }
     }


### PR DESCRIPTION
Thank you for element plus!
when radio is disabled, the label color should be disabled instead of placeholder.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
