### PR TITLE
feat(components): [splitter] add collapse event

### DIFF
--- a/docs/en-US/component/splitter.md
+++ b/docs/en-US/component/splitter.md
@@ -67,11 +67,12 @@ splitter/size
 
 ### Splitter Events
 
-| Name         | Description                                                              | type                                                  |
-| ------------ | ------------------------------------------------------------------------ | ----------------------------------------------------- |
-| resize-start | Triggered when starting to resize a panel, `index` is the drag bar index | ^[Function]`(index: number, sizes: number[]) => void` |
-| resize       | Triggered while resizing a panel, `index` is the drag bar index          | ^[Function]`(index: number, sizes: number[]) => void` |
-| resize-end   | Triggered when panel resizing ends, `index` is the drag bar index        | ^[Function]`(index: number, sizes: number[]) => void` |
+| Name         | Description                                                              | type                                                                          |
+| ------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| resize-start | Triggered when starting to resize a panel, `index` is the drag bar index | ^[Function]`(index: number, sizes: number[]) => void`                         |
+| resize       | Triggered while resizing a panel, `index` is the drag bar index          | ^[Function]`(index: number, sizes: number[]) => void`                         |
+| resize-end   | Triggered when panel resizing ends, `index` is the drag bar index        | ^[Function]`(index: number, sizes: number[]) => void`                         |
+| collapse     | Triggered when a panel is collapsed, `index` is the drag bar index       | ^[Function]`(index: number, type: 'start' \| 'end', sizes: number[]) => void` |
 
 ## SplitterPanel API
 

--- a/docs/en-US/component/splitter.md
+++ b/docs/en-US/component/splitter.md
@@ -67,12 +67,12 @@ splitter/size
 
 ### Splitter Events
 
-| Name         | Description                                                              | type                                                                          |
-| ------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| resize-start | Triggered when starting to resize a panel, `index` is the drag bar index | ^[Function]`(index: number, sizes: number[]) => void`                         |
-| resize       | Triggered while resizing a panel, `index` is the drag bar index          | ^[Function]`(index: number, sizes: number[]) => void`                         |
-| resize-end   | Triggered when panel resizing ends, `index` is the drag bar index        | ^[Function]`(index: number, sizes: number[]) => void`                         |
-| collapse     | Triggered when a panel is collapsed, `index` is the drag bar index       | ^[Function]`(index: number, type: 'start' \| 'end', sizes: number[]) => void` |
+| Name               | Description                                                              | type                                                                          |
+| ------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| resize-start       | Triggered when starting to resize a panel, `index` is the drag bar index | ^[Function]`(index: number, sizes: number[]) => void`                         |
+| resize             | Triggered while resizing a panel, `index` is the drag bar index          | ^[Function]`(index: number, sizes: number[]) => void`                         |
+| resize-end         | Triggered when panel resizing ends, `index` is the drag bar index        | ^[Function]`(index: number, sizes: number[]) => void`                         |
+| collapse ^(2.10.3) | Triggered when a panel is collapsed, `index` is the drag bar index       | ^[Function]`(index: number, type: 'start' \| 'end', sizes: number[]) => void` |
 
 ## SplitterPanel API
 

--- a/packages/components/splitter/src/splitter.vue
+++ b/packages/components/splitter/src/splitter.vue
@@ -15,6 +15,7 @@ const emits = defineEmits<{
   (e: 'resizeStart', index: number, sizes: number[]): void
   (e: 'resize', index: number, sizes: number[]): void
   (e: 'resizeEnd', index: number, sizes: number[]): void
+  (e: 'collapse', index: number, type: 'start' | 'end', sizes: number[]): void
 }>()
 
 const props = defineProps(splitterProps)
@@ -56,6 +57,11 @@ const onResizeEnd = (index: number) => {
   emits('resizeEnd', index, pxSizes.value)
 }
 
+const onCollapsible = (index: number, type: 'start' | 'end') => {
+  onCollapse(index, type)
+  emits('collapse', index, type, pxSizes.value)
+}
+
 provide(
   splitterRootContextKey,
   reactive({
@@ -68,7 +74,7 @@ provide(
     onMoveStart: onResizeStart,
     onMoving: onResize,
     onMoveEnd: onResizeEnd,
-    onCollapse,
+    onCollapse: onCollapsible,
     registerPanel: (panel: PanelItemState) => {
       panels.value.push(panel)
     },


### PR DESCRIPTION
I need this event because currently, I can't get the updated sizes after a panel is collapsed. It would be really helpful to have this, and I appreciate your consideration!

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.