### PR TITLE
docs: optimize contributors style

### DIFF
--- a/docs/.vitepress/vitepress/components/globals/contributors.vue
+++ b/docs/.vitepress/vitepress/components/globals/contributors.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { ElTooltip } from '@element-plus/components'
 import _contributors from '@element-plus/metadata/dist/contributors.json'
 import VpLink from '../common/vp-link.vue'
 
@@ -15,23 +16,25 @@ const withSize = (rawURL: string) => {
 </script>
 
 <template>
-  <div class="mb-4">
-    <div class="flex flex-wrap gap-4 pt-2">
-      <div v-for="c of contributors" :key="c.hash">
-        <vp-link
-          :href="`https://github.com/${c.login}`"
-          class="flex gap-2 items-center link"
-          no-icon
-        >
-          <img
-            :src="withSize(c.avatar)"
-            class="w-8 h-8 rounded-full"
-            loading="lazy"
-          />
-          {{ c.name }}
-        </vp-link>
-      </div>
-    </div>
+  <div class="flex flex-wrap gap-2 pb-2">
+    <ElTooltip
+      v-for="{ login, avatar, name, hash } of contributors"
+      :key="hash"
+      :content="name"
+      placement="top"
+    >
+      <vp-link
+        :href="`https://github.com/${login}`"
+        class="flex gap-2 items-center link"
+        no-icon
+      >
+        <img
+          :src="withSize(avatar)"
+          class="w-8 h-8 rounded-full"
+          loading="lazy"
+        />
+      </vp-link>
+    </ElTooltip>
   </div>
 </template>
 

--- a/docs/.vitepress/vitepress/components/globals/contributors.vue
+++ b/docs/.vitepress/vitepress/components/globals/contributors.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { ElTooltip } from '@element-plus/components'
 import _contributors from '@element-plus/metadata/dist/contributors.json'
 import VpLink from '../common/vp-link.vue'
 
@@ -17,7 +16,7 @@ const withSize = (rawURL: string) => {
 
 <template>
   <div class="flex flex-wrap gap-2 pb-2">
-    <ElTooltip
+    <el-tooltip
       v-for="{ login, avatar, name, hash } of contributors"
       :key="hash"
       :content="name"
@@ -34,7 +33,7 @@ const withSize = (rawURL: string) => {
           loading="lazy"
         />
       </vp-link>
-    </ElTooltip>
+    </el-tooltip>
   </div>
 </template>
 


### PR DESCRIPTION
贡献者 这一栏对名字长度没有做限制,如果贡献者很多,并且他的名字很长,会占据很多的空间,虽然他在页面的底部.

<img width="1116" alt="image" src="https://github.com/user-attachments/assets/395b7fc1-87ac-4a66-8c74-653b23a3d992" />

修改后只保留图像,名字用 tooltip 显示.