### PR TITLE
perf(components): [table] remove redundant `updateSelectionByRowKey`

### DIFF
--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -55,7 +55,9 @@ function useStore<T>() {
       instance.store.updateTreeData(
         instance.store.states.defaultExpandAll.value
       )
-      if (!unref(states.reserveSelection)) {
+      if (unref(states.reserveSelection)) {
+        instance.store.assertRowKey()
+      } else {
         if (dataInstanceChanged) {
           instance.store.clearSelection()
         } else {

--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -55,10 +55,7 @@ function useStore<T>() {
       instance.store.updateTreeData(
         instance.store.states.defaultExpandAll.value
       )
-      if (unref(states.reserveSelection)) {
-        instance.store.assertRowKey()
-        instance.store.updateSelectionByRowKey()
-      } else {
+      if (!unref(states.reserveSelection)) {
         if (dataInstanceChanged) {
           instance.store.clearSelection()
         } else {

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -294,16 +294,6 @@ function useWatcher<T>() {
     instance.emit('select-all', (selection.value || []).slice())
   }
 
-  const updateSelectionByRowKey = () => {
-    data.value.forEach((row) => {
-      const rowId = getRowIdentity(row, rowKey.value)
-      const rowInfo = selectedMap.value![rowId]
-      if (rowInfo) {
-        selection.value[rowInfo.index] = row
-      }
-    })
-  }
-
   const updateAllSelected = () => {
     // data 为 null 时，解构时的默认值会被忽略
     if (data.value?.length === 0) {
@@ -534,7 +524,6 @@ function useWatcher<T>() {
     toggleRowSelection,
     _toggleAllSelection,
     toggleAllSelection: null,
-    updateSelectionByRowKey,
     updateAllSelected,
     updateFilters,
     updateCurrentRow,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

This PR builds upon #20995, which addressed the issue where child nodes in a tree structure could not be selected after toggling pages when `reserve-selection` was enabled.

Since the issue has been resolved by copying the data properly, the `updateSelectionByRowKey` function is now redundant. To improve performance and reduce unnecessary computation, this function has been removed.