### PR TITLE
perf(components): [table] optimize fixed column shadow

### DIFF
--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -2264,4 +2264,123 @@ describe('Table.vue', () => {
 
     mockRangeRect.mockRestore()
   })
+
+  it('change fixed column width is sync with the fixed-left-shadow', async () => {
+    const NEW_MIN_WIDTH = 19200
+
+    const wrapper = mount({
+      components: {
+        ElTable,
+        ElTableColumn,
+      },
+      template: `
+            <button class="change-column" @click="changeFixedColumnWidth"></button>
+            <el-table :data="testData">
+              <el-table-column
+                v-for="item in columnsData"
+                :prop="item.prop"
+                :label="item.label"
+                :fixed="item.fixed"
+                :min-width="item.minWidth"
+                :key="item.prop" />
+            </el-table>
+          `,
+      data() {
+        const testData = getTestData() as any
+
+        return {
+          testData,
+          columnsData: [
+            { label: 'name', prop: 'name', fixed: 'left', minWidth: 120 },
+            { label: 'release', prop: 'release' },
+            { label: 'director', prop: 'director' },
+            { label: 'runtime', prop: 'runtime' },
+          ] as Array<{
+            label: string
+            prop: string
+            fixed?: string
+            minWidth?: number
+          }>,
+        }
+      },
+
+      methods: {
+        changeFixedColumnWidth() {
+          this.columnsData[0].minWidth = NEW_MIN_WIDTH
+        },
+      },
+    })
+    await doubleWait()
+
+    const shadowEl = wrapper.find('.el-table__fixed-left-shadow')
+    await expect(shadowEl.exists()).toBe(true)
+
+    await wrapper.find('button.change-column').trigger('click')
+    await doubleWait()
+
+    const newFixedWidth = `${NEW_MIN_WIDTH}px`
+    await expect(shadowEl.element.style.left).toBe(newFixedWidth)
+  })
+
+  it('change fixed column width is sync with the fixed-right-shadow', async () => {
+    const NEW_MIN_WIDTH = 190
+
+    const wrapper = mount({
+      components: {
+        ElTable,
+        ElTableColumn,
+      },
+      template: `
+            <button class="change-column" @click="changeFixedColumnWidth"></button>
+            <el-table :data="testData">
+              <el-table-column
+                v-for="item in columnsData"
+                :prop="item.prop"
+                :label="item.label"
+                :fixed="item.fixed"
+                :min-width="item.minWidth"
+                :key="item.prop" />
+            </el-table>
+          `,
+      data() {
+        const testData = getTestData() as any
+
+        return {
+          testData,
+          columnsData: [
+            { label: 'name', prop: 'name' },
+            { label: 'release', prop: 'release' },
+            { label: 'director', prop: 'director' },
+            {
+              label: 'runtime',
+              prop: 'runtime',
+              fixed: 'right',
+              minWidth: 120,
+            },
+          ] as Array<{
+            label: string
+            prop: string
+            fixed?: string
+            minWidth?: number
+          }>,
+        }
+      },
+
+      methods: {
+        changeFixedColumnWidth() {
+          this.columnsData[3].minWidth = NEW_MIN_WIDTH
+        },
+      },
+    })
+    await doubleWait()
+
+    const shadowEl = wrapper.find('.el-table__fixed-right-shadow')
+    await expect(shadowEl.exists()).toBe(true)
+
+    await wrapper.find('button.change-column').trigger('click')
+    await doubleWait()
+
+    const newFixedWidth = `${NEW_MIN_WIDTH}px`
+    await expect(shadowEl.element.style.right).toBe(newFixedWidth)
+  })
 })

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -27,6 +27,14 @@
     @mouseleave="handleMouseLeave"
   >
     <div :class="ns.e('inner-wrapper')">
+      <div
+        ref="leftFixedShadow"
+        :class="ns.e('fixed-left-shadow')"
+        :style="{
+          left: `${layout.fixedWidth.value}px`,
+        }"
+      />
+
       <div ref="hiddenColumns" class="hidden-columns">
         <slot />
       </div>
@@ -160,6 +168,14 @@
         </table>
       </div>
       <div v-if="border || isGroup" :class="ns.e('border-left-patch')" />
+
+      <div
+        ref="rightFixedShadow"
+        :class="ns.e('fixed-right-shadow')"
+        :style="{
+          right: `${layout.rightFixedWidth.value}px`,
+        }"
+      />
     </div>
     <div
       v-show="resizeProxyVisible"

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -982,8 +982,8 @@ $table: map.merge(
     'bg-color': getCssVar('fill-color', 'blank'),
     'tr-bg-color': getCssVar('bg-color'),
     'expanded-cell-bg-color': getCssVar('fill-color', 'blank'),
-    'fixed-left-column': inset 10px 0 10px -10px rgb(0 0 0 / 15%),
-    'fixed-right-column': inset -10px 0 10px -10px rgb(0 0 0 / 15%),
+    'shadow-color': 'rgba(0, 0, 0, 0.12)',
+    'shadow-width': '10px',
     'index': getCssVar('index-normal'),
   ),
   $table

