### PR TITLE
docs: add placement demo for popover/popconfirm

### DIFF
--- a/docs/en-US/component/popconfirm.md
+++ b/docs/en-US/component/popconfirm.md
@@ -7,6 +7,16 @@ lang: en-US
 
 A simple confirmation dialog of an element click action.
 
+## Placement
+
+popconfirm has 9 placements.
+
+:::demo Use attribute `content` to set the display content when hover. The attribute `placement` determines the position of the popconfirm. Its value is `[orientation]-[alignment]` with four orientations `top`, `left`, `right`, `bottom` and three alignments `start`, `end`, `null`, and the default alignment is null. Take `placement="left-end"` for example, popconfirm will display on the left of the element which you are hovering and the bottom of the popconfirm aligns with the bottom of the element.
+
+popconfirm/placement
+
+:::
+
 ## Basic usage
 
 Popconfirm is similar to Popover. So for some duplicated attributes, please refer to the documentation of Popover.

--- a/docs/en-US/component/popconfirm.md
+++ b/docs/en-US/component/popconfirm.md
@@ -11,7 +11,7 @@ A simple confirmation dialog of an element click action.
 
 popconfirm has 9 placements.
 
-:::demo Use attribute `content` to set the display content when click the reference element. The attribute `placement` determines the position of the popconfirm. Its value is `[orientation]-[alignment]` with four orientations `top`, `left`, `right`, `bottom` and three alignments `start`, `end`, `null`, and the default alignment is null. Take `placement="left-end"` for example, popconfirm will display on the left of the element which you are hovering and the bottom of the popconfirm aligns with the bottom of the element.
+:::demo Use attribute `title` to set the display content when click the reference element. The attribute `placement` determines the position of the popconfirm. Its value is `[orientation]-[alignment]` with four orientations `top`, `left`, `right`, `bottom` and three alignments `start`, `end`, `null`, and the default alignment is null. Take `placement="left-end"` for example, popconfirm will display on the left of the element which you are hovering and the bottom of the popconfirm aligns with the bottom of the element.
 
 popconfirm/placement
 

--- a/docs/en-US/component/popconfirm.md
+++ b/docs/en-US/component/popconfirm.md
@@ -11,7 +11,7 @@ A simple confirmation dialog of an element click action.
 
 popconfirm has 9 placements.
 
-:::demo Use attribute `content` to set the display content when hover. The attribute `placement` determines the position of the popconfirm. Its value is `[orientation]-[alignment]` with four orientations `top`, `left`, `right`, `bottom` and three alignments `start`, `end`, `null`, and the default alignment is null. Take `placement="left-end"` for example, popconfirm will display on the left of the element which you are hovering and the bottom of the popconfirm aligns with the bottom of the element.
+:::demo Use attribute `content` to set the display content when click the reference element. The attribute `placement` determines the position of the popconfirm. Its value is `[orientation]-[alignment]` with four orientations `top`, `left`, `right`, `bottom` and three alignments `start`, `end`, `null`, and the default alignment is null. Take `placement="left-end"` for example, popconfirm will display on the left of the element which you are hovering and the bottom of the popconfirm aligns with the bottom of the element.
 
 popconfirm/placement
 

--- a/docs/en-US/component/popover.md
+++ b/docs/en-US/component/popover.md
@@ -5,6 +5,16 @@ lang: en-US
 
 # Popover
 
+## Placement
+
+Popover has 9 placements.
+
+:::demo Use attribute `content` to set the display content when hover. The attribute `placement` determines the position of the Popover. Its value is `[orientation]-[alignment]` with four orientations `top`, `left`, `right`, `bottom` and three alignments `start`, `end`, `null`, and the default alignment is null. Take `placement="left-end"` for example, Popover will display on the left of the element which you are hovering and the bottom of the Popover aligns with the bottom of the element.
+
+popover/placement
+
+:::
+
 ## Basic usage
 
 Popover is built with `ElTooltip`. So for some duplicated attributes, please refer to the documentation of Tooltip.

