### PR TITLE
fix(components): [time-picker] fix keyboard arrow controls

### DIFF
--- a/packages/components/time-picker/src/time-picker-com/basic-time-spinner.vue
+++ b/packages/components/time-picker/src/time-picker-com/basic-time-spinner.vue
@@ -179,19 +179,33 @@ const getAmPmFlag = (hour: number) => {
 
 const emitSelectRange = (type: TimeUnit) => {
   let range = [0, 0]
-  if (!format || format === DEFAULT_FORMATS_TIME) {
-    switch (type) {
-      case 'hours':
-        range = [0, 2]
-        break
-      case 'minutes':
-        range = [3, 5]
-        break
-      case 'seconds':
-        range = [6, 8]
-        break
-    }
+
+  // 根据实际format计算选择范围
+  const actualFormat = format || DEFAULT_FORMATS_TIME
+
+  // 查找小时、分钟、秒在格式字符串中的位置
+  const hourIndex = actualFormat.indexOf('HH')
+  const minuteIndex = actualFormat.indexOf('mm')
+  const secondIndex = actualFormat.indexOf('ss')
+
+  switch (type) {
+    case 'hours':
+      if (hourIndex !== -1) {
+        range = [hourIndex, hourIndex + 2]
+      }
+      break
+    case 'minutes':
+      if (minuteIndex !== -1) {
+        range = [minuteIndex, minuteIndex + 2]
+      }
+      break
+    case 'seconds':
+      if (secondIndex !== -1) {
+        range = [secondIndex, secondIndex + 2]
+      }
+      break
   }
+
   const [left, right] = range
 
   emit('select-range', left, right)

--- a/packages/components/time-picker/src/time-picker-com/basic-time-spinner.vue
+++ b/packages/components/time-picker/src/time-picker-com/basic-time-spinner.vue
@@ -180,10 +180,8 @@ const getAmPmFlag = (hour: number) => {
 const emitSelectRange = (type: TimeUnit) => {
   let range = [0, 0]
 
-  // 根据实际format计算选择范围
   const actualFormat = format || DEFAULT_FORMATS_TIME
 
-  // 查找小时、分钟、秒在格式字符串中的位置
   const hourIndex = actualFormat.indexOf('HH')
   const minuteIndex = actualFormat.indexOf('mm')
   const secondIndex = actualFormat.indexOf('ss')

--- a/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
@@ -116,10 +116,28 @@ const setSelectionRange = (start: number, end: number) => {
 }
 
 const changeSelectionRange = (step: number) => {
-  const list = [0, 3].concat(showSeconds.value ? [6] : [])
-  const mapping = ['hours', 'minutes'].concat(
-    showSeconds.value ? ['seconds'] : []
-  )
+  // 根据实际format动态计算位置列表
+  const actualFormat = props.format
+  const hourIndex = actualFormat.indexOf('HH')
+  const minuteIndex = actualFormat.indexOf('mm')
+  const secondIndex = actualFormat.indexOf('ss')
+
+  const list: number[] = []
+  const mapping: string[] = []
+
+  if (hourIndex !== -1) {
+    list.push(hourIndex)
+    mapping.push('hours')
+  }
+  if (minuteIndex !== -1) {
+    list.push(minuteIndex)
+    mapping.push('minutes')
+  }
+  if (secondIndex !== -1 && showSeconds.value) {
+    list.push(secondIndex)
+    mapping.push('seconds')
+  }
+
   const index = list.indexOf(selectionRange.value[0])
   const next = (index + step + list.length) % list.length
   timePickerOptions['start_emitSelectRange'](mapping[next])

--- a/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
+++ b/packages/components/time-picker/src/time-picker-com/panel-time-pick.vue
@@ -116,7 +116,6 @@ const setSelectionRange = (start: number, end: number) => {
 }
 
 const changeSelectionRange = (step: number) => {
-  // 根据实际format动态计算位置列表
   const actualFormat = props.format
   const hourIndex = actualFormat.indexOf('HH')
   const minuteIndex = actualFormat.indexOf('mm')


### PR DESCRIPTION
### Problem Description  
When the `format` property of the `el-time-picker` component is set to `HH:mm`, the keyboard arrow controls fail:  
- Left/right arrows cannot switch between hours and minutes  

### Root Cause  
1. The `emitSelectRange` function in **basic-time-spinner.vue** only sets the correct selection range when `format` is empty or equals `DEFAULT_FORMATS_TIME` (`HH:mm:ss`)  
2. The `changeSelectionRange` function in **panel-time-pick.vue** uses a hardcoded position list `[0, 3, 6]`, which does not adapt to different time formats  

### Solution  
- Modify `emitSelectRange` to dynamically calculate selection ranges based on the actual `format` string  
- Update `changeSelectionRange` to dynamically generate position lists according to the actual locations of `HH`, `mm`, and `ss` in the `format` string  
- Support various time formats: `HH:mm`, `HH:mm:ss`, etc.  

Fix #21143  