### PR TITLE
refactor(components): [message] use message type constants

### DIFF
--- a/packages/components/message/__tests__/message-manager.test.tsx
+++ b/packages/components/message/__tests__/message-manager.test.tsx
@@ -4,6 +4,7 @@ import { getStyle } from '@element-plus/utils'
 import { rAF } from '@element-plus/test-utils/tick'
 import { ElMessage } from '..'
 import Message from '../src/method'
+import { messageTypes } from '../src/message'
 
 const selector = '.el-message'
 // TODO: testing the original transition with `nextTick`'
@@ -126,10 +127,9 @@ describe('Message on command', () => {
   })
 
   test('it should have 4 other types of message', () => {
-    expect(Message.success).toBeInstanceOf(Function)
-    expect(Message.warning).toBeInstanceOf(Function)
-    expect(Message.info).toBeInstanceOf(Function)
-    expect(Message.error).toBeInstanceOf(Function)
+    messageTypes.forEach((type) => {
+      expect(Message[type]).toBeInstanceOf(Function)
+    })
   })
 
   test('it should appendTo specified HTMLElement', async () => {

--- a/packages/components/message/__tests__/message.test.ts
+++ b/packages/components/message/__tests__/message.test.ts
@@ -5,6 +5,7 @@ import { rAF } from '@element-plus/test-utils/tick'
 import { TypeComponentsMap } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import Message from '../src/message.vue'
+import { messageTypes } from '../src/message'
 import type { CSSProperties, Component, ComponentPublicInstance } from 'vue'
 
 const AXIOM = 'Rem is the best girl'
@@ -76,7 +77,7 @@ describe('Message.vue', () => {
 
   describe('Message.type', () => {
     test('should be able to render typed messages', () => {
-      for (const type of ['success', 'warning', 'info', 'error'] as const) {
+      for (const type of messageTypes) {
         const wrapper = _mount({ props: { type } })
 
         expect(wrapper.findComponent(TypeComponentsMap[type]).exists()).toBe(

--- a/packages/components/message/src/message.ts
+++ b/packages/components/message/src/message.ts
@@ -196,9 +196,6 @@ export type MessageTypedFn = (
   appContext?: null | AppContext
 ) => MessageHandler
 
-export interface Message extends MessageFn {
-  success: MessageTypedFn
-  warning: MessageTypedFn
-  info: MessageTypedFn
-  error: MessageTypedFn
+export type Message = MessageFn & {
+  [K in messageType]: MessageTypedFn
 }


### PR DESCRIPTION
- Update tests to use `messageTypes` for dynamic type checking
- Refactor `Message` type definition to use mapped type for better scalability