--- a/docs/examples/popconfirm/placement.vue
+++ b/docs/examples/popconfirm/placement.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="popover-base-box">
+    <div class="row center">
+      <el-popconfirm
+        class="box-item"
+        title="Top Left prompts info"
+        placement="top-start"
+      >
+        <template #reference>
+          <el-button>top-start</el-button>
+        </template>
+      </el-popconfirm>
+      <el-popconfirm
+        class="box-item"
+        title="Top Center prompts info"
+        placement="top"
+      >
+        <template #reference>
+          <el-button>top</el-button>
+        </template>
+      </el-popconfirm>
+      <el-popconfirm
+        class="box-item"
+        title="Top Right prompts info"
+        placement="top-end"
+      >
+        <template #reference>
+          <el-button>top-end</el-button>
+        </template>
+      </el-popconfirm>
+    </div>
+    <div class="row">
+      <el-popconfirm
+        class="box-item"
+        title="Left Top prompts info"
+        placement="left-start"
+      >
+        <template #reference>
+          <el-button>left-start</el-button>
+        </template>
+      </el-popconfirm>
+      <el-popconfirm
+        class="box-item"
+        title="Right Top prompts info"
+        placement="right-start"
+      >
+        <template #reference>
+          <el-button>right-start</el-button>
+        </template>
+      </el-popconfirm>
+    </div>
+    <div class="row">
+      <el-popconfirm
+        class="box-item"
+        title="Left Center prompts info"
+        placement="left"
+      >
+        <template #reference>
+          <el-button class="mt-3 mb-3">left</el-button>
+        </template>
+      </el-popconfirm>
+      <el-popconfirm
+        class="box-item"
+        title="Right Center prompts info"
+        placement="right"
+      >
+        <template #reference>
+          <el-button>right</el-button>
+        </template>
+      </el-popconfirm>
+    </div>
+    <div class="row">
+      <el-popconfirm
+        class="box-item"
+        title="Left Bottom prompts info"
+        placement="left-end"
+      >
+        <template #reference>
+          <el-button>left-end</el-button>
+        </template>
+      </el-popconfirm>
+      <el-popconfirm
+        class="box-item"
+        title="Right Bottom prompts info"
+        placement="right-end"
+      >
+        <template #reference>
+          <el-button>right-end</el-button>
+        </template>
+      </el-popconfirm>
+    </div>
+    <div class="row center">
+      <el-popconfirm
+        class="box-item"
+        title="Bottom Left prompts info"
+        placement="bottom-start"
+      >
+        <template #reference> <el-button>bottom-start</el-button></template>
+      </el-popconfirm>
+      <el-popconfirm
+        class="box-item"
+        title="Bottom Center prompts info"
+        placement="bottom"
+      >
+        <template #reference> <el-button>bottom</el-button></template>
+      </el-popconfirm>
+      <el-popconfirm
+        class="box-item"
+        title="Bottom Right prompts info"
+        placement="bottom-end"
+      >
+        <template #reference>
+          <el-button>bottom-end</el-button>
+        </template>
+      </el-popconfirm>
+    </div>
+  </div>
+</template>
+
+<style>
+.popover-base-box {
+  width: 600px;
+}
+
+.popover-base-box .row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.popover-base-box .center {
+  justify-content: center;
+}
+
+.popover-base-box .box-item {
+  width: 110px;
+  margin-top: 10px;
+}
+</style>

--- a/docs/examples/popconfirm/placement.vue
+++ b/docs/examples/popconfirm/placement.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popover-base-box">
+  <div class="popconfirm-base-box">
     <div class="row center">
       <el-popconfirm
         class="box-item"
@@ -118,21 +118,21 @@
 </template>
 
 <style>
