### PR TITLE
fix(docs):对switch组件的文档中一个注意事项补充说明

### DIFF
--- a/docs/en-US/component/switch.md
+++ b/docs/en-US/component/switch.md
@@ -52,6 +52,7 @@ switch/custom-icons
 :::demo You can set `active-value` and `inactive-value` attributes. They both receive a `Boolean`, `String` or `Number` typed value.
 
 switch/extended-value-types
+When binding a member property of an object and using non-Boolean types at the same time, active-value and inactive-value should use `v-bind` or `:` to make el-switch handle types correctly, otherwise unexpected errors will occur.
 
 :::
 


### PR DESCRIPTION
在绑定对象的某个成员属性的时候，可能无法准确识别非Bollean类型，需要在active-value 和 inactive-value 属性增加v-bind或者:来确保传递给 el-switch 的是准确的类型
