### PR TITLE
style(theme-chalk): update style of tag line-height

### DIFF
--- a/packages/theme-chalk/src/input-tag.scss
+++ b/packages/theme-chalk/src/input-tag.scss
@@ -146,7 +146,6 @@
 
       .#{$namespace}-tag__content {
         min-width: 0;
-        line-height: normal;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -165,7 +165,6 @@
 
   @include e(tags-text) {
     display: block;
-    line-height: normal;
     @include utils-ellipsis;
   }
 


### PR DESCRIPTION
The default line-height of el-tag is 1.
Before:
![image](https://github.com/user-attachments/assets/61a13e40-4e64-47f9-adbc-2f6c8a046906)
After:
![image](https://github.com/user-attachments/assets/fd2a9824-6ae6-4474-a826-d44fb9e52e45)
