### PR TITLE
fix(components): [table] `align=center` affects the scrolling area style

### DIFF
--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -66,6 +66,7 @@
           :wrap-style="scrollbarStyle"
           :always="scrollbarAlwaysOn"
           :tabindex="scrollbarTabindex"
+          style="text-align: left"
           @scroll="$emit('scroll', $event)"
         >
           <table

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -500,7 +500,6 @@
     overflow: hidden;
     position: relative;
     flex: 1;
-    text-align: left;
 
     .#{$namespace}-scrollbar__bar {
       z-index: calc(getCssVar('table-index') + 2);

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -500,6 +500,7 @@
     overflow: hidden;
     position: relative;
     flex: 1;
+    text-align: left;
 
     .#{$namespace}-scrollbar__bar {
       z-index: calc(getCssVar('table-index') + 2);


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [X] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [X] Make sure you are merging your commits to `dev` branch.
- [X] Add some descriptions and refer to relative issues for your PR.

## description
Explicitly set el-scrollar text-align to avoid it being affected by the align attribute 

## issue
fix #20840 
