### PR TITLE
docs: resolve code copy button alignment issue

### DIFF
--- a/docs/.vitepress/vitepress/styles/code.scss
+++ b/docs/.vitepress/vitepress/styles/code.scss
@@ -240,7 +240,7 @@ samp {
 
 .doc-content [class*='language-'] > button.copy.copied::before,
 .doc-content [class*='language-'] > button.copy:hover.copied::before {
-  position: relative;
+  position: absolute;
   top: -1px;
   /*rtl:ignore*/
   transform: translateX(calc(-100% - 1px));


### PR DESCRIPTION
Fix the alignment issue of the code block copy button's `copied` element. Changed the `::before` element's positioning from `relative` to `absolute`, resolving the 1px vertical gap caused by the browser's user agent stylesheet (padding-block: 1px).

|before|after|
|---|---|
|![image](https://github.com/user-attachments/assets/57f581c2-fd3d-4447-b25b-717eeaa0d15f) | ![image](https://github.com/user-attachments/assets/b086acd7-de61-46b7-974d-364033c5731e)|