### PR TITLE
ci: enable `publish-size-resport` action for all branch

### DIFF
--- a/.github/workflows/publish-size-report.yml
+++ b/.github/workflows/publish-size-report.yml
@@ -2,8 +2,6 @@ name: 📦 Package Size Report
 
 on:
   pull_request:
-    branches:
-      - 'master'
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
或许不需要做分支的限制，这样子的好处：
 可以关心每个 PR 带来的体积变更，如果过大的话，可以仔细审查。
![image](https://github.com/user-attachments/assets/1a429f16-3e9d-4bd0-80ce-d917951d5edb)
![image](https://github.com/user-attachments/assets/47ae9f14-4e3b-474c-a4f8-e759ee2648f0)

