### PR TITLE
fix(components): [dropdown-item] fix directives not function as intended

### DIFF
--- a/packages/components/collection/src/collection-item.vue
+++ b/packages/components/collection/src/collection-item.vue
@@ -1,5 +1,7 @@
 <template>
-  <slot />
+  <div>
+    <slot />
+  </div>
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
[Vue warn]: Runtime directive used on component with non-element root node. The directives will not function as intended.

at `<ElDropdownCollectionItem disabled=false text-value="" >`

closed #12300



example:
```

<el-dropdown-menu>
    <el-dropdown-item v-xxx-xxxx="['yyyy']">

    </el-dropdown-item>
</el-dropdown-menu>
```