### PR TITLE
chore: enable eslint formater for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "cSpell.words": ["Element Plus", "element-plus", "vnode"],
   "typescript.tsdk": "node_modules/typescript/lib",
+  "eslint.format.enable": true,
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"


### PR DESCRIPTION
在格式化时可以采用ESLint作为默认格式化程序，避免在手动格式化时出现“配置默认格式化程序”弹窗。

![image](https://github.com/user-attachments/assets/57ce74f4-a61f-4fab-943e-f876ab803388)