### PR TITLE
docs: optimize example import

### DIFF
--- a/docs/examples/checkbox/intermediate.vue
+++ b/docs/examples/checkbox/intermediate.vue
@@ -18,7 +18,6 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-
 import type { CheckboxValueType } from 'element-plus'
 
 const checkAll = ref(false)

--- a/docs/examples/dialog/customization-header.vue
+++ b/docs/examples/dialog/customization-header.vue
@@ -19,7 +19,6 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-import { ElButton, ElDialog } from 'element-plus'
 import { CircleCloseFilled } from '@element-plus/icons-vue'
 
 const visible = ref(false)

--- a/docs/examples/drawer/customization-content.vue
+++ b/docs/examples/drawer/customization-content.vue
@@ -52,7 +52,7 @@
 
 <script lang="ts" setup>
 import { reactive, ref } from 'vue'
-import { ElDrawer, ElMessageBox } from 'element-plus'
+import { ElMessageBox } from 'element-plus'
 
 const formLabelWidth = '80px'
 let timer

--- a/docs/examples/drawer/customization-header.vue
+++ b/docs/examples/drawer/customization-header.vue
@@ -16,7 +16,6 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-import { ElButton, ElDrawer } from 'element-plus'
 import { CircleCloseFilled } from '@element-plus/icons-vue'
 
 const visible = ref(false)

--- a/docs/examples/pagination/more-elements.vue
+++ b/docs/examples/pagination/more-elements.vue
@@ -80,6 +80,7 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 import type { ComponentSize } from 'element-plus'
+
 const currentPage1 = ref(5)
 const currentPage2 = ref(5)
 const currentPage3 = ref(5)

--- a/docs/examples/scrollbar/manual-scroll.vue
+++ b/docs/examples/scrollbar/manual-scroll.vue
@@ -17,8 +17,8 @@
 
 <script lang="ts" setup>
 import { onMounted, ref } from 'vue'
-
 import type { ScrollbarInstance } from 'element-plus'
+
 type Arrayable<T> = T | T[]
 
 const max = ref(0)

--- a/docs/examples/select-v2/custom-header.vue
+++ b/docs/examples/select-v2/custom-header.vue
@@ -24,7 +24,6 @@
 
 <script lang="ts" setup>
 import { ref, watch } from 'vue'
-
 import type { CheckboxValueType } from 'element-plus'
 
 const initials = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']

--- a/docs/examples/select/custom-footer.vue
+++ b/docs/examples/select/custom-footer.vue
@@ -28,7 +28,6 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-
 import type { CheckboxValueType } from 'element-plus'
 
 const isAdding = ref(false)

--- a/docs/examples/select/custom-header.vue
+++ b/docs/examples/select/custom-header.vue
@@ -29,7 +29,6 @@
 
 <script lang="ts" setup>
 import { ref, watch } from 'vue'
-
 import type { CheckboxValueType } from 'element-plus'
 
 const checkAll = ref(false)

--- a/docs/examples/table-v2/cell-templating.vue
+++ b/docs/examples/table-v2/cell-templating.vue
@@ -19,7 +19,6 @@ import {
   TableV2FixedDir,
 } from 'element-plus'
 import { Timer } from '@element-plus/icons-vue'
-
 import type { Column } from 'element-plus'
 
 let id = 0

--- a/docs/examples/table-v2/dynamic-height.vue
+++ b/docs/examples/table-v2/dynamic-height.vue
@@ -19,7 +19,6 @@ import {
   TableV2FixedDir,
   TableV2SortOrder,
 } from 'element-plus'
-
 import type { Column, SortBy } from '@element-plus/components/table-v2'
 
 const longText =

--- a/docs/examples/table-v2/filter.vue
+++ b/docs/examples/table-v2/filter.vue
@@ -18,7 +18,6 @@ import {
   TableV2FixedDir,
 } from 'element-plus'
 import { Filter } from '@element-plus/icons-vue'
-
 import type { HeaderCellSlotProps } from 'element-plus'
 
 const generateColumns = (length = 10, prefix = 'column-', props?: any) =>

