### PR TITLE
fix(components): [cascader-panel] check if children label are comments

### DIFF
--- a/packages/components/cascader-panel/src/node-content.ts
+++ b/packages/components/cascader-panel/src/node-content.ts
@@ -2,14 +2,11 @@
 import { defineComponent, h } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 
+import type { VNode } from 'vue'
+
 //https://github.com/vuejs/core/issues/4733#issuecomment-933284261
-function isVNodeEmpty(vnodes?: VNode | VNode[] | null) {
-  return (
-    !!vnodes &&
-    (Array.isArray(vnodes)
-      ? vnodes.every((vnode) => vnode.type !== Comment)
-      : vnodes.type !== Comment)
-  )
+function isVNodeEmpty(vnodes?: VNode[]) {
+  return !!vnodes?.every((vnode) => vnode.type !== Comment)
 }
 
 export default defineComponent({

--- a/packages/components/cascader-panel/src/node-content.ts
+++ b/packages/components/cascader-panel/src/node-content.ts
@@ -2,11 +2,10 @@
 import { defineComponent, h } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 
-import type { VNode } from 'vue'
+import type { Comment, VNode } from 'vue'
 
-//https://github.com/vuejs/core/issues/4733#issuecomment-933284261
 function isVNodeEmpty(vnodes?: VNode[]) {
-  return !!vnodes?.every((vnode) => vnode.type !== Comment)
+  return !!vnodes?.every((vnode) => vnode.type === Comment)
 }
 
 export default defineComponent({

--- a/packages/components/cascader-panel/src/node-content.ts
+++ b/packages/components/cascader-panel/src/node-content.ts
@@ -13,12 +13,15 @@ export default defineComponent({
   render() {
     const { ns } = this
     const { node, panel } = this.$parent
-    const { data, label } = node
+    const { data, label: nodeLabel } = node
     const { renderLabelFn } = panel
-    return h(
-      'span',
-      { class: ns.e('label') },
-      renderLabelFn ? renderLabelFn({ node, data }) : label
-    )
+    const label = () => {
+      let renderLabel = renderLabelFn?.({ node, data })
+      if (renderLabel?.every((child) => child?.children === 'v-if')) {
+        renderLabel = nodeLabel
+      }
+      return renderLabel ?? nodeLabel
+    }
+    return h('span', { class: ns.e('label') }, label())
   },
 })

--- a/packages/components/cascader-panel/src/node-content.ts
+++ b/packages/components/cascader-panel/src/node-content.ts
@@ -2,6 +2,16 @@
 import { defineComponent, h } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 
+//https://github.com/vuejs/core/issues/4733#issuecomment-933284261
+function isVNodeEmpty(vnodes?: VNode | VNode[] | null) {
+  return (
+    !!vnodes &&
+    (Array.isArray(vnodes)
+      ? vnodes.every((vnode) => vnode.type !== Comment)
+      : vnodes.type !== Comment)
+  )
+}
+
 export default defineComponent({
   name: 'NodeContent',
   setup() {
@@ -17,7 +27,7 @@ export default defineComponent({
     const { renderLabelFn } = panel
     const label = () => {
       let renderLabel = renderLabelFn?.({ node, data })
-      if (renderLabel?.every((child) => child?.children === 'v-if')) {
+      if (isVNodeEmpty(renderLabel)) {
         renderLabel = nodeLabel
       }
       return renderLabel ?? nodeLabel

--- a/packages/components/cascader-panel/src/node-content.ts
+++ b/packages/components/cascader-panel/src/node-content.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
-import { defineComponent, h } from 'vue'
+import { Comment, defineComponent, h } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 
-import type { Comment, VNode } from 'vue'
+import type { VNode } from 'vue'
 
 function isVNodeEmpty(vnodes?: VNode[]) {
   return !!vnodes?.every((vnode) => vnode.type === Comment)

--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -1,4 +1,4 @@
-import { nextTick, reactive, ref } from 'vue'
+import { Comment, h, nextTick, reactive, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, test, vi } from 'vitest'
 import { EVENT_CODE } from '@element-plus/constants'
@@ -557,6 +557,50 @@ describe('Cascader.vue', () => {
         '.el-cascader-menu__empty-text'
       )
       expect(emptySlotEl?.textContent).toBe('-=-empty-=-no-data')
+    })
+  })
+
+  describe('render default slot', () => {
+    it('should render default slot correctly', async () => {
+      const wrapper = _mount(() => (
+        <Cascader options={OPTIONS}>
+          {{
+            default: () => <>default slot!</>,
+          }}
+        </Cascader>
+      ))
+
+      await wrapper.find(TRIGGER).trigger('click')
+      const defaultSlotEl = document.querySelector('.el-cascader-node__label')
+      expect(defaultSlotEl?.textContent).toBe('default slot!')
+    })
+
+    it('should fallback to option label when it has v-if comment', async () => {
+      const wrapper = _mount(() => (
+        <Cascader options={OPTIONS}>
+          {{
+            default: () => false && <div>{AXIOM}</div>,
+          }}
+        </Cascader>
+      ))
+
+      await wrapper.find(TRIGGER).trigger('click')
+      const defaultSlotEl = document.querySelector('.el-cascader-node__label')
+      expect(defaultSlotEl?.textContent).toBe(OPTIONS[0].label)
+    })
+
+    it('should fallback to option label when default has a single comment', async () => {
+      const wrapper = _mount(() => (
+        <Cascader options={OPTIONS}>
+          {{
+            default: () => h(Comment, AXIOM),
+          }}
+        </Cascader>
+      ))
+
+      await wrapper.find(TRIGGER).trigger('click')
+      const defaultSlotEl = document.querySelector('.el-cascader-node__label')
+      expect(defaultSlotEl?.textContent).toBe(OPTIONS[0].label)
     })
   })
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

close #20898

The issue is that slots.defaults is evaluated as true when there are comments.