### PR TITLE
docs: add `check-on-click-leaf` warnings

### DIFF
--- a/docs/en-US/component/tree-select.md
+++ b/docs/en-US/component/tree-select.md
@@ -23,18 +23,23 @@ tree-select/basic
 When using the `check-strictly=true` attribute, any node can be checked,
 otherwise only leaf nodes are supported.
 
-:::demo
-
-tree-select/check-strictly
-
-:::
-
 :::tip
 
 When using `show-checkbox`, since `check-on-click-node` is false by default,
 it can only be selected by checking, you can set it to true,
 and then click the node to select.
 
+:::
+
+:::demo
+
+tree-select/check-strictly
+
+:::
+
+:::warning
+When using show-checkbox, since `check-on-click-leaf` is true by default,
+last tree children's can be checked by clicking their nodes.
 :::
 
 ## Multiple Selection

--- a/docs/en-US/component/tree-v2.md
+++ b/docs/en-US/component/tree-v2.md
@@ -27,6 +27,11 @@ tree-v2/selectable
 
 :::
 
+:::warning
+When using show-checkbox, since `check-on-click-leaf` is true by default,
+last tree children's can be checked by clicking their nodes.
+:::
+
 ## Disabled checkbox
 
 The checkbox of a node can be set as disabled.

--- a/docs/en-US/component/tree.md
+++ b/docs/en-US/component/tree.md
@@ -27,6 +27,11 @@ tree/selectable
 
 :::
 
+:::warning
+When using show-checkbox, since `check-on-click-leaf` is true by default,
+last tree children's can be checked by clicking their nodes.
+:::
+
 ## Custom leaf node in lazy mode
 
 :::demo A node's data is not fetched until it is clicked, so the Tree cannot predict whether a node is a leaf node. That's why a drop-down button is added to each node, and if it is a leaf node, the drop-down button will disappear when clicked. That being said, you can also tell the Tree in advance whether the node is a leaf node, avoiding the render of the drop-down button before a leaf node.

--- a/docs/examples/tree-select/check-strictly.vue
+++ b/docs/examples/tree-select/check-strictly.vue
@@ -7,7 +7,7 @@
     style="width: 240px"
   />
   <el-divider />
-  show checkbox(only click checkbox to select):
+  show checkbox:
   <el-tree-select
     v-model="value"
     :data="data"


### PR DESCRIPTION
Developers can be surprised by the new `:check-on-click-leaf="true"` attribute since the tree api provide `check-on-click-node` default to false.

close #20735 i think