### PR TITLE
fix(components): [splitter-panel] the style file path error

### DIFF
--- a/packages/components/splitter-panel/style/css.ts
+++ b/packages/components/splitter-panel/style/css.ts
@@ -1,2 +1,2 @@
 import '@element-plus/components/base/style/css'
-import '@element-plus/theme-chalk/splitter-panel.css'
+import '@element-plus/theme-chalk/el-splitter-panel.css'


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

> Failed to resolve import "element-plus/theme-chalk/splitter-panel.css"

The built file should be `el-splitter-panel.css`