### PR TITLE
fix(components): [tree-v2] props defaultExpandedKeys not reactive

### DIFF
--- a/packages/components/tree-v2/__tests__/tree.test.ts
+++ b/packages/components/tree-v2/__tests__/tree.test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { nextTick } from 'vue'
+import { nextTick, ref } from 'vue'
 import { describe, expect, test, vi } from 'vitest'
 import { NOOP } from '@element-plus/utils'
 import { makeMountFunc } from '@element-plus/test-utils/make-mount'
@@ -710,6 +710,7 @@ describe('Virtual Tree', () => {
   })
 
   test('defaultExpandedKeys', async () => {
+    const defaultExpandedKeys = ref([])
     const { wrapper } = createTree({
       data() {
         return {
@@ -754,10 +755,12 @@ describe('Virtual Tree', () => {
               label: 'node-2',
             },
           ],
-          defaultExpandedKeys: ['1'],
+          defaultExpandedKeys,
         }
       },
     })
+    await nextTick()
+    defaultExpandedKeys.value = ['1']
     await nextTick()
     const nodes = wrapper.findAll(TREE_NODE_CLASS_NAME)
     expect(nodes.length).toBe(5)

--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -31,7 +31,7 @@ export function useTree(
   props: TreeProps,
   emit: SetupContext<typeof treeEmits>['emit']
 ) {
-  const expandedKeySet = ref<Set<TreeKey>>(new Set(props.defaultExpandedKeys))
+  const expandedKeySet = ref<Set<TreeKey>>(new Set())
   const currentKey = ref<TreeKey | undefined>()
   const tree = shallowRef<Tree | undefined>()
   const listRef = ref<typeof FixedSizeList | undefined>()
@@ -293,6 +293,16 @@ export function useTree(
     () => props.currentNodeKey,
     (key) => {
       currentKey.value = key
+    },
+    {
+      immediate: true,
+    }
+  )
+
+  watch(
+    () => props.defaultExpandedKeys,
+    (key) => {
+      expandedKeySet.value = new Set<TreeKey>(key)
     },
     {
       immediate: true,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #21172