### PR TITLE
fix(components): [affix] scroll event value sync

### DIFF
--- a/packages/components/affix/src/affix.vue
+++ b/packages/components/affix/src/affix.vue
@@ -7,7 +7,15 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref, shallowRef, watch, watchEffect, nextTick } from 'vue'
+import {
+  computed,
+  nextTick,
+  onMounted,
+  ref,
+  shallowRef,
+  watch,
+  watchEffect,
+} from 'vue'
 import {
   useElementBounding,
   useEventListener,
@@ -131,3 +139,4 @@ defineExpose({
   updateRoot,
 })
 </script>
+playground

--- a/packages/components/affix/src/affix.vue
+++ b/packages/components/affix/src/affix.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref, shallowRef, watch, watchEffect } from 'vue'
+import { computed, onMounted, ref, shallowRef, watch, watchEffect, nextTick } from 'vue'
 import {
   useElementBounding,
   useEventListener,
@@ -97,8 +97,9 @@ const update = () => {
   }
 }
 
-const handleScroll = () => {
+const handleScroll = async () => {
   updateRoot()
+  await nextTick()
   emit('scroll', {
     scrollTop: scrollTop.value,
     fixed: fixed.value,

--- a/packages/components/affix/src/affix.vue
+++ b/packages/components/affix/src/affix.vue
@@ -139,4 +139,3 @@ defineExpose({
   updateRoot,
 })
 </script>
-playground


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
affix handleScroll 事件在执行的时候会调用 updateRoot方法触发 watchEffect(update)，watchEffect更新是异步的，这时候handleScroll方法获取到的 scrollTop.value 不是最新的，需要等待watchEffect执行完再进行emit scroll 事件