--- a/docs/examples/table-v2/fixed-columns.vue
+++ b/docs/examples/table-v2/fixed-columns.vue
@@ -13,7 +13,6 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 import { TableV2FixedDir, TableV2SortOrder } from 'element-plus'
-
 import type { SortBy } from 'element-plus'
 
 const generateColumns = (length = 10, prefix = 'column-', props?: any) =>

--- a/docs/examples/table-v2/grouping-header.vue
+++ b/docs/examples/table-v2/grouping-header.vue
@@ -16,7 +16,6 @@
 
 <script lang="tsx" setup>
 import { TableV2FixedDir, TableV2Placeholder } from 'element-plus'
-
 import type { FunctionalComponent } from 'vue'
 import type {
   HeaderClassNameGetter,

--- a/docs/examples/table-v2/inline-editing.vue
+++ b/docs/examples/table-v2/inline-editing.vue
@@ -17,7 +17,6 @@
 <script lang="tsx" setup>
 import { ref, withKeys } from 'vue'
 import { ElInput } from 'element-plus'
-
 import type { FunctionalComponent } from 'vue'
 import type { Column, InputInstance } from 'element-plus'
 

--- a/docs/examples/table-v2/manual-scroll.vue
+++ b/docs/examples/table-v2/manual-scroll.vue
@@ -29,7 +29,6 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-
 import type { TableV2Instance } from 'element-plus'
 
 const generateColumns = (length = 10, prefix = 'column-', props?: any) =>

--- a/docs/examples/table-v2/row-class.vue
+++ b/docs/examples/table-v2/row-class.vue
@@ -19,7 +19,6 @@ import {
   TableV2FixedDir,
 } from 'element-plus'
 import { Timer } from '@element-plus/icons-vue'
-
 import type { Column, RowClassNameGetter } from 'element-plus'
 
 let id = 0

--- a/docs/examples/table-v2/selection.vue
+++ b/docs/examples/table-v2/selection.vue
@@ -17,7 +17,6 @@
 <script lang="tsx" setup>
 import { ref, unref } from 'vue'
 import { ElCheckbox } from 'element-plus'
-
 import type { FunctionalComponent } from 'vue'
 import type { CheckboxValueType, Column } from 'element-plus'
 

--- a/docs/examples/table-v2/tree-data.vue
+++ b/docs/examples/table-v2/tree-data.vue
@@ -15,7 +15,6 @@
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
 import { TableV2FixedDir } from 'element-plus'
-
 import type { ExpandedRowsChangeHandler, RowExpandHandler } from 'element-plus'
 
 const generateColumns = (length = 10, prefix = 'column-', props?: any) =>

--- a/docs/examples/table/show-overflow-tooltip.vue
+++ b/docs/examples/table/show-overflow-tooltip.vue
@@ -16,8 +16,6 @@
 </template>
 
 <script lang="ts" setup>
-import { ElTable } from 'element-plus'
-
 interface User {
   date: string
   name: string

--- a/docs/examples/table/single-select.vue
+++ b/docs/examples/table/single-select.vue
@@ -19,7 +19,7 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-import { ElTable } from 'element-plus'
+import type { TableInstance } from 'element-plus'
 
 interface User {
   date: string
@@ -28,7 +28,7 @@ interface User {
 }
 
 const currentRow = ref()
-const singleTableRef = ref<InstanceType<typeof ElTable>>()
+const singleTableRef = ref<TableInstance>()
 
 const setCurrent = (row?: User) => {
   singleTableRef.value!.setCurrentRow(row)

--- a/docs/examples/tag/editable.vue
+++ b/docs/examples/tag/editable.vue
@@ -26,7 +26,6 @@
 
 <script lang="ts" setup>
 import { nextTick, ref } from 'vue'
-import { ElInput } from 'element-plus'
 import type { InputInstance } from 'element-plus'
 
 const inputValue = ref('')

--- a/docs/examples/tag/rounded.vue
+++ b/docs/examples/tag/rounded.vue
@@ -36,7 +36,6 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-
 import type { TagProps } from 'element-plus'
 
 type Item = { type: TagProps['type']; label: string }

--- a/docs/examples/tag/theme.vue
+++ b/docs/examples/tag/theme.vue
@@ -36,7 +36,6 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-
 import type { TagProps } from 'element-plus'
 
 type Item = { type: TagProps['type']; label: string }

--- a/docs/examples/tree/checking-tree.vue
+++ b/docs/examples/tree/checking-tree.vue
@@ -21,7 +21,7 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-import { ElTree } from 'element-plus'
+import type { TreeInstance } from 'element-plus'
 import type Node from 'element-plus/es/components/tree/src/model/node'
 
 interface Tree {
@@ -30,7 +30,7 @@ interface Tree {
   children?: Tree[]
 }
 
-const treeRef = ref<InstanceType<typeof ElTree>>()
+const treeRef = ref<TreeInstance>()
 
 const getCheckedNodes = () => {
   console.log(treeRef.value!.getCheckedNodes(false, false))

--- a/docs/examples/tree/custom-node-class.vue
+++ b/docs/examples/tree/custom-node-class.vue
@@ -15,6 +15,7 @@
 <script lang="ts" setup>
 import type Node from 'element-plus/es/components/tree/src/model/node'
 import type { TreeNodeData } from 'element-plus/es/components/tree/src/tree.type'
+
 interface Tree {
   id: number
   label: string

--- a/docs/examples/tree/filtering.vue
+++ b/docs/examples/tree/filtering.vue
@@ -18,14 +18,14 @@
 
 <script lang="ts" setup>
 import { ref, watch } from 'vue'
-import { ElTree } from 'element-plus'
+import type { TreeInstance } from 'element-plus'
 
 interface Tree {
   [key: string]: any
 }
 
 const filterText = ref('')
-const treeRef = ref<InstanceType<typeof ElTree>>()
+const treeRef = ref<TreeInstance>()
 
 const defaultProps = {
   children: 'children',

--- a/docs/examples/tree/selectable.vue
+++ b/docs/examples/tree/selectable.vue
@@ -11,12 +11,12 @@
 
 <script lang="ts" setup>
 import type Node from 'element-plus/es/components/tree/src/model/node'
-let count = 1
 
 interface Tree {
   name: string
 }
 
+let count = 1
 const props = {
   label: 'name',
   children: 'zones',

--- a/docs/examples/upload/avatar.vue
+++ b/docs/examples/upload/avatar.vue
@@ -15,7 +15,6 @@
 import { ref } from 'vue'
 import { ElMessage } from 'element-plus'
 import { Plus } from '@element-plus/icons-vue'
-
 import type { UploadProps } from 'element-plus'
 
 const imageUrl = ref('')

--- a/docs/examples/upload/basic.vue
+++ b/docs/examples/upload/basic.vue
@@ -22,7 +22,6 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
-
 import type { UploadProps, UploadUserFile } from 'element-plus'
 
 const fileList = ref<UploadUserFile[]>([

--- a/docs/examples/upload/custom-thumbnail.vue
+++ b/docs/examples/upload/custom-thumbnail.vue
@@ -39,7 +39,6 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 import { Delete, Download, Plus, ZoomIn } from '@element-plus/icons-vue'
-
 import type { UploadFile } from 'element-plus'
 
 const dialogImageUrl = ref('')

--- a/docs/examples/upload/file-list-with-thumbnail.vue
+++ b/docs/examples/upload/file-list-with-thumbnail.vue
@@ -18,7 +18,6 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-
 import type { UploadProps, UploadUserFile } from 'element-plus'
 
 const fileList = ref<UploadUserFile[]>([

--- a/docs/examples/upload/file-list.vue
+++ b/docs/examples/upload/file-list.vue
@@ -16,7 +16,6 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-
 import type { UploadProps, UploadUserFile } from 'element-plus'
 
 const fileList = ref<UploadUserFile[]>([

--- a/docs/examples/upload/photo-wall.vue
+++ b/docs/examples/upload/photo-wall.vue
@@ -17,7 +17,6 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 import { Plus } from '@element-plus/icons-vue'
-
 import type { UploadProps, UploadUserFile } from 'element-plus'
 
 const fileList = ref<UploadUserFile[]>([


### PR DESCRIPTION
- Remove unnecessary component imports
- Replace `InstanceType<typeof` with an existing `XxInstance`
- Remove import type blank Line