### PR TITLE
style(theme-chalk): fix form label style

### DIFF
--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -113,7 +113,15 @@ $form-item-label-top-margin-bottom: map.merge(
 
   @include m(label-left) {
     .#{$namespace}-form-item__label {
+      text-align: left;
       justify-content: flex-start;
+    }
+  }
+
+  @include m(label-right) {
+    .#{$namespace}-form-item__label {
+      text-align: right;
+      justify-content: flex-end;
     }
   }
 
@@ -121,8 +129,7 @@ $form-item-label-top-margin-bottom: map.merge(
     display: block;
 
     .#{$namespace}-form-item__label {
-      display: inline-block;
-      vertical-align: middle;
+      display: block;
       height: auto;
       text-align: left;
       margin-bottom: #{map.get($form-item-label-top-margin-bottom, 'default')};
@@ -136,7 +143,6 @@ $form-item-label-top-margin-bottom: map.merge(
 
   @include e(label) {
     display: inline-flex;
-    justify-content: flex-end;
     align-items: flex-start;
 
     flex: 0 0 auto;


### PR DESCRIPTION
When there's a global `text-align: right`.
Before:
![image](https://github.com/user-attachments/assets/a2a57fe0-fedd-4043-bd6d-3258da2a3292)
After:
![image](https://github.com/user-attachments/assets/ccf64f48-69ab-49a0-91cc-d802ed75347d)

When there's a line wrap.
Before:
![image](https://github.com/user-attachments/assets/9208f5dc-78ed-45a4-8a17-6654a384d92f)
After:
![image](https://github.com/user-attachments/assets/f3c413e5-702b-450a-baa1-0911fadca89e)
