### PR TITLE
fix(components): Width issue of el-select in form component （#20853）

### DIFF
--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -63,6 +63,10 @@ $form-item-label-top-margin-bottom: map.merge(
       display: inline-flex;
       vertical-align: middle;
       margin-right: 32px;
+
+      .#{$namespace}-select {
+        min-width: 200px;
+      }
     }
 
     &.#{$namespace}-form--label-top {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [√ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [√ ] Make sure you are merging your commits to `dev` branch.
- [√ ] Add some descriptions and refer to relative issues for your PR.

组件默认宽度为100%，行内表单会造成组件宽度无法自适应。因此给
.el-form--inline .el-form-item.el-select 添加最小宽度
