### PR TITLE
docs: fix dark mode switch transition effect offset

### DIFF
--- a/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
+++ b/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
@@ -40,7 +40,8 @@ const beforeChange = () => {
 
     const ratioX = (100 * x) / innerWidth
     const ratioY = (100 * y) / innerHeight
-    const ratioR = (100 * endRadius) / Math.min(innerWidth, innerHeight)
+    const referR = Math.hypot(innerWidth, innerHeight) / Math.SQRT2
+    const ratioR = (100 * endRadius) / referR
 
     // @ts-expect-error: Transition API
     const transition = document.startViewTransition(async () => {

--- a/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
+++ b/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
@@ -37,6 +37,11 @@ const beforeChange = () => {
       Math.max(x, innerWidth - x),
       Math.max(y, innerHeight - y)
     )
+
+    const ratioX = (100 * x) / innerWidth
+    const ratioY = (100 * y) / innerHeight
+    const ratioR = (100 * endRadius) / Math.min(innerWidth, innerHeight)
+
     // @ts-expect-error: Transition API
     const transition = document.startViewTransition(async () => {
       resolve(true)
@@ -44,8 +49,8 @@ const beforeChange = () => {
     })
     transition.ready.then(() => {
       const clipPath = [
-        `circle(0px at ${x}px ${y}px)`,
-        `circle(${endRadius}px at ${x}px ${y}px)`,
+        `circle(0% at ${ratioX}% ${ratioY}%)`,
+        `circle(${ratioR}% at ${ratioX}% ${ratioY}%)`,
       ]
       document.documentElement.animate(
         {


### PR DESCRIPTION
use viewport-relative units for transition calculation to resolve scaling misalignment

使用相对单位代替像素单位，该尝试已在 Edge 134.0.3124.72 PC 环境下以及移动设备模拟器上生效。

closed #20235 

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
