### PR TITLE
refactor(components): [table] remove `@ts-nocheck`

### DIFF
--- a/packages/components/table/src/store/expand.ts
+++ b/packages/components/table/src/store/expand.ts
@@ -1,12 +1,11 @@
-// @ts-nocheck
 import { getCurrentInstance, ref } from 'vue'
 import { getKeysMap, getRowIdentity, toggleRowStatus } from '../util'
 
 import type { Ref } from 'vue'
 import type { WatcherPropsData } from '.'
-import type { Table } from '../table/defaults'
+import type { DefaultRow, Table } from '../table/defaults'
 
-function useExpand<T>(watcherData: WatcherPropsData<T>) {
+function useExpand<T extends DefaultRow>(watcherData: WatcherPropsData<T>) {
   const instance = getCurrentInstance() as Table<T>
   const defaultExpandAll = ref(false)
   const expandRows: Ref<T[]> = ref([])
@@ -46,13 +45,13 @@ function useExpand<T>(watcherData: WatcherPropsData<T>) {
     }
   }
 
-  const setExpandRowKeys = (rowKeys: string[]) => {
+  const setExpandRowKeys = (rowKeys: (string | number)[]) => {
     instance.store.assertRowKey()
     // TODO：这里的代码可以优化
     const data = watcherData.data.value || []
     const rowKey = watcherData.rowKey.value
     const keysMap = getKeysMap(data, rowKey)
-    expandRows.value = rowKeys.reduce((prev: T[], cur: string) => {
+    expandRows.value = rowKeys.reduce((prev: T[], cur) => {
       const info = keysMap[cur]
       if (info) {
         prev.push(info.row)

--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -118,8 +118,8 @@ function useStore<T extends DefaultRow>() {
       updateColumnOrder: () => void
     ) {
       const array = unref(states._columns) || []
-      if (parent?.children) {
-        parent.children.splice(
+      if (parent) {
+        parent.children?.splice(
           parent.children.findIndex((item) => item.id === column.id),
           1
         )

--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -217,10 +217,10 @@ function useStore<T extends DefaultRow>() {
   const commit = function (name: keyof typeof mutations, ...args: any[]) {
     const mutations = instance.store.mutations
     if (mutations[name]) {
-      ;(mutations[name] as any).apply(
-        instance,
-        [instance.store.states].concat(args)
-      )
+      ;(mutations[name] as any).apply(instance, [
+        instance.store.states,
+        ...args,
+      ])
     } else {
       throw new Error(`Action not found: ${name}`)
     }

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -36,11 +36,9 @@ function useTree<T extends DefaultRow>(watcherData: WatcherPropsData<T>) {
         const item: typeof res[number] = { children: [] }
         lazyTreeNodeMap.value[key].forEach((row) => {
           const currentRowKey = getRowIdentity(row, rowKey)
-          if (currentRowKey) {
-            item.children.push(currentRowKey)
-            if (row[lazyColumnIdentifier.value] && !res[currentRowKey]) {
-              res[currentRowKey] = { children: [] }
-            }
+          item.children.push(currentRowKey)
+          if (row[lazyColumnIdentifier.value] && !res[currentRowKey]) {
+            res[currentRowKey] = { children: [] }
           }
         })
         res[key] = item

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -1,17 +1,22 @@
-// @ts-nocheck
 import { computed, getCurrentInstance, ref, unref, watch } from 'vue'
 import { isArray, isUndefined } from '@element-plus/utils'
 import { getRowIdentity, walkTreeNode } from '../util'
 
 import type { WatcherPropsData } from '.'
-import type { Table, TableProps } from '../table/defaults'
+import type { DefaultRow, Table, TableProps, TreeNode } from '../table/defaults'
 
-function useTree<T>(watcherData: WatcherPropsData<T>) {
+export interface TreeData extends TreeNode {
+  children?: string[]
+  lazy?: boolean
+  loaded?: boolean
+}
+
+function useTree<T extends DefaultRow>(watcherData: WatcherPropsData<T>) {
   const expandRowKeys = ref<Array<string | number>>([])
-  const treeData = ref<unknown>({})
+  const treeData = ref<Record<string, TreeData>>({})
   const indent = ref(16)
   const lazy = ref(false)
-  const lazyTreeNodeMap = ref({})
+  const lazyTreeNodeMap = ref<Record<string, T[]>>({})
   const lazyColumnIdentifier = ref('hasChildren')
   const childrenColumnName = ref('children')
   const checkStrictly = ref(false)
@@ -24,16 +29,18 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
   const normalizedLazyNode = computed(() => {
     const rowKey = watcherData.rowKey.value
     const keys = Object.keys(lazyTreeNodeMap.value)
-    const res = {}
+    const res: Record<string, { children: string[] }> = {}
     if (!keys.length) return res
     keys.forEach((key) => {
       if (lazyTreeNodeMap.value[key].length) {
-        const item = { children: [] }
+        const item: typeof res[number] = { children: [] }
         lazyTreeNodeMap.value[key].forEach((row) => {
           const currentRowKey = getRowIdentity(row, rowKey)
-          item.children.push(currentRowKey)
-          if (row[lazyColumnIdentifier.value] && !res[currentRowKey]) {
-            res[currentRowKey] = { children: [] }
+          if (currentRowKey) {
+            item.children.push(currentRowKey)
+            if (row[lazyColumnIdentifier.value] && !res[currentRowKey]) {
+              res[currentRowKey] = { children: [] }
+            }
           }
         })
         res[key] = item
@@ -42,16 +49,16 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     return res
   })
 
-  const normalize = (data) => {
+  const normalize = (data: T[]) => {
     const rowKey = watcherData.rowKey.value
-    const res = new Map<string | number, object>() // 使用 Map 替代 Object，解决 number key 的问题
+    const res = new Map<string | number, TreeData>() // 使用 Map 替代 Object，解决 number key 的问题
     walkTreeNode(
       data,
       (parent, children, level) => {
         const parentId = getRowIdentity(parent, rowKey, true)
         if (isArray(children)) {
           res.set(parentId, {
-            children: children.map((row) => row[rowKey]),
+            children: children.map((row) => row[rowKey!]),
             level,
           })
         } else if (lazy.value) {
@@ -72,15 +79,16 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
 
   const updateTreeData = (
     ifChangeExpandRowKeys = false,
-    ifExpandAll = instance.store?.states.defaultExpandAll.value
+    ifExpandAll?: boolean
   ) => {
+    ifExpandAll ||= instance.store?.states.defaultExpandAll.value
     const nested = normalizedData.value
     const normalizedLazyNode_ = normalizedLazyNode.value
-    const newTreeData = {}
+    const newTreeData: Record<string, TreeData> = {}
     if (nested instanceof Map && nested.size) {
       const oldTreeData = unref(treeData)
-      const rootLazyRowKeys = []
-      const getExpanded = (oldValue, key) => {
+      const rootLazyRowKeys: string[] = []
+      const getExpanded = (oldValue: TreeData, key: string) => {
         if (ifChangeExpandRowKeys) {
           if (expandRowKeys.value) {
             return ifExpandAll || expandRowKeys.value.includes(key)
@@ -115,7 +123,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
           const lazyNodeChildren = normalizedLazyNode_[key].children
           if (rootLazyRowKeys.includes(key)) {
             // 懒加载的 root 节点，更新一下原有的数据，原来的 children 一定是空数组
-            if (newTreeData[key].children.length !== 0) {
+            if (newTreeData[key].children?.length !== 0) {
               throw new Error('[ElTable]children must be an empty array.')
             }
             newTreeData[key].children = lazyNodeChildren
@@ -127,7 +135,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
               loading: !!loading,
               expanded: getExpanded(oldValue, key),
               children: lazyNodeChildren,
-              level: '',
+              level: undefined,
             }
           }
         })
@@ -157,11 +165,11 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     }
   )
 
-  const updateTreeExpandKeys = (value: string[]) => {
+  const updateTreeExpandKeys = (value: (string | number)[]) => {
     expandRowKeys.value = value
     updateTreeData()
   }
-  const isUseLazy = (data): boolean => {
+  const isUseLazy = (data: TreeData) => {
     return lazy.value && data && 'loaded' in data && !data.loaded
   }
   const toggleTreeExpansion = (row: T, expanded?: boolean) => {
@@ -182,7 +190,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     }
   }
 
-  const loadOrToggle = (row) => {
+  const loadOrToggle = (row: T) => {
     instance.store.assertRowKey()
     const rowKey = watcherData.rowKey.value
     const id = getRowIdentity(row, rowKey)
@@ -194,7 +202,7 @@ function useTree<T>(watcherData: WatcherPropsData<T>) {
     }
   }
 
-  const loadData = (row: T, key: string, treeNode) => {
+  const loadData = (row: T, key: string, treeNode: TreeNode) => {
     const { load } = instance.props as unknown as TableProps<T>
     if (load && !treeData.value[key].loaded) {
       treeData.value[key].loading = true

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -1,6 +1,5 @@
-// @ts-nocheck
 import { computed, getCurrentInstance, ref, toRefs, unref, watch } from 'vue'
-import { hasOwn, isArray, isString } from '@element-plus/utils'
+import { ensureArray, hasOwn, isArray, isString } from '@element-plus/utils'
 import {
   getColumnById,
   getColumnByKey,
@@ -15,10 +14,22 @@ import useTree from './tree'
 
 import type { Ref } from 'vue'
 import type { TableColumnCtx } from '../table-column/defaults'
-import type { DefaultRow, Table, TableRefs } from '../table/defaults'
+import type {
+  DefaultRow,
+  Table,
+  TableRefs,
+  TableSortOrder,
+} from '../table/defaults'
 import type { StoreFilter } from '.'
 
-const sortData = (data, states) => {
+const sortData = <T extends DefaultRow>(
+  data: T[],
+  states: {
+    sortingColumn: TableColumnCtx<T> | null
+    sortProp: string | null
+    sortOrder: string | number | null
+  }
+) => {
   const sortingColumn = states.sortingColumn
   if (!sortingColumn || isString(sortingColumn.sortable)) {
     return data
@@ -32,8 +43,10 @@ const sortData = (data, states) => {
   )
 }
 
-const doFlattenColumns = (columns) => {
-  const result = []
+const doFlattenColumns = <T extends DefaultRow>(
+  columns: TableColumnCtx<T>[]
+) => {
+  const result: TableColumnCtx<T>[] = []
   columns.forEach((column) => {
     if (column.children && column.children.length > 0) {
       // eslint-disable-next-line prefer-spread
@@ -45,10 +58,10 @@ const doFlattenColumns = (columns) => {
   return result
 }
 
-function useWatcher<T>() {
+function useWatcher<T extends DefaultRow>() {
   const instance = getCurrentInstance() as Table<T>
   const { size: tableSize } = toRefs(instance.proxy?.$props as any)
-  const rowKey: Ref<string> = ref(null)
+  const rowKey: Ref<string | null> = ref(null)
   const data: Ref<T[]> = ref([])
   const _data: Ref<T[]> = ref([])
   const isComplex = ref(false)
@@ -68,13 +81,13 @@ function useWatcher<T>() {
   const selection: Ref<T[]> = ref([])
   const reserveSelection = ref(false)
   const selectOnIndeterminate = ref(false)
-  const selectable: Ref<(row: T, index: number) => boolean> = ref(null)
+  const selectable: Ref<((row: T, index: number) => boolean) | null> = ref(null)
   const filters: Ref<StoreFilter> = ref({})
-  const filteredData = ref(null)
-  const sortingColumn = ref(null)
-  const sortProp = ref(null)
-  const sortOrder = ref(null)
-  const hoverRow = ref(null)
+  const filteredData: Ref<T[] | null> = ref(null)
+  const sortingColumn: Ref<TableColumnCtx<T> | null> = ref(null)
+  const sortProp: Ref<string | null> = ref(null)
+  const sortOrder: Ref<string | number | null> = ref(null)
+  const hoverRow: Ref<T | null> = ref(null)
 
   const selectedMap = computed(() => {
     return rowKey.value ? getKeysMap(selection.value, rowKey.value) : undefined
@@ -122,7 +135,7 @@ function useWatcher<T>() {
       (column) => column.type === 'selection'
     )
 
-    let selectColFixLeft
+    let selectColFixLeft: boolean
     if (
       selectColumn &&
       selectColumn.fixed !== 'right' &&
@@ -144,8 +157,7 @@ function useWatcher<T>() {
         (selectColFixLeft ? column.type !== 'selection' : true) && !column.fixed
     )
 
-    originColumns.value = []
-      .concat(fixedColumns.value)
+    originColumns.value = Array.from(fixedColumns.value)
       .concat(notFixedColumns)
       .concat(rightFixedColumns.value)
     const leafColumns = doFlattenColumns(notFixedColumns)
@@ -156,8 +168,7 @@ function useWatcher<T>() {
     fixedLeafColumnsLength.value = fixedLeafColumns.length
     rightFixedLeafColumnsLength.value = rightFixedLeafColumns.length
 
-    columns.value = []
-      .concat(fixedLeafColumns)
+    columns.value = Array.from(fixedLeafColumns)
       .concat(leafColumns)
       .concat(rightFixedLeafColumns)
     isComplex.value =
@@ -177,7 +188,7 @@ function useWatcher<T>() {
   }
 
   // 选择
-  const isSelected = (row: DefaultRow) => {
+  const isSelected = (row: T) => {
     if (selectedMap.value) {
       return !!selectedMap.value[getRowIdentity(row, rowKey.value)]
     } else {
@@ -305,7 +316,7 @@ function useWatcher<T>() {
     let rowIndex = 0
     let selectedCount = 0
 
-    const checkSelectedStatus = (data: DefaultRow[]) => {
+    const checkSelectedStatus = (data: T[]) => {
       for (const row of data) {
         const isRowSelectable =
           selectable.value && selectable.value.call(null, row, rowIndex)
@@ -348,19 +359,20 @@ function useWatcher<T>() {
   }
 
   // 过滤与排序
-  const updateFilters = (columns, values) => {
-    if (!isArray(columns)) {
-      columns = [columns]
-    }
-    const filters_ = {}
-    columns.forEach((col) => {
+  const updateFilters = (column: TableColumnCtx<T>, values: string[]) => {
+    const filters_: Record<string, string[]> = {}
+    ensureArray(column).forEach((col) => {
       filters.value[col.id] = values
       filters_[col.columnKey || col.id] = values
     })
     return filters_
   }
 
-  const updateSort = (column, prop, order) => {
+  const updateSort = (
+    column: TableColumnCtx<T> | null,
+    prop: string | null,
+    order: TableSortOrder | null
+  ) => {
     if (sortingColumn.value && sortingColumn.value !== column) {
       sortingColumn.value.order = null
     }
@@ -388,12 +400,11 @@ function useWatcher<T>() {
         })
       }
     })
-
     filteredData.value = sourceData
   }
 
   const execSort = () => {
-    data.value = sortData(filteredData.value, {
+    data.value = sortData(filteredData.value ?? [], {
       sortingColumn: sortingColumn.value,
       sortProp: sortProp.value,
       sortOrder: sortOrder.value,
@@ -401,14 +412,14 @@ function useWatcher<T>() {
   }
 
   // 根据 filters 与 sort 去过滤 data
-  const execQuery = (ignore = undefined) => {
-    if (!(ignore && ignore.filter)) {
+  const execQuery = (ignore: { filter: boolean } | undefined = undefined) => {
+    if (!ignore?.filter) {
       execFilter()
     }
     execSort()
   }
 
-  const clearFilter = (columnKeys) => {
+  const clearFilter = (columnKeys?: string[] | string) => {
     const { tableHeaderRef } = instance.refs as TableRefs
     if (!tableHeaderRef) return
     const panels = Object.assign({}, tableHeaderRef.filterPanels)
@@ -497,7 +508,7 @@ function useWatcher<T>() {
     rowKey,
   })
   // 适配层，expand-row-keys 在 Expand 与 TreeTable 中都有使用
-  const setExpandRowKeysAdapter = (val: string[]) => {
+  const setExpandRowKeysAdapter = (val: (string | number)[]) => {
     // 这里会触发额外的计算，但为了兼容性，暂时这么做
     setExpandRowKeys(val)
     updateTreeExpandKeys(val)
@@ -523,7 +534,7 @@ function useWatcher<T>() {
     getSelectionRows,
     toggleRowSelection,
     _toggleAllSelection,
-    toggleAllSelection: null,
+    toggleAllSelection: null as (() => void) | null,
     updateAllSelected,
     updateFilters,
     updateCurrentRow,

--- a/packages/components/table/src/table-column/defaults.ts
+++ b/packages/components/table/src/table-column/defaults.ts
@@ -1,37 +1,46 @@
-// @ts-nocheck
 import type { ComponentInternalInstance, PropType, Ref, VNode } from 'vue'
-import type { DefaultRow, Table } from '../table/defaults'
+import type { DefaultRow, Table, TableSortOrder } from '../table/defaults'
 import type {
   TableOverflowTooltipFormatter,
   TableOverflowTooltipOptions,
 } from '../util'
+import type { Store } from '../store'
 
-type CI<T> = { column: TableColumnCtx<T>; $index: number }
+type CI<T extends DefaultRow> = {
+  column: TableColumnCtx<T>
+  $index: number
+  store: Store<T>
+  _self: any
+}
 
 type Filters = {
   text: string
   value: string
 }[]
 
-type FilterMethods<T> = (value, row: T, column: TableColumnCtx<T>) => void
+type FilterMethods<T extends DefaultRow> = (
+  value: string,
+  row: T,
+  column: TableColumnCtx<T>
+) => void
 
 type ValueOf<T> = T[keyof T]
 
-interface TableColumnCtx<T> {
+type TableColumnCtx<T extends DefaultRow = DefaultRow> = {
   id: string
-  realWidth: number
+  realWidth: number | null
   type: string
   label: string
   className: string
   labelClassName: string
   property: string
   prop: string
-  width: string | number
+  width?: string | number
   minWidth: string | number
   renderHeader: (data: CI<T>) => VNode
   sortable: boolean | string
   sortMethod: (a: T, b: T) => number
-  sortBy: string | ((row: T, index: number) => string) | string[]
+  sortBy: string | ((row: T, index: number, array?: T[]) => string) | string[]
   resizable: boolean
   columnKey: string
   rawColumnKey: string
@@ -43,7 +52,7 @@ interface TableColumnCtx<T> {
   formatter: (
     row: T,
     column: TableColumnCtx<T>,
-    cellValue,
+    cellValue: any,
     index: number
   ) => VNode | string
   selectable: (row: T, index: number) => boolean
@@ -55,23 +64,25 @@ interface TableColumnCtx<T> {
   filterMultiple: boolean
   filterClassName: string
   index: number | ((index: number) => number)
-  sortOrders: ('ascending' | 'descending' | null)[]
+  sortOrders: (TableSortOrder | null)[]
   renderCell: (data: any) => void
   colSpan: number
   rowSpan: number
-  children: TableColumnCtx<T>[]
+  children?: TableColumnCtx<T>[]
   level: number
   filterable: boolean | FilterMethods<T> | Filters
-  order: string
+  order: TableSortOrder | null
   isColumnGroup: boolean
   isSubColumn: boolean
   columns: TableColumnCtx<T>[]
   getColumnIndex: () => number
   no: number
   filterOpened?: boolean
+  renderFilterIcon?: (scope: any) => VNode
+  renderExpand?: (scope: any) => VNode
 }
 
-interface TableColumn<T> extends ComponentInternalInstance {
+interface TableColumn<T extends DefaultRow> extends ComponentInternalInstance {
   vnode: {
     vParent: TableColumn<T> | Table<T>
   } & VNode
@@ -127,9 +138,7 @@ export default {
   /**
    * @description render function for table header of this column
    */
-  renderHeader: Function as PropType<
-    TableColumnCtx<DefaultRow>['renderHeader']
-  >,
+  renderHeader: Function as PropType<TableColumnCtx<any>['renderHeader']>,
   /**
    * @description whether column can be sorted. Remote sorting can be done by setting this attribute to 'custom' and listening to the `sort-change` event of Table
    */
@@ -140,13 +149,11 @@ export default {
   /**
    * @description sorting method, works when `sortable` is `true`. Should return a number, just like Array.sort
    */
-  sortMethod: Function as PropType<TableColumnCtx<DefaultRow>['sortMethod']>,
+  sortMethod: Function as PropType<TableColumnCtx<any>['sortMethod']>,
   /**
    * @description specify which property to sort by, works when `sortable` is `true` and `sort-method` is `undefined`. If set to an Array, the column will sequentially sort by the next property if the previous one is equal
    */
-  sortBy: [String, Function, Array] as PropType<
-    TableColumnCtx<DefaultRow>['sortBy']
-  >,
+  sortBy: [String, Function, Array] as PropType<TableColumnCtx<any>['sortBy']>,
   /**
    * @description whether column width can be resized, works when `border` of `el-table` is `true`
    */
@@ -171,7 +178,7 @@ export default {
    */
   showOverflowTooltip: {
     type: [Boolean, Object] as PropType<
-      TableColumnCtx<DefaultRow>['showOverflowTooltip']
+      TableColumnCtx<any>['showOverflowTooltip']
     >,
     default: undefined,
   },
@@ -179,7 +186,7 @@ export default {
    * @description function that formats cell tooltip content, works when `show-overflow-tooltip` is `true`
    */
   tooltipFormatter: Function as PropType<
-    TableColumnCtx<DefaultRow>['tooltipFormatter']
+    TableColumnCtx<any>['tooltipFormatter']
   >,
   /**
    * @description whether column is fixed at left / right. Will be fixed at left if `true`
@@ -188,11 +195,11 @@ export default {
   /**
    * @description function that formats cell content
    */
-  formatter: Function as PropType<TableColumnCtx<DefaultRow>['formatter']>,
+  formatter: Function as PropType<TableColumnCtx<any>['formatter']>,
   /**
    * @description function that determines if a certain row can be selected, works when `type` is 'selection'
    */
-  selectable: Function as PropType<TableColumnCtx<DefaultRow>['selectable']>,
+  selectable: Function as PropType<TableColumnCtx<any>['selectable']>,
   /**
    * @description whether to reserve selection after data refreshing, works when `type` is 'selection'. Note that `row-key` is required for this to work
    */
@@ -200,17 +207,15 @@ export default {
   /**
    * @description data filtering method. If `filter-multiple` is on, this method will be called multiple times for each row, and a row will display if one of the calls returns `true`
    */
-  filterMethod: Function as PropType<
-    TableColumnCtx<DefaultRow>['filterMethod']
-  >,
+  filterMethod: Function as PropType<TableColumnCtx<any>['filterMethod']>,
   /**
    * @description filter value for selected data, might be useful when table header is rendered with `render-header`
    */
-  filteredValue: Array as PropType<TableColumnCtx<DefaultRow>['filteredValue']>,
+  filteredValue: Array as PropType<TableColumnCtx<any>['filteredValue']>,
   /**
    * @description an array of data filtering options. For each element in this array, `text` and `value` are required
    */
-  filters: Array as PropType<TableColumnCtx<DefaultRow>['filters']>,
+  filters: Array as PropType<TableColumnCtx<any>['filters']>,
   /**
    * @description placement for the filter dropdown
    */
@@ -229,17 +234,17 @@ export default {
   /**
    * @description customize indices for each row, works on columns with `type=index`
    */
-  index: [Number, Function] as PropType<TableColumnCtx<DefaultRow>['index']>,
+  index: [Number, Function] as PropType<TableColumnCtx<any>['index']>,
   /**
    * @description the order of the sorting strategies used when sorting the data, works when `sortable` is `true`. Accepts an array, as the user clicks on the header, the column is sorted in order of the elements in the array
    */
   sortOrders: {
-    type: Array as PropType<TableColumnCtx<DefaultRow>['sortOrders']>,
+    type: Array as PropType<TableColumnCtx<any>['sortOrders']>,
     default: () => {
       return ['ascending', 'descending', null]
     },
-    validator: (val: TableColumnCtx<unknown>['sortOrders']) => {
-      return val.every((order: string) =>
+    validator: (val: TableColumnCtx<any>['sortOrders']) => {
+      return val.every((order: TableSortOrder | null) =>
         ['ascending', 'descending', null].includes(order)
       )
     },

--- a/packages/components/table/src/table-footer/style-helper.ts
+++ b/packages/components/table/src/table-footer/style-helper.ts
@@ -7,9 +7,10 @@ import {
 import useMapState from './mapState-helper'
 
 import type { TableColumnCtx } from '../table-column/defaults'
+import type { DefaultRow } from '../table/defaults'
 import type { TableFooter } from '.'
 
-function useStyle<T>(props: TableFooter<T>) {
+function useStyle<T extends DefaultRow>(props: TableFooter<T>) {
   const { columns } = useMapState()
   const ns = useNamespace('table')
 

--- a/packages/components/table/src/table-header/style.helper.ts
+++ b/packages/components/table/src/table-header/style.helper.ts
@@ -9,9 +9,10 @@ import {
 import { TABLE_INJECTION_KEY } from '../tokens'
 
 import type { TableColumnCtx } from '../table-column/defaults'
+import type { DefaultRow } from '../table/defaults'
 import type { TableHeaderProps } from '.'
 
-function useStyle<T>(props: TableHeaderProps<T>) {
+function useStyle<T extends DefaultRow>(props: TableHeaderProps<T>) {
   const parent = inject(TABLE_INJECTION_KEY)
   const ns = useNamespace('table')
 

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -170,7 +170,6 @@
 </template>
 
 <script lang="ts">
-// @ts-nocheck
 import {
   computed,
   defineComponent,
@@ -275,7 +274,6 @@ export default defineComponent({
       handleHeaderFooterMousewheel,
       tableSize,
       emptyBlockStyle,
-      handleFixedMousewheel,
       resizeProxyVisible,
       bodyWidth,
       resizeState,
@@ -336,7 +334,6 @@ export default defineComponent({
       tableBodyStyles,
       emptyBlockStyle,
       debouncedUpdateLayout,
-      handleFixedMousewheel,
       /**
        * @description used in single selection Table, set a certain row selected. If called without any parameter, it will clear selection
        */

--- a/packages/components/table/src/table/defaults.ts
+++ b/packages/components/table/src/table/defaults.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useSizeProp } from '@element-plus/hooks'
 
 import type {
@@ -18,7 +17,7 @@ import type {
   TableOverflowTooltipOptions,
 } from '../util'
 
-export type DefaultRow = any
+type DefaultRow = Record<PropertyKey, any>
 
 interface TableRefs {
   tableWrapper: HTMLElement
@@ -47,29 +46,34 @@ interface TreeProps {
   checkStrictly?: boolean
 }
 
-type HoverState<T> = Nullable<{
+type HoverState<T extends DefaultRow> = Nullable<{
   cell: HTMLElement
   column: TableColumnCtx<T>
   row: T
 }>
 
-type RIS<T> = { row: T; $index: number; store: Store<T>; expanded: boolean }
+type RIS<T extends DefaultRow> = {
+  row: T
+  $index: number
+  store: Store<T>
+  expanded: boolean
+}
 
-type RenderExpanded<T> = ({
+type RenderExpanded<T extends DefaultRow> = ({
   row,
   $index,
   store,
-  expanded: boolean,
+  expanded,
 }: RIS<T>) => VNode
 
-type SummaryMethod<T> = (data: {
+type SummaryMethod<T extends DefaultRow> = (data: {
   columns: TableColumnCtx<T>[]
   data: T[]
 }) => (string | VNode)[]
 
-interface Table<T> extends ComponentInternalInstance {
+interface Table<T extends DefaultRow = any> extends ComponentInternalInstance {
   $ready: boolean
-  hoverState?: HoverState<T>
+  hoverState?: HoverState<T> | null
   renderExpanded: RenderExpanded<T>
   store: Store<T>
   layout: TableLayout<T>
@@ -82,7 +86,7 @@ type ColumnCls<T> = string | ((data: { row: T; rowIndex: number }) => string)
 type ColumnStyle<T> =
   | CSSProperties
   | ((data: { row: T; rowIndex: number }) => CSSProperties)
-type CellCls<T> =
+type CellCls<T extends DefaultRow> =
   | string
   | ((data: {
       row: T
@@ -90,7 +94,7 @@ type CellCls<T> =
       column: TableColumnCtx<T>
       columnIndex: number
     }) => string)
-type CellStyle<T> =
+type CellStyle<T extends DefaultRow> =
   | CSSProperties
   | ((data: {
       row: T
@@ -99,7 +103,7 @@ type CellStyle<T> =
       columnIndex: number
     }) => CSSProperties)
 type Layout = 'fixed' | 'auto'
-interface TableProps<T> {
+interface TableProps<T extends DefaultRow> {
   data: T[]
   size?: ComponentSize
   width?: string | number
@@ -158,16 +162,19 @@ interface TableProps<T> {
   scrollbarTabindex?: number | string
 }
 
-type TableTooltipData<T = any> = Parameters<TableOverflowTooltipFormatter<T>>[0]
+type TableTooltipData<T extends DefaultRow> = Parameters<
+  TableOverflowTooltipFormatter<T>
+>[0]
+type TableSortOrder = 'ascending' | 'descending'
 
 interface Sort {
   prop: string
-  order: 'ascending' | 'descending'
+  order: TableSortOrder
   init?: any
   silent?: any
 }
 
-interface Filter<T> {
+interface Filter<T extends DefaultRow> {
   column: TableColumnCtx<T>
   values: string[]
   silent: any
@@ -182,12 +189,13 @@ interface TreeNode {
   display?: boolean
 }
 
-interface RenderRowData<T> {
+interface RenderRowData<T extends DefaultRow> {
   store: Store<T>
   _self: Table<T>
   column: TableColumnCtx<T>
   row: T
   $index: number
+  cellIndex: number
   treeNode?: TreeNode
   expanded: boolean
 }
@@ -197,7 +205,7 @@ export default {
    * @description table data
    */
   data: {
-    type: Array as PropType<DefaultRow[]>,
+    type: Array as PropType<any[]>,
     default: () => [],
   },
   /**
@@ -231,7 +239,7 @@ export default {
   /**
    * @description key of row data, used for optimizing rendering. Required if `reserve-selection` is on or display tree data. When its type is String, multi-level access is supported, e.g. `user.info.id`, but `user.info[0].id` is not supported, in which case `Function` should be used
    */
-  rowKey: [String, Function] as PropType<TableProps<DefaultRow>['rowKey']>,
+  rowKey: [String, Function] as PropType<TableProps<any>['rowKey']>,
   /**
    * @description whether Table header is visible
    */
@@ -250,52 +258,48 @@ export default {
   /**
    * @description custom summary method
    */
-  summaryMethod: Function as PropType<TableProps<DefaultRow>['summaryMethod']>,
+  summaryMethod: Function as PropType<TableProps<any>['summaryMethod']>,
   /**
    * @description function that returns custom class names for a row, or a string assigning class names for every row
    */
-  rowClassName: [String, Function] as PropType<
-    TableProps<DefaultRow>['rowClassName']
-  >,
+  rowClassName: [String, Function] as PropType<TableProps<any>['rowClassName']>,
   /**
    * @description function that returns custom style for a row, or an object assigning custom style for every row
    */
-  rowStyle: [Object, Function] as PropType<TableProps<DefaultRow>['rowStyle']>,
+  rowStyle: [Object, Function] as PropType<TableProps<any>['rowStyle']>,
   /**
    * @description function that returns custom class names for a cell, or a string assigning class names for every cell
    */
   cellClassName: [String, Function] as PropType<
-    TableProps<DefaultRow>['cellClassName']
+    TableProps<any>['cellClassName']
   >,
   /**
    * @description function that returns custom style for a cell, or an object assigning custom style for every cell
    */
-  cellStyle: [Object, Function] as PropType<
-    TableProps<DefaultRow>['cellStyle']
-  >,
+  cellStyle: [Object, Function] as PropType<TableProps<any>['cellStyle']>,
   /**
    * @description function that returns custom class names for a row in table header, or a string assigning class names for every row in table header
    */
   headerRowClassName: [String, Function] as PropType<
-    TableProps<DefaultRow>['headerRowClassName']
+    TableProps<any>['headerRowClassName']
   >,
   /**
    * @description function that returns custom style for a row in table header, or an object assigning custom style for every row in table header
    */
   headerRowStyle: [Object, Function] as PropType<
-    TableProps<DefaultRow>['headerRowStyle']
+    TableProps<any>['headerRowStyle']
   >,
   /**
    * @description function that returns custom class names for a cell in table header, or a string assigning class names for every cell in table header
    */
   headerCellClassName: [String, Function] as PropType<
-    TableProps<DefaultRow>['headerCellClassName']
+    TableProps<any>['headerCellClassName']
   >,
   /**
    * @description function that returns custom style for a cell in table header, or an object assigning custom style for every cell in table header
    */
   headerCellStyle: [Object, Function] as PropType<
-    TableProps<DefaultRow>['headerCellStyle']
+    TableProps<any>['headerCellStyle']
   >,
   /**
    * @description whether current row is highlighted
@@ -312,7 +316,7 @@ export default {
   /**
    * @description set expanded rows by this prop, prop's value is the keys of expand rows, you should set row-key before using this prop
    */
-  expandRowKeys: Array as PropType<TableProps<DefaultRow>['expandRowKeys']>,
+  expandRowKeys: Array as PropType<TableProps<any>['expandRowKeys']>,
   /**
    * @description whether expand all rows by default, works when the table has a column type="expand" or contains tree structure data
    */
@@ -320,7 +324,7 @@ export default {
   /**
    * @description set the default sort column and order. property `prop` is used to set default sort column, property `order` is used to set default sort order
    */
-  defaultSort: Object as PropType<TableProps<DefaultRow>['defaultSort']>,
+  defaultSort: Object as PropType<TableProps<any>['defaultSort']>,
   /**
    * @description the `effect` of the overflow tooltip
    */
@@ -328,11 +332,11 @@ export default {
   /**
    * @description the options for the overflow tooltip, [see the following tooltip component](tooltip.html#attributes)
    */
-  tooltipOptions: Object as PropType<TableProps<DefaultRow>['tooltipOptions']>,
+  tooltipOptions: Object as PropType<TableProps<any>['tooltipOptions']>,
   /**
    * @description method that returns rowspan and colspan
    */
-  spanMethod: Function as PropType<TableProps<DefaultRow>['spanMethod']>,
+  spanMethod: Function as PropType<TableProps<any>['spanMethod']>,
   /**
    * @description controls the behavior of master checkbox in multi-select tables when only some rows are selected (but not all). If true, all rows will be selected, else deselected
    */
@@ -351,7 +355,7 @@ export default {
    * @description configuration for rendering nested data
    */
   treeProps: {
-    type: Object as PropType<TableProps<DefaultRow>['treeProps']>,
+    type: Object as PropType<TableProps<any>['treeProps']>,
     default: () => {
       return {
         hasChildren: 'hasChildren',
@@ -367,7 +371,7 @@ export default {
   /**
    * @description method for loading child row data, only works when `lazy` is true
    */
-  load: Function as PropType<TableProps<DefaultRow>['load']>,
+  load: Function as PropType<TableProps<any>['load']>,
   style: {
     type: Object as PropType<CSSProperties>,
     default: () => ({}),
@@ -395,14 +399,12 @@ export default {
    * @description whether to hide extra content and show them in a tooltip when hovering on the cell.It will affect all the table columns
    */
   showOverflowTooltip: [Boolean, Object] as PropType<
-    TableProps<DefaultRow>['showOverflowTooltip']
+    TableProps<any>['showOverflowTooltip']
   >,
   /**
    * @description function that formats cell tooltip content, works when `show-overflow-tooltip` is `true`
    */
-  tooltipFormatter: Function as PropType<
-    TableProps<DefaultRow>['tooltipFormatter']
-  >,
+  tooltipFormatter: Function as PropType<TableProps<any>['tooltipFormatter']>,
   appendFilterPanelTo: String,
   scrollbarTabindex: {
     type: [Number, String],
@@ -432,6 +434,7 @@ export type {
   ColumnStyle,
   CellCls,
   CellStyle,
+  DefaultRow,
   TreeNode,
   RenderRowData,
   Sort,
@@ -439,4 +442,5 @@ export type {
   TableColumnCtx,
   TreeProps,
   TableTooltipData,
+  TableSortOrder,
 }

--- a/packages/components/table/src/table/style-helper.ts
+++ b/packages/components/table/src/table/style-helper.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   computed,
   nextTick,
@@ -11,12 +10,12 @@ import {
 import { useEventListener, useResizeObserver } from '@vueuse/core'
 import { useFormSize } from '@element-plus/components/form'
 
-import type { Table, TableProps } from './defaults'
+import type { DefaultRow, Table, TableProps } from './defaults'
 import type { Store } from '../store'
 import type TableLayout from '../table-layout'
 import type { TableColumnCtx } from '../table-column/defaults'
 
-function useStyle<T>(
+function useStyle<T extends DefaultRow>(
   props: TableProps<T>,
   layout: TableLayout<T>,
   store: Store<T>,
@@ -50,10 +49,10 @@ function useStyle<T>(
   const appendScrollHeight = ref(0)
 
   watchEffect(() => {
-    layout.setHeight(props.height)
+    layout.setHeight(props.height ?? null)
   })
   watchEffect(() => {
-    layout.setMaxHeight(props.maxHeight)
+    layout.setMaxHeight(props.maxHeight ?? null)
   })
   watch(
     () => [props.currentRowKey, store.states.rowKey],
@@ -86,7 +85,7 @@ function useStyle<T>(
     if (table.hoverState) table.hoverState = null
   }
 
-  const handleHeaderFooterMousewheel = (event, data) => {
+  const handleHeaderFooterMousewheel = (_event: WheelEvent, data: any) => {
     const { pixelX, pixelY } = data
     if (Math.abs(pixelX) >= Math.abs(pixelY)) {
       table.refs.bodyWrapper.scrollLeft += data.pixelX / 5
@@ -278,7 +277,7 @@ function useStyle<T>(
   })
 
   const emptyBlockStyle = computed(() => {
-    if (props.data && props.data.length) return null
+    if (props.data && props.data.length) return
     let height = '100%'
     if (props.height && bodyScrollHeight.value) {
       height = `${bodyScrollHeight.value}px`
@@ -300,7 +299,7 @@ function useStyle<T>(
       if (!Number.isNaN(Number(props.maxHeight))) {
         return {
           maxHeight: `${
-            props.maxHeight -
+            +props.maxHeight -
             headerScrollHeight.value -
             footerScrollHeight.value
           }px`,
@@ -317,28 +316,6 @@ function useStyle<T>(
     return {}
   })
 
-  /**
-   * fix layout
-   */
-  const handleFixedMousewheel = (event, data) => {
-    const bodyWrapper = table.refs.bodyWrapper
-    if (Math.abs(data.spinY) > 0) {
-      const currentScrollTop = bodyWrapper.scrollTop
-      if (data.pixelY < 0 && currentScrollTop !== 0) {
-        event.preventDefault()
-      }
-      if (
-        data.pixelY > 0 &&
-        bodyWrapper.scrollHeight - bodyWrapper.clientHeight > currentScrollTop
-      ) {
-        event.preventDefault()
-      }
-      bodyWrapper.scrollTop += Math.ceil(data.pixelY / 5)
-    } else {
-      bodyWrapper.scrollLeft += Math.ceil(data.pixelX / 5)
-    }
-  }
-
   return {
     isHidden,
     renderExpanded,
@@ -348,7 +325,6 @@ function useStyle<T>(
     handleHeaderFooterMousewheel,
     tableSize,
     emptyBlockStyle,
-    handleFixedMousewheel,
     resizeProxyVisible,
     bodyWidth,
     resizeState,

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -1,7 +1,7 @@
-// @ts-nocheck
 import { createVNode, isVNode, render } from 'vue'
 import { flatMap, get, isNull, merge } from 'lodash-unified'
 import {
+  ensureArray,
   getProp,
   hasOwn,
   isArray,
@@ -17,9 +17,9 @@ import ElTooltip, {
   type ElTooltipProps,
 } from '@element-plus/components/tooltip'
 
-import type { Table, TreeProps } from './table/defaults'
+import type { DefaultRow, Table, TreeProps } from './table/defaults'
 import type { TableColumnCtx } from './table-column/defaults'
-import type { VNode } from 'vue'
+import type { CSSProperties, VNode } from 'vue'
 
 export type TableOverflowTooltipOptions = Partial<
   Pick<
@@ -38,10 +38,10 @@ export type TableOverflowTooltipOptions = Partial<
   >
 >
 
-export type TableOverflowTooltipFormatter<T = any> = (data: {
+export type TableOverflowTooltipFormatter<T extends DefaultRow> = (data: {
   row: T
   column: TableColumnCtx<T>
-  cellValue
+  cellValue: any
 }) => VNode | string
 
 type RemovePopperFn = (() => void) & {
@@ -49,16 +49,22 @@ type RemovePopperFn = (() => void) & {
   vm?: VNode
 }
 
+type CompareValue<T> = {
+  value: T
+  index: number
+  key: any[] | null
+}
+
 export const getCell = function (event: Event) {
   return (event.target as HTMLElement)?.closest('td')
 }
 
-export const orderBy = function <T>(
+export const orderBy = function <T extends DefaultRow>(
   array: T[],
-  sortKey: string,
-  reverse: string | number,
-  sortMethod,
-  sortBy: string | (string | ((a: T, b: T, array?: T[]) => number))[]
+  sortKey: string | null,
+  reverse: string | number | null,
+  sortMethod: TableColumnCtx<T>['sortMethod'] | null,
+  sortBy: string | string[] | ((a: T, index: number, array?: T[]) => string)
 ) {
   if (
     !sortKey &&
@@ -74,12 +80,9 @@ export const orderBy = function <T>(
   }
   const getKey = sortMethod
     ? null
-    : function (value, index) {
+    : function (value: T, index: number) {
         if (sortBy) {
-          if (!isArray(sortBy)) {
-            sortBy = [sortBy]
-          }
-          return sortBy.map((by) => {
+          return flatMap(ensureArray(sortBy), (by) => {
             if (isString(by)) {
               return get(value, by)
             } else {
@@ -90,24 +93,26 @@ export const orderBy = function <T>(
         if (sortKey !== '$key') {
           if (isObject(value) && '$value' in value) value = value.$value
         }
-        return [isObject(value) ? get(value, sortKey) : value]
+        return [
+          isObject(value) ? (sortKey ? get(value, sortKey) : null) : value,
+        ]
       }
-  const compare = function (a, b) {
+  const compare = function (a: CompareValue<T>, b: CompareValue<T>) {
     if (sortMethod) {
       return sortMethod(a.value, b.value)
     }
-    for (let i = 0, len = a.key.length; i < len; i++) {
-      if (a.key[i] < b.key[i]) {
+    for (let i = 0, len = a.key?.length ?? 0; i < len; i++) {
+      if (a.key?.[i] < b.key?.[i]) {
         return -1
       }
-      if (a.key[i] > b.key[i]) {
+      if (a.key?.[i] > b.key?.[i]) {
         return 1
       }
     }
     return 0
   }
   return array
-    .map((value, index) => {
+    .map<CompareValue<T>>((value: T, index) => {
       return {
         value,
         index,
@@ -125,7 +130,7 @@ export const orderBy = function <T>(
     .map((item) => item.value)
 }
 
-export const getColumnById = function <T>(
+export const getColumnById = function <T extends DefaultRow>(
   table: {
     columns: TableColumnCtx<T>[]
   },
@@ -140,7 +145,7 @@ export const getColumnById = function <T>(
   return column
 }
 
-export const getColumnByKey = function <T>(
+export const getColumnByKey = function <T extends DefaultRow>(
   table: {
     columns: TableColumnCtx<T>[]
   },
@@ -159,7 +164,7 @@ export const getColumnByKey = function <T>(
   return column
 }
 
-export const getColumnByCell = function <T>(
+export const getColumnByCell = function <T extends DefaultRow>(
   table: {
     columns: TableColumnCtx<T>[]
   },
@@ -175,9 +180,9 @@ export const getColumnByCell = function <T>(
   return null
 }
 
-export const getRowIdentity = <T>(
+export const getRowIdentity = <T extends DefaultRow>(
   row: T,
-  rowKey: string | ((row: T) => any),
+  rowKey: string | ((row: T) => string) | null,
   isReturnRawValue: boolean = false
 ): string => {
   if (!row) throw new Error('Row is required when get row identity')
@@ -186,24 +191,27 @@ export const getRowIdentity = <T>(
       return isReturnRawValue ? row[rowKey] : `${row[rowKey]}`
     }
     const key = rowKey.split('.')
-    let current = row
+    let current: any = row
     for (const element of key) {
       current = current[element]
     }
-    return isReturnRawValue ? current : `${current}`
+    //TODO: "current" is now any, we just satisfies typecheck here
+    // but this function can actually return a number
+    return isReturnRawValue ? (current as string) : `${current}`
   } else if (isFunction(rowKey)) {
     return rowKey.call(null, row)
   }
+  return ''
 }
 
-export const getKeysMap = function <T>(
+export const getKeysMap = function <T extends DefaultRow>(
   array: T[],
-  rowKey: string,
+  rowKey: string | null,
   flatten = false,
   childrenKey = 'children'
-): Record<string, { row: T; index: number }> {
+): Record<PropertyKey, { row: T; index: number }> {
   const data = array || []
-  const arrayMap = {}
+  const arrayMap: Record<string, { row: T; index: number }> = {}
 
   data.forEach((row, index) => {
     arrayMap[getRowIdentity(row, rowKey)] = { row, index }
@@ -219,24 +227,27 @@ export const getKeysMap = function <T>(
   return arrayMap
 }
 
-export function mergeOptions<T, K>(defaults: T, config: K): T & K {
+export function mergeOptions<T extends DefaultRow, K extends DefaultRow>(
+  defaults: T,
+  config: K
+): T & K {
   const options = {} as T & K
-  let key
+  let key: keyof T & keyof K
   for (key in defaults) {
     options[key] = defaults[key]
   }
   for (key in config) {
-    if (hasOwn(config as unknown as Record<string, any>, key)) {
+    if (hasOwn(config, key)) {
       const value = config[key]
       if (!isUndefined(value)) {
-        options[key] = value
+        options[key as keyof K] = value
       }
     }
   }
   return options
 }
 
-export function parseWidth(width: number | string): number | string {
+export function parseWidth(width?: number | string): number | string {
   if (width === '') return width
   if (!isUndefined(width)) {
     width = Number.parseInt(width as string, 10)
@@ -244,7 +255,7 @@ export function parseWidth(width: number | string): number | string {
       width = ''
     }
   }
-  return width
+  return width!
 }
 
 export function parseMinWidth(minWidth: number | string): number | string {
@@ -258,7 +269,7 @@ export function parseMinWidth(minWidth: number | string): number | string {
   return minWidth
 }
 
-export function parseHeight(height: number | string) {
+export function parseHeight(height: number | string | null) {
   if (isNumber(height)) {
     return height
   }
@@ -272,29 +283,29 @@ export function parseHeight(height: number | string) {
   return null
 }
 
-// https://github.com/reduxjs/redux/blob/master/src/compose.js
-export function compose(...funcs) {
+// https://github.com/reduxjs/redux/blob/master/src/compose.ts
+export function compose(...funcs: ((...args: any[]) => void)[]) {
   if (funcs.length === 0) {
-    return (arg) => arg
+    return <T>(arg: T) => arg
   }
   if (funcs.length === 1) {
     return funcs[0]
   }
   return funcs.reduce(
     (a, b) =>
-      (...args) =>
+      (...args: any[]) =>
         a(b(...args))
   )
 }
 
-export function toggleRowStatus<T>(
+export function toggleRowStatus<T extends DefaultRow>(
   statusArr: T[],
   row: T,
   newVal?: boolean,
   tableTreeProps?: TreeProps,
-  selectable?: (row: T, index?: number) => boolean,
+  selectable?: ((row: T, index: number) => boolean) | null,
   rowIndex?: number,
-  rowKey?: string
+  rowKey?: string | null
 ): boolean {
   let _rowIndex = rowIndex ?? 0
   let changed = false
@@ -322,7 +333,7 @@ export function toggleRowStatus<T>(
     }
     changed = true
   }
-  const getChildrenCount = (row: T) => {
+  const getChildrenCount = <T extends DefaultRow>(row: T) => {
     let count = 0
     const children = tableTreeProps?.children && row[tableTreeProps.children]
     if (children && isArray(children)) {
@@ -351,7 +362,7 @@ export function toggleRowStatus<T>(
     tableTreeProps?.children &&
     isArray(row[tableTreeProps.children])
   ) {
-    row[tableTreeProps.children].forEach((item) => {
+    row[tableTreeProps.children].forEach((item: T) => {
       const childChanged = toggleRowStatus(
         statusArr,
         item,
@@ -370,18 +381,18 @@ export function toggleRowStatus<T>(
   return changed
 }
 
-export function walkTreeNode(
-  root,
-  cb,
+export function walkTreeNode<T extends DefaultRow>(
+  root: T[],
+  cb: (parent: any, children: T | T[] | null, level: number) => void,
   childrenKey = 'children',
   lazyKey = 'hasChildren',
   lazy = false
 ) {
-  const isNil = (array) => !(isArray(array) && array.length)
+  const isNil = (array: any): array is null => !(isArray(array) && array.length)
 
-  function _walker(parent, children, level) {
+  function _walker(parent: any, children: T | T[], level: number) {
     cb(parent, children, level)
-    children.forEach((item) => {
+    children.forEach((item: any) => {
       if (item[lazyKey] && lazy) {
         cb(item, null, level + 1)
         return
@@ -393,7 +404,7 @@ export function walkTreeNode(
     })
   }
 
-  root.forEach((item) => {
+  root.forEach((item: any) => {
     if (item[lazyKey] && lazy) {
       cb(item, null, 0)
       return
@@ -405,11 +416,11 @@ export function walkTreeNode(
   })
 }
 
-const getTableOverflowTooltipProps = (
+const getTableOverflowTooltipProps = <T extends DefaultRow>(
   props: TableOverflowTooltipOptions,
   innerText: string,
   row: T,
-  column: TableColumnCtx<T>
+  column: TableColumnCtx<T> | null
 ) => {
   // merge popperOptions
   const popperOptions = {
@@ -417,7 +428,7 @@ const getTableOverflowTooltipProps = (
     ...props.popperOptions,
   }
 
-  const tooltipFormatterContent = isFunction(column.tooltipFormatter)
+  const tooltipFormatterContent = isFunction(column?.tooltipFormatter)
     ? column.tooltipFormatter({
         row,
         column,
@@ -444,13 +455,13 @@ const getTableOverflowTooltipProps = (
 
 export let removePopper: RemovePopperFn | null = null
 
-export function createTablePopper(
+export function createTablePopper<T extends DefaultRow>(
   props: TableOverflowTooltipOptions,
   popperContent: string,
   row: T,
-  column: TableColumnCtx<T>,
-  trigger: HTMLElement,
-  table: Table<[]>
+  column: TableColumnCtx<T> | null,
+  trigger: HTMLElement | null,
+  table: Table<DefaultRow>
 ) {
   const tableOverflowTooltipProps = getTableOverflowTooltipProps(
     props,
@@ -463,9 +474,9 @@ export function createTablePopper(
     slotContent: undefined,
   }
   if (removePopper?.trigger === trigger) {
-    const comp = removePopper!.vm.component
-    merge(comp.props, mergedProps)
-    if (tableOverflowTooltipProps.slotContent) {
+    const comp = removePopper.vm?.component
+    merge(comp?.props, mergedProps)
+    if (comp && tableOverflowTooltipProps.slotContent) {
       comp.slots.content = () => [tableOverflowTooltipProps.slotContent]
     }
     return
@@ -501,12 +512,14 @@ export function createTablePopper(
     scrollContainer?.removeEventListener('scroll', removePopper!)
     removePopper = null
   }
-  removePopper.trigger = trigger
+  removePopper.trigger = trigger ?? undefined
   removePopper.vm = vm
   scrollContainer?.addEventListener('scroll', removePopper)
 }
 
-function getCurrentColumns<T>(column: TableColumnCtx<T>): TableColumnCtx<T>[] {
+function getCurrentColumns<T extends DefaultRow>(
+  column: TableColumnCtx<T>
+): TableColumnCtx<T>[] {
   if (column.children) {
     return flatMap(column.children, getCurrentColumns)
   } else {
@@ -514,13 +527,16 @@ function getCurrentColumns<T>(column: TableColumnCtx<T>): TableColumnCtx<T>[] {
   }
 }
 
-function getColSpan<T>(colSpan: number, column: TableColumnCtx<T>) {
+function getColSpan<T extends DefaultRow>(
+  colSpan: number,
+  column: TableColumnCtx<T>
+) {
   return colSpan + column.colSpan
 }
 
-export const isFixedColumn = <T>(
+export const isFixedColumn = <T extends DefaultRow>(
   index: number,
-  fixed: string | boolean,
+  fixed: string | boolean | undefined,
   store: any,
   realColumns?: TableColumnCtx<T>[]
 ) => {
@@ -571,10 +587,10 @@ export const isFixedColumn = <T>(
     : {}
 }
 
-export const getFixedColumnsClass = <T>(
+export const getFixedColumnsClass = <T extends DefaultRow>(
   namespace: string,
   index: number,
-  fixed: string | boolean,
+  fixed: string | boolean | undefined,
   store: any,
   realColumns?: TableColumnCtx<T>[],
   offset = 0
@@ -606,7 +622,10 @@ export const getFixedColumnsClass = <T>(
   return classes
 }
 
-function getOffset<T>(offset: number, column: TableColumnCtx<T>) {
+function getOffset<T extends DefaultRow>(
+  offset: number,
+  column: TableColumnCtx<T>
+) {
   return (
     offset +
     (isNull(column.realWidth) || Number.isNaN(column.realWidth)
@@ -615,9 +634,9 @@ function getOffset<T>(offset: number, column: TableColumnCtx<T>) {
   )
 }
 
-export const getFixedColumnOffset = <T>(
+export const getFixedColumnOffset = <T extends DefaultRow>(
   index: number,
-  fixed: string | boolean,
+  fixed: string | boolean | undefined,
   store: any,
   realColumns?: TableColumnCtx<T>[]
 ) => {
@@ -627,9 +646,9 @@ export const getFixedColumnOffset = <T>(
     after = 0,
   } = isFixedColumn(index, fixed, store, realColumns)
   if (!direction) {
-    return
+    return null
   }
-  const styles: any = {}
+  const styles: CSSProperties = {}
   const isLeft = direction === 'left'
   const columns = store.states.columns.value
   if (isLeft) {
@@ -643,9 +662,12 @@ export const getFixedColumnOffset = <T>(
   return styles
 }
 
-export const ensurePosition = (style, key: string) => {
+export const ensurePosition = (
+  style: CSSProperties | null,
+  key: keyof CSSProperties
+) => {
   if (!style) return
   if (!Number.isNaN(style[key])) {
-    style[key] = `${style[key]}px`
+    style[key] = `${style[key]}px` as any
   }
 }

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -646,7 +646,7 @@ export const getFixedColumnOffset = <T extends DefaultRow>(
     after = 0,
   } = isFixedColumn(index, fixed, store, realColumns)
   if (!direction) {
-    return null
+    return
   }
   const styles: CSSProperties = {}
   const isLeft = direction === 'left'
@@ -663,7 +663,7 @@ export const getFixedColumnOffset = <T extends DefaultRow>(
 }
 
 export const ensurePosition = (
-  style: CSSProperties | null,
+  style: CSSProperties | undefined,
   key: keyof CSSProperties
 ) => {
   if (!style) return


### PR DESCRIPTION
1/3

`@ts-nocheck` removed: **10**.
`@ts-nocheck` remaining: **19**.

It's hard to remove smoothly `ts-nocheck` when trying to handle files that depend on `useStore`, `TableColumnCtx`, `util.ts`. So i decided to copy paste files from https://github.com/element-plus/element-plus/pull/21090.
It's surely this pr who will have the biggest change.

---
#### Summary ([copying](https://github.com/element-plus/element-plus/pull/21090#issue-3161599447)):

This pr prepare will remove `ts-nocheck` for table component, it will facilitate contribution on this component and it has been made to bring generic easily when we'll upgrade vue.

However, it introduce a small breaking change, since the generic across the component has been change:
```diff
- type DefaultRow = any
+ type DefaultRow = Record<PropertyKey, any>

here PropertyKey is a native typescript alias for string | number | symbol
```
This change is necessary to remove `ts-nocheck` properly and add more reliability.

This will break typescript when the user will have:
```diff
- interface SummaryMethodProps<T = Product> {
+ interface SummaryMethodProps<T extends Record<string, any> = Product> {
  columns: TableColumnCtx<T>[]
  data: T[]
}
```
[from this example](https://github.com/element-plus/element-plus/blob/dev/docs/examples/table/summary.vue#L40-L43)

It can affect many users.