### PR TITLE
fix(directives): [repeat-click] fix mouseup event not triggered in pup windows

### DIFF
--- a/packages/directives/repeat-click/index.ts
+++ b/packages/directives/repeat-click/index.ts
@@ -44,7 +44,7 @@ export const vRepeatClick: ObjectDirective<
       clear()
       handler()
 
-      document.addEventListener('mouseup', () => clear(), {
+      el.addEventListener('mouseup', () => clear(), {
         once: true,
       })
 


### PR DESCRIPTION
fix(directives): [repeat-click] fix mouseup event not triggered in pup windows

- Problem: Mouseup event not triggered in `window.open`/`iframe` environments due to `document` event listener
- Solution: Change `document.addEventListener('mouseup')` to `el.addEventListener('mouseup')`
- Impact: Fixes auto-increment bug in popups [el-input-number]

### How to reproduce bug
1. Open el-input-number  component in `window.open` popup
2. Click el-input-number +/- button once
3. Observe continuous increment


Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
