### PR TITLE
fix(components): [tree-v2] set expanded keys requires multiple nextTick

### DIFF
--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -1,4 +1,4 @@
-import { computed, nextTick, ref, shallowRef, watch } from 'vue'
+import { computed, ref, shallowRef, watch } from 'vue'
 import { isObject } from '@element-plus/utils'
 import {
   CURRENT_CHANGE,
@@ -34,26 +34,6 @@ export function useTree(
   const currentKey = ref<TreeKey | undefined>()
   const tree = shallowRef<Tree | undefined>()
   const listRef = ref<typeof FixedSizeList | undefined>()
-
-  watch(
-    () => props.currentNodeKey,
-    (key) => {
-      currentKey.value = key
-    },
-    {
-      immediate: true,
-    }
-  )
-
-  watch(
-    () => props.data,
-    (data: TreeData) => {
-      setData(data)
-    },
-    {
-      immediate: true,
-    }
-  )
 
   const {
     isIndeterminate,
@@ -288,7 +268,7 @@ export function useTree(
   }
 
   function setData(data: TreeData) {
-    nextTick(() => (tree.value = createTree(data)))
+    tree.value = createTree(data)
   }
 
   function getNode(data: TreeKey | TreeNodeData) {
@@ -306,6 +286,26 @@ export function useTree(
   function scrollTo(offset: number) {
     listRef.value?.scrollTo(offset)
   }
+
+  watch(
+    () => props.currentNodeKey,
+    (key) => {
+      currentKey.value = key
+    },
+    {
+      immediate: true,
+    }
+  )
+
+  watch(
+    () => props.data,
+    (data: TreeData) => {
+      setData(data)
+    },
+    {
+      immediate: true,
+    }
+  )
 
   return {
     tree,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

close #20720

**Description**
If the watch function references a variable that hasn't been initialized, it may cause runtime errors or behave unpredictably. So developer use nextTick to handle logic in the setData function. Now move the watch to the end of the code to remove the nextTick.