-.popover-base-box {
+.popconfirm-base-box {
   width: 600px;
 }
 
-.popover-base-box .row {
+.popconfirm-base-box .row {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-.popover-base-box .center {
+.popconfirm-base-box .center {
   justify-content: center;
 }
 
-.popover-base-box .box-item {
+.popconfirm-base-box .box-item {
   width: 110px;
   margin-top: 10px;
 }

--- a/docs/examples/popover/placement.vue
+++ b/docs/examples/popover/placement.vue
@@ -1,0 +1,151 @@
+<template>
+  <div class="popover-base-box">
+    <div class="row center">
+      <el-popover
+        class="box-item"
+        title="Title"
+        content="Top Left prompts info"
+        placement="top-start"
+      >
+        <template #reference>
+          <el-button>top-start</el-button>
+        </template>
+      </el-popover>
+      <el-popover
+        class="box-item"
+        title="Title"
+        content="Top Center prompts info"
+        placement="top"
+      >
+        <template #reference>
+          <el-button>top</el-button>
+        </template>
+      </el-popover>
+      <el-popover
+        class="box-item"
+        title="Title"
+        content="Top Right prompts info"
+        placement="top-end"
+      >
+        <template #reference>
+          <el-button>top-end</el-button>
+        </template>
+      </el-popover>
+    </div>
+    <div class="row">
+      <el-popover
+        class="box-item"
+        title="Title"
+        content="Left Top prompts info"
+        placement="left-start"
+      >
+        <template #reference>
+          <el-button>left-start</el-button>
+        </template>
+      </el-popover>
+      <el-popover
+        class="box-item"
+        title="Title"
+        content="Right Top prompts info"
+        placement="right-start"
+      >
+        <template #reference>
+          <el-button>right-start</el-button>
+        </template>
+      </el-popover>
+    </div>
+    <div class="row">
+      <el-popover
+        class="box-item"
+        title="Title"
+        content="Left Center prompts info"
+        placement="left"
+      >
+        <template #reference>
+          <el-button class="mt-3 mb-3">left</el-button>
+        </template>
+      </el-popover>
+      <el-popover
+        class="box-item"
+        title="Title"
+        content="Right Center prompts info"
+        placement="right"
+      >
+        <template #reference>
+          <el-button>right</el-button>
+        </template>
+      </el-popover>
+    </div>
+    <div class="row">
+      <el-popover
+        class="box-item"
+        title="Title"
+        content="Left Bottom prompts info"
+        placement="left-end"
+      >
+        <template #reference>
+          <el-button>left-end</el-button>
+        </template>
+      </el-popover>
+      <el-popover
+        class="box-item"
+        title="Title"
+        content="Right Bottom prompts info"
+        placement="right-end"
+      >
+        <template #reference>
+          <el-button>right-end</el-button>
+        </template>
+      </el-popover>
+    </div>
+    <div class="row center">
+      <el-popover
+        class="box-item"
+        title="Title"
+        content="Bottom Left prompts info"
+        placement="bottom-start"
+      >
+        <template #reference> <el-button>bottom-start</el-button></template>
+      </el-popover>
+      <el-popover
+        class="box-item"
+        title="Title"
+        content="Bottom Center prompts info"
+        placement="bottom"
+      >
+        <template #reference> <el-button>bottom</el-button></template>
+      </el-popover>
+      <el-popover
+        class="box-item"
+        title="Title"
+        content="Bottom Right prompts info"
+        placement="bottom-end"
+      >
+        <template #reference>
+          <el-button>bottom-end</el-button>
+        </template>
+      </el-popover>
+    </div>
+  </div>
+</template>
+
+<style>
+.popover-base-box {
+  width: 600px;
+}
+
+.popover-base-box .row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.popover-base-box .center {
+  justify-content: center;
+}
+
+.popover-base-box .box-item {
+  width: 110px;
+  margin-top: 10px;
+}
+</style>


### PR DESCRIPTION
增加 popover popconfirm 的 placement demo

方便呈现 placement 不同位置的效果，利于功能的展示 和 debug 调试。

![image](https://github.com/user-attachments/assets/8083f1e2-e9b0-42aa-8d3f-feb3aeb02105)
![image](https://github.com/user-attachments/assets/f0892ad7-3b65-4572-a9f8-a04ae403d44c)
