### PR TITLE
fix(components): [tooltip] listen clickoutside after open

### DIFF
--- a/packages/components/tooltip/src/content.vue
+++ b/packages/components/tooltip/src/content.vue
@@ -144,13 +144,6 @@ const onBeforeLeave = () => {
 
 const onAfterShow = () => {
   onShow()
-  stopHandle = onClickOutside(popperContentRef, () => {
-    if (unref(controlled)) return
-    const $trigger = unref(trigger)
-    if ($trigger !== 'hover') {
-      onClose()
-    }
-  })
 }
 
 const onBlur = () => {
@@ -174,6 +167,13 @@ watch(
       stopHandle?.()
     } else {
       ariaHidden.value = false
+      stopHandle = onClickOutside(popperContentRef, () => {
+        if (unref(controlled)) return
+        const $trigger = unref(trigger)
+        if ($trigger !== 'hover') {
+          onClose()
+        }
+      })
     }
   },
   {


### PR DESCRIPTION
Deplace listenner clickoutside right after open instead of at the end of transition (0.3s).

closed #14580