--- a/packages/theme-chalk/src/dark/var.scss
+++ b/packages/theme-chalk/src/dark/var.scss
@@ -89,6 +89,15 @@ $border-color: map.merge(
   $border-color
 );
 
+// Table
+$table: () !default;
+$table: map.merge(
+    (
+      'shadow-color': 'rgba(255, 255, 255, 0.2)',
+    ),
+    $table
+);
+
 // mix to hex to avoid overlay issues
 @each $key, $val in $border-color {
   $border-color: map.merge(

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -321,6 +321,26 @@
     visibility: hidden;
   }
 
+  @include e((fixed-left-shadow, fixed-right-shadow)) {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: getCssVar('table-shadow-width');
+    z-index: calc(getCssVar('table-index') + 2);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity getCssVar('transition-duration');
+    will-change: opacity;
+  }
+
+  @include e(fixed-left-shadow) {
+    background: linear-gradient(to right, getCssVar('table-shadow-color'), transparent getCssVar('table-shadow-width'));
+  }
+
+  @include e(fixed-right-shadow) {
+    background: linear-gradient(to left, getCssVar('table-shadow-color'), transparent getCssVar('table-shadow-width'));
+  }
+
   @include e((header-wrapper, body-wrapper, footer-wrapper)) {
     width: 100%;
 
@@ -332,34 +352,6 @@
           position: sticky !important;
           background: inherit;
           z-index: calc(getCssVar('table-index') + 1);
-
-          &.is-last-column,
-          &.is-first-column {
-            &::before {
-              content: '';
-              position: absolute;
-              top: 0px;
-              width: 10px;
-              bottom: -1px;
-              overflow-x: hidden;
-              overflow-y: hidden;
-              box-shadow: none;
-              touch-action: none;
-              pointer-events: none;
-            }
-          }
-
-          &.is-first-column {
-            &::before {
-              left: -10px;
-            }
-          }
-
-          &.is-last-column {
-            &::before {
-              right: -10px;
-            }
-          }
         }
 
         &.#{$namespace}-table__fixed-right-patch {
@@ -424,10 +416,11 @@
   }
 
   @include when(scrolling-left) {
-    .#{$namespace}-table-fixed-column--right.is-first-column {
-      &::before {
-        box-shadow: getCssVar('table-fixed-right-column');
-      }
+    .#{$namespace}-table__fixed-left-shadow {
+      opacity: 0;
+    }
+    .#{$namespace}-table__fixed-right-shadow {
+      opacity: 1;
     }
 
     &.#{$namespace}-table--border {
@@ -446,10 +439,11 @@
   }
 
   @include when(scrolling-right) {
-    .#{$namespace}-table-fixed-column--left.is-last-column {
-      &::before {
-        box-shadow: getCssVar('table-fixed-left-column');
-      }
+    .#{$namespace}-table__fixed-right-shadow {
+      opacity: 0;
+    }
+    .#{$namespace}-table__fixed-left-shadow {
+      opacity: 1;
     }
 
     .#{$namespace}-table-fixed-column--left.is-last-column.#{$namespace}-table__cell {
@@ -462,34 +456,17 @@
   }
 
   @include when(scrolling-middle) {
+    .#{$namespace}-table__fixed-left-shadow,
+    .#{$namespace}-table__fixed-right-shadow {
+      opacity: 1;
+    }
+
     .#{$namespace}-table-fixed-column--left.is-last-column.#{$namespace}-table__cell {
       border-right: none;
-    }
-
-    .#{$namespace}-table-fixed-column--right.is-first-column {
-      &::before {
-        box-shadow: getCssVar('table-fixed-right-column');
-      }
-    }
-
-    .#{$namespace}-table-fixed-column--left.is-last-column {
-      &::before {
-        box-shadow: getCssVar('table-fixed-left-column');
-      }
     }
   }
 
   @include when(scrolling-none) {
-    .#{$namespace}-table-fixed-column--left,
-    .#{$namespace}-table-fixed-column--right {
-      &.is-first-column,
-      &.is-last-column {
-        &::before {
-          box-shadow: none;
-        }
-      }
-    }
-
     th.#{$namespace}-table-fixed-column--left,
     th.#{$namespace}-table-fixed-column--right {
       background-color: getCssVar('table-header-bg-color');


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

In the previous version, fixed-column shadows were implemented by attaching ::before pseudo-elements to each cell, causing performance overhead that grows linearly with the number of columns.

To optimize performance, the fixed-column shadows are now rendered as two independent div elements, positioned via left and right offsets. This reduces the overhead from 2n (where n is the number of fixed columns) down to a constant 2, improving complexity from O(n) to O(1):

  ```text
  Overhead_before = 2n  
  Overhead_after  = 2  
  Complexity:      O(n) → O(1)
