### PR TITLE
fix(theme-chalk): [description] remove useless font-weight declaration

### DIFF
--- a/packages/theme-chalk/src/descriptions.scss
+++ b/packages/theme-chalk/src/descriptions.scss
@@ -84,7 +84,6 @@ $descriptions-cell-font-size: map.merge(
       .#{$namespace}-descriptions__cell {
         box-sizing: border-box;
         text-align: left;
-        font-weight: normal;
         line-height: 23px;
         font-size: map.get($descriptions-cell-font-size, 'default');
 


### PR DESCRIPTION
This pr prevent the lost style of `el-description-item` in dev + auto import mode.

The real issue may be relate on how vite or rollup execute module https://github.com/rollup/rollup/issues/5423.
And because there is no precise answer on how to fix this issue on our side https://github.com/vitejs/vite/pull/9278#issuecomment-1488092234, i just deleted the useless `font-weight` that overrided the good one in dev + auto import mode.

related https://github.com/vitejs/vite/issues/19668
fix #20122

WDYT @makedopamine 