### PR TITLE
fix(components): [dropdown] `button-props` as a `Partial` type

### DIFF
--- a/packages/components/dropdown/src/dropdown.ts
+++ b/packages/components/dropdown/src/dropdown.ts
@@ -133,7 +133,7 @@ export const dropdownProps = buildProps({
     default: 'menu',
   },
   buttonProps: {
-    type: definePropType<ButtonProps>(Object),
+    type: definePropType<Partial<ButtonProps>>(Object),
   },
   /**
    * @description whether the dropdown popup is teleported to the body


### PR DESCRIPTION
`button-props` should be partial in this situation because it have default value from required props value's.
![image](https://github.com/user-attachments/assets/eba98b0b-aa06-44f8-a894-beb0caf2d189)

[ref discussion](https://github.com/element-plus/element-plus/discussions/19883)