### PR TITLE
docs(components): [form] simplified validation example

### DIFF
--- a/docs/examples/form/validation.vue
+++ b/docs/examples/form/validation.vue
@@ -5,9 +5,6 @@
     :model="ruleForm"
     :rules="rules"
     label-width="auto"
-    class="demo-ruleForm"
-    :size="formSize"
-    status-icon
   >
     <el-form-item label="Activity name" prop="name">
       <el-input v-model="ruleForm.name" />
@@ -93,7 +90,7 @@
 
 <script lang="ts" setup>
 import { reactive, ref } from 'vue'
-import type { ComponentSize, FormInstance, FormRules } from 'element-plus'
+import type { FormInstance, FormRules } from 'element-plus'
 
 interface RuleForm {
   name: string
@@ -108,7 +105,6 @@ interface RuleForm {
   desc: string
 }
 
-const formSize = ref<ComponentSize>('default')
 const ruleFormRef = ref<FormInstance>()
 const ruleForm = reactive<RuleForm>({
   name: 'Hello',


### PR DESCRIPTION
### Why ？

- Validation form is the most common example.
- `status-icon` is not suitable to be added in this example. see refer: 

https://ui.shadcn.com/docs/components/form
https://vuetifyjs.com/en/components/forms/
https://ant.design/components/form-cn
https://www.naiveui.com/zh-CN/os-theme/components/form
https://element.eleme.io/#/zh-CN/component/form#biao-dan-yan-zheng

### Before:
![image](https://github.com/user-attachments/assets/44143124-f666-498e-97e0-6e7350bc2d2e)  

### After:
![image](https://github.com/user-attachments/assets/1888b443-1014-4af7-91c8-6248755a23f4)


