### PR TITLE
docs: remove confusing dialog attributes

### DIFF
--- a/docs/examples/dialog/fullscreen.vue
+++ b/docs/examples/dialog/fullscreen.vue
@@ -3,13 +3,7 @@
     Open the fullscreen Dialog
   </el-button>
 
-  <el-dialog
-    v-model="dialogVisible"
-    fullscreen
-    top="40vh"
-    width="70%"
-    draggable
-  >
+  <el-dialog v-model="dialogVisible" fullscreen>
     <span>It's a fullscreen Dialog</span>
     <template #footer>
       <div class="dialog-footer">


### PR DESCRIPTION
From the doc:
![image](https://github.com/user-attachments/assets/451155be-67bc-4d37-8395-bc4763e7c58e)

Is more confusing to demonstrate the opposite, the tip helper is sufficient IMO.