### PR TITLE
chore: use event constants instead string

### DIFF
--- a/packages/components/affix/src/affix.vue
+++ b/packages/components/affix/src/affix.vue
@@ -15,6 +15,7 @@ import {
 } from '@vueuse/core'
 import { addUnit, getScrollContainer, throwError } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
+import { CHANGE_EVENT } from '@element-plus/constants'
 import { affixEmits, affixProps } from './affix'
 import type { CSSProperties } from 'vue'
 
@@ -104,7 +105,7 @@ const handleScroll = () => {
   })
 }
 
-watch(fixed, (val) => emit('change', val))
+watch(fixed, (val) => emit(CHANGE_EVENT, val))
 
 onMounted(() => {
   if (props.target) {

--- a/packages/components/anchor/__tests__/anchor.test.tsx
+++ b/packages/components/anchor/__tests__/anchor.test.tsx
@@ -1,6 +1,7 @@
 import { nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vitest'
+import { CHANGE_EVENT } from '@element-plus/constants'
 import Anchor from '../src/anchor.vue'
 import AnchorLink from '../src/anchor-link.vue'
 
@@ -107,7 +108,7 @@ describe('Anchor.vue', () => {
     ))
     wrapper.find(`a[href="${hash1}"]`).trigger('click')
     wrapper.find(`a[href="${hash2}"]`).trigger('click')
-    expect(wrapper.findComponent(Anchor).emitted('change')).toEqual([
+    expect(wrapper.findComponent(Anchor).emitted(CHANGE_EVENT)).toEqual([
       [hash1],
       [hash2],
     ])

--- a/packages/components/anchor/src/anchor.vue
+++ b/packages/components/anchor/src/anchor.vue
@@ -26,6 +26,7 @@ import {
   isWindow,
   throttleByRaf,
 } from '@element-plus/utils'
+import { CHANGE_EVENT } from '@element-plus/constants'
 import { anchorEmits, anchorProps } from './anchor'
 import { anchorKey } from './constants'
 
@@ -67,7 +68,7 @@ const setCurrentAnchor = (href: string) => {
   const activeHref = currentAnchor.value
   if (activeHref !== href) {
     currentAnchor.value = href
-    emit('change', href)
+    emit(CHANGE_EVENT, href)
   }
 }
 

--- a/packages/components/carousel/src/use-carousel.ts
+++ b/packages/components/carousel/src/use-carousel.ts
@@ -15,6 +15,7 @@ import { throttle } from 'lodash-unified'
 import { useResizeObserver } from '@vueuse/core'
 import { debugWarn, flattedChildren, isString } from '@element-plus/utils'
 import { useOrderedChildren } from '@element-plus/hooks'
+import { CHANGE_EVENT } from '@element-plus/constants'
 import { CAROUSEL_ITEM_NAME, carouselContextKey } from './constants'
 
 import type { SetupContext } from 'vue'
@@ -275,7 +276,7 @@ export const useCarousel = (
         prev = prev % 2
       }
       if (prev > -1) {
-        emit('change', current, prev)
+        emit(CHANGE_EVENT, current, prev)
       }
     }
   )

--- a/packages/components/checkbox/src/checkbox-group.vue
+++ b/packages/components/checkbox/src/checkbox-group.vue
@@ -16,7 +16,7 @@
 <script lang="ts" setup>
 import { computed, nextTick, provide, toRefs, watch } from 'vue'
 import { pick } from 'lodash-unified'
-import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
+import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { debugWarn } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { useFormItem, useFormItemInputId } from '@element-plus/components/form'
@@ -41,7 +41,7 @@ const { inputId: groupId, isLabeledByFormItem } = useFormItemInputId(props, {
 const changeEvent = async (value: CheckboxGroupValueType) => {
   emit(UPDATE_MODEL_EVENT, value)
   await nextTick()
-  emit('change', value)
+  emit(CHANGE_EVENT, value)
 }
 
 const modelValue = computed({

--- a/packages/components/checkbox/src/composables/use-checkbox-event.ts
+++ b/packages/components/checkbox/src/composables/use-checkbox-event.ts
@@ -1,6 +1,7 @@
 import { computed, getCurrentInstance, inject, nextTick, watch } from 'vue'
 import { useFormItem } from '@element-plus/components/form'
 import { debugWarn } from '@element-plus/utils'
+import { CHANGE_EVENT } from '@element-plus/constants'
 import { checkboxGroupContextKey } from '../constants'
 
 import type { useFormItemInputId } from '@element-plus/components/form'
@@ -38,14 +39,14 @@ export const useCheckboxEvent = (
     checked: string | number | boolean,
     e: InputEvent | MouseEvent
   ) {
-    emit('change', getLabeledValue(checked), e)
+    emit(CHANGE_EVENT, getLabeledValue(checked), e)
   }
 
   function handleChange(e: Event) {
     if (isLimitExceeded.value) return
 
     const target = e.target as HTMLInputElement
-    emit('change', getLabeledValue(target.checked), e)
+    emit(CHANGE_EVENT, getLabeledValue(target.checked), e)
   }
 
   async function onClickRoot(e: MouseEvent) {

--- a/packages/components/color-picker/src/color-picker.vue
+++ b/packages/components/color-picker/src/color-picker.vue
@@ -136,7 +136,11 @@ import {
   useLocale,
   useNamespace,
 } from '@element-plus/hooks'
-import { EVENT_CODE, UPDATE_MODEL_EVENT } from '@element-plus/constants'
+import {
+  CHANGE_EVENT,
+  EVENT_CODE,
+  UPDATE_MODEL_EVENT,
+} from '@element-plus/constants'
 import { debugWarn } from '@element-plus/utils'
 import { ArrowDown, Close } from '@element-plus/icons-vue'
 import AlphaSlider from './components/alpha-slider.vue'
@@ -286,7 +290,7 @@ function handleConfirm() {
 function confirmValue() {
   const value = color.value
   emit(UPDATE_MODEL_EVENT, value)
-  emit('change', value)
+  emit(CHANGE_EVENT, value)
   if (props.validateEvent) {
     formItem?.validate('change').catch((err) => debugWarn(err))
   }
@@ -307,7 +311,7 @@ function confirmValue() {
 function clear() {
   debounceSetShowPicker(false)
   emit(UPDATE_MODEL_EVENT, null)
-  emit('change', null)
+  emit(CHANGE_EVENT, null)
   if (props.modelValue !== null && props.validateEvent) {
     formItem?.validate('change').catch((err) => debugWarn(err))
   }

--- a/packages/components/countdown/src/countdown.vue
+++ b/packages/components/countdown/src/countdown.vue
@@ -17,6 +17,7 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { ElStatistic } from '@element-plus/components/statistic'
 import { cAF, rAF } from '@element-plus/utils'
+import { CHANGE_EVENT } from '@element-plus/constants'
 import { countdownEmits, countdownProps } from './countdown'
 import { formatTime, getTime } from './utils'
 
@@ -44,7 +45,7 @@ const startTimer = () => {
   const timestamp = getTime(props.value)
   const frameFunc = () => {
     let diff = timestamp - Date.now()
-    emit('change', diff)
+    emit(CHANGE_EVENT, diff)
     if (diff <= 0) {
       diff = 0
       stopTimer()

--- a/packages/components/date-picker/src/date-picker.tsx
+++ b/packages/components/date-picker/src/date-picker.tsx
@@ -16,6 +16,7 @@ import {
   type DateModelType,
   type SingleOrRange,
 } from '@element-plus/components/time-picker'
+import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { ROOT_PICKER_INJECTION_KEY } from './constants'
 
 import { datePickerProps } from './props/date-picker'
@@ -35,7 +36,7 @@ export default defineComponent({
   name: 'ElDatePicker',
   install: null,
   props: datePickerProps,
-  emits: ['update:modelValue'],
+  emits: [UPDATE_MODEL_EVENT],
   setup(props, { expose, emit, slots }) {
     const ns = useNamespace('picker-panel')
 
@@ -64,7 +65,7 @@ export default defineComponent({
     expose(refProps)
 
     const onModelValueUpdated = (val: SingleOrRange<DateModelType> | null) => {
-      emit('update:modelValue', val)
+      emit(UPDATE_MODEL_EVENT, val)
     }
 
     return () => {

--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, test, vi } from 'vitest'
 import { ArrowDown, ArrowUp } from '@element-plus/icons-vue'
 import { ElFormItem } from '@element-plus/components/form'
 import { ElIcon } from '@element-plus/components/icon'
+import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import InputNumber from '../src/input-number.vue'
 
 const mouseup = new Event('mouseup')
@@ -316,7 +317,7 @@ describe('InputNumber.vue', () => {
       1, 0,
     ])
     expect(
-      wrapper.getComponent(InputNumber).emitted('update:modelValue')
+      wrapper.getComponent(InputNumber).emitted(UPDATE_MODEL_EVENT)
     ).toHaveLength(1)
     wrapper.find('.el-input-number__increase').trigger('mousedown')
     document.dispatchEvent(mouseup)
@@ -326,7 +327,7 @@ describe('InputNumber.vue', () => {
       2, 1,
     ])
     expect(
-      wrapper.getComponent(InputNumber).emitted('update:modelValue')
+      wrapper.getComponent(InputNumber).emitted(UPDATE_MODEL_EVENT)
     ).toHaveLength(2)
     await wrapper.find('input').setValue(0)
     expect(wrapper.getComponent(InputNumber).emitted('change')).toHaveLength(3)
@@ -334,7 +335,7 @@ describe('InputNumber.vue', () => {
       0, 2,
     ])
     expect(
-      wrapper.getComponent(InputNumber).emitted('update:modelValue')
+      wrapper.getComponent(InputNumber).emitted(UPDATE_MODEL_EVENT)
     ).toHaveLength(4)
     await wrapper.find('input').setValue('')
     expect(wrapper.getComponent(InputNumber).emitted('change')).toHaveLength(4)

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -186,7 +186,11 @@ import {
   useFocusController,
   useNamespace,
 } from '@element-plus/hooks'
-import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
+import {
+  CHANGE_EVENT,
+  INPUT_EVENT,
+  UPDATE_MODEL_EVENT,
+} from '@element-plus/constants'
 import { calcTextareaHeight } from './utils'
 import { inputEmits, inputProps } from './input'
 import type { StyleValue } from 'vue'
@@ -407,7 +411,7 @@ const handleInput = async (event: Event) => {
   }
 
   emit(UPDATE_MODEL_EVENT, value)
-  emit('input', value)
+  emit(INPUT_EVENT, value)
 
   // ensure native input value is controlled
   // see: https://github.com/ElemeFE/element/issues/12850
@@ -422,7 +426,7 @@ const handleChange = (event: Event) => {
   if (props.formatter && props.parser) {
     value = props.parser(value)
   }
-  emit('change', value)
+  emit(CHANGE_EVENT, value)
 }
 
 const {
@@ -463,9 +467,9 @@ const select = () => {
 
 const clear = () => {
   emit(UPDATE_MODEL_EVENT, '')
-  emit('change', '')
+  emit(CHANGE_EVENT, '')
   emit('clear')
-  emit('input', '')
+  emit(INPUT_EVENT, '')
 }
 
 watch(

--- a/packages/components/mention/src/mention.vue
+++ b/packages/components/mention/src/mention.vue
@@ -121,7 +121,7 @@ const hoveringId = computed(() => {
 })
 
 const handleInputChange = (value: string) => {
-  emit('update:modelValue', value)
+  emit(UPDATE_MODEL_EVENT, value)
   syncAfterCursorMove()
 }
 

--- a/packages/components/pagination/src/components/pager.vue
+++ b/packages/components/pagination/src/components/pager.vue
@@ -73,12 +73,13 @@
 import { computed, ref, watchEffect } from 'vue'
 import { DArrowLeft, DArrowRight, MoreFilled } from '@element-plus/icons-vue'
 import { useLocale, useNamespace } from '@element-plus/hooks'
+import { CHANGE_EVENT } from '@element-plus/constants'
 import { paginationPagerProps } from './pager'
 defineOptions({
   name: 'ElPaginationPager',
 })
 const props = defineProps(paginationPagerProps)
-const emit = defineEmits(['change'])
+const emit = defineEmits([CHANGE_EVENT])
 const nsPager = useNamespace('pager')
 const nsIcon = useNamespace('icon')
 const { t } = useLocale()
@@ -177,7 +178,7 @@ function onEnter(e: UIEvent) {
   ) {
     const newPage = Number(target.textContent)
     if (newPage !== props.currentPage) {
-      emit('change', newPage)
+      emit(CHANGE_EVENT, newPage)
     }
   } else if (
     target.tagName.toLowerCase() === 'li' &&
@@ -211,7 +212,7 @@ function onPagerClick(event: UIEvent) {
     }
   }
   if (newPage !== currentPage) {
-    emit('change', newPage)
+    emit(CHANGE_EVENT, newPage)
   }
 }
 </script>

--- a/packages/components/pagination/src/pagination.ts
+++ b/packages/components/pagination/src/pagination.ts
@@ -23,6 +23,7 @@ import {
   useNamespace,
   useSizeProp,
 } from '@element-plus/hooks'
+import { CHANGE_EVENT } from '@element-plus/constants'
 import { elPaginationKey } from './constants'
 
 import Prev from './components/prev.vue'
@@ -318,7 +319,7 @@ export default defineComponent({
     watch(
       [currentPageBridge, pageSizeBridge],
       (value) => {
-        emit('change', ...value)
+        emit(CHANGE_EVENT, ...value)
       },
       { flush: 'post' }
     )

--- a/packages/components/radio/src/radio-group.vue
+++ b/packages/components/radio/src/radio-group.vue
@@ -23,7 +23,7 @@ import {
   watch,
 } from 'vue'
 import { useFormItem, useFormItemInputId } from '@element-plus/components/form'
-import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
+import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { useId, useNamespace } from '@element-plus/hooks'
 import { debugWarn } from '@element-plus/utils'
 import { radioGroupEmits, radioGroupProps } from './radio-group'
@@ -48,7 +48,7 @@ const { inputId: groupId, isLabeledByFormItem } = useFormItemInputId(props, {
 
 const changeEvent = (value: RadioGroupProps['modelValue']) => {
   emit(UPDATE_MODEL_EVENT, value)
-  nextTick(() => emit('change', value))
+  nextTick(() => emit(CHANGE_EVENT, value))
 }
 
 onMounted(() => {

--- a/packages/components/radio/src/radio.vue
+++ b/packages/components/radio/src/radio.vue
@@ -43,6 +43,7 @@
 <script lang="ts" setup>
 import { nextTick } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
+import { CHANGE_EVENT } from '@element-plus/constants'
 import { radioEmits, radioProps } from './radio'
 import { useRadio } from './use-radio'
 
@@ -58,6 +59,6 @@ const { radioRef, radioGroup, focus, size, disabled, modelValue, actualValue } =
   useRadio(props, emit)
 
 function handleChange() {
-  nextTick(() => emit('change', modelValue.value))
+  nextTick(() => emit(CHANGE_EVENT, modelValue.value))
 }
 </script>

--- a/packages/components/rate/src/rate.vue
+++ b/packages/components/rate/src/rate.vue
@@ -57,7 +57,11 @@
 
 <script lang="ts" setup>
 import { computed, inject, markRaw, ref, watch } from 'vue'
-import { EVENT_CODE, UPDATE_MODEL_EVENT } from '@element-plus/constants'
+import {
+  CHANGE_EVENT,
+  EVENT_CODE,
+  UPDATE_MODEL_EVENT,
+} from '@element-plus/constants'
 import { hasClass, isArray, isObject, isString } from '@element-plus/utils'
 import {
   formContextKey,
@@ -214,7 +218,7 @@ function emitValue(value: number) {
 
   emit(UPDATE_MODEL_EVENT, value)
   if (props.modelValue !== value) {
-    emit('change', value)
+    emit(CHANGE_EVENT, value)
   }
 }
 
@@ -255,7 +259,7 @@ function handleKey(e: KeyboardEvent) {
   _currentValue = _currentValue < 0 ? 0 : _currentValue
   _currentValue = _currentValue > props.max ? props.max : _currentValue
   emit(UPDATE_MODEL_EVENT, _currentValue)
-  emit('change', _currentValue)
+  emit(CHANGE_EVENT, _currentValue)
   return _currentValue
 }
 

--- a/packages/components/switch/__tests__/switch.test.tsx
+++ b/packages/components/switch/__tests__/switch.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 import { debugWarn } from '@element-plus/utils'
 import { Checked, CircleClose, Hide, View } from '@element-plus/icons-vue'
 import { ElFormItem } from '@element-plus/components/form'
+import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import Switch from '../src/switch.vue'
 import type { VueWrapper } from '@vue/test-utils'
 import type { SwitchInstance } from '../src/switch'
@@ -97,7 +98,7 @@ describe('Switch.vue', () => {
     const coreWrapper = wrapper.find('.el-switch__core')
     await coreWrapper.trigger('click')
     const switchWrapper = wrapper.findComponent(Switch)
-    expect(switchWrapper.emitted()['update:modelValue']).toBeTruthy()
+    expect(switchWrapper.emitted()[UPDATE_MODEL_EVENT]).toBeTruthy()
     expect(target.value).toEqual(false)
   })
 

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -179,7 +179,7 @@ import ElInput from '@element-plus/components/input'
 import ElIcon from '@element-plus/components/icon'
 import ElTooltip from '@element-plus/components/tooltip'
 import { NOOP, debugWarn, isArray } from '@element-plus/utils'
-import { EVENT_CODE } from '@element-plus/constants'
+import { EVENT_CODE, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { Calendar, Clock } from '@element-plus/icons-vue'
 import { dayOrDaysToDate, formatter, parseDate, valueEquals } from '../utils'
 import { timePickerDefaultProps } from './props'
@@ -205,7 +205,7 @@ defineOptions({
 
 const props = defineProps(timePickerDefaultProps)
 const emit = defineEmits([
-  'update:modelValue',
+  UPDATE_MODEL_EVENT,
   'change',
   'focus',
   'blur',
@@ -309,7 +309,7 @@ const emitInput = (input: SingleOrRange<DateModelType> | null) => {
     } else if (input) {
       formatted = formatter(input, props.valueFormat, lang.value)
     }
-    emit('update:modelValue', input ? formatted : input, lang.value)
+    emit(UPDATE_MODEL_EVENT, input ? formatted : input, lang.value)
   }
 }
 const emitKeydown = (e: KeyboardEvent) => {

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -179,7 +179,11 @@ import ElInput from '@element-plus/components/input'
 import ElIcon from '@element-plus/components/icon'
 import ElTooltip from '@element-plus/components/tooltip'
 import { NOOP, debugWarn, isArray } from '@element-plus/utils'
-import { EVENT_CODE, UPDATE_MODEL_EVENT } from '@element-plus/constants'
+import {
+  CHANGE_EVENT,
+  EVENT_CODE,
+  UPDATE_MODEL_EVENT,
+} from '@element-plus/constants'
 import { Calendar, Clock } from '@element-plus/icons-vue'
 import { dayOrDaysToDate, formatter, parseDate, valueEquals } from '../utils'
 import { timePickerDefaultProps } from './props'
@@ -206,7 +210,7 @@ defineOptions({
 const props = defineProps(timePickerDefaultProps)
 const emit = defineEmits([
   UPDATE_MODEL_EVENT,
-  'change',
+  CHANGE_EVENT,
   'focus',
   'blur',
   'clear',
@@ -292,7 +296,7 @@ const emitChange = (
 ) => {
   // determine user real change only
   if (isClear || !valueEquals(val, valueOnOpen.value)) {
-    emit('change', val)
+    emit(CHANGE_EVENT, val)
     // Set the value of valueOnOpen when clearing to avoid triggering change events multiple times.
     isClear && (valueOnOpen.value = val)
     props.validateEvent &&

--- a/packages/components/time-picker/src/time-picker-com/basic-time-spinner.vue
+++ b/packages/components/time-picker/src/time-picker-com/basic-time-spinner.vue
@@ -87,6 +87,7 @@ import ElIcon from '@element-plus/components/icon'
 import { ArrowDown, ArrowUp } from '@element-plus/icons-vue'
 import { useNamespace } from '@element-plus/hooks'
 import { getStyle, isNumber } from '@element-plus/utils'
+import { CHANGE_EVENT } from '@element-plus/constants'
 import { timeUnits } from '../constants'
 import { buildTimeList } from '../utils'
 import { basicTimeSpinnerProps } from '../props/basic-time-spinner'
@@ -100,7 +101,7 @@ import type { TimeList } from '../utils'
 const props = defineProps(basicTimeSpinnerProps)
 const pickerBase = inject('EP_PICKER_BASE') as any
 const { isRange } = pickerBase.props
-const emit = defineEmits(['change', 'select-range', 'set-option'])
+const emit = defineEmits([CHANGE_EVENT, 'select-range', 'set-option'])
 
 const ns = useNamespace('time')
 
@@ -281,7 +282,7 @@ const modifyDateField = (type: TimeUnit, value: number) => {
       changeTo = props.spinnerDate.hour(hours).minute(minutes).second(value)
       break
   }
-  emit('change', changeTo)
+  emit(CHANGE_EVENT, changeTo)
 }
 
 const handleClick = (

--- a/packages/components/time-picker/src/time-picker.tsx
+++ b/packages/components/time-picker/src/time-picker.tsx
@@ -1,6 +1,7 @@
 import { defineComponent, provide, ref } from 'vue'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat.js'
+import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { DEFAULT_FORMATS_TIME } from './constants'
 import Picker from './common/picker.vue'
 import TimePickPanel from './time-picker-com/panel-time-pick.vue'
@@ -21,14 +22,14 @@ export default defineComponent({
       default: false,
     },
   },
-  emits: ['update:modelValue'],
+  emits: [UPDATE_MODEL_EVENT],
   setup(props, ctx) {
     const commonPicker = ref<InstanceType<typeof Picker>>()
     const [type, Panel] = props.isRange
       ? ['timerange', TimeRangePanel]
       : ['time', TimePickPanel]
 
-    const modelUpdater = (value: any) => ctx.emit('update:modelValue', value)
+    const modelUpdater = (value: any) => ctx.emit(UPDATE_MODEL_EVENT, value)
     provide('ElPopperOptions', props.popperOptions)
     ctx.expose({
       /**

--- a/packages/components/tour/src/tour.vue
+++ b/packages/components/tour/src/tour.vue
@@ -35,6 +35,7 @@ import { useVModel } from '@vueuse/core'
 import { useNamespace, useZIndex } from '@element-plus/hooks'
 import { isBoolean } from '@element-plus/utils'
 import ElTeleport from '@element-plus/components/teleport'
+import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import ElTourMask from './mask.vue'
 import ElTourContent from './content.vue'
 import ElTourSteps from './steps'
@@ -111,7 +112,7 @@ watch(
 
 const onEscClose = () => {
   if (props.closeOnPressEscape) {
-    emit('update:modelValue', false)
+    emit(UPDATE_MODEL_EVENT, false)
     emit('close', current.value)
   }
 }
@@ -132,7 +133,7 @@ provide(tourKey, {
   ns,
   slots,
   updateModelValue(modelValue) {
-    emit('update:modelValue', modelValue)
+    emit(UPDATE_MODEL_EVENT, modelValue)
   },
   onClose() {
     emit('close', current.value)

--- a/packages/components/tour/src/tour.vue
+++ b/packages/components/tour/src/tour.vue
@@ -35,7 +35,7 @@ import { useVModel } from '@vueuse/core'
 import { useNamespace, useZIndex } from '@element-plus/hooks'
 import { isBoolean } from '@element-plus/utils'
 import ElTeleport from '@element-plus/components/teleport'
-import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
+import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import ElTourMask from './mask.vue'
 import ElTourContent from './content.vue'
 import ElTourSteps from './steps'
@@ -142,7 +142,7 @@ provide(tourKey, {
     emit('finish')
   },
   onChange() {
-    emit('change', current.value)
+    emit(CHANGE_EVENT, current.value)
   },
 })
 </script>


### PR DESCRIPTION
避免硬编码字符串：使用常量可以避免在代码中多次硬编码相同的字符串，减少了拼写错误的风险。

易于维护：如果事件名称需要更改，只需修改常量的值，而不需要在代码中查找和替换所有出现的字符串。

提高可读性：常量名称通常能更清晰地表达其含义，增加代码的可读性。

一致性：使用常量可以确保在整个代码库中使用一致的事件名称。

还能减小体积。
![image](https://github.com/user-attachments/assets/a45b6d92-350b-4002-a414-a22ca0fed172)
