### PR TITLE
refactor(components): [table] remove ts-nocheck

### DIFF
--- a/docs/examples/table/summary.vue
+++ b/docs/examples/table/summary.vue
@@ -37,7 +37,7 @@ interface Product {
   amount3: number
 }
 
-interface SummaryMethodProps<T extends Record<string, any> = Product> {
+interface SummaryMethodProps<T extends Product = Product> {
   columns: TableColumnCtx<T>[]
   data: T[]
 }

--- a/docs/examples/table/summary.vue
+++ b/docs/examples/table/summary.vue
@@ -37,7 +37,7 @@ interface Product {
   amount3: number
 }
 
-interface SummaryMethodProps<T = Product> {
+interface SummaryMethodProps<T extends Record<string, any> = Product> {
   columns: TableColumnCtx<T>[]
   data: T[]
 }

--- a/packages/components/table/src/config.ts
+++ b/packages/components/table/src/config.ts
@@ -38,8 +38,8 @@ export const cellStarts = {
   },
 }
 
-export const getDefaultClassName = (type: keyof typeof defaultClassNames) => {
-  return defaultClassNames[type] || ''
+export const getDefaultClassName = (type: string) => {
+  return defaultClassNames[type as keyof typeof defaultClassNames] || ''
 }
 
 // 这些选项不应该被覆盖

--- a/packages/components/table/src/config.ts
+++ b/packages/components/table/src/config.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { h } from 'vue'
 import ElCheckbox from '@element-plus/components/checkbox'
 import { ElIcon } from '@element-plus/components/icon'
@@ -8,12 +7,12 @@ import { getProp, isBoolean, isFunction, isNumber } from '@element-plus/utils'
 import type { VNode } from 'vue'
 import type { TableColumnCtx } from './table-column/defaults'
 import type { Store } from './store'
-import type { TreeNode } from './table/defaults'
+import type { DefaultRow, TreeNode } from './table/defaults'
 
 const defaultClassNames = {
   selection: 'table-column--selection',
   expand: 'table__expand-column',
-}
+} as const
 
 export const cellStarts = {
   default: {
@@ -39,14 +38,20 @@ export const cellStarts = {
   },
 }
 
-export const getDefaultClassName = (type) => {
+export const getDefaultClassName = (type: keyof typeof defaultClassNames) => {
   return defaultClassNames[type] || ''
 }
 
 // 这些选项不应该被覆盖
 export const cellForced = {
   selection: {
-    renderHeader<T>({ store, column }: { store: Store<T> }) {
+    renderHeader<T extends DefaultRow>({
+      store,
+      column,
+    }: {
+      store: Store<T>
+      column: TableColumnCtx<T>
+    }) {
       function isDisabled() {
         return store.states.data.value && store.states.data.value.length === 0
       }
@@ -56,12 +61,12 @@ export const cellForced = {
         indeterminate:
           store.states.selection.value.length > 0 &&
           !store.states.isAllSelected.value,
-        'onUpdate:modelValue': store.toggleAllSelection,
+        'onUpdate:modelValue': store.toggleAllSelection ?? undefined,
         modelValue: store.states.isAllSelected.value,
         ariaLabel: column.label,
       })
     },
-    renderCell<T>({
+    renderCell<T extends DefaultRow>({
       row,
       column,
       store,
@@ -70,7 +75,7 @@ export const cellForced = {
       row: T
       column: TableColumnCtx<T>
       store: Store<T>
-      $index: string
+      $index: number
     }) {
       return h(ElCheckbox, {
         disabled: column.selectable
@@ -89,10 +94,14 @@ export const cellForced = {
     resizable: false,
   },
   index: {
-    renderHeader<T>({ column }: { column: TableColumnCtx<T> }) {
+    renderHeader<T extends DefaultRow>({
+      column,
+    }: {
+      column: TableColumnCtx<T>
+    }) {
       return column.label || '#'
     },
-    renderCell<T>({
+    renderCell<T extends DefaultRow>({
       column,
       $index,
     }: {
@@ -112,10 +121,14 @@ export const cellForced = {
     sortable: false,
   },
   expand: {
-    renderHeader<T>({ column }: { column: TableColumnCtx<T> }) {
+    renderHeader<T extends DefaultRow>({
+      column,
+    }: {
+      column: TableColumnCtx<T>
+    }) {
       return column.label || ''
     },
-    renderCell<T>({
+    renderCell<T extends DefaultRow>({
       column,
       row,
       store,
@@ -168,7 +181,7 @@ export const cellForced = {
   },
 }
 
-export function defaultRenderCell<T>({
+export function defaultRenderCell<T extends DefaultRow>({
   row,
   column,
   $index,
@@ -185,7 +198,7 @@ export function defaultRenderCell<T>({
   return value?.toString?.() || ''
 }
 
-export function treeCellPrefix<T>(
+export function treeCellPrefix<T extends DefaultRow>(
   {
     row,
     treeNode,
@@ -209,7 +222,7 @@ export function treeCellPrefix<T>(
     return null
   }
   const ele: VNode[] = []
-  const callback = function (e) {
+  const callback = function (e: Event) {
     e.stopPropagation()
     if (treeNode.loading) {
       return

--- a/packages/components/table/src/filter-panel.vue
+++ b/packages/components/table/src/filter-panel.vue
@@ -175,7 +175,7 @@ export default defineComponent({
         if (props.column) {
           return props.column.filteredValue || []
         }
-        return [] as string[]
+        return []
       },
       set(value: string[]) {
         if (props.column) {

--- a/packages/components/table/src/filter-panel.vue
+++ b/packages/components/table/src/filter-panel.vue
@@ -79,7 +79,7 @@
       >
         <el-icon>
           <slot name="filter-icon">
-            <arrow-up v-if="column.filterOpened" />
+            <arrow-up v-if="column?.filterOpened" />
             <arrow-down v-else />
           </slot>
         </el-icon>
@@ -89,7 +89,6 @@
 </template>
 
 <script lang="ts">
-// @ts-nocheck
 import { computed, defineComponent, getCurrentInstance, ref, watch } from 'vue'
 import ElCheckbox from '@element-plus/components/checkbox'
 import { ElIcon } from '@element-plus/components/icon'
@@ -102,6 +101,7 @@ import ElTooltip, {
 import ElScrollbar from '@element-plus/components/scrollbar'
 import { isPropAbsent } from '@element-plus/utils'
 
+import type { DefaultRow } from './table/defaults'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
 import type { Placement } from '@element-plus/components/popper'
 import type { PropType, WritableComputedRef } from 'vue'
@@ -129,10 +129,10 @@ export default defineComponent({
       default: 'bottom-start',
     },
     store: {
-      type: Object as PropType<Store<unknown>>,
+      type: Object as PropType<Store<DefaultRow>>,
     },
     column: {
-      type: Object as PropType<TableColumnCtx<unknown>>,
+      type: Object as PropType<TableColumnCtx<DefaultRow>>,
     },
     upDataColumn: {
       type: Function,
@@ -144,7 +144,7 @@ export default defineComponent({
     const { t } = useLocale()
     const ns = useNamespace('table-filter')
     const parent = instance?.parent as TableHeader
-    if (!parent.filterPanels.value[props.column.id]) {
+    if (props.column && !parent.filterPanels.value[props.column.id]) {
       parent.filterPanels.value[props.column.id] = instance
     }
     const tooltipVisible = ref(false)
@@ -153,14 +153,14 @@ export default defineComponent({
       return props.column && props.column.filters
     })
     const filterClassName = computed(() => {
-      if (props.column.filterClassName) {
+      if (props.column && props.column.filterClassName) {
         return `${ns.b()} ${props.column.filterClassName}`
       }
       return ns.b()
     })
     const filterValue = computed({
       get: () => (props.column?.filteredValue || [])[0],
-      set: (value: string) => {
+      set: (value?: string | null) => {
         if (filteredValue.value) {
           if (!isPropAbsent(value)) {
             filteredValue.value.splice(0, 1, value)
@@ -170,16 +170,16 @@ export default defineComponent({
         }
       },
     })
-    const filteredValue: WritableComputedRef<unknown[]> = computed({
+    const filteredValue: WritableComputedRef<string[]> = computed({
       get() {
         if (props.column) {
           return props.column.filteredValue || []
         }
-        return []
+        return [] as string[]
       },
-      set(value: unknown[]) {
+      set(value: string[]) {
         if (props.column) {
-          props.upDataColumn('filteredValue', value)
+          props.upDataColumn?.('filteredValue', value)
         }
       },
     })
@@ -189,7 +189,7 @@ export default defineComponent({
       }
       return true
     })
-    const isActive = (filter) => {
+    const isActive = (filter: { value: string; text: string }) => {
       return filter.value === filterValue.value
     }
     const hidden = () => {
@@ -211,8 +211,8 @@ export default defineComponent({
       confirmFilter(filteredValue.value)
       hidden()
     }
-    const handleSelect = (_filterValue?: string) => {
-      filterValue.value = _filterValue
+    const handleSelect = (_filterValue?: string | null) => {
+      filterValue.value = _filterValue!
       if (!isPropAbsent(_filterValue)) {
         confirmFilter(filteredValue.value)
       } else {
@@ -221,17 +221,17 @@ export default defineComponent({
       hidden()
     }
     const confirmFilter = (filteredValue: unknown[]) => {
-      props.store.commit('filterChange', {
+      props.store?.commit('filterChange', {
         column: props.column,
         values: filteredValue,
       })
-      props.store.updateAllSelected()
+      props.store?.updateAllSelected()
     }
     watch(
       tooltipVisible,
       (value) => {
         if (props.column) {
-          props.upDataColumn('filterOpened', value)
+          props.upDataColumn?.('filterOpened', value)
         }
       },
       {

--- a/packages/components/table/src/h-helper.ts
+++ b/packages/components/table/src/h-helper.ts
@@ -1,8 +1,15 @@
-// @ts-nocheck
 import { h } from 'vue'
 import { isUndefined } from '@element-plus/utils'
 
-export function hColgroup(props) {
+import type { TableColumnCtx } from './table-column/defaults'
+import type { DefaultRow } from './table/defaults'
+
+type Props = {
+  tableLayout: 'fixed' | 'auto'
+  columns?: TableColumnCtx<DefaultRow>[]
+}
+
+export function hColgroup(props: Props) {
   const isAuto = props.tableLayout === 'auto'
   let columns = props.columns || []
   if (isAuto) {
@@ -10,11 +17,11 @@ export function hColgroup(props) {
       columns = []
     }
   }
-  const getPropsData = (column) => {
+  const getPropsData = (column: TableColumnCtx<DefaultRow>) => {
     const propsData = {
       key: `${props.tableLayout}_${column.id}`,
       style: {},
-      name: undefined,
+      name: undefined as string | undefined,
     }
     if (isAuto) {
       propsData.style = {

--- a/packages/components/table/src/store/current.ts
+++ b/packages/components/table/src/store/current.ts
@@ -1,7 +1,8 @@
-import { Ref, getCurrentInstance, ref, unref } from 'vue'
+import { getCurrentInstance, ref, unref } from 'vue'
 import { isNull } from 'lodash-unified'
 import { getRowIdentity } from '../util'
 
+import type { Ref } from 'vue'
 import type { DefaultRow, Table } from '../table/defaults'
 import type { WatcherPropsData } from '.'
 

--- a/packages/components/table/src/store/current.ts
+++ b/packages/components/table/src/store/current.ts
@@ -1,16 +1,14 @@
-// @ts-nocheck
-import { getCurrentInstance, ref, unref } from 'vue'
+import { Ref, getCurrentInstance, ref, unref } from 'vue'
 import { isNull } from 'lodash-unified'
 import { getRowIdentity } from '../util'
 
-import type { Ref } from 'vue'
-import type { Table } from '../table/defaults'
+import type { DefaultRow, Table } from '../table/defaults'
 import type { WatcherPropsData } from '.'
 
-function useCurrent<T>(watcherData: WatcherPropsData<T>) {
+function useCurrent<T extends DefaultRow>(watcherData: WatcherPropsData<T>) {
   const instance = getCurrentInstance() as Table<T>
-  const _currentRowKey = ref<string>(null)
-  const currentRow: Ref<T> = ref(null)
+  const _currentRowKey: Ref<string | null> = ref(null)
+  const currentRow: Ref<T | null> = ref(null)
 
   const setCurrentRowKey = (key: string) => {
     instance.store.assertRowKey()
@@ -24,13 +22,14 @@ function useCurrent<T>(watcherData: WatcherPropsData<T>) {
 
   const setCurrentRowByKey = (key: string) => {
     const { data, rowKey } = watcherData
-    let _currentRow = null
+    let _currentRow: T | null = null
     if (rowKey.value) {
-      _currentRow = (unref(data) || []).find(
-        (item) => getRowIdentity(item, rowKey.value) === key
-      )
+      _currentRow =
+        (unref(data) || []).find(
+          (item) => getRowIdentity(item, rowKey.value) === key
+        ) ?? null
     }
-    currentRow.value = _currentRow
+    currentRow.value = _currentRow ?? null
     instance.emit('current-change', currentRow.value, null)
   }
 
@@ -53,7 +52,7 @@ function useCurrent<T>(watcherData: WatcherPropsData<T>) {
     const data = watcherData.data.value || []
     const oldCurrentRow = currentRow.value
     // 当 currentRow 不在 data 中时尝试更新数据
-    if (!data.includes(oldCurrentRow) && oldCurrentRow) {
+    if (oldCurrentRow && !data.includes(oldCurrentRow)) {
       if (rowKey) {
         const currentRowKey = getRowIdentity(oldCurrentRow, rowKey)
         setCurrentRowByKey(currentRowKey)

--- a/packages/components/table/src/store/expand.ts
+++ b/packages/components/table/src/store/expand.ts
@@ -1,12 +1,11 @@
-// @ts-nocheck
 import { getCurrentInstance, ref } from 'vue'
 import { getKeysMap, getRowIdentity, toggleRowStatus } from '../util'
 
 import type { Ref } from 'vue'
 import type { WatcherPropsData } from '.'
-import type { Table } from '../table/defaults'
+import type { DefaultRow, Table } from '../table/defaults'
 
-function useExpand<T>(watcherData: WatcherPropsData<T>) {
+function useExpand<T extends DefaultRow>(watcherData: WatcherPropsData<T>) {
   const instance = getCurrentInstance() as Table<T>
   const defaultExpandAll = ref(false)
   const expandRows: Ref<T[]> = ref([])

--- a/packages/components/table/src/store/helper.ts
+++ b/packages/components/table/src/store/helper.ts
@@ -39,7 +39,7 @@ export function createStore<T extends DefaultRow>(
   // fix https://github.com/ElemeFE/element/issues/14075
   // related pr https://github.com/ElemeFE/element/pull/14146
   store.toggleAllSelection = debounce(store._toggleAllSelection, 10)
-  Object.keys(InitialStateMap).forEach((key: any) => {
+  Object.keys(InitialStateMap).forEach((key) => {
     handleValue(getArrKeysValue(props, key), key, store)
   })
   proxyTableProps(store, props)

--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -84,7 +84,7 @@ function useStore<T extends DefaultRow>() {
         if (parent && !parent.children) {
           parent.children = []
         }
-        parent.children!.push(column)
+        parent.children?.push(column)
         newColumns = replaceColumn(array, parent)
       }
       sortColumn(newColumns)
@@ -118,7 +118,7 @@ function useStore<T extends DefaultRow>() {
       updateColumnOrder: () => void
     ) {
       const array = unref(states._columns) || []
-      if (parent && parent.children) {
+      if (parent?.children) {
         parent.children.splice(
           parent.children.findIndex((item) => item.id === column.id),
           1
@@ -198,7 +198,7 @@ function useStore<T extends DefaultRow>() {
     },
 
     toggleAllSelection() {
-      ;(instance.store.toggleAllSelection as any)()
+      instance.store.toggleAllSelection?.()
     },
 
     rowSelectedChanged(_states: StoreStates, row: T) {
@@ -214,7 +214,7 @@ function useStore<T extends DefaultRow>() {
       instance.store.updateCurrentRow(row)
     },
   }
-  const commit = function (name: keyof typeof mutations, ...args: any) {
+  const commit = function (name: keyof typeof mutations, ...args: any[]) {
     const mutations = instance.store.mutations
     if (mutations[name]) {
       ;(mutations[name] as any).apply(

--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -36,7 +36,7 @@ function sortColumn<T>(array: TableColumnCtx<T>[]) {
   array.sort((cur, pre) => cur.no - pre.no)
 }
 
-function useStore<T>() {
+function useStore<T extends Record<string, any>>() {
   const instance = getCurrentInstance() as Table<T>
   const watcher = useWatcher<T>()
   const ns = useNamespace('table')
@@ -198,7 +198,6 @@ function useStore<T>() {
     },
 
     toggleAllSelection() {
-      //TODO: enquete la dessus
       ;(instance.store.toggleAllSelection as any)()
     },
 
@@ -240,10 +239,10 @@ function useStore<T>() {
 
 export default useStore
 
-class HelperStore<T> {
+class HelperStore<T extends Record<string, any>> {
   Return = useStore<T>()
 }
 
 type StoreFilter = Record<string, string[]>
-type Store<T> = HelperStore<T>['Return']
+type Store<T extends Record<string, any>> = HelperStore<T>['Return']
 export type { WatcherPropsData, Store, StoreFilter }

--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -5,9 +5,9 @@ import useWatcher from './watcher'
 
 import type { Ref } from 'vue'
 import type { TableColumnCtx } from '../table-column/defaults'
-import type { Filter, Sort, Table } from '../table/defaults'
+import type { DefaultRow, Filter, Sort, Table } from '../table/defaults'
 
-interface WatcherPropsData<T> {
+interface WatcherPropsData<T extends DefaultRow> {
   data: Ref<T[]>
   rowKey: Ref<string | null>
 }
@@ -36,7 +36,7 @@ function sortColumn<T>(array: TableColumnCtx<T>[]) {
   array.sort((cur, pre) => cur.no - pre.no)
 }
 
-function useStore<T extends Record<string, any>>() {
+function useStore<T extends DefaultRow>() {
   const instance = getCurrentInstance() as Table<T>
   const watcher = useWatcher<T>()
   const ns = useNamespace('table')
@@ -239,10 +239,10 @@ function useStore<T extends Record<string, any>>() {
 
 export default useStore
 
-class HelperStore<T extends Record<string, any>> {
+class HelperStore<T extends DefaultRow> {
   Return = useStore<T>()
 }
 
 type StoreFilter = Record<string, string[]>
-type Store<T extends Record<string, any>> = HelperStore<T>['Return']
+type Store<T extends DefaultRow> = HelperStore<T>['Return']
 export type { WatcherPropsData, Store, StoreFilter }

--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -12,7 +12,7 @@ interface WatcherPropsData<T extends DefaultRow> {
   rowKey: Ref<string | null>
 }
 
-function replaceColumn<T>(
+function replaceColumn<T extends DefaultRow>(
   array: TableColumnCtx<T>[],
   column: TableColumnCtx<T>
 ) {
@@ -26,7 +26,7 @@ function replaceColumn<T>(
   })
 }
 
-function sortColumn<T>(array: TableColumnCtx<T>[]) {
+function sortColumn<T extends DefaultRow>(array: TableColumnCtx<T>[]) {
   array.forEach((item) => {
     item.no = item.getColumnIndex?.()
     if (item.children?.length) {

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -3,7 +3,7 @@ import { isArray, isUndefined } from '@element-plus/utils'
 import { getRowIdentity, walkTreeNode } from '../util'
 
 import type { WatcherPropsData } from '.'
-import type { Table, TableProps, TreeNode } from '../table/defaults'
+import type { DefaultRow, Table, TableProps, TreeNode } from '../table/defaults'
 
 export interface TreeData extends TreeNode {
   children?: string[]
@@ -11,7 +11,7 @@ export interface TreeData extends TreeNode {
   loaded?: boolean
 }
 
-function useTree<T extends Record<string, any>(watcherData: WatcherPropsData<T>) {
+function useTree<T extends DefaultRow>(watcherData: WatcherPropsData<T>) {
   const expandRowKeys = ref<Array<string | number>>([])
   const treeData = ref<Record<string, TreeData>>({})
   const indent = ref(16)

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -135,7 +135,7 @@ function useTree<T extends Record<string, any>(watcherData: WatcherPropsData<T>)
               loading: !!loading,
               expanded: getExpanded(oldValue, key),
               children: lazyNodeChildren,
-              //level: '',
+              level: undefined,
             }
           }
         })

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -50,7 +50,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     return res
   })
 
-  const normalize = (data: any) => {
+  const normalize = (data: T[]) => {
     const rowKey = watcherData.rowKey.value
     const res = new Map<string | number, TreeData>() // 使用 Map 替代 Object，解决 number key 的问题
     walkTreeNode(

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -11,7 +11,7 @@ export interface TreeData extends TreeNode {
   loaded?: boolean
 }
 
-function useTree<T>(watcherData: WatcherPropsData<T>) {
+function useTree<T extends Record<string, any>(watcherData: WatcherPropsData<T>) {
   const expandRowKeys = ref<Array<string | number>>([])
   const treeData = ref<Record<string, TreeData>>({})
   const indent = ref(16)
@@ -36,12 +36,11 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
         const item: typeof res[number] = { children: [] }
         lazyTreeNodeMap.value[key].forEach((row) => {
           const currentRowKey = getRowIdentity(row, rowKey)
-          item.children.push(currentRowKey)
-          if (
-            row[lazyColumnIdentifier.value as keyof T] &&
-            !res[currentRowKey]
-          ) {
-            res[currentRowKey] = { children: [] }
+          if (currentRowKey) {
+            item.children.push(currentRowKey)
+            if (row[lazyColumnIdentifier.value] && !res[currentRowKey]) {
+              res[currentRowKey] = { children: [] }
+            }
           }
         })
         res[key] = item
@@ -56,7 +55,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     walkTreeNode(
       data,
       (parent: any, children: T, level: number) => {
-        const parentId = getRowIdentity(parent, rowKey, true)
+        const parentId = getRowIdentity(parent, rowKey, true)!
         if (isArray(children)) {
           res.set(parentId, {
             children: children.map((row) => row[rowKey]),
@@ -78,11 +77,11 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     return res
   }
 
-  //instance.store?.states.defaultExpandAll.value
   const updateTreeData = (
     ifChangeExpandRowKeys = false,
-    ifExpandAll: boolean = false
+    ifExpandAll?: boolean //=
   ): void => {
+    ifExpandAll ||= instance.store?.states.defaultExpandAll.value
     const nested = normalizedData.value
     const normalizedLazyNode_ = normalizedLazyNode.value
     const newTreeData: Record<string, TreeData> = {}

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -1,17 +1,22 @@
-// @ts-nocheck
 import { computed, getCurrentInstance, ref, unref, watch } from 'vue'
 import { isArray, isUndefined } from '@element-plus/utils'
 import { getRowIdentity, walkTreeNode } from '../util'
 
 import type { WatcherPropsData } from '.'
-import type { Table, TableProps } from '../table/defaults'
+import type { Table, TableProps, TreeNode } from '../table/defaults'
+
+export interface TreeData extends TreeNode {
+  children?: string[]
+  lazy?: boolean
+  loaded?: boolean
+}
 
 function useTree<T>(watcherData: WatcherPropsData<T>) {
   const expandRowKeys = ref<Array<string | number>>([])
-  const treeData = ref<unknown>({})
+  const treeData = ref<Record<string, TreeData>>({})
   const indent = ref(16)
   const lazy = ref(false)
-  const lazyTreeNodeMap = ref({})
+  const lazyTreeNodeMap = ref<Record<string, T[]>>({})
   const lazyColumnIdentifier = ref('hasChildren')
   const childrenColumnName = ref('children')
   const checkStrictly = ref(false)
@@ -24,15 +29,18 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
   const normalizedLazyNode = computed(() => {
     const rowKey = watcherData.rowKey.value
     const keys = Object.keys(lazyTreeNodeMap.value)
-    const res = {}
+    const res: Record<string, { children: string[] }> = {}
     if (!keys.length) return res
     keys.forEach((key) => {
       if (lazyTreeNodeMap.value[key].length) {
-        const item = { children: [] }
+        const item: typeof res[number] = { children: [] }
         lazyTreeNodeMap.value[key].forEach((row) => {
           const currentRowKey = getRowIdentity(row, rowKey)
           item.children.push(currentRowKey)
-          if (row[lazyColumnIdentifier.value] && !res[currentRowKey]) {
+          if (
+            row[lazyColumnIdentifier.value as keyof T] &&
+            !res[currentRowKey]
+          ) {
             res[currentRowKey] = { children: [] }
           }
         })
@@ -42,12 +50,12 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     return res
   })
 
-  const normalize = (data) => {
+  const normalize = (data: any) => {
     const rowKey = watcherData.rowKey.value
-    const res = new Map<string | number, object>() // 使用 Map 替代 Object，解决 number key 的问题
+    const res = new Map<string | number, TreeData>() // 使用 Map 替代 Object，解决 number key 的问题
     walkTreeNode(
       data,
-      (parent, children, level) => {
+      (parent: any, children: T, level: number) => {
         const parentId = getRowIdentity(parent, rowKey, true)
         if (isArray(children)) {
           res.set(parentId, {
@@ -70,17 +78,18 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     return res
   }
 
+  //instance.store?.states.defaultExpandAll.value
   const updateTreeData = (
     ifChangeExpandRowKeys = false,
-    ifExpandAll = instance.store?.states.defaultExpandAll.value
-  ) => {
+    ifExpandAll: boolean = false
+  ): void => {
     const nested = normalizedData.value
     const normalizedLazyNode_ = normalizedLazyNode.value
-    const newTreeData = {}
+    const newTreeData: Record<string, TreeData> = {}
     if (nested instanceof Map && nested.size) {
       const oldTreeData = unref(treeData)
-      const rootLazyRowKeys = []
-      const getExpanded = (oldValue, key) => {
+      const rootLazyRowKeys: string[] = []
+      const getExpanded = (oldValue: TreeData, key: string) => {
         if (ifChangeExpandRowKeys) {
           if (expandRowKeys.value) {
             return ifExpandAll || expandRowKeys.value.includes(key)
@@ -115,7 +124,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
           const lazyNodeChildren = normalizedLazyNode_[key].children
           if (rootLazyRowKeys.includes(key)) {
             // 懒加载的 root 节点，更新一下原有的数据，原来的 children 一定是空数组
-            if (newTreeData[key].children.length !== 0) {
+            if (newTreeData[key].children?.length !== 0) {
               throw new Error('[ElTable]children must be an empty array.')
             }
             newTreeData[key].children = lazyNodeChildren
@@ -127,7 +136,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
               loading: !!loading,
               expanded: getExpanded(oldValue, key),
               children: lazyNodeChildren,
-              level: '',
+              //level: '',
             }
           }
         })
@@ -161,7 +170,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     expandRowKeys.value = value
     updateTreeData()
   }
-  const isUseLazy = (data): boolean => {
+  const isUseLazy = (data: TreeData) => {
     return lazy.value && data && 'loaded' in data && !data.loaded
   }
   const toggleTreeExpansion = (row: T, expanded?: boolean) => {
@@ -182,7 +191,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     }
   }
 
-  const loadOrToggle = (row) => {
+  const loadOrToggle = (row: T) => {
     instance.store.assertRowKey()
     const rowKey = watcherData.rowKey.value
     const id = getRowIdentity(row, rowKey)
@@ -194,7 +203,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     }
   }
 
-  const loadData = (row: T, key: string, treeNode) => {
+  const loadData = (row: T, key: string, treeNode: TreeNode) => {
     const { load } = instance.props as unknown as TableProps<T>
     if (load && !treeData.value[key].loaded) {
       treeData.value[key].loading = true

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -79,8 +79,8 @@ function useTree<T extends Record<string, any>(watcherData: WatcherPropsData<T>)
 
   const updateTreeData = (
     ifChangeExpandRowKeys = false,
-    ifExpandAll?: boolean //=
-  ): void => {
+    ifExpandAll?: boolean
+  ) => {
     ifExpandAll ||= instance.store?.states.defaultExpandAll.value
     const nested = normalizedData.value
     const normalizedLazyNode_ = normalizedLazyNode.value

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -20,9 +20,9 @@ import type { StoreFilter } from '.'
 const sortData = <T>(
   data: T[],
   states: {
-    sortingColumn: TableColumnCtx<T>
+    sortingColumn: TableColumnCtx<T> | null
     sortProp: string | null
-    sortOrder: string | null
+    sortOrder: string | number | null
   }
 ) => {
   const sortingColumn = states.sortingColumn
@@ -128,7 +128,7 @@ function useWatcher<T>() {
       (column) => column.type === 'selection'
     )
 
-    let selectColFixLeft
+    let selectColFixLeft: boolean
     if (
       selectColumn &&
       selectColumn.fixed !== 'right' &&

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -22,7 +22,7 @@ import type {
 } from '../table/defaults'
 import type { StoreFilter } from '.'
 
-const sortData = <T>(
+const sortData = <T extends DefaultRow>(
   data: T[],
   states: {
     sortingColumn: TableColumnCtx<T> | null
@@ -43,7 +43,9 @@ const sortData = <T>(
   )
 }
 
-const doFlattenColumns = <T>(columns: TableColumnCtx<T>[]) => {
+const doFlattenColumns = <T extends DefaultRow>(
+  columns: TableColumnCtx<T>[]
+) => {
   const result: TableColumnCtx<T>[] = []
   columns.forEach((column) => {
     if (column.children && column.children.length > 0) {
@@ -56,7 +58,7 @@ const doFlattenColumns = <T>(columns: TableColumnCtx<T>[]) => {
   return result
 }
 
-function useWatcher<T extends Record<string, any>>() {
+function useWatcher<T extends DefaultRow>() {
   const instance = getCurrentInstance() as Table<T>
   const { size: tableSize } = toRefs(instance.proxy?.$props as any)
   const rowKey: Ref<string | null> = ref(null)
@@ -186,7 +188,7 @@ function useWatcher<T extends Record<string, any>>() {
   }
 
   // 选择
-  const isSelected = (row: DefaultRow) => {
+  const isSelected = (row: T) => {
     if (selectedMap.value && rowKey.value) {
       return !!selectedMap.value[getRowIdentity(row, rowKey.value)]
     } else {
@@ -314,7 +316,7 @@ function useWatcher<T extends Record<string, any>>() {
     let rowIndex = 0
     let selectedCount = 0
 
-    const checkSelectedStatus = (data: DefaultRow[]) => {
+    const checkSelectedStatus = (data: T[]) => {
       for (const row of data) {
         const isRowSelectable =
           selectable.value && selectable.value.call(null, row, rowIndex)
@@ -532,7 +534,7 @@ function useWatcher<T extends Record<string, any>>() {
     getSelectionRows,
     toggleRowSelection,
     _toggleAllSelection,
-    toggleAllSelection: null,
+    toggleAllSelection: null as (() => void) | null,
     updateAllSelected,
     updateFilters,
     updateCurrentRow,

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -419,7 +419,7 @@ function useWatcher<T extends DefaultRow>() {
     execSort()
   }
 
-  const clearFilter = (columnKeys: any) => {
+  const clearFilter = (columnKeys?: string[] | string) => {
     const { tableHeaderRef } = instance.refs as TableRefs
     if (!tableHeaderRef) return
     const panels = Object.assign({}, tableHeaderRef.filterPanels)

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -51,7 +51,7 @@ const doFlattenColumns = <T>(columns: TableColumnCtx<T>[]) => {
   return result
 }
 
-function useWatcher<T>() {
+function useWatcher<T extends Record<string, any>>() {
   const instance = getCurrentInstance() as Table<T>
   const { size: tableSize } = toRefs(instance.proxy?.$props as any)
   const rowKey: Ref<string | null> = ref(null)

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -189,7 +189,7 @@ function useWatcher<T extends DefaultRow>() {
 
   // 选择
   const isSelected = (row: T) => {
-    if (selectedMap.value && rowKey.value) {
+    if (selectedMap.value) {
       return !!selectedMap.value[getRowIdentity(row, rowKey.value)]
     } else {
       return selection.value.includes(row)
@@ -399,8 +399,8 @@ function useWatcher<T extends DefaultRow>() {
           )
         })
       }
-    }) as any
-    ;(filteredData.value as any) = sourceData
+    })
+    filteredData.value = sourceData
   }
 
   const execSort = () => {
@@ -413,7 +413,7 @@ function useWatcher<T extends DefaultRow>() {
 
   // 根据 filters 与 sort 去过滤 data
   const execQuery = (ignore: { filter: boolean } | undefined = undefined) => {
-    if (!(ignore && (ignore as any).filter)) {
+    if (!ignore?.filter) {
       execFilter()
     }
     execSort()

--- a/packages/components/table/src/table-body/defaults.ts
+++ b/packages/components/table/src/table-body/defaults.ts
@@ -23,23 +23,21 @@ interface TableBodyProps<T extends DefaultRow> {
 const defaultProps = {
   store: {
     required: true,
-    type: Object as PropType<TableBodyProps<DefaultRow>['store']>,
+    type: Object as PropType<TableBodyProps<any>['store']>,
   },
   stripe: Boolean,
   tooltipEffect: String,
   tooltipOptions: {
-    type: Object as PropType<TableBodyProps<DefaultRow>['tooltipOptions']>,
+    type: Object as PropType<TableBodyProps<any>['tooltipOptions']>,
   },
   context: {
     default: () => ({}),
-    type: Object as PropType<TableBodyProps<DefaultRow>['context']>,
+    type: Object as PropType<TableBodyProps<any>['context']>,
   },
   rowClassName: [String, Function] as PropType<
-    TableBodyProps<DefaultRow>['rowClassName']
+    TableBodyProps<any>['rowClassName']
   >,
-  rowStyle: [Object, Function] as PropType<
-    TableBodyProps<DefaultRow>['rowStyle']
-  >,
+  rowStyle: [Object, Function] as PropType<TableBodyProps<any>['rowStyle']>,
   fixed: {
     type: String,
     default: '',

--- a/packages/components/table/src/table-body/defaults.ts
+++ b/packages/components/table/src/table-body/defaults.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { PropType } from 'vue'
 import type { Store } from '../store'
 import type {
@@ -9,7 +8,7 @@ import type {
 } from '../table/defaults'
 import type { TableOverflowTooltipOptions } from '../util'
 
-interface TableBodyProps<T> {
+interface TableBodyProps<T extends DefaultRow> {
   store: Store<T>
   stripe?: boolean
   context: Table<T>

--- a/packages/components/table/src/table-body/events-helper.ts
+++ b/packages/components/table/src/table-body/events-helper.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { h, inject, ref } from 'vue'
 import { debounce } from 'lodash-unified'
 import { addClass, hasClass, removeClass } from '@element-plus/utils'
@@ -13,24 +12,25 @@ import { TABLE_INJECTION_KEY } from '../tokens'
 import type { TableColumnCtx } from '../table-column/defaults'
 import type { TableBodyProps } from './defaults'
 import type { TableOverflowTooltipOptions } from '../util'
+import type { DefaultRow } from '../table/defaults'
 
 function isGreaterThan(a: number, b: number, epsilon = 0.03) {
   return a - b > epsilon
 }
 
-function useEvents<T>(props: Partial<TableBodyProps<T>>) {
+function useEvents<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
   const parent = inject(TABLE_INJECTION_KEY)
   const tooltipContent = ref('')
   const tooltipTrigger = ref(h('div'))
   const handleEvent = (event: Event, row: T, name: string) => {
     const table = parent
     const cell = getCell(event)
-    let column: TableColumnCtx<T>
+    let column: TableColumnCtx<T> | null = null
     const namespace = table?.vnode.el?.dataset.prefix
     if (cell) {
       column = getColumnByCell(
         {
-          columns: props.store.states.columns.value,
+          columns: props.store!.states.columns.value,
         },
         cell,
         namespace
@@ -45,17 +45,17 @@ function useEvents<T>(props: Partial<TableBodyProps<T>>) {
     handleEvent(event, row, 'dblclick')
   }
   const handleClick = (event: Event, row: T) => {
-    props.store.commit('setCurrentRow', row)
+    props.store?.commit('setCurrentRow', row)
     handleEvent(event, row, 'click')
   }
   const handleContextMenu = (event: Event, row: T) => {
     handleEvent(event, row, 'contextmenu')
   }
   const handleMouseEnter = debounce((index: number) => {
-    props.store.commit('setHoverRow', index)
+    props.store?.commit('setHoverRow', index)
   }, 30)
   const handleMouseLeave = debounce(() => {
-    props.store.commit('setHoverRow', null)
+    props.store?.commit('setHoverRow', null)
   }, 30)
   const getPadding = (el: HTMLElement) => {
     const style = window.getComputedStyle(el, null)
@@ -76,11 +76,12 @@ function useEvents<T>(props: Partial<TableBodyProps<T>>) {
     event: MouseEvent,
     toggle: (el: Element, cls: string) => void
   ) => {
-    let node = event.target.parentNode
+    let node: Node | null | undefined = (event?.target as Element | null)
+      ?.parentNode
     while (rowSpan > 1) {
       node = node?.nextSibling
       if (!node || node.nodeName !== 'TR') break
-      toggle(node, 'hover-row hover-fixed-row')
+      toggle(node as Element, 'hover-row hover-fixed-row')
       rowSpan--
     }
   }
@@ -90,14 +91,15 @@ function useEvents<T>(props: Partial<TableBodyProps<T>>) {
     row: T,
     tooltipOptions: TableOverflowTooltipOptions
   ) => {
+    if (!parent) return
     const table = parent
     const cell = getCell(event)
     const namespace = table?.vnode.el?.dataset.prefix
-    let column: TableColumnCtx<T>
+    let column: TableColumnCtx<T> | null = null
     if (cell) {
       column = getColumnByCell(
         {
-          columns: props.store.states.columns.value,
+          columns: props.store!.states.columns.value,
         },
         cell,
         namespace
@@ -108,7 +110,7 @@ function useEvents<T>(props: Partial<TableBodyProps<T>>) {
       if (cell.rowSpan > 1) {
         toggleRowClassByCell(cell.rowSpan, event, addClass)
       }
-      const hoverState = (table.hoverState = { cell, column, row })
+      const hoverState = (table.hoverState = { cell, column: null, row })
       table?.emit(
         'cell-mouse-enter',
         hoverState.row,
@@ -162,7 +164,7 @@ function useEvents<T>(props: Partial<TableBodyProps<T>>) {
     ) {
       createTablePopper(
         tooltipOptions,
-        cell.innerText || cell.textContent,
+        (cell?.innerText || cell?.textContent) ?? '',
         row,
         column,
         cell,
@@ -172,7 +174,7 @@ function useEvents<T>(props: Partial<TableBodyProps<T>>) {
       removePopper?.()
     }
   }
-  const handleCellMouseLeave = (event) => {
+  const handleCellMouseLeave = (event: MouseEvent) => {
     const cell = getCell(event)
     if (!cell) return
     if (cell.rowSpan > 1) {

--- a/packages/components/table/src/table-body/events-helper.ts
+++ b/packages/components/table/src/table-body/events-helper.ts
@@ -30,7 +30,7 @@ function useEvents<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
     if (cell) {
       column = getColumnByCell(
         {
-          columns: props.store!.states.columns.value,
+          columns: props.store?.states.columns.value ?? [],
         },
         cell,
         namespace
@@ -99,7 +99,7 @@ function useEvents<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
     if (cell) {
       column = getColumnByCell(
         {
-          columns: props.store!.states.columns.value,
+          columns: props.store?.states.columns.value ?? [],
         },
         cell,
         namespace

--- a/packages/components/table/src/table-body/events-helper.ts
+++ b/packages/components/table/src/table-body/events-helper.ts
@@ -110,7 +110,11 @@ function useEvents<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
       if (cell.rowSpan > 1) {
         toggleRowClassByCell(cell.rowSpan, event, addClass)
       }
-      const hoverState = (table.hoverState = { cell, column: null, row })
+      const hoverState = (table.hoverState = {
+        cell,
+        column: column as any,
+        row,
+      })
       table?.emit(
         'cell-mouse-enter',
         hoverState.row,

--- a/packages/components/table/src/table-body/index.ts
+++ b/packages/components/table/src/table-body/index.ts
@@ -28,7 +28,7 @@ export default defineComponent({
     const { onColumnsChange, onScrollableChange } = useLayoutObserver(parent!)
 
     const hoveredCellList: HTMLTableCellElement[] = []
-    watch(props.store!.states.hoverRow, (newVal: any, oldVal: any) => {
+    watch(props.store?.states.hoverRow, (newVal: any, oldVal: any) => {
       const el = instance?.vnode.el as HTMLElement
       const rows = Array.from(el?.children || []).filter((e) =>
         e?.classList.contains(`${ns.e('row')}`)

--- a/packages/components/table/src/table-body/index.ts
+++ b/packages/components/table/src/table-body/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   defineComponent,
   getCurrentInstance,
@@ -28,8 +27,8 @@ export default defineComponent({
       useRender(props)
     const { onColumnsChange, onScrollableChange } = useLayoutObserver(parent!)
 
-    const hoveredCellList = []
-    watch(props.store.states.hoverRow, (newVal: any, oldVal: any) => {
+    const hoveredCellList: HTMLTableCellElement[] = []
+    watch(props.store!.states.hoverRow, (newVal: any, oldVal: any) => {
       const el = instance?.vnode.el as HTMLElement
       const rows = Array.from(el?.children || []).filter((e) =>
         e?.classList.contains(`${ns.e('row')}`)
@@ -37,7 +36,8 @@ export default defineComponent({
 
       // hover rowSpan > 1 choose the whole row
       let rowNum = newVal
-      const childNodes = rows[rowNum]?.childNodes
+      const childNodes = rows[rowNum]
+        ?.childNodes as NodeListOf<HTMLTableCellElement>
       if (childNodes?.length) {
         let control = 0
         const indexes = Array.from(childNodes).reduce((acc, item, index) => {
@@ -50,13 +50,15 @@ export default defineComponent({
           }
           control > 0 && control--
           return acc
-        }, [])
+        }, [] as number[])
 
         indexes.forEach((rowIndex) => {
           rowNum = newVal
           while (rowNum > 0) {
             // find from previous
-            const preChildNodes = rows[rowNum - 1]?.childNodes
+            const preChildNodes = rows[rowNum - 1]
+              ?.childNodes as NodeListOf<HTMLTableCellElement>
+
             if (
               preChildNodes[rowIndex] &&
               preChildNodes[rowIndex].nodeName === 'TD' &&
@@ -73,7 +75,7 @@ export default defineComponent({
         hoveredCellList.forEach((item) => removeClass(item, 'hover-cell'))
         hoveredCellList.length = 0
       }
-      if (!props.store.states.isComplex.value || !isClient) return
+      if (!props.store?.states.isComplex.value || !isClient) return
 
       rAF(() => {
         // just get first level children; fix #9723
@@ -104,7 +106,7 @@ export default defineComponent({
   },
   render() {
     const { wrappedRowRender, store } = this
-    const data = store.states.data.value || []
+    const data = store?.states.data.value || []
     // Why do we need tabIndex: -1 ?
     // If you set the tabindex attribute on an element ,
     // then its child content cannot be scrolled with the arrow keys,
@@ -112,7 +114,7 @@ export default defineComponent({
     // See https://github.com/facebook/react/issues/25462#issuecomment-1274775248 or https://developer.mozilla.org/zh-CN/docs/Web/HTML/Global_attributes/tabindex
     return h('tbody', { tabIndex: -1 }, [
       data.reduce((acc: VNode[], row) => {
-        return acc.concat(wrappedRowRender(row, acc.length))
+        return acc.concat(wrappedRowRender(row, acc.length) as VNode[])
       }, []),
     ])
   },

--- a/packages/components/table/src/table-body/render-helper.ts
+++ b/packages/components/table/src/table-body/render-helper.ts
@@ -18,6 +18,7 @@ import type {
   TreeNode,
 } from '../table/defaults'
 import type { TreeData } from '../store/tree'
+import type { TableOverflowTooltipOptions } from '../util'
 
 function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
   const parent = inject(TABLE_INJECTION_KEY) as Table<T>
@@ -136,7 +137,11 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
             rowspan,
             colspan,
             onMouseenter: ($event: MouseEvent) =>
-              handleCellMouseEnter($event, row, mergedTooltipOptions as any),
+              handleCellMouseEnter(
+                $event,
+                row,
+                mergedTooltipOptions as TableOverflowTooltipOptions
+              ),
             onMouseleave: handleCellMouseLeave,
           },
           {

--- a/packages/components/table/src/table-body/render-helper.ts
+++ b/packages/components/table/src/table-body/render-helper.ts
@@ -230,7 +230,7 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
           if (!(children && children.length && parent)) return
           children.forEach((node) => {
             // 父节点的 display 状态影响子节点的显示状态
-            const innerTreeRowData = {
+            const innerTreeRowData: Partial<Record<string, any>> = {
               display: parent.display && parent.expanded,
               level: parent.level! + 1,
               expanded: false,
@@ -246,7 +246,7 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
             // 如果包含子节点的，设置 expanded 属性。
             // 对于它子节点的 display 属性由它本身的 expanded 与 display 共同决定。
             if (cur) {
-              innerTreeRowData.expanded = !!cur.expanded
+              innerTreeRowData.expanded = cur.expanded
               // 懒加载的某些节点，level 未知
               cur.level = cur.level || innerTreeRowData.level
               cur.display = !!(cur.expanded && innerTreeRowData.display)
@@ -256,7 +256,7 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
                     cur.children && cur.children.length
                   )
                 }
-                innerTreeRowData.loading = !!cur.loading
+                innerTreeRowData.loading = cur.loading
               }
             }
             i++

--- a/packages/components/table/src/table-body/styles-helper.ts
+++ b/packages/components/table/src/table-body/styles-helper.ts
@@ -31,7 +31,7 @@ function useStyles<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
     const classes = [ns.e('row')]
     if (
       parent?.props.highlightCurrentRow &&
-      row === props.store!.states.currentRow.value
+      row === props.store?.states.currentRow.value
     ) {
       classes.push('current-row')
     }

--- a/packages/components/table/src/table-body/styles-helper.ts
+++ b/packages/components/table/src/table-body/styles-helper.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { inject } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { isArray, isFunction, isObject, isString } from '@element-plus/utils'
@@ -11,9 +10,10 @@ import { TABLE_INJECTION_KEY } from '../tokens'
 
 import type { TableColumnCtx } from '../table-column/defaults'
 import type { TableBodyProps } from './defaults'
+import type { DefaultRow, Table } from '../table/defaults'
 
-function useStyles<T>(props: Partial<TableBodyProps<T>>) {
-  const parent = inject(TABLE_INJECTION_KEY)
+function useStyles<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
+  const parent = inject(TABLE_INJECTION_KEY) as Table<T>
   const ns = useNamespace('table')
 
   const getRowStyle = (row: T, rowIndex: number) => {
@@ -31,7 +31,7 @@ function useStyles<T>(props: Partial<TableBodyProps<T>>) {
     const classes = [ns.e('row')]
     if (
       parent?.props.highlightCurrentRow &&
-      row === props.store.states.currentRow.value
+      row === props.store!.states.currentRow.value
     ) {
       classes.push('current-row')
     }
@@ -143,7 +143,7 @@ function useStyles<T>(props: Partial<TableBodyProps<T>>) {
     index: number
   ): number => {
     if (colspan < 1) {
-      return columns[index].realWidth
+      return columns[index].realWidth!
     }
     const widthArr = columns
       .map(({ realWidth, width }) => realWidth || width)

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -19,7 +19,7 @@ type ValueOf<T> = T[keyof T]
 
 interface TableColumnCtx<T> {
   id: string
-  realWidth: number
+  realWidth: number | null
   type: string
   label: string
   className: string
@@ -59,10 +59,10 @@ interface TableColumnCtx<T> {
   renderCell: (data: any) => void
   colSpan: number
   rowSpan: number
-  children: TableColumnCtx<T>[]
+  children?: TableColumnCtx<T>[]
   level: number
   filterable: boolean | FilterMethods<T> | Filters
-  order: string
+  order: string | null
   isColumnGroup: boolean
   isSubColumn: boolean
   columns: TableColumnCtx<T>[]

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -31,7 +31,7 @@ interface TableColumnCtx<T> {
   renderHeader: (data: CI<T>) => VNode
   sortable: boolean | string
   sortMethod: (a: T, b: T) => number
-  sortBy: string | ((row: T, index: number) => string) | string[]
+  sortBy: string | ((row: T, index: number, array?: T[]) => string) | string[]
   resizable: boolean
   columnKey: string
   rawColumnKey: string

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -1,19 +1,22 @@
-// @ts-nocheck
 import type { ComponentInternalInstance, PropType, Ref, VNode } from 'vue'
-import type { DefaultRow, Table } from '../table/defaults'
+import type { DefaultRow, Table, TableSortOrder } from '../table/defaults'
 import type {
   TableOverflowTooltipFormatter,
   TableOverflowTooltipOptions,
 } from '../util'
 
-type CI<T> = { column: TableColumnCtx<T>; $index: number }
+type CI<T extends DefaultRow> = { column: TableColumnCtx<T>; $index: number }
 
 type Filters = {
   text: string
   value: string
 }[]
 
-type FilterMethods<T> = (value, row: T, column: TableColumnCtx<T>) => void
+type FilterMethods<T extends DefaultRow> = (
+  value: string,
+  row: T,
+  column: TableColumnCtx<T>
+) => void
 
 type ValueOf<T> = T[keyof T]
 
@@ -26,7 +29,7 @@ interface TableColumnCtx<T extends DefaultRow> {
   labelClassName: string
   property: string
   prop: string
-  width: string | number
+  width?: string | number
   minWidth: string | number
   renderHeader: (data: CI<T>) => VNode
   sortable: boolean | string
@@ -43,7 +46,7 @@ interface TableColumnCtx<T extends DefaultRow> {
   formatter: (
     row: T,
     column: TableColumnCtx<T>,
-    cellValue,
+    cellValue: any,
     index: number
   ) => VNode | string
   selectable: (row: T, index: number) => boolean
@@ -69,9 +72,11 @@ interface TableColumnCtx<T extends DefaultRow> {
   getColumnIndex: () => number
   no: number
   filterOpened?: boolean
+  renderFilterIcon?: (scope: any) => VNode
+  renderExpand?: (scope: any) => VNode
 }
 
-interface TableColumn<T> extends ComponentInternalInstance {
+interface TableColumn<T extends DefaultRow> extends ComponentInternalInstance {
   vnode: {
     vParent: TableColumn<T> | Table<T>
   } & VNode
@@ -238,8 +243,8 @@ export default {
     default: () => {
       return ['ascending', 'descending', null]
     },
-    validator: (val: TableColumnCtx<unknown>['sortOrders']) => {
-      return val.every((order: string) =>
+    validator: <T extends DefaultRow>(val: TableColumnCtx<T>['sortOrders']) => {
+      return val.every((order: TableSortOrder | null) =>
         ['ascending', 'descending', null].includes(order)
       )
     },

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -26,7 +26,7 @@ type FilterMethods<T extends DefaultRow> = (
 
 type ValueOf<T> = T[keyof T]
 
-interface TableColumnCtx<T extends DefaultRow> {
+type TableColumnCtx<T extends DefaultRow = DefaultRow> = {
   id: string
   realWidth: number | null
   type: string
@@ -243,7 +243,7 @@ export default {
     default: () => {
       return ['ascending', 'descending', null]
     },
-    validator: <T extends DefaultRow>(val: TableColumnCtx<T>['sortOrders']) => {
+    validator: (val: TableColumnCtx<any>['sortOrders']) => {
       return val.every((order: TableSortOrder | null) =>
         ['ascending', 'descending', null].includes(order)
       )

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -4,8 +4,14 @@ import type {
   TableOverflowTooltipFormatter,
   TableOverflowTooltipOptions,
 } from '../util'
+import type { Store } from '../store'
 
-type CI<T extends DefaultRow> = { column: TableColumnCtx<T>; $index: number }
+type CI<T extends DefaultRow> = {
+  column: TableColumnCtx<T>
+  $index: number
+  store: Store<T>
+  _self: any
+}
 
 type Filters = {
   text: string
@@ -65,7 +71,7 @@ interface TableColumnCtx<T extends DefaultRow> {
   children?: TableColumnCtx<T>[]
   level: number
   filterable: boolean | FilterMethods<T> | Filters
-  order: string | null
+  order: TableSortOrder | null
   isColumnGroup: boolean
   isSubColumn: boolean
   columns: TableColumnCtx<T>[]

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -17,7 +17,7 @@ type FilterMethods<T> = (value, row: T, column: TableColumnCtx<T>) => void
 
 type ValueOf<T> = T[keyof T]
 
-interface TableColumnCtx<T> {
+interface TableColumnCtx<T extends DefaultRow> {
   id: string
   realWidth: number | null
   type: string

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -55,7 +55,7 @@ interface TableColumnCtx<T> {
   filterMultiple: boolean
   filterClassName: string
   index: number | ((index: number) => number)
-  sortOrders: ('ascending' | 'descending' | null)[]
+  sortOrders: (TableSortOrder | null)[]
   renderCell: (data: any) => void
   colSpan: number
   rowSpan: number

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -138,9 +138,7 @@ export default {
   /**
    * @description render function for table header of this column
    */
-  renderHeader: Function as PropType<
-    TableColumnCtx<DefaultRow>['renderHeader']
-  >,
+  renderHeader: Function as PropType<TableColumnCtx<any>['renderHeader']>,
   /**
    * @description whether column can be sorted. Remote sorting can be done by setting this attribute to 'custom' and listening to the `sort-change` event of Table
    */
@@ -151,13 +149,11 @@ export default {
   /**
    * @description sorting method, works when `sortable` is `true`. Should return a number, just like Array.sort
    */
-  sortMethod: Function as PropType<TableColumnCtx<DefaultRow>['sortMethod']>,
+  sortMethod: Function as PropType<TableColumnCtx<any>['sortMethod']>,
   /**
    * @description specify which property to sort by, works when `sortable` is `true` and `sort-method` is `undefined`. If set to an Array, the column will sequentially sort by the next property if the previous one is equal
    */
-  sortBy: [String, Function, Array] as PropType<
-    TableColumnCtx<DefaultRow>['sortBy']
-  >,
+  sortBy: [String, Function, Array] as PropType<TableColumnCtx<any>['sortBy']>,
   /**
    * @description whether column width can be resized, works when `border` of `el-table` is `true`
    */
@@ -182,7 +178,7 @@ export default {
    */
   showOverflowTooltip: {
     type: [Boolean, Object] as PropType<
-      TableColumnCtx<DefaultRow>['showOverflowTooltip']
+      TableColumnCtx<any>['showOverflowTooltip']
     >,
     default: undefined,
   },
@@ -190,7 +186,7 @@ export default {
    * @description function that formats cell tooltip content, works when `show-overflow-tooltip` is `true`
    */
   tooltipFormatter: Function as PropType<
-    TableColumnCtx<DefaultRow>['tooltipFormatter']
+    TableColumnCtx<any>['tooltipFormatter']
   >,
   /**
    * @description whether column is fixed at left / right. Will be fixed at left if `true`
@@ -199,11 +195,11 @@ export default {
   /**
    * @description function that formats cell content
    */
-  formatter: Function as PropType<TableColumnCtx<DefaultRow>['formatter']>,
+  formatter: Function as PropType<TableColumnCtx<any>['formatter']>,
   /**
    * @description function that determines if a certain row can be selected, works when `type` is 'selection'
    */
-  selectable: Function as PropType<TableColumnCtx<DefaultRow>['selectable']>,
+  selectable: Function as PropType<TableColumnCtx<any>['selectable']>,
   /**
    * @description whether to reserve selection after data refreshing, works when `type` is 'selection'. Note that `row-key` is required for this to work
    */
@@ -211,17 +207,15 @@ export default {
   /**
    * @description data filtering method. If `filter-multiple` is on, this method will be called multiple times for each row, and a row will display if one of the calls returns `true`
    */
-  filterMethod: Function as PropType<
-    TableColumnCtx<DefaultRow>['filterMethod']
-  >,
+  filterMethod: Function as PropType<TableColumnCtx<any>['filterMethod']>,
   /**
    * @description filter value for selected data, might be useful when table header is rendered with `render-header`
    */
-  filteredValue: Array as PropType<TableColumnCtx<DefaultRow>['filteredValue']>,
+  filteredValue: Array as PropType<TableColumnCtx<any>['filteredValue']>,
   /**
    * @description an array of data filtering options. For each element in this array, `text` and `value` are required
    */
-  filters: Array as PropType<TableColumnCtx<DefaultRow>['filters']>,
+  filters: Array as PropType<TableColumnCtx<any>['filters']>,
   /**
    * @description placement for the filter dropdown
    */
@@ -240,12 +234,12 @@ export default {
   /**
    * @description customize indices for each row, works on columns with `type=index`
    */
-  index: [Number, Function] as PropType<TableColumnCtx<DefaultRow>['index']>,
+  index: [Number, Function] as PropType<TableColumnCtx<any>['index']>,
   /**
    * @description the order of the sorting strategies used when sorting the data, works when `sortable` is `true`. Accepts an array, as the user clicks on the header, the column is sorted in order of the elements in the array
    */
   sortOrders: {
-    type: Array as PropType<TableColumnCtx<DefaultRow>['sortOrders']>,
+    type: Array as PropType<TableColumnCtx<any>['sortOrders']>,
     default: () => {
       return ['ascending', 'descending', null]
     },

--- a/packages/components/table/src/table-column/index.ts
+++ b/packages/components/table/src/table-column/index.ts
@@ -23,6 +23,7 @@ import type { DefaultRow } from '../table/defaults'
 
 let columnIdSeed = 1
 
+//TODO: when vue 3.3 we can set this component a generic: https://github.com/vuejs/core/pull/7963
 export default defineComponent({
   name: 'ElTableColumn',
   components: {

--- a/packages/components/table/src/table-column/index.ts
+++ b/packages/components/table/src/table-column/index.ts
@@ -1,6 +1,5 @@
 import {
   Fragment,
-  VNode,
   computed,
   defineComponent,
   getCurrentInstance,
@@ -18,6 +17,7 @@ import useWatcher from './watcher-helper'
 import useRender from './render-helper'
 import defaultProps from './defaults'
 
+import type { VNode } from 'vue'
 import type { TableColumn, TableColumnCtx } from './defaults'
 import type { DefaultRow } from '../table/defaults'
 
@@ -135,7 +135,7 @@ export default defineComponent({
         setColumnWidth,
         setColumnForcedProps
       )
-      column = chains(column) as any
+      column = chains(column) as unknown as TableColumnCtx<DefaultRow>
       columnConfig.value = column
 
       // 注册 watcher

--- a/packages/components/table/src/table-column/index.ts
+++ b/packages/components/table/src/table-column/index.ts
@@ -1,6 +1,6 @@
-// @ts-nocheck
 import {
   Fragment,
+  VNode,
   computed,
   defineComponent,
   getCurrentInstance,
@@ -56,7 +56,7 @@ export default defineComponent({
       getColumnElIndex,
       realAlign,
       updateColumnOrder,
-    } = useRender(props as unknown as TableColumnCtx<unknown>, slots, owner)
+    } = useRender(props as unknown as TableColumnCtx<DefaultRow>, slots, owner)
 
     const parent = columnOrTableParent.value
     columnId.value = `${
@@ -65,7 +65,7 @@ export default defineComponent({
     onBeforeMount(() => {
       isSubColumn.value = owner.value !== parent
 
-      const type = props.type || 'default'
+      const type = (props.type as keyof typeof cellStarts) || 'default'
       const sortable = props.sortable === '' ? true : props.sortable
       //The selection column should not be affected by `showOverflowTooltip`.
       const showOverflowTooltip =
@@ -134,7 +134,7 @@ export default defineComponent({
         setColumnWidth,
         setColumnForcedProps
       )
-      column = chains(column)
+      column = chains(column) as any
       columnConfig.value = column
 
       // 注册 watcher
@@ -171,7 +171,7 @@ export default defineComponent({
     })
     instance.columnId = columnId.value
 
-    instance.columnConfig = columnConfig
+    instance.columnConfig = columnConfig as any
     return
   },
   render() {
@@ -185,7 +185,7 @@ export default defineComponent({
       if (isArray(renderDefault)) {
         for (const childNode of renderDefault) {
           if (
-            childNode.type?.name === 'ElTableColumn' ||
+            (childNode.type as any)?.name === 'ElTableColumn' ||
             childNode.shapeFlag & 2
           ) {
             children.push(childNode)
@@ -195,7 +195,10 @@ export default defineComponent({
           ) {
             childNode.children.forEach((vnode) => {
               // No rendering when vnode is dynamic slot or text
-              if (vnode?.patchFlag !== 1024 && !isString(vnode?.children)) {
+              if (
+                (vnode as VNode)?.patchFlag !== 1024 &&
+                !isString((vnode as VNode)?.children)
+              ) {
                 children.push(vnode)
               }
             })

--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Comment,
   computed,
@@ -13,25 +12,27 @@ import { debugWarn, isArray, isUndefined } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import {
   cellForced,
+  cellStarts,
   defaultRenderCell,
   getDefaultClassName,
   treeCellPrefix,
 } from '../config'
 import { parseMinWidth, parseWidth } from '../util'
 
-import type { ComputedRef } from 'vue'
+import type { ComputedRef, RendererNode, Slots } from 'vue'
 import type { TableColumn, TableColumnCtx } from './defaults'
+import type { DefaultRow, Table } from '../table/defaults'
 
-function useRender<T>(
+function useRender<T extends DefaultRow>(
   props: TableColumnCtx<T>,
-  slots,
+  slots: Slots,
   owner: ComputedRef<any>
 ) {
   const instance = getCurrentInstance() as TableColumn<T>
   const columnId = ref('')
   const isSubColumn = ref(false)
-  const realAlign = ref<string>()
-  const realHeaderAlign = ref<string>()
+  const realAlign = ref<string | null>()
+  const realHeaderAlign = ref<string | null | undefined>()
   const ns = useNamespace('table')
   watchEffect(() => {
     realAlign.value = props.align ? `is-${props.align}` : null
@@ -53,7 +54,7 @@ function useRender<T>(
     return parent
   })
   const hasTreeColumn = computed<boolean>(() => {
-    const { store } = instance.parent
+    const { store } = (instance.parent as Table<T>)!
     if (!store) return false
     const { treeData } = store.states
     const treeDataValue = treeData.value
@@ -80,12 +81,12 @@ function useRender<T>(
   }
   const setColumnForcedProps = (column: TableColumnCtx<T>) => {
     // 对于特定类型的 column，某些属性不允许设置
-    const type = column.type
-    const source = cellForced[type] || {}
+    const type = column.type as keyof typeof cellStarts
+    const source = (cellForced as any)[type] || {}
     Object.keys(source).forEach((prop) => {
       const value = source[prop]
       if (prop !== 'className' && !isUndefined(value)) {
-        column[prop] = value
+        ;(column as any)[prop] = value
       }
     })
     const className = getDefaultClassName(type)
@@ -149,7 +150,7 @@ function useRender<T>(
           },
           [originRenderCell(data)]
         )
-      owner.value.renderExpanded = (data) => {
+      owner.value.renderExpanded = (data: any) => {
         return slots.default ? slots.default(data) : slots.default
       }
     } else {
@@ -168,7 +169,7 @@ function useRender<T>(
 
         const { columns } = owner.value.store.states
         const firstUserColumnIndex = columns.value.findIndex(
-          (item) => item.type === 'default'
+          (item: any) => item.type === 'default'
         )
         const shouldCreatePlaceholder =
           hasTreeColumn.value && data.cellIndex === firstUserColumnIndex
@@ -185,23 +186,23 @@ function useRender<T>(
             }px`,
           }
         }
-        checkSubColumn(children)
+        checkSubColumn(children as any)
         return h('div', props, [prefix, children])
       }
     }
     return column
   }
-  const getPropsData = (...propsKey: unknown[]) => {
+  const getPropsData = (...propsKey: string[][]) => {
     return propsKey.reduce((prev, cur) => {
       if (isArray(cur)) {
         cur.forEach((key) => {
-          prev[key] = props[key]
+          prev[key] = props[key as keyof TableColumnCtx<T>]
         })
       }
       return prev
-    }, {})
+    }, {} as Record<string, any>)
   }
-  const getColumnElIndex = (children, child) => {
+  const getColumnElIndex = (children: T[], child: RendererNode | null) => {
     return Array.prototype.indexOf.call(children, child)
   }
 

--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -12,7 +12,6 @@ import { debugWarn, isArray, isUndefined } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import {
   cellForced,
-  cellStarts,
   defaultRenderCell,
   getDefaultClassName,
   treeCellPrefix,
@@ -81,7 +80,7 @@ function useRender<T extends DefaultRow>(
   }
   const setColumnForcedProps = (column: TableColumnCtx<T>) => {
     // 对于特定类型的 column，某些属性不允许设置
-    const type = column.type as keyof typeof cellStarts
+    const type = column.type
     const source = (cellForced as any)[type] || {}
     Object.keys(source).forEach((prop) => {
       const value = source[prop]

--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -113,6 +113,7 @@ function useRender<T extends DefaultRow>(
   }
   const setColumnRenders = (column: TableColumnCtx<T>) => {
     // renderHeader 属性不推荐使用。
+    //@ts-expect-error
     if (props.renderHeader) {
       debugWarn(
         'TableColumn',

--- a/packages/components/table/src/table-column/watcher-helper.ts
+++ b/packages/components/table/src/table-column/watcher-helper.ts
@@ -1,25 +1,25 @@
-// @ts-nocheck
 import { getCurrentInstance, watch } from 'vue'
 import { hasOwn } from '@element-plus/utils'
 import { parseMinWidth, parseWidth } from '../util'
 
 import type { ComputedRef } from 'vue'
+import type { DefaultRow } from '../table/defaults'
 import type { TableColumn, TableColumnCtx, ValueOf } from './defaults'
 
-function getAllAliases(props, aliases) {
+function getAllAliases(props: string[], aliases: Record<string, string>) {
   return props.reduce((prev, cur) => {
-    prev[cur] = cur
+    prev[cur as keyof typeof prev] = cur
     return prev
   }, aliases)
 }
-function useWatcher<T>(
+function useWatcher<T extends DefaultRow>(
   owner: ComputedRef<any>,
   props_: Partial<TableColumnCtx<T>>
 ) {
   const instance = getCurrentInstance() as TableColumn<T>
   const registerComplexWatchers = () => {
     const props = ['fixed']
-    const aliases = {
+    const aliases: Record<string, string> = {
       realWidth: 'width',
       realMinWidth: 'minWidth',
     }
@@ -37,8 +37,8 @@ function useWatcher<T>(
             if (columnKey === 'minWidth' && key === 'realMinWidth') {
               value = parseMinWidth(newVal)
             }
-            instance.columnConfig.value[columnKey as any] = value
-            instance.columnConfig.value[key] = value
+            instance.columnConfig.value[columnKey as never] = value as never
+            instance.columnConfig.value[key as never] = value as never
             const updateColumns = columnKey === 'fixed'
             owner.value.store.scheduleLayout(updateColumns)
           }
@@ -61,7 +61,7 @@ function useWatcher<T>(
       'showOverflowTooltip',
       'tooltipFormatter',
     ]
-    const aliases = {
+    const aliases: Record<string, string> = {
       property: 'prop',
       align: 'realAlign',
       headerAlign: 'realHeaderAlign',
@@ -73,7 +73,7 @@ function useWatcher<T>(
         watch(
           () => props_[columnKey],
           (newVal) => {
-            instance.columnConfig.value[key] = newVal
+            instance.columnConfig.value[key as never] = newVal
           }
         )
       }

--- a/packages/components/table/src/table-footer/index.ts
+++ b/packages/components/table/src/table-footer/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { defineComponent, h, inject } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import useLayoutObserver from '../layout-observer'
@@ -6,10 +5,10 @@ import { TABLE_INJECTION_KEY } from '../tokens'
 import useStyle from './style-helper'
 
 import type { Store } from '../store'
-import type { PropType } from 'vue'
-import type { DefaultRow, Sort, SummaryMethod } from '../table/defaults'
+import type { PropType, VNode } from 'vue'
+import type { DefaultRow, Sort, SummaryMethod, Table } from '../table/defaults'
 
-export interface TableFooter<T> {
+export interface TableFooter<T extends DefaultRow> {
   fixed: string
   store: Store<T>
   summaryMethod: SummaryMethod<T>
@@ -46,7 +45,7 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const parent = inject(TABLE_INJECTION_KEY)
+    const parent = inject(TABLE_INJECTION_KEY) as Table<DefaultRow>
     const ns = useNamespace('table')
     const { getCellClasses, getCellStyles, columns } = useStyle(
       props as TableFooter<DefaultRow>
@@ -66,7 +65,7 @@ export default defineComponent({
     const { columns, getCellStyles, getCellClasses, summaryMethod, sumText } =
       this
     const data = this.store.states.data.value
-    let sums = []
+    let sums: (string | VNode | number)[] = []
     if (summaryMethod) {
       sums = summaryMethod({
         columns,
@@ -75,11 +74,11 @@ export default defineComponent({
     } else {
       columns.forEach((column, index) => {
         if (index === 0) {
-          sums[index] = sumText
+          sums[index] = sumText!
           return
         }
         const values = data.map((item) => Number(item[column.property]))
-        const precisions = []
+        const precisions: number[] = []
         let notNumber = true
         values.forEach((value) => {
           if (!Number.isNaN(+value)) {

--- a/packages/components/table/src/table-footer/index.ts
+++ b/packages/components/table/src/table-footer/index.ts
@@ -65,7 +65,7 @@ export default defineComponent({
     const { columns, getCellStyles, getCellClasses, summaryMethod, sumText } =
       this
     const data = this.store.states.data.value
-    let sums: (string | VNode | number)[] = []
+    let sums: (string | VNode | number | undefined)[] = []
     if (summaryMethod) {
       sums = summaryMethod({
         columns,
@@ -74,7 +74,7 @@ export default defineComponent({
     } else {
       columns.forEach((column, index) => {
         if (index === 0) {
-          sums[index] = sumText!
+          sums[index] = sumText
           return
         }
         const values = data.map((item) => Number(item[column.property]))

--- a/packages/components/table/src/table-footer/index.ts
+++ b/packages/components/table/src/table-footer/index.ts
@@ -27,15 +27,13 @@ export default defineComponent({
     },
     store: {
       required: true,
-      type: Object as PropType<TableFooter<DefaultRow>['store']>,
+      type: Object as PropType<TableFooter<any>['store']>,
     },
-    summaryMethod: Function as PropType<
-      TableFooter<DefaultRow>['summaryMethod']
-    >,
+    summaryMethod: Function as PropType<TableFooter<any>['summaryMethod']>,
     sumText: String,
     border: Boolean,
     defaultSort: {
-      type: Object as PropType<TableFooter<DefaultRow>['defaultSort']>,
+      type: Object as PropType<TableFooter<any>['defaultSort']>,
       default: () => {
         return {
           prop: '',

--- a/packages/components/table/src/table-footer/index.ts
+++ b/packages/components/table/src/table-footer/index.ts
@@ -43,10 +43,10 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const parent = inject(TABLE_INJECTION_KEY) as Table<DefaultRow>
+    const parent = inject(TABLE_INJECTION_KEY) as Table<any>
     const ns = useNamespace('table')
     const { getCellClasses, getCellStyles, columns } = useStyle(
-      props as TableFooter<DefaultRow>
+      props as TableFooter<any>
     )
     const { onScrollableChange, onColumnsChange } = useLayoutObserver(parent!)
 

--- a/packages/components/table/src/table-footer/mapState-helper.ts
+++ b/packages/components/table/src/table-footer/mapState-helper.ts
@@ -26,7 +26,7 @@ function useMapState() {
     columnsCount,
     leftFixedCount,
     rightFixedCount,
-    columns: store?.states.columns ?? [],
+    columns: computed(() => store?.states.columns.value ?? []),
   }
 }
 

--- a/packages/components/table/src/table-footer/style-helper.ts
+++ b/packages/components/table/src/table-footer/style-helper.ts
@@ -7,9 +7,10 @@ import {
 import useMapState from './mapState-helper'
 
 import type { TableColumnCtx } from '../table-column/defaults'
+import type { DefaultRow } from '../table/defaults'
 import type { TableFooter } from '.'
 
-function useStyle<T>(props: TableFooter<T>) {
+function useStyle<T extends DefaultRow>(props: TableFooter<T>) {
   const { columns } = useMapState()
   const ns = useNamespace('table')
 

--- a/packages/components/table/src/table-header/event-helper.ts
+++ b/packages/components/table/src/table-header/event-helper.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { getCurrentInstance, inject, ref } from 'vue'
 import { isNull } from 'lodash-unified'
 import {
@@ -10,10 +9,15 @@ import {
 } from '@element-plus/utils'
 import { TABLE_INJECTION_KEY } from '../tokens'
 
+import type { EmitFn } from '@element-plus/utils'
 import type { TableHeaderProps } from '.'
 import type { TableColumnCtx } from '../table-column/defaults'
+import type { DefaultRow, TableSortOrder } from '../table/defaults'
 
-function useEvent<T>(props: TableHeaderProps<T>, emit) {
+function useEvent<T extends DefaultRow>(
+  props: TableHeaderProps<T>,
+  emit: EmitFn<string[]>
+) {
   const instance = getCurrentInstance()
   const parent = inject(TABLE_INJECTION_KEY)
   const handleFilterClick = (event: Event) => {
@@ -33,9 +37,14 @@ function useEvent<T>(props: TableHeaderProps<T>, emit) {
   const handleHeaderContextMenu = (event: Event, column: TableColumnCtx<T>) => {
     parent?.emit('header-contextmenu', column, event)
   }
-  const draggingColumn = ref(null)
+  const draggingColumn = ref<TableColumnCtx<T> | null>(null)
   const dragging = ref(false)
-  const dragState = ref({})
+  const dragState = ref<{
+    startMouseLeft: number
+    startLeft: number
+    startColumnLeft: number
+    tableLeft: number
+  }>()
   const handleMouseDown = (event: MouseEvent, column: TableColumnCtx<T>) => {
     if (!isClient) return
     if (column.children && column.children.length > 0) return
@@ -46,8 +55,8 @@ function useEvent<T>(props: TableHeaderProps<T>, emit) {
       const table = parent
       emit('set-drag-visible', true)
       const tableEl = table?.vnode.el
-      const tableLeft = tableEl.getBoundingClientRect().left
-      const columnEl = instance.vnode.el.querySelector(`th.${column.id}`)
+      const tableLeft = tableEl?.getBoundingClientRect().left
+      const columnEl = instance?.vnode?.el?.querySelector(`th.${column.id}`)
       const columnRect = columnEl.getBoundingClientRect()
       const minLeft = columnRect.left - tableLeft + 30
 
@@ -96,7 +105,7 @@ function useEvent<T>(props: TableHeaderProps<T>, emit) {
           document.body.style.cursor = ''
           dragging.value = false
           draggingColumn.value = null
-          dragState.value = {}
+          dragState.value = undefined
           emit('set-drag-visible', false)
         }
 
@@ -136,7 +145,7 @@ function useEvent<T>(props: TableHeaderProps<T>, emit) {
         if (hasClass(target, 'is-sortable')) {
           target.style.cursor = 'col-resize'
         }
-        draggingColumn.value = column
+        draggingColumn.value = column as any
       } else if (!dragging.value) {
         bodyStyle.cursor = ''
         if (hasClass(target, 'is-sortable')) {
@@ -151,19 +160,20 @@ function useEvent<T>(props: TableHeaderProps<T>, emit) {
     if (!isClient) return
     document.body.style.cursor = ''
   }
-  const toggleOrder = ({ order, sortOrders }) => {
-    if (order === '') return sortOrders[0]
+  const toggleOrder = ({ order, sortOrders }: TableColumnCtx<T>) => {
+    if ((order as string) === '') return sortOrders[0]
     const index = sortOrders.indexOf(order || null)
     return sortOrders[index > sortOrders.length - 2 ? 0 : index + 1]
   }
   const handleSortClick = (
     event: Event,
     column: TableColumnCtx<T>,
-    givenOrder: string | boolean
+    givenOrder?: TableSortOrder | boolean
   ) => {
     event.stopPropagation()
-    const order =
+    const order = (
       column.order === givenOrder ? null : givenOrder || toggleOrder(column)
+    ) as TableSortOrder | null
     const target = (event.target as HTMLElement)?.closest('th')
 
     if (target) {
@@ -179,7 +189,9 @@ function useEvent<T>(props: TableHeaderProps<T>, emit) {
 
     if (
       ['ascending', 'descending'].some(
-        (str) => hasClass(clickTarget, str) && !column.sortOrders.includes(str)
+        (str) =>
+          hasClass(clickTarget as Element, str) &&
+          !column.sortOrders.includes(str as TableSortOrder)
       )
     ) {
       return

--- a/packages/components/table/src/table-header/index.ts
+++ b/packages/components/table/src/table-header/index.ts
@@ -28,7 +28,7 @@ export interface TableHeader extends ComponentInternalInstance {
     onColumnsChange
     onScrollableChange
   }
-  filterPanels: Ref<unknown>
+  filterPanels: Ref<DefaultRow>
 }
 export interface TableHeaderProps<T> {
   fixed: string

--- a/packages/components/table/src/table-header/index.ts
+++ b/packages/components/table/src/table-header/index.ts
@@ -25,8 +25,8 @@ import type { Store } from '../store'
 
 export interface TableHeader extends ComponentInternalInstance {
   state: {
-    onColumnsChange: (layout: TableLayout<DefaultRow>) => void
-    onScrollableChange: (layout: TableLayout<DefaultRow>) => void
+    onColumnsChange: (layout: TableLayout<any>) => void
+    onScrollableChange: (layout: TableLayout<any>) => void
   }
   filterPanels: Ref<DefaultRow>
 }
@@ -117,15 +117,15 @@ export default defineComponent({
       handleMouseOut,
       handleSortClick,
       handleFilterClick,
-    } = useEvent(props as TableHeaderProps<DefaultRow>, emit)
+    } = useEvent(props as TableHeaderProps<any>, emit)
     const {
       getHeaderRowStyle,
       getHeaderRowClass,
       getHeaderCellStyle,
       getHeaderCellClass,
-    } = useStyle(props as TableHeaderProps<DefaultRow>)
+    } = useStyle(props as TableHeaderProps<any>)
     const { isGroup, toggleAllSelection, columnRows } = useUtils(
-      props as TableHeaderProps<DefaultRow>
+      props as TableHeaderProps<any>
     )
 
     instance.state = {

--- a/packages/components/table/src/table-header/index.ts
+++ b/packages/components/table/src/table-header/index.ts
@@ -50,11 +50,11 @@ export default defineComponent({
     },
     store: {
       required: true,
-      type: Object as PropType<TableHeaderProps<DefaultRow>['store']>,
+      type: Object as PropType<TableHeaderProps<any>['store']>,
     },
     border: Boolean,
     defaultSort: {
-      type: Object as PropType<TableHeaderProps<DefaultRow>['defaultSort']>,
+      type: Object as PropType<TableHeaderProps<any>['defaultSort']>,
       default: () => {
         return {
           prop: '',

--- a/packages/components/table/src/table-header/index.ts
+++ b/packages/components/table/src/table-header/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   defineComponent,
   getCurrentInstance,
@@ -15,6 +14,7 @@ import { useNamespace } from '@element-plus/hooks'
 import FilterPanel from '../filter-panel.vue'
 import useLayoutObserver from '../layout-observer'
 import { TABLE_INJECTION_KEY } from '../tokens'
+import TableLayout from '../table-layout'
 import useEvent from './event-helper'
 import useStyle from './style.helper'
 import useUtils from './utils-helper'
@@ -25,12 +25,12 @@ import type { Store } from '../store'
 
 export interface TableHeader extends ComponentInternalInstance {
   state: {
-    onColumnsChange
-    onScrollableChange
+    onColumnsChange: (layout: TableLayout<DefaultRow>) => void
+    onScrollableChange: (layout: TableLayout<DefaultRow>) => void
   }
   filterPanels: Ref<DefaultRow>
 }
-export interface TableHeaderProps<T> {
+export interface TableHeaderProps<T extends DefaultRow> {
   fixed: string
   store: Store<T>
   border: boolean
@@ -117,15 +117,15 @@ export default defineComponent({
       handleMouseOut,
       handleSortClick,
       handleFilterClick,
-    } = useEvent(props as TableHeaderProps<unknown>, emit)
+    } = useEvent(props as TableHeaderProps<DefaultRow>, emit)
     const {
       getHeaderRowStyle,
       getHeaderRowClass,
       getHeaderCellStyle,
       getHeaderCellClass,
-    } = useStyle(props as TableHeaderProps<unknown>)
+    } = useStyle(props as TableHeaderProps<DefaultRow>)
     const { isGroup, toggleAllSelection, columnRows } = useUtils(
-      props as TableHeaderProps<unknown>
+      props as TableHeaderProps<DefaultRow>
     )
 
     instance.state = {
@@ -220,16 +220,22 @@ export default defineComponent({
                   subColumns,
                   column
                 ),
-                onClick: ($event) => {
-                  if ($event.currentTarget.classList.contains('noclick')) {
+                onClick: ($event: MouseEvent) => {
+                  if (
+                    ($event.currentTarget as Element)?.classList.contains(
+                      'noclick'
+                    )
+                  ) {
                     return
                   }
                   handleHeaderClick($event, column)
                 },
-                onContextmenu: ($event) =>
+                onContextmenu: ($event: MouseEvent) =>
                   handleHeaderContextMenu($event, column),
-                onMousedown: ($event) => handleMouseDown($event, column),
-                onMousemove: ($event) => handleMouseMove($event, column),
+                onMousedown: ($event: MouseEvent) =>
+                  handleMouseDown($event, column),
+                onMousemove: ($event: MouseEvent) =>
+                  handleMouseMove($event, column),
                 onMouseout: handleMouseOut,
               },
               [
@@ -256,17 +262,18 @@ export default defineComponent({
                       h(
                         'span',
                         {
-                          onClick: ($event) => handleSortClick($event, column),
+                          onClick: ($event: Event) =>
+                            handleSortClick($event, column),
                           class: 'caret-wrapper',
                         },
                         [
                           h('i', {
-                            onClick: ($event) =>
+                            onClick: ($event: Event) =>
                               handleSortClick($event, column, 'ascending'),
                             class: 'sort-caret ascending',
                           }),
                           h('i', {
-                            onClick: ($event) =>
+                            onClick: ($event: Event) =>
                               handleSortClick($event, column, 'descending'),
                             class: 'sort-caret descending',
                           }),
@@ -274,13 +281,13 @@ export default defineComponent({
                       ),
                     column.filterable &&
                       h(
-                        FilterPanel,
+                        FilterPanel as any,
                         {
                           store,
                           placement: column.filterPlacement || 'bottom-start',
-                          appendTo: $parent.appendFilterPanelTo,
+                          appendTo: ($parent as any)?.appendFilterPanelTo,
                           column,
-                          upDataColumn: (key, value) => {
+                          upDataColumn: (key: never, value: never) => {
                             column[key] = value
                           },
                         },

--- a/packages/components/table/src/table-header/index.ts
+++ b/packages/components/table/src/table-header/index.ts
@@ -220,7 +220,7 @@ export default defineComponent({
                   subColumns,
                   column
                 ),
-                onClick: ($event: MouseEvent) => {
+                onClick: ($event: Event) => {
                   if (
                     ($event.currentTarget as Element)?.classList.contains(
                       'noclick'

--- a/packages/components/table/src/table-header/style.helper.ts
+++ b/packages/components/table/src/table-header/style.helper.ts
@@ -9,9 +9,10 @@ import {
 import { TABLE_INJECTION_KEY } from '../tokens'
 
 import type { TableColumnCtx } from '../table-column/defaults'
+import type { DefaultRow } from '../table/defaults'
 import type { TableHeaderProps } from '.'
 
-function useStyle<T>(props: TableHeaderProps<T>) {
+function useStyle<T extends DefaultRow>(props: TableHeaderProps<T>) {
   const parent = inject(TABLE_INJECTION_KEY)
   const ns = useNamespace('table')
 

--- a/packages/components/table/src/table-header/utils-helper.ts
+++ b/packages/components/table/src/table-header/utils-helper.ts
@@ -1,11 +1,11 @@
-// @ts-nocheck
 import { computed, inject } from 'vue'
 import { TABLE_INJECTION_KEY } from '../tokens'
 
+import type { DefaultRow } from '../table/defaults'
 import type { TableColumnCtx } from '../table-column/defaults'
 import type { TableHeaderProps } from '.'
 
-const getAllColumns = <T>(
+const getAllColumns = <T extends DefaultRow>(
   columns: TableColumnCtx<T>[]
 ): TableColumnCtx<T>[] => {
   const result: TableColumnCtx<T>[] = []
@@ -21,11 +21,11 @@ const getAllColumns = <T>(
   return result
 }
 
-export const convertToRows = <T>(
+export const convertToRows = <T extends DefaultRow>(
   originColumns: TableColumnCtx<T>[]
-): TableColumnCtx<T>[] => {
+): TableColumnCtx<T>[][] => {
   let maxLevel = 1
-  const traverse = (column: TableColumnCtx<T>, parent: TableColumnCtx<T>) => {
+  const traverse = (column: TableColumnCtx<T>, parent?: TableColumnCtx<T>) => {
     if (parent) {
       column.level = parent.level + 1
       if (maxLevel < column.level) {
@@ -49,7 +49,7 @@ export const convertToRows = <T>(
     traverse(column, undefined)
   })
 
-  const rows = []
+  const rows: TableColumnCtx<T>[][] = []
   for (let i = 0; i < maxLevel; i++) {
     rows.push([])
   }
@@ -69,7 +69,7 @@ export const convertToRows = <T>(
   return rows
 }
 
-function useUtils<T>(props: TableHeaderProps<T>) {
+function useUtils<T extends DefaultRow>(props: TableHeaderProps<T>) {
   const parent = inject(TABLE_INJECTION_KEY)
   const columnRows = computed(() => {
     return convertToRows(props.store.states.originColumns.value)

--- a/packages/components/table/src/table-layout.ts
+++ b/packages/components/table/src/table-layout.ts
@@ -9,7 +9,7 @@ import type { TableHeader } from './table-header'
 import type { DefaultRow, Table } from './table/defaults'
 import type { Store } from './store'
 
-class TableLayout<T extends Record<string, any>> {
+class TableLayout<T extends DefaultRow> {
   observers: TableHeader[]
   table: Table<T>
   store: Store<T>

--- a/packages/components/table/src/table-layout.ts
+++ b/packages/components/table/src/table-layout.ts
@@ -98,7 +98,7 @@ class TableLayout<T extends Record<string, any>> {
     }
   }
 
-  setMaxHeight(value: string | number) {
+  setMaxHeight(value: string | number | null) {
     this.setHeight(value, 'max-height')
   }
 

--- a/packages/components/table/src/table-layout.ts
+++ b/packages/components/table/src/table-layout.ts
@@ -103,9 +103,9 @@ class TableLayout<T extends Record<string, any>> {
   }
 
   getFlattenColumns(): TableColumnCtx<T>[] {
-    const flattenColumns: any[] = []
+    const flattenColumns: TableColumnCtx<T>[] = []
     const columns = this.table.store.states.columns.value
-    columns.forEach((column: any) => {
+    columns.forEach((column) => {
       if (column.isColumnGroup) {
         // eslint-disable-next-line prefer-spread
         flattenColumns.push.apply(flattenColumns, column.columns)
@@ -211,7 +211,7 @@ class TableLayout<T extends Record<string, any>> {
 
     if (fixedColumns.length > 0) {
       let fixedWidth = 0
-      fixedColumns.forEach((column: any) => {
+      fixedColumns.forEach((column) => {
         fixedWidth += Number(column.realWidth || column.width)
       })
 
@@ -221,7 +221,7 @@ class TableLayout<T extends Record<string, any>> {
     const rightFixedColumns = this.store.states.rightFixedColumns.value
     if (rightFixedColumns.length > 0) {
       let rightFixedWidth = 0
-      rightFixedColumns.forEach((column: any) => {
+      rightFixedColumns.forEach((column) => {
         rightFixedWidth += Number(column.realWidth || column.width)
       })
 

--- a/packages/components/table/src/table-layout.ts
+++ b/packages/components/table/src/table-layout.ts
@@ -6,7 +6,7 @@ import { parseHeight } from './util'
 import type { Ref } from 'vue'
 import type { TableColumnCtx } from './table-column/defaults'
 import type { TableHeader } from './table-header'
-import type { Table } from './table/defaults'
+import type { DefaultRow, Table } from './table/defaults'
 import type { Store } from './store'
 
 class TableLayout<T extends Record<string, any>> {
@@ -246,10 +246,10 @@ class TableLayout<T extends Record<string, any>> {
     observers.forEach((observer) => {
       switch (event) {
         case 'columns':
-          observer.state?.onColumnsChange(this)
+          observer.state?.onColumnsChange(this as TableLayout<DefaultRow>)
           break
         case 'scrollable':
-          observer.state?.onScrollableChange(this)
+          observer.state?.onScrollableChange(this as TableLayout<DefaultRow>)
           break
         default:
           throw new Error(`Table Layout don't have event ${event}.`)

--- a/packages/components/table/src/table-layout.ts
+++ b/packages/components/table/src/table-layout.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { isRef, nextTick, ref } from 'vue'
 import { isNull } from 'lodash-unified'
 import { hasOwn, isClient, isNumber, isString } from '@element-plus/utils'
@@ -24,15 +23,16 @@ class TableLayout<T> {
   bodyWidth: Ref<null | number>
   fixedWidth: Ref<null | number>
   rightFixedWidth: Ref<null | number>
-  tableHeight: Ref<null | number>
-  headerHeight: Ref<null | number> // Table Header Height
-  appendHeight: Ref<null | number> // Append Slot Height
-  footerHeight: Ref<null | number> // Table Footer Height
+  //HACK: should not be normal to comment this ?
+  //tableHeight: Ref<null | number>
+  //headerHeight: Ref<null | number> // Table Header Height
+  //appendHeight: Ref<null | number> // Append Slot Height
+  //footerHeight: Ref<null | number> // Table Footer Height
   gutterWidth: number
   constructor(options: Record<string, any>) {
     this.observers = []
-    this.table = null
-    this.store = null
+    this.table = null as unknown as Table<T>
+    this.store = null as unknown as Store<T>
     this.columns = []
     this.fit = true
     this.showHeader = true
@@ -46,9 +46,9 @@ class TableLayout<T> {
     for (const name in options) {
       if (hasOwn(options, name)) {
         if (isRef(this[name])) {
-          this[name as string].value = options[name]
+          ;(this[name] as Ref<any>).value = options[name] as any
         } else {
-          this[name as string] = options[name]
+          this[name as keyof typeof this] = options[name]
         }
       }
     }
@@ -79,19 +79,21 @@ class TableLayout<T> {
     return false
   }
 
-  setHeight(value: string | number, prop = 'height') {
+  setHeight(value: string | number | null, prop = 'height'): void {
     if (!isClient) return
     const el = this.table.vnode.el
     value = parseHeight(value)
     this.height.value = Number(value)
 
-    if (!el && (value || value === 0))
-      return nextTick(() => this.setHeight(value, prop))
+    if (!el && (value || value === 0)) {
+      nextTick(() => this.setHeight(value, prop))
+      return
+    }
 
-    if (isNumber(value)) {
+    if (el && isNumber(value)) {
       el.style[prop] = `${value}px`
       this.updateElsHeight()
-    } else if (isString(value)) {
+    } else if (el && isString(value)) {
       el.style[prop] = value
       this.updateElsHeight()
     }
@@ -102,9 +104,9 @@ class TableLayout<T> {
   }
 
   getFlattenColumns(): TableColumnCtx<T>[] {
-    const flattenColumns = []
+    const flattenColumns: any[] = []
     const columns = this.table.store.states.columns.value
-    columns.forEach((column) => {
+    columns.forEach((column: any) => {
       if (column.isColumnGroup) {
         // eslint-disable-next-line prefer-spread
         flattenColumns.push.apply(flattenColumns, column.columns)
@@ -128,7 +130,7 @@ class TableLayout<T> {
       if (getComputedStyle(headerChild).display === 'none') {
         return true
       }
-      headerChild = headerChild.parentElement
+      headerChild = headerChild.parentElement!
     }
     return false
   }
@@ -136,7 +138,7 @@ class TableLayout<T> {
   updateColumnsWidth() {
     if (!isClient) return
     const fit = this.fit
-    const bodyWidth = this.table.vnode.el.clientWidth
+    const bodyWidth = this.table.vnode.el?.clientWidth
     let bodyMinWidth = 0
 
     const flattenColumns = this.getFlattenColumns()
@@ -210,7 +212,7 @@ class TableLayout<T> {
 
     if (fixedColumns.length > 0) {
       let fixedWidth = 0
-      fixedColumns.forEach((column) => {
+      fixedColumns.forEach((column: any) => {
         fixedWidth += Number(column.realWidth || column.width)
       })
 
@@ -220,7 +222,7 @@ class TableLayout<T> {
     const rightFixedColumns = this.store.states.rightFixedColumns.value
     if (rightFixedColumns.length > 0) {
       let rightFixedWidth = 0
-      rightFixedColumns.forEach((column) => {
+      rightFixedColumns.forEach((column: any) => {
         rightFixedWidth += Number(column.realWidth || column.width)
       })
 

--- a/packages/components/table/src/table-layout.ts
+++ b/packages/components/table/src/table-layout.ts
@@ -9,7 +9,7 @@ import type { TableHeader } from './table-header'
 import type { Table } from './table/defaults'
 import type { Store } from './store'
 
-class TableLayout<T> {
+class TableLayout<T extends Record<string, any>> {
   observers: TableHeader[]
   table: Table<T>
   store: Store<T>
@@ -23,11 +23,10 @@ class TableLayout<T> {
   bodyWidth: Ref<null | number>
   fixedWidth: Ref<null | number>
   rightFixedWidth: Ref<null | number>
-  //HACK: should not be normal to comment this ?
-  //tableHeight: Ref<null | number>
-  //headerHeight: Ref<null | number> // Table Header Height
-  //appendHeight: Ref<null | number> // Append Slot Height
-  //footerHeight: Ref<null | number> // Table Footer Height
+  tableHeight!: Ref<null | number>
+  headerHeight!: Ref<null | number> // Table Header Height
+  appendHeight!: Ref<null | number> // Append Slot Height
+  footerHeight!: Ref<null | number> // Table Footer Height
   gutterWidth: number
   constructor(options: Record<string, any>) {
     this.observers = []
@@ -46,7 +45,7 @@ class TableLayout<T> {
     for (const name in options) {
       if (hasOwn(options, name)) {
         if (isRef(this[name])) {
-          ;(this[name] as Ref<any>).value = options[name] as any
+          ;(this[name] as Ref).value = options[name]
         } else {
           this[name as keyof typeof this] = options[name]
         }
@@ -79,7 +78,7 @@ class TableLayout<T> {
     return false
   }
 
-  setHeight(value: string | number | null, prop = 'height'): void {
+  setHeight(value: string | number | null, prop = 'height') {
     if (!isClient) return
     const el = this.table.vnode.el
     value = parseHeight(value)

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -170,7 +170,6 @@
 </template>
 
 <script lang="ts">
-// @ts-nocheck
 import {
   computed,
   defineComponent,

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -274,7 +274,6 @@ export default defineComponent({
       handleHeaderFooterMousewheel,
       tableSize,
       emptyBlockStyle,
-      handleFixedMousewheel,
       resizeProxyVisible,
       bodyWidth,
       resizeState,
@@ -335,7 +334,6 @@ export default defineComponent({
       tableBodyStyles,
       emptyBlockStyle,
       debouncedUpdateLayout,
-      handleFixedMousewheel,
       /**
        * @description used in single selection Table, set a certain row selected. If called without any parameter, it will clear selection
        */

--- a/packages/components/table/src/table/defaults.ts
+++ b/packages/components/table/src/table/defaults.ts
@@ -17,7 +17,7 @@ import type {
   TableOverflowTooltipOptions,
 } from '../util'
 
-type DefaultRow = Record<string, any>
+type DefaultRow = Record<PropertyKey, any>
 
 interface TableRefs {
   tableWrapper: HTMLElement
@@ -71,8 +71,7 @@ type SummaryMethod<T extends DefaultRow> = (data: {
   data: T[]
 }) => (string | VNode)[]
 
-interface Table<T extends DefaultRow = DefaultRow>
-  extends ComponentInternalInstance {
+interface Table<T extends DefaultRow = any> extends ComponentInternalInstance {
   $ready: boolean
   hoverState?: HoverState<T> | null
   renderExpanded: RenderExpanded<T>
@@ -206,7 +205,7 @@ export default {
    * @description table data
    */
   data: {
-    type: Array as PropType<DefaultRow[]>,
+    type: Array as PropType<any[]>,
     default: () => [],
   },
   /**
@@ -240,7 +239,7 @@ export default {
   /**
    * @description key of row data, used for optimizing rendering. Required if `reserve-selection` is on or display tree data. When its type is String, multi-level access is supported, e.g. `user.info.id`, but `user.info[0].id` is not supported, in which case `Function` should be used
    */
-  rowKey: [String, Function] as PropType<TableProps<DefaultRow>['rowKey']>,
+  rowKey: [String, Function] as PropType<TableProps<any>['rowKey']>,
   /**
    * @description whether Table header is visible
    */
@@ -259,52 +258,48 @@ export default {
   /**
    * @description custom summary method
    */
-  summaryMethod: Function as PropType<TableProps<DefaultRow>['summaryMethod']>,
+  summaryMethod: Function as PropType<TableProps<any>['summaryMethod']>,
   /**
    * @description function that returns custom class names for a row, or a string assigning class names for every row
    */
-  rowClassName: [String, Function] as PropType<
-    TableProps<DefaultRow>['rowClassName']
-  >,
+  rowClassName: [String, Function] as PropType<TableProps<any>['rowClassName']>,
   /**
    * @description function that returns custom style for a row, or an object assigning custom style for every row
    */
-  rowStyle: [Object, Function] as PropType<TableProps<DefaultRow>['rowStyle']>,
+  rowStyle: [Object, Function] as PropType<TableProps<any>['rowStyle']>,
   /**
    * @description function that returns custom class names for a cell, or a string assigning class names for every cell
    */
   cellClassName: [String, Function] as PropType<
-    TableProps<DefaultRow>['cellClassName']
+    TableProps<any>['cellClassName']
   >,
   /**
    * @description function that returns custom style for a cell, or an object assigning custom style for every cell
    */
-  cellStyle: [Object, Function] as PropType<
-    TableProps<DefaultRow>['cellStyle']
-  >,
+  cellStyle: [Object, Function] as PropType<TableProps<any>['cellStyle']>,
   /**
    * @description function that returns custom class names for a row in table header, or a string assigning class names for every row in table header
    */
   headerRowClassName: [String, Function] as PropType<
-    TableProps<DefaultRow>['headerRowClassName']
+    TableProps<any>['headerRowClassName']
   >,
   /**
    * @description function that returns custom style for a row in table header, or an object assigning custom style for every row in table header
    */
   headerRowStyle: [Object, Function] as PropType<
-    TableProps<DefaultRow>['headerRowStyle']
+    TableProps<any>['headerRowStyle']
   >,
   /**
    * @description function that returns custom class names for a cell in table header, or a string assigning class names for every cell in table header
    */
   headerCellClassName: [String, Function] as PropType<
-    TableProps<DefaultRow>['headerCellClassName']
+    TableProps<any>['headerCellClassName']
   >,
   /**
    * @description function that returns custom style for a cell in table header, or an object assigning custom style for every cell in table header
    */
   headerCellStyle: [Object, Function] as PropType<
-    TableProps<DefaultRow>['headerCellStyle']
+    TableProps<any>['headerCellStyle']
   >,
   /**
    * @description whether current row is highlighted
@@ -321,7 +316,7 @@ export default {
   /**
    * @description set expanded rows by this prop, prop's value is the keys of expand rows, you should set row-key before using this prop
    */
-  expandRowKeys: Array as PropType<TableProps<DefaultRow>['expandRowKeys']>,
+  expandRowKeys: Array as PropType<TableProps<any>['expandRowKeys']>,
   /**
    * @description whether expand all rows by default, works when the table has a column type="expand" or contains tree structure data
    */
@@ -329,7 +324,7 @@ export default {
   /**
    * @description set the default sort column and order. property `prop` is used to set default sort column, property `order` is used to set default sort order
    */
-  defaultSort: Object as PropType<TableProps<DefaultRow>['defaultSort']>,
+  defaultSort: Object as PropType<TableProps<any>['defaultSort']>,
   /**
    * @description the `effect` of the overflow tooltip
    */
@@ -337,11 +332,11 @@ export default {
   /**
    * @description the options for the overflow tooltip, [see the following tooltip component](tooltip.html#attributes)
    */
-  tooltipOptions: Object as PropType<TableProps<DefaultRow>['tooltipOptions']>,
+  tooltipOptions: Object as PropType<TableProps<any>['tooltipOptions']>,
   /**
    * @description method that returns rowspan and colspan
    */
-  spanMethod: Function as PropType<TableProps<DefaultRow>['spanMethod']>,
+  spanMethod: Function as PropType<TableProps<any>['spanMethod']>,
   /**
    * @description controls the behavior of master checkbox in multi-select tables when only some rows are selected (but not all). If true, all rows will be selected, else deselected
    */
@@ -360,7 +355,7 @@ export default {
    * @description configuration for rendering nested data
    */
   treeProps: {
-    type: Object as PropType<TableProps<DefaultRow>['treeProps']>,
+    type: Object as PropType<TableProps<any>['treeProps']>,
     default: () => {
       return {
         hasChildren: 'hasChildren',
@@ -376,7 +371,7 @@ export default {
   /**
    * @description method for loading child row data, only works when `lazy` is true
    */
-  load: Function as PropType<TableProps<DefaultRow>['load']>,
+  load: Function as PropType<TableProps<any>['load']>,
   style: {
     type: Object as PropType<CSSProperties>,
     default: () => ({}),
@@ -404,14 +399,12 @@ export default {
    * @description whether to hide extra content and show them in a tooltip when hovering on the cell.It will affect all the table columns
    */
   showOverflowTooltip: [Boolean, Object] as PropType<
-    TableProps<DefaultRow>['showOverflowTooltip']
+    TableProps<any>['showOverflowTooltip']
   >,
   /**
    * @description function that formats cell tooltip content, works when `show-overflow-tooltip` is `true`
    */
-  tooltipFormatter: Function as PropType<
-    TableProps<DefaultRow>['tooltipFormatter']
-  >,
+  tooltipFormatter: Function as PropType<TableProps<any>['tooltipFormatter']>,
   appendFilterPanelTo: String,
   scrollbarTabindex: {
     type: [Number, String],

--- a/packages/components/table/src/table/defaults.ts
+++ b/packages/components/table/src/table/defaults.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useSizeProp } from '@element-plus/hooks'
 
 import type {
@@ -18,7 +17,7 @@ import type {
   TableOverflowTooltipOptions,
 } from '../util'
 
-export type DefaultRow = any
+type DefaultRow = any
 
 interface TableRefs {
   tableWrapper: HTMLElement
@@ -53,13 +52,18 @@ type HoverState<T> = Nullable<{
   row: T
 }>
 
-type RIS<T> = { row: T; $index: number; store: Store<T>; expanded: boolean }
+type RIS<T extends Record<string, any>> = {
+  row: T
+  $index: number
+  store: Store<T>
+  expanded: boolean
+}
 
-type RenderExpanded<T> = ({
+type RenderExpanded<T extends Record<string, any>> = ({
   row,
   $index,
   store,
-  expanded: boolean,
+  expanded,
 }: RIS<T>) => VNode
 
 type SummaryMethod<T> = (data: {
@@ -67,7 +71,8 @@ type SummaryMethod<T> = (data: {
   data: T[]
 }) => (string | VNode)[]
 
-interface Table<T> extends ComponentInternalInstance {
+interface Table<T extends Record<string, any>>
+  extends ComponentInternalInstance {
   $ready: boolean
   hoverState?: HoverState<T>
   renderExpanded: RenderExpanded<T>
@@ -99,7 +104,7 @@ type CellStyle<T> =
       columnIndex: number
     }) => CSSProperties)
 type Layout = 'fixed' | 'auto'
-interface TableProps<T> {
+interface TableProps<T extends Record<string, any>> {
   data: T[]
   size?: ComponentSize
   width?: string | number
@@ -159,10 +164,11 @@ interface TableProps<T> {
 }
 
 type TableTooltipData<T = any> = Parameters<TableOverflowTooltipFormatter<T>>[0]
+type TableSortOrder = 'ascending' | 'descending'
 
 interface Sort {
   prop: string
-  order: 'ascending' | 'descending'
+  order: TableSortOrder
   init?: any
   silent?: any
 }
@@ -182,7 +188,7 @@ interface TreeNode {
   display?: boolean
 }
 
-interface RenderRowData<T> {
+interface RenderRowData<T extends Record<string, any>> {
   store: Store<T>
   _self: Table<T>
   column: TableColumnCtx<T>
@@ -432,6 +438,7 @@ export type {
   ColumnStyle,
   CellCls,
   CellStyle,
+  DefaultRow,
   TreeNode,
   RenderRowData,
   Sort,
@@ -439,4 +446,5 @@ export type {
   TableColumnCtx,
   TreeProps,
   TableTooltipData,
+  TableSortOrder,
 }

--- a/packages/components/table/src/table/defaults.ts
+++ b/packages/components/table/src/table/defaults.ts
@@ -17,7 +17,7 @@ import type {
   TableOverflowTooltipOptions,
 } from '../util'
 
-type DefaultRow = any
+type DefaultRow = Record<string, any>
 
 interface TableRefs {
   tableWrapper: HTMLElement
@@ -52,14 +52,14 @@ type HoverState<T> = Nullable<{
   row: T
 }>
 
-type RIS<T extends Record<string, any>> = {
+type RIS<T extends DefaultRow> = {
   row: T
   $index: number
   store: Store<T>
   expanded: boolean
 }
 
-type RenderExpanded<T extends Record<string, any>> = ({
+type RenderExpanded<T extends DefaultRow> = ({
   row,
   $index,
   store,
@@ -71,8 +71,7 @@ type SummaryMethod<T> = (data: {
   data: T[]
 }) => (string | VNode)[]
 
-interface Table<T extends Record<string, any>>
-  extends ComponentInternalInstance {
+interface Table<T extends DefaultRow> extends ComponentInternalInstance {
   $ready: boolean
   hoverState?: HoverState<T>
   renderExpanded: RenderExpanded<T>
@@ -104,7 +103,7 @@ type CellStyle<T> =
       columnIndex: number
     }) => CSSProperties)
 type Layout = 'fixed' | 'auto'
-interface TableProps<T extends Record<string, any>> {
+interface TableProps<T extends DefaultRow> {
   data: T[]
   size?: ComponentSize
   width?: string | number
@@ -188,7 +187,7 @@ interface TreeNode {
   display?: boolean
 }
 
-interface RenderRowData<T extends Record<string, any>> {
+interface RenderRowData<T extends DefaultRow> {
   store: Store<T>
   _self: Table<T>
   column: TableColumnCtx<T>

--- a/packages/components/table/src/table/defaults.ts
+++ b/packages/components/table/src/table/defaults.ts
@@ -8,7 +8,6 @@ import type {
   VNode,
 } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
-import type { Nullable } from '@element-plus/utils'
 import type { Store } from '../store'
 import type { TableColumnCtx } from '../table-column/defaults'
 import type TableLayout from '../table-layout'
@@ -46,11 +45,11 @@ interface TreeProps {
   checkStrictly?: boolean
 }
 
-type HoverState<T> = Nullable<{
-  cell: HTMLElement
-  column: TableColumnCtx<T>
-  row: T
-}>
+type HoverState<T extends DefaultRow> = {
+  cell: HTMLElement | null
+  column: TableColumnCtx<T> | null
+  row: T | null
+}
 
 type RIS<T extends DefaultRow> = {
   row: T
@@ -66,14 +65,15 @@ type RenderExpanded<T extends DefaultRow> = ({
   expanded,
 }: RIS<T>) => VNode
 
-type SummaryMethod<T> = (data: {
+type SummaryMethod<T extends DefaultRow> = (data: {
   columns: TableColumnCtx<T>[]
   data: T[]
 }) => (string | VNode)[]
 
-interface Table<T extends DefaultRow> extends ComponentInternalInstance {
+interface Table<T extends DefaultRow = DefaultRow>
+  extends ComponentInternalInstance {
   $ready: boolean
-  hoverState?: HoverState<T>
+  hoverState?: HoverState<T> | null
   renderExpanded: RenderExpanded<T>
   store: Store<T>
   layout: TableLayout<T>
@@ -86,7 +86,7 @@ type ColumnCls<T> = string | ((data: { row: T; rowIndex: number }) => string)
 type ColumnStyle<T> =
   | CSSProperties
   | ((data: { row: T; rowIndex: number }) => CSSProperties)
-type CellCls<T> =
+type CellCls<T extends DefaultRow> =
   | string
   | ((data: {
       row: T
@@ -94,7 +94,7 @@ type CellCls<T> =
       column: TableColumnCtx<T>
       columnIndex: number
     }) => string)
-type CellStyle<T> =
+type CellStyle<T extends DefaultRow> =
   | CSSProperties
   | ((data: {
       row: T
@@ -162,7 +162,9 @@ interface TableProps<T extends DefaultRow> {
   scrollbarTabindex?: number | string
 }
 
-type TableTooltipData<T = any> = Parameters<TableOverflowTooltipFormatter<T>>[0]
+type TableTooltipData<T extends DefaultRow> = Parameters<
+  TableOverflowTooltipFormatter<T>
+>[0]
 type TableSortOrder = 'ascending' | 'descending'
 
 interface Sort {
@@ -172,7 +174,7 @@ interface Sort {
   silent?: any
 }
 
-interface Filter<T> {
+interface Filter<T extends DefaultRow> {
   column: TableColumnCtx<T>
   values: string[]
   silent: any
@@ -193,6 +195,7 @@ interface RenderRowData<T extends DefaultRow> {
   column: TableColumnCtx<T>
   row: T
   $index: number
+  cellIndex: number
   treeNode?: TreeNode
   expanded: boolean
 }

--- a/packages/components/table/src/table/defaults.ts
+++ b/packages/components/table/src/table/defaults.ts
@@ -8,6 +8,7 @@ import type {
   VNode,
 } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
+import type { Nullable } from '@element-plus/utils'
 import type { Store } from '../store'
 import type { TableColumnCtx } from '../table-column/defaults'
 import type TableLayout from '../table-layout'
@@ -45,11 +46,11 @@ interface TreeProps {
   checkStrictly?: boolean
 }
 
-type HoverState<T extends DefaultRow> = {
-  cell: HTMLElement | null
-  column: TableColumnCtx<T> | null
-  row: T | null
-}
+type HoverState<T extends DefaultRow> = Nullable<{
+  cell: HTMLElement
+  column: TableColumnCtx<T>
+  row: T
+}>
 
 type RIS<T extends DefaultRow> = {
   row: T

--- a/packages/components/table/src/table/key-render-helper.ts
+++ b/packages/components/table/src/table/key-render-helper.ts
@@ -1,8 +1,8 @@
 import { onMounted, onUnmounted, ref } from 'vue'
 
-import type { Table } from './defaults'
+import type { DefaultRow, Table } from './defaults'
 
-export default function useKeyRender(table: Table<[]>) {
+export default function useKeyRender(table: Table<DefaultRow>) {
   const observer = ref<MutationObserver>()
 
   const initWatchDom = () => {

--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -278,7 +278,7 @@ function useStyle<T>(
   })
 
   const emptyBlockStyle = computed(() => {
-    if (props.data && props.data.length) return null
+    if (props.data && props.data.length) return
     let height = '100%'
     if (props.height && bodyScrollHeight.value) {
       height = `${bodyScrollHeight.value}px`

--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -316,28 +316,6 @@ function useStyle<T extends DefaultRow>(
     return {}
   })
 
-  /**
-   * fix layout
-   */
-  const handleFixedMousewheel = (event: WheelEvent, data: any) => {
-    const bodyWrapper = table.refs.bodyWrapper
-    if (Math.abs(data.spinY) > 0) {
-      const currentScrollTop = bodyWrapper.scrollTop
-      if (data.pixelY < 0 && currentScrollTop !== 0) {
-        event.preventDefault()
-      }
-      if (
-        data.pixelY > 0 &&
-        bodyWrapper.scrollHeight - bodyWrapper.clientHeight > currentScrollTop
-      ) {
-        event.preventDefault()
-      }
-      bodyWrapper.scrollTop += Math.ceil(data.pixelY / 5)
-    } else {
-      bodyWrapper.scrollLeft += Math.ceil(data.pixelX / 5)
-    }
-  }
-
   return {
     isHidden,
     renderExpanded,
@@ -347,7 +325,6 @@ function useStyle<T extends DefaultRow>(
     handleHeaderFooterMousewheel,
     tableSize,
     emptyBlockStyle,
-    handleFixedMousewheel,
     resizeProxyVisible,
     bodyWidth,
     resizeState,

--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   computed,
   nextTick,
@@ -11,12 +10,12 @@ import {
 import { useEventListener, useResizeObserver } from '@vueuse/core'
 import { useFormSize } from '@element-plus/components/form'
 
-import type { Table, TableProps } from './defaults'
+import type { DefaultRow, Table, TableProps } from './defaults'
 import type { Store } from '../store'
 import type TableLayout from '../table-layout'
 import type { TableColumnCtx } from '../table-column/defaults'
 
-function useStyle<T>(
+function useStyle<T extends DefaultRow>(
   props: TableProps<T>,
   layout: TableLayout<T>,
   store: Store<T>,
@@ -50,10 +49,10 @@ function useStyle<T>(
   const appendScrollHeight = ref(0)
 
   watchEffect(() => {
-    layout.setHeight(props.height)
+    layout.setHeight(props.height ?? null)
   })
   watchEffect(() => {
-    layout.setMaxHeight(props.maxHeight)
+    layout.setMaxHeight(props.maxHeight ?? null)
   })
   watch(
     () => [props.currentRowKey, store.states.rowKey],
@@ -86,7 +85,7 @@ function useStyle<T>(
     if (table.hoverState) table.hoverState = null
   }
 
-  const handleHeaderFooterMousewheel = (event, data) => {
+  const handleHeaderFooterMousewheel = (_event: WheelEvent, data: any) => {
     const { pixelX, pixelY } = data
     if (Math.abs(pixelX) >= Math.abs(pixelY)) {
       table.refs.bodyWrapper.scrollLeft += data.pixelX / 5
@@ -300,7 +299,7 @@ function useStyle<T>(
       if (!Number.isNaN(Number(props.maxHeight))) {
         return {
           maxHeight: `${
-            props.maxHeight -
+            +props.maxHeight -
             headerScrollHeight.value -
             footerScrollHeight.value
           }px`,
@@ -320,7 +319,7 @@ function useStyle<T>(
   /**
    * fix layout
    */
-  const handleFixedMousewheel = (event, data) => {
+  const handleFixedMousewheel = (event: WheelEvent, data: any) => {
     const bodyWrapper = table.refs.bodyWrapper
     if (Math.abs(data.spinY) > 0) {
       const currentScrollTop = bodyWrapper.scrollTop

--- a/packages/components/table/src/table/utils-helper.ts
+++ b/packages/components/table/src/table/utils-helper.ts
@@ -19,7 +19,7 @@ function useUtils<T extends DefaultRow>(store: Store<T>) {
   const clearSelection = () => {
     store.clearSelection()
   }
-  const clearFilter = (columnKeys?: string[]) => {
+  const clearFilter = (columnKeys?: string[] | string) => {
     store.clearFilter(columnKeys)
   }
   const toggleAllSelection = () => {

--- a/packages/components/table/src/table/utils-helper.ts
+++ b/packages/components/table/src/table/utils-helper.ts
@@ -1,7 +1,6 @@
-// @ts-nocheck
 import type { Store } from '../store'
 
-function useUtils<T>(store: Store<T>) {
+function useUtils<T extends Record<string, any>>(store: Store<T>) {
   const setCurrentRow = (row: T) => {
     store.commit('setCurrentRow', row)
   }

--- a/packages/components/table/src/table/utils-helper.ts
+++ b/packages/components/table/src/table/utils-helper.ts
@@ -1,6 +1,7 @@
 import type { Store } from '../store'
+import type { DefaultRow } from './defaults'
 
-function useUtils<T extends Record<string, any>>(store: Store<T>) {
+function useUtils<T extends DefaultRow>(store: Store<T>) {
   const setCurrentRow = (row: T) => {
     store.commit('setCurrentRow', row)
   }

--- a/packages/components/table/src/tokens.ts
+++ b/packages/components/table/src/tokens.ts
@@ -1,5 +1,4 @@
 import type { InjectionKey } from 'vue'
-import type { DefaultRow, Table } from './table/defaults'
+import type { Table } from './table/defaults'
 
-export const TABLE_INJECTION_KEY: InjectionKey<Table<DefaultRow>> =
-  Symbol('ElTable')
+export const TABLE_INJECTION_KEY: InjectionKey<Table> = Symbol('ElTable')

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -1,6 +1,7 @@
 import { createVNode, isVNode, render } from 'vue'
 import { flatMap, get, isNull, merge } from 'lodash-unified'
 import {
+  ensureArray,
   getProp,
   hasOwn,
   isArray,
@@ -18,7 +19,7 @@ import ElTooltip, {
 
 import type { Table, TreeProps } from './table/defaults'
 import type { TableColumnCtx } from './table-column/defaults'
-import type { VNode } from 'vue'
+import type { CSSProperties, VNode } from 'vue'
 
 export type TableOverflowTooltipOptions = Partial<
   Pick<
@@ -40,12 +41,18 @@ export type TableOverflowTooltipOptions = Partial<
 export type TableOverflowTooltipFormatter<T = any> = (data: {
   row: T
   column: TableColumnCtx<T>
-  cellValue
+  cellValue: any
 }) => VNode | string
 
 type RemovePopperFn = (() => void) & {
   trigger?: HTMLElement
   vm?: VNode
+}
+
+type CompareValue<T> = {
+  value: T
+  index: number
+  key: any[] | null
 }
 
 export const getCell = function (event: Event) {
@@ -57,7 +64,7 @@ export const orderBy = function <T>(
   sortKey: string | null,
   reverse: string | number | null,
   sortMethod: TableColumnCtx<T>['sortMethod'] | null,
-  sortBy: TableColumnCtx<T>['sortBy'] //string | (string | ((a: T, b: T, array?: T[]) => number))[]
+  sortBy: string | string[] | ((a: T, index: number, array?: T[]) => string)
 ) {
   if (
     !sortKey &&
@@ -75,11 +82,7 @@ export const orderBy = function <T>(
     ? null
     : function (value: T, index: number) {
         if (sortBy) {
-          const wrapper: (string | ((row: T, index: number) => string))[] = []
-          if (!isArray(sortBy)) {
-            wrapper.push(sortBy)
-          }
-          return wrapper.map((by) => {
+          return ensureArray(sortBy).flatMap((by) => {
             if (isString(by)) {
               return get(value, by)
             } else {
@@ -87,27 +90,27 @@ export const orderBy = function <T>(
             }
           })
         }
-        if (sortKey !== '$key') {
+        if (sortBy !== '$key') {
           if (isObject(value) && '$value' in value) value = value.$value
         }
         return [isObject(value) ? get(value, sortKey) : value]
       }
-  const compare = function (a, b) {
+  const compare = function (a: CompareValue<T>, b: CompareValue<T>) {
     if (sortMethod) {
       return sortMethod(a.value, b.value)
     }
-    for (let i = 0, len = a.key.length; i < len; i++) {
-      if (a.key[i] < b.key[i]) {
+    for (let i = 0, len = a.key?.length ?? 0; i < len; i++) {
+      if (a.key?.[i] < b.key?.[i]) {
         return -1
       }
-      if (a.key[i] > b.key[i]) {
+      if (a.key?.[i] > b.key?.[i]) {
         return 1
       }
     }
     return 0
   }
   return array
-    .map((value, index) => {
+    .map<CompareValue<T>>((value: T, index) => {
       return {
         value,
         index,
@@ -175,11 +178,11 @@ export const getColumnByCell = function <T>(
   return null
 }
 
-export const getRowIdentity = <T>(
+export const getRowIdentity = <T extends Record<string, any>>(
   row: T,
   rowKey: string | ((row: T) => any) | null
   isReturnRawValue: boolean = false
-): string => {
+): string | undefined => {
   if (!row) throw new Error('Row is required when get row identity')
   if (isString(rowKey)) {
     if (!rowKey.includes('.')) {
@@ -196,17 +199,18 @@ export const getRowIdentity = <T>(
   }
 }
 
-export const getKeysMap = function <T>(
+export const getKeysMap = function <T extends Record<string, any>>(
   array: T[],
   rowKey: string,
   flatten = false,
   childrenKey = 'children'
 ): Record<string, { row: T; index: number }> {
   const data = array || []
-  const arrayMap = {}
+  const arrayMap: Record<string, { row: T; index: number }> = {}
 
   data.forEach((row, index) => {
-    arrayMap[getRowIdentity(row, rowKey)] = { row, index }
+    const identifier = getRowIdentity(row, rowKey)
+    if (identifier) arrayMap[identifier] = { row, index }
 
     if (flatten) {
       const children = row[childrenKey]
@@ -219,17 +223,20 @@ export const getKeysMap = function <T>(
   return arrayMap
 }
 
-export function mergeOptions<T, K>(defaults: T, config: K): T & K {
+export function mergeOptions<
+  T extends Record<string, any>,
+  K extends Record<string, any>
+>(defaults: T, config: K): T & K {
   const options = {} as T & K
-  let key
+  let key: keyof T & keyof K
   for (key in defaults) {
     options[key] = defaults[key]
   }
   for (key in config) {
-    if (hasOwn(config as unknown as Record<string, any>, key)) {
+    if (hasOwn(config, key)) {
       const value = config[key]
       if (!isUndefined(value)) {
-        options[key] = value
+        options[key as keyof K] = value
       }
     }
   }
@@ -272,22 +279,22 @@ export function parseHeight(height: number | string | null) {
   return null
 }
 
-// https://github.com/reduxjs/redux/blob/master/src/compose.js
-export function compose(...funcs) {
+// https://github.com/reduxjs/redux/blob/master/src/compose.ts
+export function compose(...funcs: Function[]) {
   if (funcs.length === 0) {
-    return (arg) => arg
+    return <T>(arg: T) => arg
   }
   if (funcs.length === 1) {
     return funcs[0]
   }
   return funcs.reduce(
     (a, b) =>
-      (...args) =>
+      (...args: any) =>
         a(b(...args))
   )
 }
 
-export function toggleRowStatus<T>(
+export function toggleRowStatus<T extends Record<string, any>>(
   statusArr: T[],
   row: T,
   newVal?: boolean,
@@ -322,7 +329,7 @@ export function toggleRowStatus<T>(
     }
     changed = true
   }
-  const getChildrenCount = (row: T) => {
+  const getChildrenCount = <T extends Record<string, any>>(row: T) => {
     let count = 0
     const children = tableTreeProps?.children && row[tableTreeProps.children]
     if (children && isArray(children)) {
@@ -351,7 +358,7 @@ export function toggleRowStatus<T>(
     tableTreeProps?.children &&
     isArray(row[tableTreeProps.children])
   ) {
-    row[tableTreeProps.children].forEach((item) => {
+    row[tableTreeProps.children].forEach((item: T) => {
       const childChanged = toggleRowStatus(
         statusArr,
         item,
@@ -370,18 +377,18 @@ export function toggleRowStatus<T>(
   return changed
 }
 
-export function walkTreeNode(
-  root,
-  cb,
+export function walkTreeNode<T extends Record<string, any>>(
+  root: T[],
+  cb: (parent: any, children: T | null, level: number) => void,
   childrenKey = 'children',
   lazyKey = 'hasChildren',
   lazy = false
 ) {
-  const isNil = (array) => !(isArray(array) && array.length)
+  const isNil = (array: any): array is null => !(isArray(array) && array.length)
 
-  function _walker(parent, children, level) {
+  function _walker(parent: any, children: T, level: number) {
     cb(parent, children, level)
-    children.forEach((item) => {
+    children.forEach((item: any) => {
       if (item[lazyKey] && lazy) {
         cb(item, null, level + 1)
         return
@@ -393,7 +400,7 @@ export function walkTreeNode(
     })
   }
 
-  root.forEach((item) => {
+  root.forEach((item: any) => {
     if (item[lazyKey] && lazy) {
       cb(item, null, 0)
       return
@@ -405,7 +412,7 @@ export function walkTreeNode(
   })
 }
 
-const getTableOverflowTooltipProps = (
+const getTableOverflowTooltipProps = <T extends Record<string, any>>(
   props: TableOverflowTooltipOptions,
   innerText: string,
   row: T,
@@ -444,7 +451,7 @@ const getTableOverflowTooltipProps = (
 
 export let removePopper: RemovePopperFn | null = null
 
-export function createTablePopper(
+export function createTablePopper<T extends Record<string, any>>(
   props: TableOverflowTooltipOptions,
   popperContent: string,
   row: T,
@@ -463,10 +470,10 @@ export function createTablePopper(
     slotContent: undefined,
   }
   if (removePopper?.trigger === trigger) {
-    const comp = removePopper!.vm.component
-    merge(comp.props, mergedProps)
+    const comp = removePopper.vm?.component
+    merge(comp?.props, mergedProps)
     if (tableOverflowTooltipProps.slotContent) {
-      comp.slots.content = () => [tableOverflowTooltipProps.slotContent]
+      comp!.slots.content = () => [tableOverflowTooltipProps.slotContent]
     }
     return
   }
@@ -629,7 +636,7 @@ export const getFixedColumnOffset = <T>(
   if (!direction) {
     return
   }
-  const styles: any = {}
+  const styles: CSSProperties = {}
   const isLeft = direction === 'left'
   const columns = store.states.columns.value
   if (isLeft) {
@@ -643,9 +650,12 @@ export const getFixedColumnOffset = <T>(
   return styles
 }
 
-export const ensurePosition = (style, key: string) => {
+export const ensurePosition = (
+  style: CSSProperties | null,
+  key: keyof CSSProperties
+) => {
   if (!style) return
   if (!Number.isNaN(style[key])) {
-    style[key] = `${style[key]}px`
+    style[key] = `${style[key]}px` as any
   }
 }

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -38,7 +38,7 @@ export type TableOverflowTooltipOptions = Partial<
   >
 >
 
-export type TableOverflowTooltipFormatter<T = any> = (data: {
+export type TableOverflowTooltipFormatter<T extends DefaultRow> = (data: {
   row: T
   column: TableColumnCtx<T>
   cellValue: any
@@ -59,7 +59,7 @@ export const getCell = function (event: Event) {
   return (event.target as HTMLElement)?.closest('td')
 }
 
-export const orderBy = function <T>(
+export const orderBy = function <T extends DefaultRow>(
   array: T[],
   sortKey: string | null,
   reverse: string | number | null,
@@ -93,7 +93,7 @@ export const orderBy = function <T>(
         if (sortBy !== '$key') {
           if (isObject(value) && '$value' in value) value = value.$value
         }
-        return [isObject(value) ? get(value, sortKey) : value]
+        return [isObject(value) ? get(value, sortKey!) : value]
       }
   const compare = function (a: CompareValue<T>, b: CompareValue<T>) {
     if (sortMethod) {
@@ -128,7 +128,7 @@ export const orderBy = function <T>(
     .map((item) => item.value)
 }
 
-export const getColumnById = function <T>(
+export const getColumnById = function <T extends DefaultRow>(
   table: {
     columns: TableColumnCtx<T>[]
   },
@@ -143,7 +143,7 @@ export const getColumnById = function <T>(
   return column
 }
 
-export const getColumnByKey = function <T>(
+export const getColumnByKey = function <T extends DefaultRow>(
   table: {
     columns: TableColumnCtx<T>[]
   },
@@ -162,7 +162,7 @@ export const getColumnByKey = function <T>(
   return column
 }
 
-export const getColumnByCell = function <T>(
+export const getColumnByCell = function <T extends DefaultRow>(
   table: {
     columns: TableColumnCtx<T>[]
   },
@@ -202,7 +202,7 @@ export const getRowIdentity = <T extends DefaultRow>(
 
 export const getKeysMap = function <T extends DefaultRow>(
   array: T[],
-  rowKey: string,
+  rowKey: string | null,
   flatten = false,
   childrenKey = 'children'
 ): Record<string, { row: T; index: number }> {
@@ -513,7 +513,9 @@ export function createTablePopper<T extends DefaultRow>(
   scrollContainer?.addEventListener('scroll', removePopper)
 }
 
-function getCurrentColumns<T>(column: TableColumnCtx<T>): TableColumnCtx<T>[] {
+function getCurrentColumns<T extends DefaultRow>(
+  column: TableColumnCtx<T>
+): TableColumnCtx<T>[] {
   if (column.children) {
     return flatMap(column.children, getCurrentColumns)
   } else {
@@ -521,11 +523,14 @@ function getCurrentColumns<T>(column: TableColumnCtx<T>): TableColumnCtx<T>[] {
   }
 }
 
-function getColSpan<T>(colSpan: number, column: TableColumnCtx<T>) {
+function getColSpan<T extends DefaultRow>(
+  colSpan: number,
+  column: TableColumnCtx<T>
+) {
   return colSpan + column.colSpan
 }
 
-export const isFixedColumn = <T>(
+export const isFixedColumn = <T extends DefaultRow>(
   index: number,
   fixed: string | boolean,
   store: any,
@@ -578,7 +583,7 @@ export const isFixedColumn = <T>(
     : {}
 }
 
-export const getFixedColumnsClass = <T>(
+export const getFixedColumnsClass = <T extends DefaultRow>(
   namespace: string,
   index: number,
   fixed: string | boolean,
@@ -613,7 +618,10 @@ export const getFixedColumnsClass = <T>(
   return classes
 }
 
-function getOffset<T>(offset: number, column: TableColumnCtx<T>) {
+function getOffset<T extends DefaultRow>(
+  offset: number,
+  column: TableColumnCtx<T>
+) {
   return (
     offset +
     (isNull(column.realWidth) || Number.isNaN(column.realWidth)
@@ -622,7 +630,7 @@ function getOffset<T>(offset: number, column: TableColumnCtx<T>) {
   )
 }
 
-export const getFixedColumnOffset = <T>(
+export const getFixedColumnOffset = <T extends DefaultRow>(
   index: number,
   fixed: string | boolean,
   store: any,

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -301,7 +301,7 @@ export function toggleRowStatus<T extends DefaultRow>(
   tableTreeProps?: TreeProps,
   selectable?: ((row: T, index: number) => boolean) | null,
   rowIndex?: number,
-  rowKey?: string
+  rowKey?: string | null
 ): boolean {
   let _rowIndex = rowIndex ?? 0
   let changed = false

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -17,7 +17,7 @@ import ElTooltip, {
   type ElTooltipProps,
 } from '@element-plus/components/tooltip'
 
-import type { Table, TreeProps } from './table/defaults'
+import type { DefaultRow, Table, TreeProps } from './table/defaults'
 import type { TableColumnCtx } from './table-column/defaults'
 import type { CSSProperties, VNode } from 'vue'
 
@@ -178,7 +178,7 @@ export const getColumnByCell = function <T>(
   return null
 }
 
-export const getRowIdentity = <T extends Record<string, any>>(
+export const getRowIdentity = <T extends DefaultRow>(
   row: T,
   rowKey: string | ((row: T) => string) | null
   isReturnRawValue: boolean = false
@@ -200,7 +200,7 @@ export const getRowIdentity = <T extends Record<string, any>>(
   return rowKey?.(row) ?? ''
 }
 
-export const getKeysMap = function <T extends Record<string, any>>(
+export const getKeysMap = function <T extends DefaultRow>(
   array: T[],
   rowKey: string,
   flatten = false,
@@ -223,10 +223,10 @@ export const getKeysMap = function <T extends Record<string, any>>(
   return arrayMap
 }
 
-export function mergeOptions<
-  T extends Record<string, any>,
-  K extends Record<string, any>
->(defaults: T, config: K): T & K {
+export function mergeOptions<T extends DefaultRow, K extends DefaultRow>(
+  defaults: T,
+  config: K
+): T & K {
   const options = {} as T & K
   let key: keyof T & keyof K
   for (key in defaults) {
@@ -294,7 +294,7 @@ export function compose(...funcs: ((...args: any[]) => void)[]) {
   )
 }
 
-export function toggleRowStatus<T extends Record<string, any>>(
+export function toggleRowStatus<T extends DefaultRow>(
   statusArr: T[],
   row: T,
   newVal?: boolean,
@@ -329,7 +329,7 @@ export function toggleRowStatus<T extends Record<string, any>>(
     }
     changed = true
   }
-  const getChildrenCount = <T extends Record<string, any>>(row: T) => {
+  const getChildrenCount = <T extends DefaultRow>(row: T) => {
     let count = 0
     const children = tableTreeProps?.children && row[tableTreeProps.children]
     if (children && isArray(children)) {
@@ -377,7 +377,7 @@ export function toggleRowStatus<T extends Record<string, any>>(
   return changed
 }
 
-export function walkTreeNode<T extends Record<string, any>>(
+export function walkTreeNode<T extends DefaultRow>(
   root: T[],
   cb: (parent: any, children: T | null, level: number) => void,
   childrenKey = 'children',
@@ -412,7 +412,7 @@ export function walkTreeNode<T extends Record<string, any>>(
   })
 }
 
-const getTableOverflowTooltipProps = <T extends Record<string, any>>(
+const getTableOverflowTooltipProps = <T extends DefaultRow>(
   props: TableOverflowTooltipOptions,
   innerText: string,
   row: T,
@@ -451,7 +451,7 @@ const getTableOverflowTooltipProps = <T extends Record<string, any>>(
 
 export let removePopper: RemovePopperFn | null = null
 
-export function createTablePopper<T extends Record<string, any>>(
+export function createTablePopper<T extends DefaultRow>(
   props: TableOverflowTooltipOptions,
   popperContent: string,
   row: T,

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { createVNode, isVNode, render } from 'vue'
 import { flatMap, get, isNull, merge } from 'lodash-unified'
 import {
@@ -55,10 +54,10 @@ export const getCell = function (event: Event) {
 
 export const orderBy = function <T>(
   array: T[],
-  sortKey: string,
-  reverse: string | number,
-  sortMethod,
-  sortBy: string | (string | ((a: T, b: T, array?: T[]) => number))[]
+  sortKey: string | null,
+  reverse: string | number | null,
+  sortMethod: TableColumnCtx<T>['sortMethod'] | null,
+  sortBy: TableColumnCtx<T>['sortBy'] //string | (string | ((a: T, b: T, array?: T[]) => number))[]
 ) {
   if (
     !sortKey &&
@@ -74,12 +73,13 @@ export const orderBy = function <T>(
   }
   const getKey = sortMethod
     ? null
-    : function (value, index) {
+    : function (value: T, index: number) {
         if (sortBy) {
+          const wrapper: (string | ((row: T, index: number) => string))[] = []
           if (!isArray(sortBy)) {
-            sortBy = [sortBy]
+            wrapper.push(sortBy)
           }
-          return sortBy.map((by) => {
+          return wrapper.map((by) => {
             if (isString(by)) {
               return get(value, by)
             } else {
@@ -177,7 +177,7 @@ export const getColumnByCell = function <T>(
 
 export const getRowIdentity = <T>(
   row: T,
-  rowKey: string | ((row: T) => any),
+  rowKey: string | ((row: T) => any) | null
   isReturnRawValue: boolean = false
 ): string => {
   if (!row) throw new Error('Row is required when get row identity')
@@ -258,7 +258,7 @@ export function parseMinWidth(minWidth: number | string): number | string {
   return minWidth
 }
 
-export function parseHeight(height: number | string) {
+export function parseHeight(height: number | string | null) {
   if (isNumber(height)) {
     return height
   }
@@ -292,7 +292,7 @@ export function toggleRowStatus<T>(
   row: T,
   newVal?: boolean,
   tableTreeProps?: TreeProps,
-  selectable?: (row: T, index?: number) => boolean,
+  selectable?: ((row: T, index: number) => boolean) | null,
   rowIndex?: number,
   rowKey?: string
 ): boolean {

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -243,7 +243,7 @@ export function mergeOptions<T extends DefaultRow, K extends DefaultRow>(
   return options
 }
 
-export function parseWidth(width: number | string): number | string {
+export function parseWidth(width?: number | string): number | string {
   if (width === '') return width
   if (!isUndefined(width)) {
     width = Number.parseInt(width as string, 10)
@@ -251,7 +251,7 @@ export function parseWidth(width: number | string): number | string {
       width = ''
     }
   }
-  return width
+  return width!
 }
 
 export function parseMinWidth(minWidth: number | string): number | string {
@@ -416,7 +416,7 @@ const getTableOverflowTooltipProps = <T extends DefaultRow>(
   props: TableOverflowTooltipOptions,
   innerText: string,
   row: T,
-  column: TableColumnCtx<T>
+  column: TableColumnCtx<T> | null
 ) => {
   // merge popperOptions
   const popperOptions = {
@@ -424,7 +424,7 @@ const getTableOverflowTooltipProps = <T extends DefaultRow>(
     ...props.popperOptions,
   }
 
-  const tooltipFormatterContent = isFunction(column.tooltipFormatter)
+  const tooltipFormatterContent = isFunction(column?.tooltipFormatter)
     ? column.tooltipFormatter({
         row,
         column,
@@ -455,9 +455,9 @@ export function createTablePopper<T extends DefaultRow>(
   props: TableOverflowTooltipOptions,
   popperContent: string,
   row: T,
-  column: TableColumnCtx<T>,
-  trigger: HTMLElement,
-  table: Table<[]>
+  column: TableColumnCtx<T> | null,
+  trigger: HTMLElement | null,
+  table: Table<DefaultRow>
 ) {
   const tableOverflowTooltipProps = getTableOverflowTooltipProps(
     props,
@@ -508,7 +508,7 @@ export function createTablePopper<T extends DefaultRow>(
     scrollContainer?.removeEventListener('scroll', removePopper!)
     removePopper = null
   }
-  removePopper.trigger = trigger
+  removePopper.trigger = trigger ?? undefined
   removePopper.vm = vm
   scrollContainer?.addEventListener('scroll', removePopper)
 }
@@ -532,7 +532,7 @@ function getColSpan<T extends DefaultRow>(
 
 export const isFixedColumn = <T extends DefaultRow>(
   index: number,
-  fixed: string | boolean,
+  fixed: string | boolean | undefined,
   store: any,
   realColumns?: TableColumnCtx<T>[]
 ) => {
@@ -586,7 +586,7 @@ export const isFixedColumn = <T extends DefaultRow>(
 export const getFixedColumnsClass = <T extends DefaultRow>(
   namespace: string,
   index: number,
-  fixed: string | boolean,
+  fixed: string | boolean | undefined,
   store: any,
   realColumns?: TableColumnCtx<T>[],
   offset = 0
@@ -632,7 +632,7 @@ function getOffset<T extends DefaultRow>(
 
 export const getFixedColumnOffset = <T extends DefaultRow>(
   index: number,
-  fixed: string | boolean,
+  fixed: string | boolean | undefined,
   store: any,
   realColumns?: TableColumnCtx<T>[]
 ) => {

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -90,7 +90,7 @@ export const orderBy = function <T extends DefaultRow>(
             }
           })
         }
-        if (sortBy !== '$key') {
+        if (sortKey !== '$key') {
           if (isObject(value) && '$value' in value) value = value.$value
         }
         return [isObject(value) ? get(value, sortKey!) : value]
@@ -472,8 +472,8 @@ export function createTablePopper<T extends DefaultRow>(
   if (removePopper?.trigger === trigger) {
     const comp = removePopper.vm?.component
     merge(comp?.props, mergedProps)
-    if (tableOverflowTooltipProps.slotContent) {
-      comp!.slots.content = () => [tableOverflowTooltipProps.slotContent]
+    if (comp && tableOverflowTooltipProps.slotContent) {
+      comp.slots.content = () => [tableOverflowTooltipProps.slotContent]
     }
     return
   }

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -93,7 +93,9 @@ export const orderBy = function <T extends DefaultRow>(
         if (sortKey !== '$key') {
           if (isObject(value) && '$value' in value) value = value.$value
         }
-        return [isObject(value) ? get(value, sortKey!) : value]
+        return [
+          isObject(value) ? (sortKey ? get(value, sortKey) : null) : value,
+        ]
       }
   const compare = function (a: CompareValue<T>, b: CompareValue<T>) {
     if (sortMethod) {

--- a/packages/directives/mousewheel/index.ts
+++ b/packages/directives/mousewheel/index.ts
@@ -1,11 +1,16 @@
 import normalizeWheel from 'normalize-wheel-es'
 
-import type { DirectiveBinding, ObjectDirective } from 'vue'
+import type { ObjectDirective } from 'vue'
 import type { NormalizedWheelEvent } from 'normalize-wheel-es'
+
+type OnMouseWheelHandler = (
+  e: WheelEvent,
+  normalized: NormalizedWheelEvent
+) => void
 
 const mousewheel = function (
   element: HTMLElement,
-  callback: (e: WheelEvent, normalized: NormalizedWheelEvent) => void
+  callback: OnMouseWheelHandler
 ) {
   if (element && element.addEventListener) {
     const fn = function (this: HTMLElement, event: WheelEvent) {
@@ -16,8 +21,8 @@ const mousewheel = function (
   }
 }
 
-const Mousewheel: ObjectDirective = {
-  beforeMount(el: HTMLElement, binding: DirectiveBinding) {
+const Mousewheel: ObjectDirective<HTMLElement, OnMouseWheelHandler> = {
+  beforeMount(el, binding) {
     mousewheel(el, binding.value)
   },
 }

--- a/packages/utils/dom/style.ts
+++ b/packages/utils/dom/style.ts
@@ -11,7 +11,7 @@ const SCOPE = 'utils/dom/style'
 export const classNameToArray = (cls = '') =>
   cls.split(' ').filter((item) => !!item.trim())
 
-export const hasClass = (el: Element, cls: string): boolean => {
+export const hasClass = (el: Element | null, cls: string): boolean => {
   if (!el || !cls) return false
   if (cls.includes(' ')) throw new Error('className should not contain space.')
   return el.classList.contains(cls)


### PR DESCRIPTION
This pr prepare will remove `ts-nocheck` for table component, it will facilitate contribution on this component and it has been made to bring generic easily when we'll upgrade vue.

However, it introduce a small breaking change, since the generic across the component has been change:
```diff
- type DefaultRow = any
+ type DefaultRow = Record<PropertyKey, any>

here PropertyKey is a native typescript alias for string | number | symbol
```
This change is necessary to remove `ts-nocheck` properly and add more reliability.

This will break typescript when the user will have:
```diff
- interface SummaryMethodProps<T = Product> {
+ interface SummaryMethodProps<T extends Record<string, any> = Product> {
  columns: TableColumnCtx<T>[]
  data: T[]
}
```
[from this example](https://github.com/element-plus/element-plus/blob/947a88d255b92928e7197285dd8d244579b1c329/docs/examples/table/summary.vue#L40-L43)

It can affect many users. 