### PR TITLE
feat(components): [input-tag] add delimiter

### DIFF
--- a/docs/en-US/component/input-tag.md
+++ b/docs/en-US/component/input-tag.md
@@ -67,6 +67,16 @@ input-tag/draggable
 
 :::
 
+## Delimiter ^(2.9.9)
+
+You can add a tag when a delimiter is matched.
+
+:::demo
+
+input-tag/delimiter
+
+:::
+
 ## Sizes
 
 Add `size` attribute to change the size of InputTag. In addition to the default size, there are two other options: `large`, `small`.
@@ -109,6 +119,7 @@ input-tag/prefix-suffix
 | tag-effect            | tag effect                                                 | ^[enum]`'' \| 'light' \| 'dark' \| 'plain'`                 | light   |
 | trigger               | the key to trigger input tag                               | ^[enum]`'Enter' \| 'Space'`                                 | Enter   |
 | draggable             | whether tags can be dragged                                | ^[boolean]                                                  | false   |
+| delimiter             | add a tag when a delimiter is matched                      | ^[string] / ^[regex]                                        | —       |
 | size                  | input box size                                             | ^[enum]`'large' \| 'default' \| 'small'`                    | —       |
 | save-on-blur ^(2.9.7) | whether to save the input value when the input loses focus | ^[boolean]                                                  | true    |
 | clearable             | whether to show clear button                               | ^[boolean]                                                  | false   |

--- a/docs/en-US/component/input-tag.md
+++ b/docs/en-US/component/input-tag.md
@@ -119,7 +119,7 @@ input-tag/prefix-suffix
 | tag-effect            | tag effect                                                 | ^[enum]`'' \| 'light' \| 'dark' \| 'plain'`                 | light   |
 | trigger               | the key to trigger input tag                               | ^[enum]`'Enter' \| 'Space'`                                 | Enter   |
 | draggable             | whether tags can be dragged                                | ^[boolean]                                                  | false   |
-| delimiter             | add a tag when a delimiter is matched                      | ^[string] / ^[regex]                                        | —       |
+| delimiter ^(2.9.9)    | add a tag when a delimiter is matched                      | ^[string] / ^[regex]                                        | —       |
 | size                  | input box size                                             | ^[enum]`'large' \| 'default' \| 'small'`                    | —       |
 | save-on-blur ^(2.9.7) | whether to save the input value when the input loses focus | ^[boolean]                                                  | true    |
 | clearable             | whether to show clear button                               | ^[boolean]                                                  | false   |

--- a/docs/examples/input-tag/delimiter.vue
+++ b/docs/examples/input-tag/delimiter.vue
@@ -1,0 +1,13 @@
+<template>
+  <el-input-tag
+    v-model="input"
+    draggable
+    placeholder="Try to separate words with ,"
+    delimiter=","
+  />
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+const input = ref<string[]>([])
+</script>

--- a/packages/components/input-tag/__tests__/input-tag.test.tsx
+++ b/packages/components/input-tag/__tests__/input-tag.test.tsx
@@ -230,6 +230,31 @@ describe('InputTag.vue', () => {
     expect(wrapper.find('input').attributes('data-test')).toBe('input-tag')
   })
 
+  describe('delimiter', () => {
+    test('with string', async () => {
+      const inputValue = ref<string[]>()
+      const wrapper = mount(() => (
+        <InputTag v-model={inputValue.value} delimiter="," />
+      ))
+
+      await wrapper.find('input').setValue(`${AXIOM},`)
+      expect(wrapper.findAll('.el-tag').length).toBe(1)
+      expect(wrapper.find('.el-tag').text()).toBe(AXIOM)
+      expect(inputValue.value).toEqual([AXIOM])
+    })
+    test('with RegExp', async () => {
+      const inputValue = ref<string[]>()
+      const wrapper = mount(() => (
+        <InputTag v-model={inputValue.value} delimiter={/\./} />
+      ))
+
+      await wrapper.find('input').setValue(`${AXIOM}.`)
+      expect(wrapper.findAll('.el-tag').length).toBe(1)
+      expect(wrapper.find('.el-tag').text()).toBe(AXIOM)
+      expect(inputValue.value).toEqual([AXIOM])
+    })
+  })
+
   describe('events', () => {
     test('focus', async () => {
       const handleFocus = vi.fn()

--- a/packages/components/input-tag/src/composables/use-input-tag.ts
+++ b/packages/components/input-tag/src/composables/use-input-tag.ts
@@ -47,6 +47,13 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
     }
 
     if (isComposing.value) return
+    if (props.delimiter) {
+      const replacement = inputValue.value?.replace(props.delimiter, '')
+      if (replacement?.length !== inputValue.value?.length) {
+        inputValue.value = replacement
+        handleAddTag()
+      }
+    }
     emit(INPUT_EVENT, (event.target as HTMLInputElement).value)
   }
 

--- a/packages/components/input-tag/src/input-tag.ts
+++ b/packages/components/input-tag/src/input-tag.ts
@@ -50,6 +50,13 @@ export const inputTagProps = buildProps({
     default: false,
   },
   /**
+   * @description add a tag when a delimiter is matched
+   */
+  delimiter: {
+    type: [String, RegExp],
+    default: '',
+  },
+  /**
    * @description input box size
    */
   size: useSizeProp,


### PR DESCRIPTION
Offer the opportunity to add tags with delimiter. Works with string and regexp.

resolve https://github.com/element-plus/element-plus/discussions/20490

cc @tolking (#18885)