### PR TITLE
fix(components): [tree] When highlight-current is added, hover background color isn't removed by clicking expand button

### DIFF
--- a/packages/components/tree/src/tree-node.vue
+++ b/packages/components/tree/src/tree-node.vue
@@ -38,7 +38,7 @@
             expanded: !node.isLeaf && expanded,
           },
         ]"
-        @click.stop="handleExpandIconClick"
+        @click.stop="handleExpandIconClick(true)"
       >
         <component :is="tree.props.icon || CaretRight" />
       </el-icon>
@@ -72,6 +72,7 @@
           :render-content="renderContent"
           :render-after-expand="renderAfterExpand"
           :show-checkbox="showCheckbox"
+          :highlight-current="highlightCurrent"
           :node="child"
           :accordion="accordion"
           :props="props"
@@ -130,6 +131,10 @@ export default defineComponent({
     renderContent: Function,
     renderAfterExpand: Boolean,
     showCheckbox: {
+      type: Boolean,
+      default: false,
+    },
+    highlightCurrent: {
       type: Boolean,
       default: false,
     },
@@ -272,8 +277,11 @@ export default defineComponent({
       )
     }
 
-    const handleExpandIconClick = () => {
+    const handleExpandIconClick = (isOnlyHandleIcon = false) => {
       if (props.node.isLeaf) return
+      if (isOnlyHandleIcon && props.highlightCurrent) {
+        node$.value?.blur?.()
+      }
       if (expanded.value) {
         tree.ctx.emit('node-collapse', props.node.data, props.node, instance)
         props.node.collapse()

--- a/packages/components/tree/src/tree.vue
+++ b/packages/components/tree/src/tree.vue
@@ -19,6 +19,7 @@
       :render-after-expand="renderAfterExpand"
       :show-checkbox="showCheckbox"
       :render-content="renderContent"
+      :highlight-current="highlightCurrent"
       @node-expand="handleNodeExpand"
     />
     <div v-if="isEmpty" :class="ns.e('empty-block')">


### PR DESCRIPTION
fix #19976

Select Level one 2, then only click the expand button for Level two 2-2

before:
![image](https://github.com/user-attachments/assets/df29a6f4-fe4b-4eec-b5d5-1c8a12b8029e)

after:
![image](https://github.com/user-attachments/assets/b0bee420-1a0c-4c07-8ecf-7873e5f88bce)
