### PR TITLE
docs: table-v2 add `@end-reached` parameter description

### DIFF
--- a/docs/en-US/component/notification.md
+++ b/docs/en-US/component/notification.md
@@ -96,7 +96,7 @@ import { CloseBold } from '@element-plus/icons-vue'
 ElNotification({
   title: 'Title',
   message: 'This is a message',
-  closeIcon: CloseBold
+  closeIcon: CloseBold,
 })
 ```
 
@@ -143,7 +143,7 @@ ElNotification({}, appContext)
 | offset                   | offset from the top edge of the screen. Every Notification instance of the same moment should have the same offset | ^[number]                                                             | 0         |
 | appendTo                 | set the root element for the notification, default to `document.body`                                              | ^[string] / ^[HTMLElement]                                            | —         |
 | zIndex                   | initial zIndex                                                                                                     | ^[number]                                                             | 0         |
-| closeIcon  ^(2.9.8)      | custom close icon, default is Close                                                                                | ^[string] / ^[Component]                                              | —         |
+| closeIcon ^(2.9.8)       | custom close icon, default is Close                                                                                | ^[string] / ^[Component]                                              | —         |
 
 ### Method
 

--- a/docs/en-US/component/table-v2.md
+++ b/docs/en-US/component/table-v2.md
@@ -343,14 +343,14 @@ table-v2/manual-scroll
 
 ## TableV2 Events
 
-| Name                 | Description                                                           | Parameters                                 |
-| -------------------- | --------------------------------------------------------------------- | ------------------------------------------ |
-| column-sort          | Invoked when column sorted                                            | `object`\<[ColumnSortParam](#typings)\>    |
-| expanded-rows-change | Invoked when expanded rows changed                                    | [KeyType[]](#typings)                      |
-| end-reached          | Invoked when the end of the table is reached                          | —                                          |
-| scroll               | Invoked after scrolling                                               | `object`\<[ScrollParams](#typings)\>       |
-| rows-rendered        | Invoked when rows are rendered                                        | `object`\<[RowsRenderedParams](#typings)\> |
-| row-expand           | Invoked when expand/collapse the tree node by clicking the arrow icon | `object`\<[RowExpandParams](#typings)\>    |
+| Name                 | Description                                                                                                                     | Parameters                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| column-sort          | Invoked when column sorted                                                                                                      | `object`\<[ColumnSortParam](#typings)\>       |
+| expanded-rows-change | Invoked when expanded rows changed                                                                                              | [KeyType[]](#typings)                         |
+| end-reached          | Invoked when the end of the table is reached. The callback contain the remain distance, it is the usually the scrollbar height. | ^[Function]`(remainDistance: number) => void` |
+| scroll               | Invoked after scrolling                                                                                                         | `object`\<[ScrollParams](#typings)\>          |
+| rows-rendered        | Invoked when rows are rendered                                                                                                  | `object`\<[RowsRenderedParams](#typings)\>    |
+| row-expand           | Invoked when expand/collapse the tree node by clicking the arrow icon                                                           | `object`\<[RowExpandParams](#typings)\>       |
 
 ## TableV2 Methods
 

--- a/packages/components/table-v2/src/table.ts
+++ b/packages/components/table-v2/src/table.ts
@@ -192,7 +192,7 @@ export const tableV2Props = buildProps({
     type: definePropType<ExpandedRowsChangeHandler>(Function),
   },
   onEndReached: {
-    type: definePropType<(distance: number) => void>(Function),
+    type: definePropType<(remainDistance: number) => void>(Function),
   },
   onRowExpand: tableV2RowProps.onRowExpand,
   onScroll: tableV2GridProps.onScroll,

--- a/packages/components/table-v2/src/use-table.ts
+++ b/packages/components/table-v2/src/use-table.ts
@@ -147,14 +147,14 @@ function useTable(props: TableV2Props) {
     const _totalHeight = unref(rowsHeight)
     const clientHeight = unref(windowHeight)
 
-    const heightUntilEnd =
+    const remainDistance =
       _totalHeight - (scrollTop + clientHeight) + props.hScrollbarSize
 
     if (
       unref(lastRenderedRowIndex) >= 0 &&
       _totalHeight === scrollTop + unref(mainTableHeight) - unref(headerHeight)
     ) {
-      onEndReached(heightUntilEnd)
+      onEndReached(remainDistance)
     }
   }
 


### PR DESCRIPTION
I was confused about `distance` parameter, i renamed it to `remainDistance` to be more clear.
Also added the type parameter and description in docs.

after:
![image](https://github.com/user-attachments/assets/67960fb4-2080-4cd8-8bb2-4a425ab528f5)