### PR TITLE
fix(components): [select-v2] option need double click in IOS

### DIFF
--- a/packages/components/select-v2/src/select-dropdown.tsx
+++ b/packages/components/select-v2/src/select-dropdown.tsx
@@ -8,7 +8,7 @@ import {
   watch,
 } from 'vue'
 import { get } from 'lodash-unified'
-import { isObject, isUndefined } from '@element-plus/utils'
+import { isIOS, isObject, isUndefined } from '@element-plus/utils'
 import {
   DynamicSizeList,
   FixedSizeList,
@@ -253,6 +253,11 @@ export default defineComponent({
     return () => {
       const { data, width } = props
       const { height, multiple, scrollbarAlwaysOn } = select.props
+      const isScrollbarAlwaysOn = computed(() => {
+        // fix https://github.com/element-plus/element-plus/issues/19127
+        if (isIOS) return true
+        return scrollbarAlwaysOn
+      })
 
       const List = unref(isSized) ? FixedSizeList : DynamicSizeList
 
@@ -269,7 +274,7 @@ export default defineComponent({
               ref={listRef}
               {...unref(listProps)}
               className={ns.be('dropdown', 'list')}
-              scrollbarAlwaysOn={scrollbarAlwaysOn}
+              scrollbarAlwaysOn={isScrollbarAlwaysOn.value}
               data={data}
               height={height}
               width={width}

--- a/packages/components/select-v2/src/select-dropdown.tsx
+++ b/packages/components/select-v2/src/select-dropdown.tsx
@@ -255,8 +255,7 @@ export default defineComponent({
       const { height, multiple, scrollbarAlwaysOn } = select.props
       const isScrollbarAlwaysOn = computed(() => {
         // fix https://github.com/element-plus/element-plus/issues/19127
-        if (isIOS) return true
-        return scrollbarAlwaysOn
+        return isIOS ? true : scrollbarAlwaysOn
       })
 
       const List = unref(isSized) ? FixedSizeList : DynamicSizeList


### PR DESCRIPTION
### Description

fix: https://github.com/element-plus/element-plus/issues/19127

- I checked the source code and couldn't find a suitable solution, I think this is a temporary solution, better than clicking twice.

### In IOS

![96d725e5e6d59cd524f7d6b43e01610](https://github.com/user-attachments/assets/aa55a3aa-41df-4512-bc12-845347c2881a)
