### PR TITLE
fix(components): [tree] ensure no checked nodes in regular tree

### DIFF
--- a/packages/components/tree/__tests__/tree.test.ts
+++ b/packages/components/tree/__tests__/tree.test.ts
@@ -578,6 +578,23 @@ describe('Tree.vue', () => {
     expect(treeVm.getCheckedNodes().length).toEqual(0)
   })
 
+  test('ensure no checked nodes in non show-checkbox mode', async () => {
+    const { wrapper } = getTreeVm(`:props="defaultProps" check-on-click-node`)
+    const treeVm = wrapper.findComponent(Tree).vm
+
+    expect(treeVm.getCheckedNodes().length).toEqual(0)
+
+    const secondTreeNodeWrapper = wrapper.findAll('.el-tree-node')[2]
+    await secondTreeNodeWrapper.trigger('click')
+
+    const secondNodeContentWrapper = secondTreeNodeWrapper.findAll(
+      '.el-tree-node__content'
+    )[1]
+    await secondNodeContentWrapper.trigger('click')
+
+    expect(treeVm.getCheckedNodes().length).toEqual(0)
+  })
+
   test('setCheckedNodes', async () => {
     const { wrapper } = getTreeVm(
       `:props="defaultProps" show-checkbox node-key="id"`

--- a/packages/components/tree/__tests__/tree.test.ts
+++ b/packages/components/tree/__tests__/tree.test.ts
@@ -4,6 +4,7 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vitest'
 import defineGetter from '@element-plus/test-utils/define-getter'
 import sleep from '@element-plus/test-utils/sleep'
+import ElIcon from '@element-plus/components/icon'
 import Tree from '../src/tree.vue'
 import Button from '../../button/src/button.vue'
 import type Node from '../src/model/node'
@@ -579,7 +580,7 @@ describe('Tree.vue', () => {
   })
 
   test('ensure no checked nodes in non show-checkbox mode', async () => {
-    const { wrapper } = getTreeVm(`:props="defaultProps" check-on-click-node`)
+    const { wrapper } = getTreeVm(`:props="defaultProps"`)
     const treeVm = wrapper.findComponent(Tree).vm
 
     expect(treeVm.getCheckedNodes().length).toEqual(0)
@@ -590,6 +591,14 @@ describe('Tree.vue', () => {
     const secondNodeContentWrapper = secondTreeNodeWrapper.findAll(
       '.el-tree-node__content'
     )[1]
+
+    expect(
+      secondNodeContentWrapper
+        .findComponent(ElIcon)
+        .classes()
+        .includes('is-leaf')
+    ).toBe(true)
+
     await secondNodeContentWrapper.trigger('click')
 
     expect(treeVm.getCheckedNodes().length).toEqual(0)

--- a/packages/components/tree/src/tree-node.vue
+++ b/packages/components/tree/src/tree-node.vue
@@ -249,6 +249,7 @@ export default defineComponent({
       }
 
       if (
+        props.showCheckbox &&
         (tree.props.checkOnClickNode ||
           (props.node.isLeaf && tree.props.checkOnClickLeaf)) &&
         !props.node.disabled

--- a/packages/components/tree/src/tree-node.vue
+++ b/packages/components/tree/src/tree-node.vue
@@ -249,9 +249,10 @@ export default defineComponent({
       }
 
       if (
-        props.showCheckbox &&
         (tree.props.checkOnClickNode ||
-          (props.node.isLeaf && tree.props.checkOnClickLeaf)) &&
+          (props.node.isLeaf &&
+            tree.props.checkOnClickLeaf &&
+            props.showCheckbox)) &&
         !props.node.disabled
       ) {
         handleCheckChange(!props.node.checked)


### PR DESCRIPTION
fix #20307
regression of https://github.com/element-plus/element-plus/pull/19494

Ensuring that no checked nodes are set in non `:showCheckbox="false"` mode.
I noticed that `check-on-click-node` was also doing `@check` even in non `:showCheckbox="false"` mode, i fixed it but be aware that maybe some users already use `check-on-click-node` in `:showCheckbox="false"` mode (weird but can exist).