### PR TITLE
fix(components): [affix] correctly updateRoot when fixed

### DIFF
--- a/packages/components/affix/src/affix.vue
+++ b/packages/components/affix/src/affix.vue
@@ -106,6 +106,18 @@ const update = () => {
   }
 }
 
+const updateRootRect = async () => {
+  if (!fixed.value) {
+    updateRoot()
+    return
+  }
+
+  fixed.value = false
+  await nextTick()
+  updateRoot()
+  fixed.value = true
+}
+
 const handleScroll = async () => {
   updateRoot()
   await nextTick()
@@ -137,6 +149,6 @@ defineExpose({
   /** @description update affix status */
   update,
   /** @description update rootRect info */
-  updateRoot,
+  updateRoot: updateRootRect,
 })
 </script>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

----------

这个pr是为了解决已固定的固钉，调用updateRoot没有作用的问题。

我发现updateRoot是使用的useElementBounding的update方法，已固定的宽高已经写死了，重新计算并不能达到预期的效果。

有几种场景都是需要这样手动更新的，比如底部固钉里的内容变高，下面的内容就看不见了。
还有这个问题#6921