### PR TITLE
fix(components): [scrollbar] stop click when click scrollbar

### DIFF
--- a/packages/components/scrollbar/__tests__/scrollbar.test.tsx
+++ b/packages/components/scrollbar/__tests__/scrollbar.test.tsx
@@ -310,7 +310,7 @@ describe('ScrollBar', () => {
     expect(wrapper.find('.el-scrollbar__view').classes()).toContain(viewClass)
   })
 
-  test('should bubble up click event on click scrollbar', async () => {
+  test('should not bubble up click event on click scrollbar', async () => {
     const parentClick = vi.fn()
     const wrapper = mount(() => (
       <div onClick={parentClick}>

--- a/packages/components/scrollbar/__tests__/scrollbar.test.tsx
+++ b/packages/components/scrollbar/__tests__/scrollbar.test.tsx
@@ -1,9 +1,10 @@
 import { nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import makeScroll from '@element-plus/test-utils/make-scroll'
 import defineGetter from '@element-plus/test-utils/define-getter'
 import Scrollbar from '../src/scrollbar.vue'
+import Thumb from '../src/thumb.vue'
 
 describe('ScrollBar', () => {
   test('vertical', async () => {
@@ -307,5 +308,19 @@ describe('ScrollBar', () => {
     const wrapper = mount(() => <Scrollbar view-class={viewClass} />)
 
     expect(wrapper.find('.el-scrollbar__view').classes()).toContain(viewClass)
+  })
+
+  test('should bubble up click event on click scrollbar', async () => {
+    const parentClick = vi.fn()
+    const wrapper = mount(() => (
+      <div onClick={parentClick}>
+        <Scrollbar style={{ width: '100px' }}>
+          ILoveRemILoveRemILoveRem
+        </Scrollbar>
+      </div>
+    ))
+    const scrollbar = wrapper.findComponent(Thumb)
+    await scrollbar.trigger('click')
+    expect(parentClick).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/components/scrollbar/src/thumb.vue
+++ b/packages/components/scrollbar/src/thumb.vue
@@ -5,6 +5,7 @@
       ref="instance"
       :class="[ns.e('bar'), ns.is(bar.key)]"
       @mousedown="clickTrackHandler"
+      @click.stop
     >
       <div
         ref="thumb"


### PR DESCRIPTION
I want to implement `<el-scrollbar>` to prevent long label from `<el-tree>` node.
here is a [playground demo of the issue](https://element-plus.run/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmludGVyZmFjZSBUcmVlIHtcbiAgaWQ6IHN0cmluZ1xuICBsYWJlbDogc3RyaW5nXG4gIGNoaWxkcmVuPzogVHJlZVtdXG59XG5cbmNvbnN0IGdldEtleSA9IChwcmVmaXg6IHN0cmluZywgaWQ6IG51bWJlcikgPT4ge1xuICByZXR1cm4gYCR7cHJlZml4fS0ke2lkfWBcbn1cblxuY29uc3QgY3JlYXRlRGF0YSA9IChcbiAgbWF4RGVlcDogbnVtYmVyLFxuICBtYXhDaGlsZHJlbjogbnVtYmVyLFxuICBtaW5Ob2Rlc051bWJlcjogbnVtYmVyLFxuICBkZWVwID0gMSxcbiAga2V5ID0gJ25vZGVub2Rlbm9kZW5vZGVub2Rlbm9kZW5vZG5vZGVlJ1xuKTogVHJlZVtdID0+IHtcbiAgbGV0IGlkID0gMFxuICByZXR1cm4gQXJyYXkuZnJvbSh7IGxlbmd0aDogbWluTm9kZXNOdW1iZXIgfSlcbiAgICAuZmlsbChkZWVwKVxuICAgIC5tYXAoKCkgPT4ge1xuICAgICAgY29uc3QgY2hpbGRyZW5OdW1iZXIgPVxuICAgICAgICBkZWVwID09PSBtYXhEZWVwID8gMCA6IE1hdGgucm91bmQoTWF0aC5yYW5kb20oKSAqIG1heENoaWxkcmVuKVxuICAgICAgY29uc3Qgbm9kZUtleSA9IGdldEtleShrZXksICsraWQpXG4gICAgICByZXR1cm4ge1xuICAgICAgICBpZDogbm9kZUtleSxcbiAgICAgICAgbGFiZWw6IG5vZGVLZXksXG4gICAgICAgIGNoaWxkcmVuOiBjaGlsZHJlbk51bWJlclxuICAgICAgICAgID8gY3JlYXRlRGF0YShtYXhEZWVwLCBtYXhDaGlsZHJlbiwgY2hpbGRyZW5OdW1iZXIsIGRlZXAgKyAxLCBub2RlS2V5KVxuICAgICAgICAgIDogdW5kZWZpbmVkLFxuICAgICAgfVxuICAgIH0pXG59XG5cbmNvbnN0IHByb3BzID0ge1xuICB2YWx1ZTogJ2lkJyxcbiAgbGFiZWw6ICdsYWJlbCcsXG4gIGNoaWxkcmVuOiAnY2hpbGRyZW4nLFxufVxuY29uc3QgZGF0YSA9IGNyZWF0ZURhdGEoNCwgMzAsIDQwKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGVsLXRyZWUtdjIgc3R5bGU9XCJtYXgtd2lkdGg6IDIwMHB4O1wiIDpkYXRhPVwiZGF0YVwiIDpwcm9wcz1cInByb3BzXCI+XG4gICAgPHRlbXBsYXRlICNkZWZhdWx0PVwieyBub2RlLCBkYXRhIH1cIj5cbiAgICAgIDxlbC1zY3JvbGxiYXI+XG4gICAgICAgIDxzcGFuPnt7IG5vZGUubGFiZWwgfX08L3NwYW4+XG4gICAgICA8L2VsLXNjcm9sbGJhcj5cbiAgICA8L3RlbXBsYXRlPlxuICA8L2VsLXRyZWUtdjI+XG48L3RlbXBsYXRlPlxuXG48c3R5bGU+XG4uY3VzdG9tLXRyZWUtbm9kZSB7XG4gIG1heC13aWR0aDogMjAwcHg7XG59XG48L3N0eWxlPlxuIiwiZWxlbWVudC1wbHVzLmpzIjoiaW1wb3J0IEVsZW1lbnRQbHVzIGZyb20gJ2VsZW1lbnQtcGx1cydcbmltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcblxubGV0IGluc3RhbGxlZCA9IGZhbHNlXG5hd2FpdCBsb2FkU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gc2V0dXBFbGVtZW50UGx1cygpIHtcbiAgaWYgKGluc3RhbGxlZCkgcmV0dXJuXG4gIGNvbnN0IGluc3RhbmNlID0gZ2V0Q3VycmVudEluc3RhbmNlKClcbiAgaW5zdGFuY2UuYXBwQ29udGV4dC5hcHAudXNlKEVsZW1lbnRQbHVzKVxuICBpbnN0YWxsZWQgPSB0cnVlXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkU3R5bGUoKSB7XG4gIGNvbnN0IHN0eWxlcyA9IFsnaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAMi45LjcvZGlzdC9pbmRleC5jc3MnLCAnaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAMi45LjcvdGhlbWUtY2hhbGsvZGFyay9jc3MtdmFycy5jc3MnXS5tYXAoKHN0eWxlKSA9PiB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgICBsaW5rLmhyZWYgPSBzdHlsZVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICAgIH0pXG4gIH0pXG4gIHJldHVybiBQcm9taXNlLmFsbFNldHRsZWQoc3R5bGVzKVxufSIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AMy4zLjQvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvc2hhcmVkQDMuMy40L2Rpc3Qvc2hhcmVkLmVzbS1idW5kbGVyLmpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0AyLjkuNy9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQDIuOS43L1wiLFxuICAgIFwiQGVsZW1lbnQtcGx1cy9pY29ucy12dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsIl9vIjp7InZ1ZVZlcnNpb24iOiIzLjMuNCIsImVwVmVyc2lvbiI6IjIuOS43In19)
The problem of this is when we end the scroll (`onmouseup`) the click event is propagated.
The PR stop the click event when we click or end scroll the scrollbar.

more context in [20260 issue](https://github.com/element-plus/element-plus/issues/20260)