### PR TITLE
fix(components): [anchor] recalculate marker style on slot update

### DIFF
--- a/packages/components/anchor/src/anchor.vue
+++ b/packages/components/anchor/src/anchor.vue
@@ -15,12 +15,12 @@
 <script lang="ts" setup>
 import {
   computed,
+  nextTick,
   onMounted,
   provide,
   ref,
   useSlots,
   watch,
-  watchEffect,
 } from 'vue'
 import { useEventListener } from '@vueuse/core'
 import { useNamespace } from '@element-plus/hooks'
@@ -171,37 +171,41 @@ const getContainer = () => {
 useEventListener(containerEl, 'scroll', handleScroll)
 
 const updateMarkerStyle = () => {
-  if (!anchorRef.value || !markerRef.value || !currentAnchor.value) {
-    markerStyle.value = {}
-    return
-  }
-  const currentLinkEl = links[currentAnchor.value]
-  if (!currentLinkEl) {
-    markerStyle.value = {}
-    return
-  }
-  const anchorRect = anchorRef.value.getBoundingClientRect()
-  const markerRect = markerRef.value.getBoundingClientRect()
-  const linkRect = currentLinkEl.getBoundingClientRect()
+  nextTick(() => {
+    if (!anchorRef.value || !markerRef.value || !currentAnchor.value) {
+      markerStyle.value = {}
+      return
+    }
+    const currentLinkEl = links[currentAnchor.value]
+    if (!currentLinkEl) {
+      markerStyle.value = {}
+      return
+    }
+    const anchorRect = anchorRef.value.getBoundingClientRect()
+    const markerRect = markerRef.value.getBoundingClientRect()
+    const linkRect = currentLinkEl.getBoundingClientRect()
 
-  if (props.direction === 'horizontal') {
-    const left = linkRect.left - anchorRect.left
-    markerStyle.value = {
-      left: `${left}px`,
-      width: `${linkRect.width}px`,
-      opacity: 1,
+    if (props.direction === 'horizontal') {
+      const left = linkRect.left - anchorRect.left
+      markerStyle.value = {
+        left: `${left}px`,
+        width: `${linkRect.width}px`,
+        opacity: 1,
+      }
+    } else {
+      const top =
+        linkRect.top -
+        anchorRect.top +
+        (linkRect.height - markerRect.height) / 2
+      markerStyle.value = {
+        top: `${top}px`,
+        opacity: 1,
+      }
     }
-  } else {
-    const top =
-      linkRect.top - anchorRect.top + (linkRect.height - markerRect.height) / 2
-    markerStyle.value = {
-      top: `${top}px`,
-      opacity: 1,
-    }
-  }
+  })
 }
 
-watchEffect(updateMarkerStyle)
+watch(currentAnchor, updateMarkerStyle)
 watch(() => slots.default?.(), updateMarkerStyle)
 
 onMounted(() => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

On the doc when switching between page, the anchor marker may not following the active state.

### Before
![pee_0](https://github.com/user-attachments/assets/f21e3bc9-8d91-4547-a040-ee94d1d2b1cc)
---
### After
![after](https://github.com/user-attachments/assets/e45758a8-6615-4ab6-a0c3-214f92b6ad01)