### PR TITLE
feat(types): [components] add props public type

### DIFF
--- a/packages/components/affix/src/affix.ts
+++ b/packages/components/affix/src/affix.ts
@@ -6,7 +6,7 @@ import {
 } from '@element-plus/utils'
 import { CHANGE_EVENT } from '@element-plus/constants'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { ZIndexProperty } from 'csstype'
 import type Affix from './affix.vue'
 
@@ -42,6 +42,7 @@ export const affixProps = buildProps({
   },
 } as const)
 export type AffixProps = ExtractPropTypes<typeof affixProps>
+export type AffixPropsPublic = __ExtractPublicPropTypes<typeof affixProps>
 
 export const affixEmits = {
   scroll: ({ scrollTop, fixed }: { scrollTop: number; fixed: boolean }) =>

--- a/packages/components/alert/src/alert.ts
+++ b/packages/components/alert/src/alert.ts
@@ -6,7 +6,7 @@ import {
   keysOf,
 } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const alertEffects = ['light', 'dark'] as const
 
@@ -60,6 +60,7 @@ export const alertProps = buildProps({
   ...useDelayedToggleProps,
 } as const)
 export type AlertProps = ExtractPropTypes<typeof alertProps>
+export type AlertPropsPublic = __ExtractPublicPropTypes<typeof alertProps>
 
 export const alertEmits = {
   open: () => true,

--- a/packages/components/anchor/src/anchor-link.ts
+++ b/packages/components/anchor/src/anchor-link.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const anchorLinkProps = buildProps({
   /**
@@ -14,3 +14,6 @@ export const anchorLinkProps = buildProps({
 })
 
 export type AnchorLinkProps = ExtractPropTypes<typeof anchorLinkProps>
+export type AnchorLinkPropsPublic = __ExtractPublicPropTypes<
+  typeof anchorLinkProps
+>

--- a/packages/components/anchor/src/anchor.ts
+++ b/packages/components/anchor/src/anchor.ts
@@ -5,7 +5,7 @@ import {
   isUndefined,
 } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Anchor from './anchor.vue'
 
 export const anchorProps = buildProps({
@@ -70,6 +70,7 @@ export const anchorProps = buildProps({
 })
 
 export type AnchorProps = ExtractPropTypes<typeof anchorProps>
+export type AnchorPropsPublic = __ExtractPublicPropTypes<typeof anchorProps>
 export type AnchorInstance = InstanceType<typeof Anchor> & unknown
 
 export const anchorEmits = {

--- a/packages/components/autocomplete/src/autocomplete.ts
+++ b/packages/components/autocomplete/src/autocomplete.ts
@@ -13,7 +13,7 @@ import {
 } from '@element-plus/constants'
 import { inputProps } from '@element-plus/components/input'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Autocomplete from './autocomplete.vue'
 import type { Placement } from '@element-plus/components/popper'
 import type { Awaitable } from '@element-plus/utils'
@@ -126,6 +126,9 @@ export const autocompleteProps = buildProps({
   },
 } as const)
 export type AutocompleteProps = ExtractPropTypes<typeof autocompleteProps>
+export type AutocompletePropsPublic = __ExtractPublicPropTypes<
+  typeof autocompleteProps
+>
 
 export const autocompleteEmits = {
   [UPDATE_MODEL_EVENT]: (value: string) => isString(value),

--- a/packages/components/avatar/src/avatar.ts
+++ b/packages/components/avatar/src/avatar.ts
@@ -6,7 +6,7 @@ import {
 } from '@element-plus/utils'
 import { componentSizes } from '@element-plus/constants'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { ObjectFitProperty } from 'csstype'
 
 export const avatarProps = buildProps({
@@ -57,6 +57,7 @@ export const avatarProps = buildProps({
   },
 } as const)
 export type AvatarProps = ExtractPropTypes<typeof avatarProps>
+export type AvatarPropsPublic = __ExtractPublicPropTypes<typeof avatarProps>
 
 export const avatarEmits = {
   error: (evt: Event) => evt instanceof Event,

--- a/packages/components/backtop/src/backtop.ts
+++ b/packages/components/backtop/src/backtop.ts
@@ -1,4 +1,4 @@
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const backtopProps = {
   /**
@@ -31,6 +31,7 @@ export const backtopProps = {
   },
 } as const
 export type BacktopProps = ExtractPropTypes<typeof backtopProps>
+export type BacktopPropsPublic = __ExtractPublicPropTypes<typeof backtopProps>
 
 export const backtopEmits = {
   click: (evt: MouseEvent) => evt instanceof MouseEvent,

--- a/packages/components/badge/src/badge.ts
+++ b/packages/components/badge/src/badge.ts
@@ -1,6 +1,10 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes, StyleValue } from 'vue'
+import type {
+  ExtractPropTypes,
+  StyleValue,
+  __ExtractPublicPropTypes,
+} from 'vue'
 
 export const badgeProps = buildProps({
   /**
@@ -65,3 +69,4 @@ export const badgeProps = buildProps({
   },
 } as const)
 export type BadgeProps = ExtractPropTypes<typeof badgeProps>
+export type BadgePropsPublic = __ExtractPublicPropTypes<typeof badgeProps>

--- a/packages/components/breadcrumb/src/breadcrumb-item.ts
+++ b/packages/components/breadcrumb/src/breadcrumb-item.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
 
 export const breadcrumbItemProps = buildProps({
@@ -17,3 +17,6 @@ export const breadcrumbItemProps = buildProps({
   replace: Boolean,
 } as const)
 export type BreadcrumbItemProps = ExtractPropTypes<typeof breadcrumbItemProps>
+export type BreadcrumbItemPropsPublic = __ExtractPublicPropTypes<
+  typeof breadcrumbItemProps
+>

--- a/packages/components/breadcrumb/src/breadcrumb.ts
+++ b/packages/components/breadcrumb/src/breadcrumb.ts
@@ -1,6 +1,6 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const breadcrumbProps = buildProps({
   /**
@@ -18,3 +18,6 @@ export const breadcrumbProps = buildProps({
   },
 } as const)
 export type BreadcrumbProps = ExtractPropTypes<typeof breadcrumbProps>
+export type BreadcrumbPropsPublic = __ExtractPublicPropTypes<
+  typeof breadcrumbProps
+>

--- a/packages/components/button/src/button-group.ts
+++ b/packages/components/button/src/button-group.ts
@@ -1,6 +1,6 @@
 import { buttonProps } from './button'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const buttonGroupProps = {
   /**
@@ -13,3 +13,6 @@ export const buttonGroupProps = {
   type: buttonProps.type,
 } as const
 export type ButtonGroupProps = ExtractPropTypes<typeof buttonGroupProps>
+export type ButtonGroupPropsPublic = __ExtractPublicPropTypes<
+  typeof buttonGroupProps
+>

--- a/packages/components/button/src/button.ts
+++ b/packages/components/button/src/button.ts
@@ -2,7 +2,7 @@ import { useSizeProp } from '@element-plus/hooks'
 import { buildProps, definePropType, iconPropType } from '@element-plus/utils'
 import { Loading } from '@element-plus/icons-vue'
 
-import type { Component, ExtractPropTypes } from 'vue'
+import type { Component, ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const buttonTypes = [
   'default',
@@ -124,6 +124,7 @@ export const buttonEmits = {
 }
 
 export type ButtonProps = ExtractPropTypes<typeof buttonProps>
+export type ButtonPropsPublic = __ExtractPublicPropTypes<typeof buttonProps>
 export type ButtonEmits = typeof buttonEmits
 
 export type ButtonType = ButtonProps['type']

--- a/packages/components/calendar/src/calendar.ts
+++ b/packages/components/calendar/src/calendar.ts
@@ -6,7 +6,7 @@ import {
 } from '@element-plus/utils'
 import { INPUT_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export type CalendarDateType =
   | 'prev-month'
@@ -35,6 +35,7 @@ export const calendarProps = buildProps({
   },
 } as const)
 export type CalendarProps = ExtractPropTypes<typeof calendarProps>
+export type CalendarPropsPublic = __ExtractPublicPropTypes<typeof calendarProps>
 
 export const calendarEmits = {
   [UPDATE_MODEL_EVENT]: (value: Date) => isDate(value),

--- a/packages/components/calendar/src/date-table.ts
+++ b/packages/components/calendar/src/date-table.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType, isObject } from '@element-plus/utils'
 import { rangeArr } from '@element-plus/components/time-picker'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Dayjs } from 'dayjs'
 
 export type CalendarDateCellType = 'next' | 'prev' | 'current'
@@ -42,6 +42,9 @@ export const dateTableProps = buildProps({
   },
 } as const)
 export type DateTableProps = ExtractPropTypes<typeof dateTableProps>
+export type DateTablePropsPublic = __ExtractPublicPropTypes<
+  typeof dateTableProps
+>
 
 export const dateTableEmits = {
   pick: (value: Dayjs) => isObject(value),

--- a/packages/components/card/src/card.ts
+++ b/packages/components/card/src/card.ts
@@ -1,6 +1,10 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes, StyleValue } from 'vue'
+import type {
+  ExtractPropTypes,
+  StyleValue,
+  __ExtractPublicPropTypes,
+} from 'vue'
 
 export const cardProps = buildProps({
   /**
@@ -43,3 +47,4 @@ export const cardProps = buildProps({
   },
 } as const)
 export type CardProps = ExtractPropTypes<typeof cardProps>
+export type CardPropsPublic = __ExtractPublicPropTypes<typeof cardProps>

--- a/packages/components/carousel/src/carousel-item.ts
+++ b/packages/components/carousel/src/carousel-item.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const carouselItemProps = buildProps({
   /**
@@ -17,3 +17,6 @@ export const carouselItemProps = buildProps({
 } as const)
 
 export type CarouselItemProps = ExtractPropTypes<typeof carouselItemProps>
+export type CarouselItemPropsPublic = __ExtractPublicPropTypes<
+  typeof carouselItemProps
+>

--- a/packages/components/carousel/src/carousel.ts
+++ b/packages/components/carousel/src/carousel.ts
@@ -1,6 +1,6 @@
 import { buildProps, isNumber } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const carouselProps = buildProps({
   /**
@@ -108,4 +108,5 @@ export const carouselEmits = {
 }
 
 export type CarouselProps = ExtractPropTypes<typeof carouselProps>
+export type CarouselPropsPublic = __ExtractPublicPropTypes<typeof carouselProps>
 export type CarouselEmits = typeof carouselEmits

--- a/packages/components/check-tag/src/check-tag.ts
+++ b/packages/components/check-tag/src/check-tag.ts
@@ -2,7 +2,7 @@ import { buildProps, isBoolean } from '@element-plus/utils'
 import { CHANGE_EVENT } from '@element-plus/constants'
 
 import type CheckTag from './check-tag.vue'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const checkTagProps = buildProps({
   /**
@@ -23,6 +23,7 @@ export const checkTagProps = buildProps({
   },
 } as const)
 export type CheckTagProps = ExtractPropTypes<typeof checkTagProps>
+export type CheckTagPropsPublic = __ExtractPublicPropTypes<typeof checkTagProps>
 
 export const checkTagEmits = {
   'update:checked': (value: boolean) => isBoolean(value),

--- a/packages/components/checkbox/src/checkbox-group.ts
+++ b/packages/components/checkbox/src/checkbox-group.ts
@@ -2,7 +2,7 @@ import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { useAriaProps, useSizeProp } from '@element-plus/hooks'
 import { buildProps, definePropType, isArray } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type checkboxGroup from './checkbox-group.vue'
 import type { CheckboxValueType } from './checkbox'
 
@@ -63,5 +63,8 @@ export const checkboxGroupEmits = {
 }
 
 export type CheckboxGroupProps = ExtractPropTypes<typeof checkboxGroupProps>
+export type CheckboxGroupPropsPublic = __ExtractPublicPropTypes<
+  typeof checkboxGroupProps
+>
 export type CheckboxGroupEmits = typeof checkboxGroupEmits
 export type CheckboxGroupInstance = InstanceType<typeof checkboxGroup> & unknown

--- a/packages/components/checkbox/src/checkbox.ts
+++ b/packages/components/checkbox/src/checkbox.ts
@@ -2,7 +2,7 @@ import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { useAriaProps, useSizeProp } from '@element-plus/hooks'
 import { isBoolean, isNumber, isString } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Checkbox from './checkbox.vue'
 
 export type CheckboxValueType = string | number | boolean
@@ -115,5 +115,6 @@ export const checkboxEmits = {
 }
 
 export type CheckboxProps = ExtractPropTypes<typeof checkboxProps>
+export type CheckboxPropsPublic = __ExtractPublicPropTypes<typeof checkboxProps>
 export type CheckboxEmits = typeof checkboxEmits
 export type CheckboxInstance = InstanceType<typeof Checkbox> & unknown

--- a/packages/components/col/src/col.ts
+++ b/packages/components/col/src/col.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType, mutable } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Col from './col.vue'
 
 export type ColSizeObject = {
@@ -84,4 +84,5 @@ export const colProps = buildProps({
   },
 } as const)
 export type ColProps = ExtractPropTypes<typeof colProps>
+export type ColPropsPublic = __ExtractPublicPropTypes<typeof colProps>
 export type ColInstance = InstanceType<typeof Col> & unknown

--- a/packages/components/collapse/src/collapse-item.ts
+++ b/packages/components/collapse/src/collapse-item.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType, iconPropType } from '@element-plus/utils'
 import { ArrowRight } from '@element-plus/icons-vue'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { CollapseActiveName } from './collapse'
 
 export const collapseItemProps = buildProps({
@@ -32,3 +32,6 @@ export const collapseItemProps = buildProps({
   disabled: Boolean,
 } as const)
 export type CollapseItemProps = ExtractPropTypes<typeof collapseItemProps>
+export type CollapseItemPropsPublic = __ExtractPublicPropTypes<
+  typeof collapseItemProps
+>

--- a/packages/components/collapse/src/collapse.ts
+++ b/packages/components/collapse/src/collapse.ts
@@ -8,7 +8,7 @@ import {
 } from '@element-plus/utils'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Arrayable, Awaitable } from '@element-plus/utils'
 
 export type CollapseActiveName = string | number
@@ -48,6 +48,7 @@ export const collapseProps = buildProps({
   },
 } as const)
 export type CollapseProps = ExtractPropTypes<typeof collapseProps>
+export type CollapsePropsPublic = __ExtractPublicPropTypes<typeof collapseProps>
 
 export const collapseEmits = {
   [UPDATE_MODEL_EVENT]: emitChangeFn,

--- a/packages/components/color-picker/src/color-picker.ts
+++ b/packages/components/color-picker/src/color-picker.ts
@@ -8,7 +8,12 @@ import {
 import { useTooltipContentProps } from '@element-plus/components/tooltip'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
-import type { ComputedRef, ExtractPropTypes, InjectionKey } from 'vue'
+import type {
+  ComputedRef,
+  ExtractPropTypes,
+  InjectionKey,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type ColorPicker from './color-picker.vue'
 
 export const colorPickerProps = buildProps({
@@ -82,6 +87,9 @@ export const colorPickerEmits = {
 }
 
 export type ColorPickerProps = ExtractPropTypes<typeof colorPickerProps>
+export type ColorPickerPropsPublic = __ExtractPublicPropTypes<
+  typeof colorPickerProps
+>
 export type ColorPickerEmits = typeof colorPickerEmits
 export type ColorPickerInstance = InstanceType<typeof ColorPicker> & unknown
 

--- a/packages/components/color-picker/src/props/alpha-slider.ts
+++ b/packages/components/color-picker/src/props/alpha-slider.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Color from '../utils/color'
 
 export const alphaSliderProps = buildProps({
@@ -15,3 +15,6 @@ export const alphaSliderProps = buildProps({
 } as const)
 
 export type AlphaSliderProps = ExtractPropTypes<typeof alphaSliderProps>
+export type AlphaSliderPropsPublic = __ExtractPublicPropTypes<
+  typeof alphaSliderProps
+>

--- a/packages/components/config-provider/src/config-provider-props.ts
+++ b/packages/components/config-provider/src/config-provider-props.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 import { useEmptyValuesProps, useSizeProp } from '@element-plus/hooks'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Language } from '@element-plus/locale'
 import type { ButtonConfigContext } from '@element-plus/components/button'
 import type { MessageConfigContext } from '@element-plus/components/message'
@@ -75,3 +75,6 @@ export const configProviderProps = buildProps({
   ...useEmptyValuesProps,
 } as const)
 export type ConfigProviderProps = ExtractPropTypes<typeof configProviderProps>
+export type ConfigProviderPropsPublic = __ExtractPublicPropTypes<
+  typeof configProviderProps
+>

--- a/packages/components/countdown/src/countdown.ts
+++ b/packages/components/countdown/src/countdown.ts
@@ -1,7 +1,11 @@
 import { buildProps, definePropType, isNumber } from '@element-plus/utils'
 import { CHANGE_EVENT } from '@element-plus/constants'
 
-import type { ExtractPropTypes, StyleValue } from 'vue'
+import type {
+  ExtractPropTypes,
+  StyleValue,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type { Dayjs } from 'dayjs'
 import type Countdown from './countdown.vue'
 
@@ -40,6 +44,9 @@ export const countdownProps = buildProps({
   },
 } as const)
 export type CountdownProps = ExtractPropTypes<typeof countdownProps>
+export type CountdownPropsPublic = __ExtractPublicPropTypes<
+  typeof countdownProps
+>
 
 export const countdownEmits = {
   finish: () => true,

--- a/packages/components/date-picker/src/props/basic-cell.ts
+++ b/packages/components/date-picker/src/props/basic-cell.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { DateCell } from '../date-picker.type'
 
 export const basicCellProps = buildProps({
@@ -10,3 +10,6 @@ export const basicCellProps = buildProps({
 } as const)
 
 export type BasicCellProps = ExtractPropTypes<typeof basicCellProps>
+export type BasicCellPropsPublic = __ExtractPublicPropTypes<
+  typeof basicCellProps
+>

--- a/packages/components/date-picker/src/props/basic-date-table.ts
+++ b/packages/components/date-picker/src/props/basic-date-table.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 import { datePickerSharedProps, selectionModeWithDefault } from './shared'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Dayjs } from 'dayjs'
 
 export const basicDateTableProps = buildProps({
@@ -16,6 +16,9 @@ export const basicDateTableProps = buildProps({
 export const basicDateTableEmits = ['changerange', 'pick', 'select']
 
 export type BasicDateTableProps = ExtractPropTypes<typeof basicDateTableProps>
+export type BasicDateTablePropsPublic = __ExtractPublicPropTypes<
+  typeof basicDateTableProps
+>
 export type BasicDateTableEmits = typeof basicDateTableEmits
 
 export type RangePickerEmits = { minDate: Dayjs; maxDate: null }

--- a/packages/components/date-picker/src/props/basic-month-table.ts
+++ b/packages/components/date-picker/src/props/basic-month-table.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 import { datePickerSharedProps, selectionModeWithDefault } from './shared'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const basicMonthTableProps = buildProps({
   ...datePickerSharedProps,
@@ -9,3 +9,6 @@ export const basicMonthTableProps = buildProps({
 })
 
 export type BasicMonthTableProps = ExtractPropTypes<typeof basicMonthTableProps>
+export type BasicMonthTablePropsPublic = __ExtractPublicPropTypes<
+  typeof basicMonthTableProps
+>

--- a/packages/components/date-picker/src/props/basic-year-table.ts
+++ b/packages/components/date-picker/src/props/basic-year-table.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 import { datePickerSharedProps, selectionModeWithDefault } from './shared'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const basicYearTableProps = buildProps({
   ...datePickerSharedProps,
@@ -9,3 +9,6 @@ export const basicYearTableProps = buildProps({
 } as const)
 
 export type BasicYearTableProps = ExtractPropTypes<typeof basicYearTableProps>
+export type BasicYearTablePropsPublic = __ExtractPublicPropTypes<
+  typeof basicYearTableProps
+>

--- a/packages/components/date-picker/src/props/date-picker.ts
+++ b/packages/components/date-picker/src/props/date-picker.ts
@@ -1,7 +1,7 @@
 import { timePickerDefaultProps } from '@element-plus/components/time-picker'
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { IDatePickerType } from '../date-picker.type'
 
 export const datePickerProps = buildProps({
@@ -16,3 +16,6 @@ export const datePickerProps = buildProps({
 } as const)
 
 export type DatePickerProps = ExtractPropTypes<typeof datePickerProps>
+export type DatePickerPropsPublic = __ExtractPublicPropTypes<
+  typeof datePickerProps
+>

--- a/packages/components/date-picker/src/props/panel-date-pick.ts
+++ b/packages/components/date-picker/src/props/panel-date-pick.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 import { panelSharedProps } from './shared'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Dayjs } from 'dayjs'
 
 export const panelDatePickProps = buildProps({
@@ -19,3 +19,6 @@ export const panelDatePickProps = buildProps({
 } as const)
 
 export type PanelDatePickProps = ExtractPropTypes<typeof panelDatePickProps>
+export type PanelDatePickPropsPublic = __ExtractPublicPropTypes<
+  typeof panelDatePickProps
+>

--- a/packages/components/date-picker/src/props/panel-date-range.ts
+++ b/packages/components/date-picker/src/props/panel-date-range.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 import { panelRangeSharedProps, panelSharedProps } from './shared'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const panelDateRangeProps = buildProps({
   ...panelSharedProps,
@@ -9,3 +9,6 @@ export const panelDateRangeProps = buildProps({
 } as const)
 
 export type PanelDateRangeProps = ExtractPropTypes<typeof panelDateRangeProps>
+export type PanelDateRangePropsPublic = __ExtractPublicPropTypes<
+  typeof panelDateRangeProps
+>

--- a/packages/components/date-picker/src/props/panel-month-range.ts
+++ b/packages/components/date-picker/src/props/panel-month-range.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 import { panelRangeSharedProps } from './shared'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const panelMonthRangeProps = buildProps({
   ...panelRangeSharedProps,
@@ -14,3 +14,6 @@ export const panelMonthRangeEmits = [
 ]
 
 export type PanelMonthRangeProps = ExtractPropTypes<typeof panelMonthRangeProps>
+export type PanelMonthRangePropsPublic = __ExtractPublicPropTypes<
+  typeof panelMonthRangeProps
+>

--- a/packages/components/date-picker/src/props/panel-year-range.ts
+++ b/packages/components/date-picker/src/props/panel-year-range.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 import { panelRangeSharedProps } from './shared'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const panelYearRangeProps = buildProps({
   ...panelRangeSharedProps,
@@ -14,3 +14,6 @@ export const panelYearRangeEmits = [
 ]
 
 export type PanelYearRangeProps = ExtractPropTypes<typeof panelYearRangeProps>
+export type PanelYearRangePropsPublic = __ExtractPublicPropTypes<
+  typeof panelYearRangeProps
+>

--- a/packages/components/date-picker/src/props/shared.ts
+++ b/packages/components/date-picker/src/props/shared.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType, isArray } from '@element-plus/utils'
 import { datePickTypes } from '@element-plus/constants'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Dayjs } from 'dayjs'
 import type { DatePickType } from '@element-plus/constants'
 
@@ -88,5 +88,8 @@ export const rangePickerSharedEmits = {
 
 export type RangePickerSharedEmits = typeof rangePickerSharedEmits
 export type PanelRangeSharedProps = ExtractPropTypes<
+  typeof panelRangeSharedProps
+>
+export type PanelRangeSharedPropsPublic = __ExtractPublicPropTypes<
   typeof panelRangeSharedProps
 >

--- a/packages/components/descriptions/src/description-item.ts
+++ b/packages/components/descriptions/src/description-item.ts
@@ -3,7 +3,12 @@ import { columnAlignment } from '@element-plus/constants'
 import { buildProps } from '@element-plus/utils'
 import { COMPONENT_NAME } from './constants'
 
-import type { ExtractPropTypes, Slot, VNode } from 'vue'
+import type {
+  ExtractPropTypes,
+  Slot,
+  VNode,
+  __ExtractPublicPropTypes,
+} from 'vue'
 
 export const descriptionItemProps = buildProps({
   /**
@@ -87,6 +92,9 @@ const DescriptionItem = defineComponent({
 export default DescriptionItem
 
 export type DescriptionItemProps = ExtractPropTypes<typeof descriptionItemProps>
+export type DescriptionItemPropsPublic = __ExtractPublicPropTypes<
+  typeof descriptionItemProps
+>
 export type DescriptionItemVNode = VNode & {
   children: { [name: string]: Slot } | null
   props: Partial<DescriptionItemProps> | null

--- a/packages/components/descriptions/src/description.ts
+++ b/packages/components/descriptions/src/description.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 import { useSizeProp } from '@element-plus/hooks'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Description from './description.vue'
 
 export const descriptionProps = buildProps({
@@ -52,4 +52,7 @@ export const descriptionProps = buildProps({
 } as const)
 
 export type DescriptionProps = ExtractPropTypes<typeof descriptionProps>
+export type DescriptionPropsPublic = __ExtractPublicPropTypes<
+  typeof descriptionProps
+>
 export type DescriptionInstance = InstanceType<typeof Description> & unknown

--- a/packages/components/dialog/src/dialog.ts
+++ b/packages/components/dialog/src/dialog.ts
@@ -3,7 +3,7 @@ import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { teleportProps } from '@element-plus/components/teleport'
 import { dialogContentProps } from './dialog-content'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Dialog from './dialog.vue'
 
 type DoneFn = (cancel?: boolean) => void
@@ -123,6 +123,7 @@ export const dialogProps = buildProps({
 } as const)
 
 export type DialogProps = ExtractPropTypes<typeof dialogProps>
+export type DialogPropsPublic = __ExtractPublicPropTypes<typeof dialogProps>
 
 export const dialogEmits = {
   open: () => true,

--- a/packages/components/divider/src/divider.ts
+++ b/packages/components/divider/src/divider.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Divider from './divider.vue'
 
 export type BorderStyle = CSSStyleDeclaration['borderStyle']
@@ -31,5 +31,6 @@ export const dividerProps = buildProps({
   },
 } as const)
 export type DividerProps = ExtractPropTypes<typeof dividerProps>
+export type DividerPropsPublic = __ExtractPublicPropTypes<typeof dividerProps>
 
 export type DividerInstance = InstanceType<typeof Divider> & unknown

--- a/packages/components/drawer/src/drawer.ts
+++ b/packages/components/drawer/src/drawer.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 import { dialogEmits, dialogProps } from '@element-plus/components/dialog'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const drawerProps = buildProps({
   ...dialogProps,
@@ -29,5 +29,6 @@ export const drawerProps = buildProps({
 } as const)
 
 export type DrawerProps = ExtractPropTypes<typeof drawerProps>
+export type DrawerPropsPublic = __ExtractPublicPropTypes<typeof drawerProps>
 
 export const drawerEmits = dialogEmits

--- a/packages/components/empty/src/empty.ts
+++ b/packages/components/empty/src/empty.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const emptyProps = buildProps({
   /**
@@ -24,3 +24,4 @@ export const emptyProps = buildProps({
 } as const)
 
 export type EmptyProps = ExtractPropTypes<typeof emptyProps>
+export type EmptyPropsPublic = __ExtractPublicPropTypes<typeof emptyProps>

--- a/packages/components/form/src/form-item.ts
+++ b/packages/components/form/src/form-item.ts
@@ -1,7 +1,7 @@
 import { componentSizes } from '@element-plus/constants'
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Arrayable } from '@element-plus/utils'
 import type { FormItemRule } from './types'
 
@@ -92,3 +92,4 @@ export const formItemProps = buildProps({
   },
 } as const)
 export type FormItemProps = ExtractPropTypes<typeof formItemProps>
+export type FormItemPropsPublic = __ExtractPublicPropTypes<typeof formItemProps>

--- a/packages/components/form/src/form.ts
+++ b/packages/components/form/src/form.ts
@@ -7,7 +7,7 @@ import {
   isString,
 } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { FormItemProp } from './form-item'
 import type { FormRules } from './types'
 
@@ -110,7 +110,10 @@ export const formProps = buildProps({
   },
 } as const)
 export type FormProps = ExtractPropTypes<typeof formProps>
+export type FormPropsPublic = __ExtractPublicPropTypes<typeof formProps>
+
 export type FormMetaProps = ExtractPropTypes<typeof formMetaProps>
+export type FormMetaPropsPublic = __ExtractPublicPropTypes<typeof formMetaProps>
 
 export const formEmits = {
   validate: (prop: FormItemProp, isValid: boolean, message: string) =>

--- a/packages/components/icon/src/icon.ts
+++ b/packages/components/icon/src/icon.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Icon from './icon.vue'
 
 export const iconProps = buildProps({
@@ -18,4 +18,5 @@ export const iconProps = buildProps({
   },
 } as const)
 export type IconProps = ExtractPropTypes<typeof iconProps>
+export type IconPropsPublic = __ExtractPublicPropTypes<typeof iconProps>
 export type IconInstance = InstanceType<typeof Icon> & unknown

--- a/packages/components/image-viewer/src/image-viewer.ts
+++ b/packages/components/image-viewer/src/image-viewer.ts
@@ -5,7 +5,7 @@ import {
   mutable,
 } from '@element-plus/utils'
 
-import type { Component, ExtractPropTypes } from 'vue'
+import type { Component, ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type ImageViewer from './image-viewer.vue'
 
 export type ImageViewerAction =
@@ -93,6 +93,9 @@ export const imageViewerProps = buildProps({
   },
 } as const)
 export type ImageViewerProps = ExtractPropTypes<typeof imageViewerProps>
+export type ImageViewerPropsPublic = __ExtractPublicPropTypes<
+  typeof imageViewerProps
+>
 
 export const imageViewerEmits = {
   close: () => true,

--- a/packages/components/image/src/image.ts
+++ b/packages/components/image/src/image.ts
@@ -5,7 +5,7 @@ import {
   mutable,
 } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Image from './image.vue'
 
 export const imageProps = buildProps({
@@ -119,6 +119,7 @@ export const imageProps = buildProps({
   },
 } as const)
 export type ImageProps = ExtractPropTypes<typeof imageProps>
+export type ImagePropsPublic = __ExtractPublicPropTypes<typeof imageProps>
 
 export const imageEmits = {
   load: (evt: Event) => evt instanceof Event,

--- a/packages/components/input-number/src/input-number.ts
+++ b/packages/components/input-number/src/input-number.ts
@@ -7,7 +7,11 @@ import {
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
 
-import type { ExtractPropTypes, HTMLAttributes } from 'vue'
+import type {
+  ExtractPropTypes,
+  HTMLAttributes,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type InputNumber from './input-number.vue'
 
 export const inputNumberProps = buildProps({
@@ -118,6 +122,9 @@ export const inputNumberProps = buildProps({
   },
 } as const)
 export type InputNumberProps = ExtractPropTypes<typeof inputNumberProps>
+export type InputNumberPropsPublic = __ExtractPublicPropTypes<
+  typeof inputNumberProps
+>
 
 export const inputNumberEmits = {
   [CHANGE_EVENT]: (cur: number | undefined, prev: number | undefined) =>

--- a/packages/components/input-tag/src/input-tag.ts
+++ b/packages/components/input-tag/src/input-tag.ts
@@ -14,7 +14,7 @@ import {
 } from '@element-plus/constants'
 import { tagProps } from '@element-plus/components/tag/src/tag'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const inputTagProps = buildProps({
   /**
@@ -136,6 +136,7 @@ export const inputTagProps = buildProps({
   ariaLabel: String,
 } as const)
 export type InputTagProps = ExtractPropTypes<typeof inputTagProps>
+export type InputTagPropsPublic = __ExtractPublicPropTypes<typeof inputTagProps>
 
 export const inputTagEmits = {
   [UPDATE_MODEL_EVENT]: (value?: string[]) =>

--- a/packages/components/input/src/input.ts
+++ b/packages/components/input/src/input.ts
@@ -8,7 +8,12 @@ import {
 import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { useAriaProps, useSizeProp } from '@element-plus/hooks'
 
-import type { ExtractPropTypes, HTMLAttributes, StyleValue } from 'vue'
+import type {
+  ExtractPropTypes,
+  HTMLAttributes,
+  StyleValue,
+  __ExtractPublicPropTypes,
+} from 'vue'
 
 export type InputAutoSize = { minRows?: number; maxRows?: number } | boolean
 
@@ -181,6 +186,7 @@ export const inputProps = buildProps({
   name: String,
 } as const)
 export type InputProps = ExtractPropTypes<typeof inputProps>
+export type InputPropsPublic = __ExtractPublicPropTypes<typeof inputProps>
 
 export const inputEmits = {
   [UPDATE_MODEL_EVENT]: (value: string) => isString(value),

--- a/packages/components/link/src/link.ts
+++ b/packages/components/link/src/link.ts
@@ -1,6 +1,6 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes, PropType } from 'vue'
+import type { ExtractPropTypes, PropType, __ExtractPublicPropTypes } from 'vue'
 import type Link from './link.vue'
 
 export const linkProps = buildProps({
@@ -43,6 +43,7 @@ export const linkProps = buildProps({
   },
 } as const)
 export type LinkProps = ExtractPropTypes<typeof linkProps>
+export type LinkPropsPublic = __ExtractPublicPropTypes<typeof linkProps>
 
 export const linkEmits = {
   click: (evt: MouseEvent) => evt instanceof MouseEvent,

--- a/packages/components/mention/src/mention.ts
+++ b/packages/components/mention/src/mention.ts
@@ -8,7 +8,7 @@ import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { inputProps } from '@element-plus/components/input'
 import { filterOption } from './helper'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Mention from './mention.vue'
 import type { MentionOption } from './types'
 import type { Options } from '@element-plus/components/popper'
@@ -119,6 +119,7 @@ export const mentionEmits = {
 
 export type MentionEmits = typeof mentionEmits
 export type MentionProps = ExtractPropTypes<typeof mentionProps>
+export type MentionPropsPublic = __ExtractPublicPropTypes<typeof mentionProps>
 export type MentionInstance = InstanceType<typeof Mention> & unknown
 
 export type { MentionOption } from './types'

--- a/packages/components/menu/src/menu-item-group.ts
+++ b/packages/components/menu/src/menu-item-group.ts
@@ -1,4 +1,4 @@
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const menuItemGroupProps = {
   /**
@@ -7,3 +7,6 @@ export const menuItemGroupProps = {
   title: String,
 } as const
 export type MenuItemGroupProps = ExtractPropTypes<typeof menuItemGroupProps>
+export type MenuItemGroupPropsPublic = __ExtractPublicPropTypes<
+  typeof menuItemGroupProps
+>

--- a/packages/components/menu/src/menu-item.ts
+++ b/packages/components/menu/src/menu-item.ts
@@ -5,7 +5,7 @@ import {
   isString,
 } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
 import type { MenuItemRegistered } from './types'
 
@@ -31,6 +31,7 @@ export const menuItemProps = buildProps({
   disabled: Boolean,
 } as const)
 export type MenuItemProps = ExtractPropTypes<typeof menuItemProps>
+export type MenuItemPropsPublic = __ExtractPublicPropTypes<typeof menuItemProps>
 
 export const menuItemEmits = {
   click: (item: MenuItemRegistered) =>

--- a/packages/components/menu/src/menu.ts
+++ b/packages/components/menu/src/menu.ts
@@ -44,6 +44,7 @@ import type {
   ExtractPropTypes,
   VNode,
   VNodeArrayChildren,
+  __ExtractPublicPropTypes,
 } from 'vue'
 import type { UseResizeObserverReturn } from '@vueuse/core'
 
@@ -171,6 +172,7 @@ export const menuProps = buildProps({
   },
 } as const)
 export type MenuProps = ExtractPropTypes<typeof menuProps>
+export type MenuPropsPublic = __ExtractPublicPropTypes<typeof menuProps>
 
 const checkIndexPath = (indexPath: unknown): indexPath is string[] =>
   isArray(indexPath) && indexPath.every((path) => isString(path))

--- a/packages/components/menu/src/sub-menu.ts
+++ b/packages/components/menu/src/sub-menu.ts
@@ -33,7 +33,11 @@ import { MENU_INJECTION_KEY, SUB_MENU_INJECTION_KEY } from './tokens'
 
 import type { Placement } from '@element-plus/components/popper'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
-import type { ExtractPropTypes, VNodeArrayChildren } from 'vue'
+import type {
+  ExtractPropTypes,
+  VNodeArrayChildren,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type { MenuProvider, SubMenuProvider } from './types'
 
 export const subMenuProps = buildProps({
@@ -97,6 +101,7 @@ export const subMenuProps = buildProps({
   },
 } as const)
 export type SubMenuProps = ExtractPropTypes<typeof subMenuProps>
+export type SubMenuPropsPublic = __ExtractPublicPropTypes<typeof subMenuProps>
 
 const COMPONENT_NAME = 'ElSubMenu'
 export default defineComponent({

--- a/packages/components/message/src/message.ts
+++ b/packages/components/message/src/message.ts
@@ -6,7 +6,12 @@ import {
   mutable,
 } from '@element-plus/utils'
 
-import type { AppContext, ExtractPropTypes, VNode } from 'vue'
+import type {
+  AppContext,
+  ExtractPropTypes,
+  VNode,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type { Mutable } from '@element-plus/utils'
 import type MessageConstructor from './message.vue'
 
@@ -153,6 +158,7 @@ export const messageProps = buildProps({
   },
 } as const)
 export type MessageProps = ExtractPropTypes<typeof messageProps>
+export type MessagePropsPublic = __ExtractPublicPropTypes<typeof messageProps>
 
 export const messageEmits = {
   destroy: () => true,

--- a/packages/components/notification/src/notification.ts
+++ b/packages/components/notification/src/notification.ts
@@ -1,7 +1,12 @@
 import { Close } from '@element-plus/icons-vue'
 import { buildProps, definePropType, iconPropType } from '@element-plus/utils'
 
-import type { AppContext, ExtractPropTypes, VNode } from 'vue'
+import type {
+  AppContext,
+  ExtractPropTypes,
+  VNode,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type Notification from './notification.vue'
 
 export const notificationTypes = [
@@ -119,6 +124,9 @@ export const notificationProps = buildProps({
   },
 } as const)
 export type NotificationProps = ExtractPropTypes<typeof notificationProps>
+export type NotificationPropsPublic = __ExtractPublicPropTypes<
+  typeof notificationProps
+>
 
 export const notificationEmits = {
   destroy: () => true,

--- a/packages/components/overlay/src/overlay.ts
+++ b/packages/components/overlay/src/overlay.ts
@@ -2,7 +2,11 @@ import { createVNode, defineComponent, h, renderSlot } from 'vue'
 import { PatchFlags, buildProps, definePropType } from '@element-plus/utils'
 import { useNamespace, useSameTarget } from '@element-plus/hooks'
 
-import type { CSSProperties, ExtractPropTypes } from 'vue'
+import type {
+  CSSProperties,
+  ExtractPropTypes,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type { ZIndexProperty } from 'csstype'
 
 export const overlayProps = buildProps({
@@ -23,6 +27,7 @@ export const overlayProps = buildProps({
   },
 } as const)
 export type OverlayProps = ExtractPropTypes<typeof overlayProps>
+export type OverlayPropsPublic = __ExtractPublicPropTypes<typeof overlayProps>
 
 export const overlayEmits = {
   click: (evt: MouseEvent) => evt instanceof MouseEvent,

--- a/packages/components/page-header/src/page-header.ts
+++ b/packages/components/page-header/src/page-header.ts
@@ -1,7 +1,7 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 import { Back } from '@element-plus/icons-vue'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type PageHeader from './page-header.vue'
 
 export const pageHeaderProps = buildProps({
@@ -25,6 +25,9 @@ export const pageHeaderProps = buildProps({
   },
 } as const)
 export type PageHeaderProps = ExtractPropTypes<typeof pageHeaderProps>
+export type PageHeaderPropsPublic = __ExtractPublicPropTypes<
+  typeof pageHeaderProps
+>
 
 export const pageHeaderEmits = {
   back: () => true,

--- a/packages/components/pagination/src/components/jumper.ts
+++ b/packages/components/pagination/src/components/jumper.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 import { componentSizes } from '@element-plus/constants'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Jumper from './jumper.vue'
 
 export const paginationJumperProps = buildProps({
@@ -12,6 +12,9 @@ export const paginationJumperProps = buildProps({
 } as const)
 
 export type PaginationJumperProps = ExtractPropTypes<
+  typeof paginationJumperProps
+>
+export type PaginationJumperPropsPublic = __ExtractPublicPropTypes<
   typeof paginationJumperProps
 >
 

--- a/packages/components/pagination/src/components/next.ts
+++ b/packages/components/pagination/src/components/next.ts
@@ -1,6 +1,6 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Next from './next.vue'
 
 export const paginationNextProps = buildProps({
@@ -22,5 +22,8 @@ export const paginationNextProps = buildProps({
 } as const)
 
 export type PaginationNextProps = ExtractPropTypes<typeof paginationNextProps>
+export type PaginationNextPropsPublic = __ExtractPublicPropTypes<
+  typeof paginationNextProps
+>
 
 export type NextInstance = InstanceType<typeof Next> & unknown

--- a/packages/components/pagination/src/components/pager.ts
+++ b/packages/components/pagination/src/components/pager.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Pager from './pager.vue'
 
 export const paginationPagerProps = buildProps({
@@ -20,5 +20,8 @@ export const paginationPagerProps = buildProps({
 } as const)
 
 export type PaginationPagerProps = ExtractPropTypes<typeof paginationPagerProps>
+export type PaginationPagerPropsPublic = __ExtractPublicPropTypes<
+  typeof paginationPagerProps
+>
 
 export type PagerInstance = InstanceType<typeof Pager> & unknown

--- a/packages/components/pagination/src/components/prev.ts
+++ b/packages/components/pagination/src/components/prev.ts
@@ -1,6 +1,6 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Prev from './prev.vue'
 
 export const paginationPrevProps = buildProps({
@@ -22,5 +22,8 @@ export const paginationPrevEmits = {
 }
 
 export type PaginationPrevProps = ExtractPropTypes<typeof paginationPrevProps>
+export type PaginationPrevPropsPublic = __ExtractPublicPropTypes<
+  typeof paginationPrevProps
+>
 
 export type PrevInstance = InstanceType<typeof Prev> & unknown

--- a/packages/components/pagination/src/components/sizes.ts
+++ b/packages/components/pagination/src/components/sizes.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType, mutable } from '@element-plus/utils'
 import { componentSizes } from '@element-plus/constants'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Sizes from './sizes.vue'
 
 export const paginationSizesProps = buildProps({
@@ -26,5 +26,8 @@ export const paginationSizesProps = buildProps({
 } as const)
 
 export type PaginationSizesProps = ExtractPropTypes<typeof paginationSizesProps>
+export type PaginationSizesPropsPublic = __ExtractPublicPropTypes<
+  typeof paginationSizesProps
+>
 
 export type SizesInstance = InstanceType<typeof Sizes> & unknown

--- a/packages/components/pagination/src/components/total.ts
+++ b/packages/components/pagination/src/components/total.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 
 import type Total from './total.vue'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const paginationTotalProps = buildProps({
   total: {
@@ -11,5 +11,8 @@ export const paginationTotalProps = buildProps({
 } as const)
 
 export type PaginationTotalProps = ExtractPropTypes<typeof paginationTotalProps>
+export type PaginationTotalPropsPublic = __ExtractPublicPropTypes<
+  typeof paginationTotalProps
+>
 
 export type TotalInstance = InstanceType<typeof Total> & unknown

--- a/packages/components/pagination/src/pagination.ts
+++ b/packages/components/pagination/src/pagination.ts
@@ -32,7 +32,7 @@ import Jumper from './components/jumper.vue'
 import Total from './components/total.vue'
 import Pager from './components/pager.vue'
 
-import type { ExtractPropTypes, VNode } from 'vue'
+import type { ExtractPropTypes, VNode, __ExtractPublicPropTypes } from 'vue'
 /**
  * It it user's responsibility to guarantee that the value of props.total... is number
  * (same as pageSize, defaultPageSize, currentPage, defaultCurrentPage, pageCount)
@@ -175,6 +175,9 @@ export const paginationProps = buildProps({
   appendSizeTo: String,
 } as const)
 export type PaginationProps = ExtractPropTypes<typeof paginationProps>
+export type PaginationPropsPublic = __ExtractPublicPropTypes<
+  typeof paginationProps
+>
 
 export const paginationEmits = {
   'update:current-page': (val: number) => isNumber(val),

--- a/packages/components/popconfirm/src/popconfirm.ts
+++ b/packages/components/popconfirm/src/popconfirm.ts
@@ -3,7 +3,7 @@ import { QuestionFilled } from '@element-plus/icons-vue'
 import { buildProps, iconPropType } from '@element-plus/utils'
 import { useTooltipContentProps } from '@element-plus/components/tooltip'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Popconfirm from './popconfirm.vue'
 
 export const popconfirmProps = buildProps({
@@ -94,5 +94,8 @@ export const popconfirmEmits = {
 export type PopconfirmEmits = typeof popconfirmEmits
 
 export type PopconfirmProps = ExtractPropTypes<typeof popconfirmProps>
+export type PopconfirmPropsPublic = __ExtractPublicPropTypes<
+  typeof popconfirmProps
+>
 
 export type PopconfirmInstance = InstanceType<typeof Popconfirm> & unknown

--- a/packages/components/popover/src/popover.ts
+++ b/packages/components/popover/src/popover.ts
@@ -5,7 +5,7 @@ import {
 } from '@element-plus/components/tooltip'
 import { dropdownProps } from '@element-plus/components/dropdown'
 
-import type { ExtractPropTypes, PropType } from 'vue'
+import type { ExtractPropTypes, PropType, __ExtractPublicPropTypes } from 'vue'
 import type Popover from './popover.vue'
 
 export const popoverProps = buildProps({
@@ -130,6 +130,7 @@ export const popoverProps = buildProps({
   },
 } as const)
 export type PopoverProps = ExtractPropTypes<typeof popoverProps>
+export type PopoverPropsPublic = __ExtractPublicPropTypes<typeof popoverProps>
 
 export const popoverEmits = {
   'update:visible': (value: boolean) => isBoolean(value),

--- a/packages/components/popper/src/arrow.ts
+++ b/packages/components/popper/src/arrow.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Arrow from './arrow.vue'
 
 export const popperArrowProps = buildProps({
@@ -10,6 +10,9 @@ export const popperArrowProps = buildProps({
   },
 } as const)
 export type PopperArrowProps = ExtractPropTypes<typeof popperArrowProps>
+export type PopperArrowPropsPublic = __ExtractPublicPropTypes<
+  typeof popperArrowProps
+>
 
 export type PopperArrowInstance = InstanceType<typeof Arrow> & unknown
 

--- a/packages/components/popper/src/content.ts
+++ b/packages/components/popper/src/content.ts
@@ -4,7 +4,11 @@ import { useAriaProps } from '@element-plus/hooks'
 import { popperArrowProps } from './arrow'
 
 import type { PopperEffect } from './popper'
-import type { ExtractPropTypes, StyleValue } from 'vue'
+import type {
+  ExtractPropTypes,
+  StyleValue,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type { Options, Placement } from '@popperjs/core'
 import type { Measurable } from './constants'
 import type Content from './content.vue'
@@ -64,6 +68,9 @@ export const popperCoreConfigProps = buildProps({
 export type PopperCoreConfigProps = ExtractPropTypes<
   typeof popperCoreConfigProps
 >
+export type PopperCoreConfigPropsPublic = __ExtractPublicPropTypes<
+  typeof popperCoreConfigProps
+>
 
 export const popperContentProps = buildProps({
   ...popperCoreConfigProps,
@@ -114,6 +121,9 @@ export const popperContentProps = buildProps({
   ...useAriaProps(['ariaLabel']),
 } as const)
 export type PopperContentProps = ExtractPropTypes<typeof popperContentProps>
+export type PopperContentPropsPublic = __ExtractPublicPropTypes<
+  typeof popperContentProps
+>
 
 export const popperContentEmits = {
   mouseenter: (evt: MouseEvent) => evt instanceof MouseEvent,

--- a/packages/components/popper/src/popper.ts
+++ b/packages/components/popper/src/popper.ts
@@ -2,7 +2,7 @@
 
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Popper from './popper.vue'
 
 const effects = ['light', 'dark'] as const
@@ -38,6 +38,7 @@ export const popperProps = buildProps({
 } as const)
 
 export type PopperProps = ExtractPropTypes<typeof popperProps>
+export type PopperPropsPublic = __ExtractPublicPropTypes<typeof popperProps>
 
 export type PopperInstance = InstanceType<typeof Popper> & unknown
 

--- a/packages/components/progress/src/progress.ts
+++ b/packages/components/progress/src/progress.ts
@@ -1,6 +1,10 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes, SVGAttributes } from 'vue'
+import type {
+  ExtractPropTypes,
+  SVGAttributes,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type Progress from './progress.vue'
 
 export type ProgressColor = { color: string; percentage: number }
@@ -103,4 +107,5 @@ export const progressProps = buildProps({
 } as const)
 
 export type ProgressProps = ExtractPropTypes<typeof progressProps>
+export type ProgressPropsPublic = __ExtractPublicPropTypes<typeof progressProps>
 export type ProgressInstance = InstanceType<typeof Progress> & unknown

--- a/packages/components/radio/src/radio-button.ts
+++ b/packages/components/radio/src/radio-button.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 import { radioPropsBase } from './radio'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type RadioButton from './radio-button.vue'
 
 export const radioButtonProps = buildProps({
@@ -9,4 +9,7 @@ export const radioButtonProps = buildProps({
 } as const)
 
 export type RadioButtonProps = ExtractPropTypes<typeof radioButtonProps>
+export type RadioButtonPropsPublic = __ExtractPublicPropTypes<
+  typeof radioButtonProps
+>
 export type RadioButtonInstance = InstanceType<typeof RadioButton> & unknown

--- a/packages/components/radio/src/radio-group.ts
+++ b/packages/components/radio/src/radio-group.ts
@@ -2,7 +2,7 @@ import { buildProps } from '@element-plus/utils'
 import { useAriaProps, useSizeProp } from '@element-plus/hooks'
 import { radioEmits } from './radio'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type RadioGroup from './radio-group.vue'
 
 export const radioGroupProps = buildProps({
@@ -59,6 +59,9 @@ export const radioGroupProps = buildProps({
   ...useAriaProps(['ariaLabel']),
 } as const)
 export type RadioGroupProps = ExtractPropTypes<typeof radioGroupProps>
+export type RadioGroupPropsPublic = __ExtractPublicPropTypes<
+  typeof radioGroupProps
+>
 
 export const radioGroupEmits = radioEmits
 export type RadioGroupEmits = typeof radioGroupEmits

--- a/packages/components/radio/src/radio.ts
+++ b/packages/components/radio/src/radio.ts
@@ -2,7 +2,7 @@ import { buildProps, isBoolean, isNumber, isString } from '@element-plus/utils'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { useSizeProp } from '@element-plus/hooks'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Radio from './radio.vue'
 
 export const radioPropsBase = buildProps({
@@ -60,5 +60,6 @@ export const radioEmits = {
 }
 
 export type RadioProps = ExtractPropTypes<typeof radioProps>
+export type RadioPropsPublic = __ExtractPublicPropTypes<typeof radioProps>
 export type RadioEmits = typeof radioEmits
 export type RadioInstance = InstanceType<typeof Radio> & unknown

--- a/packages/components/rate/src/rate.ts
+++ b/packages/components/rate/src/rate.ts
@@ -9,7 +9,7 @@ import {
 } from '@element-plus/utils'
 import { useAriaProps, useSizeProp } from '@element-plus/hooks'
 
-import type { Component, ExtractPropTypes } from 'vue'
+import type { Component, ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Rate from './rate.vue'
 
 export const rateProps = buildProps({
@@ -149,6 +149,7 @@ export const rateProps = buildProps({
 } as const)
 
 export type RateProps = ExtractPropTypes<typeof rateProps>
+export type RatePropsPublic = __ExtractPublicPropTypes<typeof rateProps>
 
 export const rateEmits = {
   [CHANGE_EVENT]: (value: number) => isNumber(value),

--- a/packages/components/result/src/result.ts
+++ b/packages/components/result/src/result.ts
@@ -6,7 +6,7 @@ import {
   WarningFilled,
 } from '@element-plus/icons-vue'
 
-import type { Component, ExtractPropTypes } from 'vue'
+import type { Component, ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Result from './result.vue'
 
 export const IconMap = {
@@ -54,5 +54,6 @@ export const resultProps = buildProps({
 } as const)
 
 export type ResultProps = ExtractPropTypes<typeof resultProps>
+export type ResultPropsPublic = __ExtractPublicPropTypes<typeof resultProps>
 
 export type ResultInstance = InstanceType<typeof Result> & unknown

--- a/packages/components/roving-focus-group/src/roving-focus-group.ts
+++ b/packages/components/roving-focus-group/src/roving-focus-group.ts
@@ -1,7 +1,12 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 import { createCollectionWithScope } from '@element-plus/components/collection'
 
-import type { ExtractPropTypes, HTMLAttributes, StyleValue } from 'vue'
+import type {
+  ExtractPropTypes,
+  HTMLAttributes,
+  StyleValue,
+  __ExtractPublicPropTypes,
+} from 'vue'
 
 export const rovingFocusGroupProps = buildProps({
   style: { type: definePropType<StyleValue>([String, Array, Object]) },
@@ -26,6 +31,10 @@ export const rovingFocusGroupProps = buildProps({
 })
 
 export type ElRovingFocusGroupProps = ExtractPropTypes<
+  typeof rovingFocusGroupProps
+>
+
+export type ElRovingFocusGroupPropsPublic = __ExtractPublicPropTypes<
   typeof rovingFocusGroupProps
 >
 

--- a/packages/components/row/src/row.ts
+++ b/packages/components/row/src/row.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Row from './row.vue'
 
 export const RowJustify = [
@@ -47,4 +47,5 @@ export const rowProps = buildProps({
 } as const)
 
 export type RowProps = ExtractPropTypes<typeof rowProps>
+export type RowPropsPublic = __ExtractPublicPropTypes<typeof rowProps>
 export type RowInstance = InstanceType<typeof Row> & unknown

--- a/packages/components/scrollbar/src/bar.ts
+++ b/packages/components/scrollbar/src/bar.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Bar from './bar.vue'
 
 export const barProps = buildProps({
@@ -14,5 +14,6 @@ export const barProps = buildProps({
   },
 } as const)
 export type BarProps = ExtractPropTypes<typeof barProps>
+export type BarPropsPublic = __ExtractPublicPropTypes<typeof barProps>
 
 export type BarInstance = InstanceType<typeof Bar> & unknown

--- a/packages/components/scrollbar/src/scrollbar.ts
+++ b/packages/components/scrollbar/src/scrollbar.ts
@@ -1,7 +1,11 @@
 import { buildProps, definePropType, isNumber } from '@element-plus/utils'
 import { useAriaProps } from '@element-plus/hooks'
 
-import type { ExtractPropTypes, StyleValue } from 'vue'
+import type {
+  ExtractPropTypes,
+  StyleValue,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type Scrollbar from './scrollbar.vue'
 
 export const scrollbarProps = buildProps({
@@ -94,6 +98,9 @@ export const scrollbarProps = buildProps({
   ...useAriaProps(['ariaLabel', 'ariaOrientation']),
 } as const)
 export type ScrollbarProps = ExtractPropTypes<typeof scrollbarProps>
+export type ScrollbarPropsPublic = __ExtractPublicPropTypes<
+  typeof scrollbarProps
+>
 
 export const scrollbarEmits = {
   'end-reached': (direction: ScrollbarDirection) =>

--- a/packages/components/scrollbar/src/thumb.ts
+++ b/packages/components/scrollbar/src/thumb.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Thumb from './thumb.vue'
 
 export const thumbProps = buildProps({
@@ -14,5 +14,6 @@ export const thumbProps = buildProps({
   always: Boolean,
 } as const)
 export type ThumbProps = ExtractPropTypes<typeof thumbProps>
+export type ThumbPropsPublic = __ExtractPublicPropTypes<typeof thumbProps>
 
 export type ThumbInstance = InstanceType<typeof Thumb> & unknown

--- a/packages/components/segmented/src/segmented.ts
+++ b/packages/components/segmented/src/segmented.ts
@@ -9,7 +9,7 @@ import { useAriaProps, useSizeProp } from '@element-plus/hooks'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
 import type { Option } from './types'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Segmented from './segmented.vue'
 
 export interface Props {
@@ -81,6 +81,9 @@ export const segmentedProps = buildProps({
 })
 
 export type SegmentedProps = ExtractPropTypes<typeof segmentedProps>
+export type SegmentedPropsPublic = __ExtractPublicPropTypes<
+  typeof segmentedProps
+>
 
 export const segmentedEmits = {
   [UPDATE_MODEL_EVENT]: (val: any) =>

--- a/packages/components/select-v2/src/defaults.ts
+++ b/packages/components/select-v2/src/defaults.ts
@@ -21,7 +21,7 @@ import SelectV2 from './select.vue'
 import type { Option, OptionType } from './select.types'
 import type { Props } from './useProps'
 import type { EmitFn } from '@element-plus/utils/vue/typescript'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type {
   Options,
   Placement,
@@ -339,7 +339,9 @@ export const optionV2Emits = {
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 export type SelectV2Props = ExtractPropTypes<typeof selectV2Props>
+export type SelectV2PropsPublic = __ExtractPublicPropTypes<typeof selectV2Props>
 export type OptionV2Props = ExtractPropTypes<typeof optionV2Props>
+export type OptionV2PropsPublic = __ExtractPublicPropTypes<typeof optionV2Props>
 export type SelectV2EmitFn = EmitFn<typeof selectV2Emits>
 export type OptionV2EmitFn = EmitFn<typeof optionV2Emits>
 

--- a/packages/components/select/src/select.ts
+++ b/packages/components/select/src/select.ts
@@ -16,7 +16,7 @@ import { ArrowDown, CircleClose } from '@element-plus/icons-vue'
 import { tagProps } from '@element-plus/components/tag'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Select from './select.vue'
 import type {
   Options,
@@ -283,5 +283,6 @@ export const selectEmits = {
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 export type SelectProps = ExtractPropTypes<typeof selectProps>
+export type SelectPropsPublic = __ExtractPublicPropTypes<typeof selectProps>
 export type SelectEmits = EmitFn<typeof selectEmits>
 export type SelectInstance = InstanceType<typeof Select> & unknown

--- a/packages/components/select/src/type.ts
+++ b/packages/components/select/src/type.ts
@@ -4,6 +4,7 @@ import type {
   ComputedRef,
   ExtractPropTypes,
   Ref,
+  __ExtractPublicPropTypes,
 } from 'vue'
 import type { SelectProps } from './select'
 import type { optionProps } from './option'
@@ -37,6 +38,7 @@ export type SelectStates = {
   isBeforeHide: boolean
 }
 export type OptionProps = ExtractPropTypes<typeof optionProps>
+export type OptionPropsPublic = __ExtractPublicPropTypes<typeof optionProps>
 export interface OptionStates {
   index: number
   groupDisabled: boolean

--- a/packages/components/skeleton/src/skeleton-item.ts
+++ b/packages/components/skeleton/src/skeleton-item.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 
 import type SkeletonItem from './skeleton-item.vue'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const skeletonItemProps = buildProps({
   /**
@@ -24,5 +24,8 @@ export const skeletonItemProps = buildProps({
   },
 } as const)
 export type SkeletonItemProps = ExtractPropTypes<typeof skeletonItemProps>
+export type SkeletonItemPropsPublic = __ExtractPublicPropTypes<
+  typeof skeletonItemProps
+>
 
 export type SkeletonItemInstance = InstanceType<typeof SkeletonItem> & unknown

--- a/packages/components/skeleton/src/skeleton.ts
+++ b/packages/components/skeleton/src/skeleton.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
 import type Skeleton from './skeleton.vue'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { ThrottleType } from '@element-plus/hooks'
 
 export const skeletonProps = buildProps({
@@ -41,5 +41,6 @@ export const skeletonProps = buildProps({
   },
 } as const)
 export type SkeletonProps = ExtractPropTypes<typeof skeletonProps>
+export type SkeletonPropsPublic = __ExtractPublicPropTypes<typeof skeletonProps>
 
 export type SkeletonInstance = InstanceType<typeof Skeleton> & unknown

--- a/packages/components/slider/src/button.ts
+++ b/packages/components/slider/src/button.ts
@@ -2,7 +2,12 @@ import { placements } from '@popperjs/core'
 import { buildProps, isNumber } from '@element-plus/utils'
 import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
-import type { ComponentPublicInstance, ExtractPropTypes, Ref } from 'vue'
+import type {
+  ComponentPublicInstance,
+  ExtractPropTypes,
+  Ref,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type Button from './button.vue'
 
 export const sliderButtonProps = buildProps({
@@ -19,6 +24,9 @@ export const sliderButtonProps = buildProps({
   },
 } as const)
 export type SliderButtonProps = ExtractPropTypes<typeof sliderButtonProps>
+export type SliderButtonPropsPublic = __ExtractPublicPropTypes<
+  typeof sliderButtonProps
+>
 
 export const sliderButtonEmits = {
   [UPDATE_MODEL_EVENT]: (value: number) => isNumber(value),

--- a/packages/components/slider/src/marker.ts
+++ b/packages/components/slider/src/marker.ts
@@ -2,7 +2,11 @@ import { computed, defineComponent, h } from 'vue'
 import { buildProps, definePropType, isString } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 
-import type { CSSProperties, ExtractPropTypes } from 'vue'
+import type {
+  CSSProperties,
+  ExtractPropTypes,
+  __ExtractPublicPropTypes,
+} from 'vue'
 
 export const sliderMarkerProps = buildProps({
   mark: {
@@ -17,6 +21,9 @@ export const sliderMarkerProps = buildProps({
   },
 } as const)
 export type SliderMarkerProps = ExtractPropTypes<typeof sliderMarkerProps>
+export type SliderMarkerPropsPublic = __ExtractPublicPropTypes<
+  typeof sliderMarkerProps
+>
 
 export default defineComponent({
   name: 'ElSliderMarker',

--- a/packages/components/slider/src/slider.ts
+++ b/packages/components/slider/src/slider.ts
@@ -13,7 +13,7 @@ import {
 import { useAriaProps, useSizeProp } from '@element-plus/hooks'
 
 import type { Arrayable } from '@element-plus/utils'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { SliderMarkerProps } from './marker'
 import type Slider from './slider.vue'
 
@@ -179,6 +179,7 @@ export const sliderProps = buildProps({
   ...useAriaProps(['ariaLabel']),
 } as const)
 export type SliderProps = ExtractPropTypes<typeof sliderProps>
+export type SliderPropsPublic = __ExtractPublicPropTypes<typeof sliderProps>
 
 const isValidValue = (value: Arrayable<number>) =>
   isNumber(value) || (isArray(value) && value.every(isNumber))

--- a/packages/components/space/src/item.ts
+++ b/packages/components/space/src/item.ts
@@ -2,7 +2,7 @@ import { computed, defineComponent, h, renderSlot } from 'vue'
 import { buildProps } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const spaceItemProps = buildProps({
   prefixCls: {
@@ -10,6 +10,9 @@ export const spaceItemProps = buildProps({
   },
 } as const)
 export type SpaceItemProps = ExtractPropTypes<typeof spaceItemProps>
+export type SpaceItemPropsPublic = __ExtractPublicPropTypes<
+  typeof spaceItemProps
+>
 
 const SpaceItem = defineComponent({
   name: 'ElSpaceItem',

--- a/packages/components/space/src/space.ts
+++ b/packages/components/space/src/space.ts
@@ -26,6 +26,7 @@ import type {
   VNode,
   VNodeArrayChildren,
   VNodeChild,
+  __ExtractPublicPropTypes,
 } from 'vue'
 import type { Arrayable } from '@element-plus/utils'
 import type { AlignItemsProperty } from 'csstype'
@@ -108,6 +109,7 @@ export const spaceProps = buildProps({
   },
 } as const)
 export type SpaceProps = ExtractPropTypes<typeof spaceProps>
+export type SpacePropsPublic = __ExtractPublicPropTypes<typeof spaceProps>
 
 const Space = defineComponent({
   name: 'ElSpace',

--- a/packages/components/splitter/src/split-panel.ts
+++ b/packages/components/splitter/src/split-panel.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type SplitterPanel from './split-panel.vue'
 
 export const splitterPanelProps = buildProps({
@@ -24,4 +24,7 @@ export const splitterPanelProps = buildProps({
 } as const)
 
 export type SplitterPanelProps = ExtractPropTypes<typeof splitterPanelProps>
+export type SplitterPanelPropsPublic = __ExtractPublicPropTypes<
+  typeof splitterPanelProps
+>
 export type SplitterPanelInstance = InstanceType<typeof SplitterPanel> & unknown

--- a/packages/components/splitter/src/splitter.ts
+++ b/packages/components/splitter/src/splitter.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Splitter from './splitter.vue'
 
 export const splitterProps = buildProps({
@@ -12,4 +12,5 @@ export const splitterProps = buildProps({
 } as const)
 
 export type SplitterProps = ExtractPropTypes<typeof splitterProps>
+export type SplitterPropsPublic = __ExtractPublicPropTypes<typeof splitterProps>
 export type SplitterInstance = InstanceType<typeof Splitter> & unknown

--- a/packages/components/statistic/src/statistic.ts
+++ b/packages/components/statistic/src/statistic.ts
@@ -1,6 +1,10 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes, StyleValue } from 'vue'
+import type {
+  ExtractPropTypes,
+  StyleValue,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type { Dayjs } from 'dayjs'
 import type Statistic from './statistic.vue'
 
@@ -58,5 +62,8 @@ export const statisticProps = buildProps({
   },
 } as const)
 export type StatisticProps = ExtractPropTypes<typeof statisticProps>
+export type StatisticPropsPublic = __ExtractPublicPropTypes<
+  typeof statisticProps
+>
 
 export type StatisticInstance = InstanceType<typeof Statistic> & unknown

--- a/packages/components/steps/src/item.ts
+++ b/packages/components/steps/src/item.ts
@@ -1,7 +1,7 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 
 import type Step from './item.vue'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const stepProps = buildProps({
   /**
@@ -35,5 +35,6 @@ export const stepProps = buildProps({
 } as const)
 
 export type StepProps = ExtractPropTypes<typeof stepProps>
+export type StepPropsPublic = __ExtractPublicPropTypes<typeof stepProps>
 
 export type StepInstance = InstanceType<typeof Step> & unknown

--- a/packages/components/steps/src/steps.ts
+++ b/packages/components/steps/src/steps.ts
@@ -2,7 +2,7 @@ import { CHANGE_EVENT } from '@element-plus/constants'
 import { buildProps, isNumber } from '@element-plus/utils'
 
 import type Steps from './steps.vue'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const stepsProps = buildProps({
   /**
@@ -57,6 +57,7 @@ export const stepsProps = buildProps({
   },
 } as const)
 export type StepsProps = ExtractPropTypes<typeof stepsProps>
+export type StepsPropsPublic = __ExtractPublicPropTypes<typeof stepsProps>
 
 export const stepsEmits = {
   [CHANGE_EVENT]: (newVal: number, oldVal: number) =>

--- a/packages/components/switch/src/switch.ts
+++ b/packages/components/switch/src/switch.ts
@@ -16,7 +16,7 @@ import { useAriaProps } from '@element-plus/hooks'
 
 import type { ComponentSize } from '@element-plus/constants'
 import type Switch from './switch.vue'
-import type { ExtractPropTypes, PropType } from 'vue'
+import type { ExtractPropTypes, PropType, __ExtractPublicPropTypes } from 'vue'
 
 export const switchProps = buildProps({
   /**
@@ -138,6 +138,7 @@ export const switchProps = buildProps({
 } as const)
 
 export type SwitchProps = ExtractPropTypes<typeof switchProps>
+export type SwitchPropsPublic = __ExtractPublicPropTypes<typeof switchProps>
 
 export const switchEmits = {
   [UPDATE_MODEL_EVENT]: (val: boolean | string | number) =>

--- a/packages/components/table-v2/src/auto-resizer.ts
+++ b/packages/components/table-v2/src/auto-resizer.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 type AutoResizeHandler = (event: { height: number; width: number }) => void
 
@@ -13,3 +13,6 @@ export const autoResizerProps = buildProps({
 } as const)
 
 export type AutoResizerProps = ExtractPropTypes<typeof autoResizerProps>
+export type AutoResizerPropsPublic = __ExtractPublicPropTypes<
+  typeof autoResizerProps
+>

--- a/packages/components/table-v2/src/cell.ts
+++ b/packages/components/table-v2/src/cell.ts
@@ -1,7 +1,11 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 import { column } from './common'
 
-import type { ExtractPropTypes, StyleValue } from 'vue'
+import type {
+  ExtractPropTypes,
+  StyleValue,
+  __ExtractPublicPropTypes,
+} from 'vue'
 
 export const tableV2CellProps = buildProps({
   class: String,
@@ -20,3 +24,6 @@ export const tableV2CellProps = buildProps({
 } as const)
 
 export type TableV2CellProps = ExtractPropTypes<typeof tableV2CellProps>
+export type TableV2CellPropsPublic = __ExtractPublicPropTypes<
+  typeof tableV2CellProps
+>

--- a/packages/components/table-v2/src/grid.ts
+++ b/packages/components/table-v2/src/grid.ts
@@ -14,7 +14,7 @@ import {
 import { tableV2HeaderProps } from './header'
 import { tableV2RowProps } from './row'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { ItemSize } from '@element-plus/components/virtual-list'
 
 export type onRowRenderedParams = {
@@ -76,3 +76,6 @@ export const tableV2GridProps = buildProps({
 } as const)
 
 export type TableV2GridProps = ExtractPropTypes<typeof tableV2GridProps>
+export type TableV2GridPropsPublic = __ExtractPublicPropTypes<
+  typeof tableV2GridProps
+>

--- a/packages/components/table-v2/src/header-cell.ts
+++ b/packages/components/table-v2/src/header-cell.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 import { classType, column } from './common'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const tableV2HeaderCell = buildProps({
   class: classType,
@@ -10,3 +10,6 @@ export const tableV2HeaderCell = buildProps({
 })
 
 export type TableV2HeaderCell = ExtractPropTypes<typeof tableV2HeaderCell>
+export type TableV2HeaderCellPublic = __ExtractPublicPropTypes<
+  typeof tableV2HeaderCell
+>

--- a/packages/components/table-v2/src/header-row.ts
+++ b/packages/components/table-v2/src/header-row.ts
@@ -1,7 +1,11 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 import { columns } from './common'
 
-import type { CSSProperties, ExtractPropTypes } from 'vue'
+import type {
+  CSSProperties,
+  ExtractPropTypes,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type { KeyType } from './types'
 
 export const tableV2HeaderRowProps = buildProps({
@@ -16,5 +20,8 @@ export const tableV2HeaderRowProps = buildProps({
 } as const)
 
 export type TableV2HeaderRowProps = ExtractPropTypes<
+  typeof tableV2HeaderRowProps
+>
+export type TableV2HeaderRowPropsPublic = __ExtractPublicPropTypes<
   typeof tableV2HeaderRowProps
 >

--- a/packages/components/table-v2/src/header.ts
+++ b/packages/components/table-v2/src/header.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 import { columns } from './common'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 const requiredNumberType = {
   type: Number,
@@ -32,3 +32,6 @@ export const tableV2HeaderProps = buildProps({
 } as const)
 
 export type TableV2HeaderProps = ExtractPropTypes<typeof tableV2HeaderProps>
+export type TableV2HeaderPropsPublic = __ExtractPublicPropTypes<
+  typeof tableV2HeaderProps
+>

--- a/packages/components/table-v2/src/row.ts
+++ b/packages/components/table-v2/src/row.ts
@@ -2,7 +2,11 @@ import { buildProps, definePropType } from '@element-plus/utils'
 import { virtualizedGridProps } from '@element-plus/components/virtual-list'
 import { columns, expandColumnKey, rowKey } from './common'
 
-import type { CSSProperties, ExtractPropTypes } from 'vue'
+import type {
+  CSSProperties,
+  ExtractPropTypes,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type { FixedDirection, KeyType, RowCommonParams } from './types'
 
 export type RowExpandParams = {
@@ -87,3 +91,6 @@ export const tableV2RowProps = buildProps({
 } as const)
 
 export type TableV2RowProps = ExtractPropTypes<typeof tableV2RowProps>
+export type TableV2RowPropsPublic = __ExtractPublicPropTypes<
+  typeof tableV2RowProps
+>

--- a/packages/components/table-v2/src/table.ts
+++ b/packages/components/table-v2/src/table.ts
@@ -16,7 +16,11 @@ import { tableV2RowProps } from './row'
 import { tableV2HeaderProps } from './header'
 import { tableV2GridProps } from './grid'
 
-import type { CSSProperties, ExtractPropTypes } from 'vue'
+import type {
+  CSSProperties,
+  ExtractPropTypes,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type { SortOrder } from './constants'
 import type {
   Column,
@@ -201,3 +205,4 @@ export const tableV2Props = buildProps({
 } as const)
 
 export type TableV2Props = ExtractPropTypes<typeof tableV2Props>
+export type TableV2PropsPublic = __ExtractPublicPropTypes<typeof tableV2Props>

--- a/packages/components/tabs/src/tab-bar.ts
+++ b/packages/components/tabs/src/tab-bar.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType, mutable } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { TabPaneName, TabsPaneContext } from './constants'
 import type TabBar from './tab-bar.vue'
 
@@ -16,4 +16,5 @@ export const tabBarProps = buildProps({
 } as const)
 
 export type TabBarProps = ExtractPropTypes<typeof tabBarProps>
+export type TabBarPropsPublic = __ExtractPublicPropTypes<typeof tabBarProps>
 export type TabBarInstance = InstanceType<typeof TabBar> & unknown

--- a/packages/components/tabs/src/tab-nav.tsx
+++ b/packages/components/tabs/src/tab-nav.tsx
@@ -31,6 +31,7 @@ import type {
   CSSProperties,
   ComponentPublicInstance,
   ExtractPropTypes,
+  __ExtractPublicPropTypes,
 } from 'vue'
 import type { TabBarInstance } from './tab-bar'
 import type { TabPaneName, TabsPaneContext } from './constants'
@@ -65,6 +66,7 @@ export const tabNavEmits = {
 }
 
 export type TabNavProps = ExtractPropTypes<typeof tabNavProps>
+export type TabNavPropsPublic = __ExtractPublicPropTypes<typeof tabNavProps>
 export type TabNavEmits = typeof tabNavEmits
 
 const COMPONENT_NAME = 'ElTabNav'

--- a/packages/components/tabs/src/tab-pane.ts
+++ b/packages/components/tabs/src/tab-pane.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type TabPane from './tab-pane.vue'
 
 export const tabPaneProps = buildProps({
@@ -32,5 +32,6 @@ export const tabPaneProps = buildProps({
 } as const)
 
 export type TabPaneProps = ExtractPropTypes<typeof tabPaneProps>
+export type TabPanePropsPublic = __ExtractPublicPropTypes<typeof tabPaneProps>
 
 export type TabPaneInstance = InstanceType<typeof TabPane> & unknown

--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -23,7 +23,7 @@ import { useNamespace, useOrderedChildren } from '@element-plus/hooks'
 import { tabsRootContextKey } from './constants'
 import TabNav from './tab-nav'
 
-import type { ExtractPropTypes, VNode } from 'vue'
+import type { ExtractPropTypes, VNode, __ExtractPublicPropTypes } from 'vue'
 import type { Awaitable } from '@element-plus/utils'
 import type { TabNavInstance } from './tab-nav'
 import type { TabPaneName, TabsPaneContext } from './constants'
@@ -78,6 +78,7 @@ export const tabsProps = buildProps({
   stretch: Boolean,
 } as const)
 export type TabsProps = ExtractPropTypes<typeof tabsProps>
+export type TabsPropsPublic = __ExtractPublicPropTypes<typeof tabsProps>
 
 const isPaneName = (value: unknown): value is string | number =>
   isString(value) || isNumber(value)

--- a/packages/components/tag/src/tag.ts
+++ b/packages/components/tag/src/tag.ts
@@ -2,7 +2,7 @@ import { buildProps } from '@element-plus/utils'
 import { componentSizes } from '@element-plus/constants'
 
 import type Tag from './tag.vue'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const tagProps = buildProps({
   /**
@@ -50,6 +50,7 @@ export const tagProps = buildProps({
   round: Boolean,
 } as const)
 export type TagProps = ExtractPropTypes<typeof tagProps>
+export type TagPropsPublic = __ExtractPublicPropTypes<typeof tagProps>
 
 export const tagEmits = {
   close: (evt: MouseEvent) => evt instanceof MouseEvent,

--- a/packages/components/teleport/src/teleport.ts
+++ b/packages/components/teleport/src/teleport.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Teleport from './teleport.vue'
 
 export const teleportProps = buildProps({
@@ -12,4 +12,5 @@ export const teleportProps = buildProps({
 } as const)
 
 export type TeleportProps = ExtractPropTypes<typeof teleportProps>
+export type TeleportPropsPublic = __ExtractPublicPropTypes<typeof teleportProps>
 export type TeleportInstance = InstanceType<typeof Teleport> & unknown

--- a/packages/components/text/src/text.ts
+++ b/packages/components/text/src/text.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@element-plus/utils'
 import { componentSizes } from '@element-plus/constants'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const textProps = buildProps({
   /**
@@ -40,3 +40,4 @@ export const textProps = buildProps({
 } as const)
 
 export type TextProps = ExtractPropTypes<typeof textProps>
+export type TextPropsPublic = __ExtractPublicPropTypes<typeof textProps>

--- a/packages/components/time-picker/src/common/props.ts
+++ b/packages/components/time-picker/src/common/props.ts
@@ -8,7 +8,7 @@ import {
 import { CircleClose } from '@element-plus/icons-vue'
 import { disabledTimeListsProps } from '../props/shared'
 
-import type { Component, ExtractPropTypes } from 'vue'
+import type { Component, ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Options } from '@popperjs/core'
 import type { Dayjs } from 'dayjs'
 import type { Placement } from '@element-plus/components/popper'
@@ -240,6 +240,9 @@ export const timePickerDefaultProps = buildProps({
 } as const)
 
 export type TimePickerDefaultProps = ExtractPropTypes<
+  typeof timePickerDefaultProps
+>
+export type TimePickerDefaultPropsPublic = __ExtractPublicPropTypes<
   typeof timePickerDefaultProps
 >
 

--- a/packages/components/time-picker/src/props/basic-time-spinner.ts
+++ b/packages/components/time-picker/src/props/basic-time-spinner.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 import { disabledTimeListsProps } from '../props/shared'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Dayjs } from 'dayjs'
 
 export const basicTimeSpinnerProps = buildProps({
@@ -27,5 +27,8 @@ export const basicTimeSpinnerProps = buildProps({
 } as const)
 
 export type BasicTimeSpinnerProps = ExtractPropTypes<
+  typeof basicTimeSpinnerProps
+>
+export type BasicTimeSpinnerPropsPublic = __ExtractPublicPropTypes<
   typeof basicTimeSpinnerProps
 >

--- a/packages/components/time-picker/src/props/panel-time-picker.ts
+++ b/packages/components/time-picker/src/props/panel-time-picker.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 import { timePanelSharedProps } from './shared'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Dayjs } from 'dayjs'
 
 export const panelTimePickerProps = buildProps({
@@ -13,3 +13,6 @@ export const panelTimePickerProps = buildProps({
 } as const)
 
 export type PanelTimePickerProps = ExtractPropTypes<typeof panelTimePickerProps>
+export type PanelTimePickerPropsPublic = __ExtractPublicPropTypes<
+  typeof panelTimePickerProps
+>

--- a/packages/components/time-picker/src/props/panel-time-range.ts
+++ b/packages/components/time-picker/src/props/panel-time-range.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 import { timePanelSharedProps } from './shared'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Dayjs } from 'dayjs'
 
 export const panelTimeRangeProps = buildProps({
@@ -12,3 +12,6 @@ export const panelTimeRangeProps = buildProps({
 } as const)
 
 export type PanelTimeRangeProps = ExtractPropTypes<typeof panelTimeRangeProps>
+export type PanelTimeRangePropsPublic = __ExtractPublicPropTypes<
+  typeof panelTimeRangeProps
+>

--- a/packages/components/time-picker/src/props/shared.ts
+++ b/packages/components/time-picker/src/props/shared.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type {
   GetDisabledHours,
   GetDisabledMinutes,
@@ -31,6 +31,9 @@ export const disabledTimeListsProps = buildProps({
 export type DisabledTimeListsProps = ExtractPropTypes<
   typeof disabledTimeListsProps
 >
+export type DisabledTimeListsPropsPublic = __ExtractPublicPropTypes<
+  typeof disabledTimeListsProps
+>
 
 export const timePanelSharedProps = buildProps({
   visible: Boolean,
@@ -45,3 +48,6 @@ export const timePanelSharedProps = buildProps({
 } as const)
 
 export type TimePanelSharedProps = ExtractPropTypes<typeof timePanelSharedProps>
+export type TimePanelSharedPropsPublic = __ExtractPublicPropTypes<
+  typeof timePanelSharedProps
+>

--- a/packages/components/time-select/src/time-select.ts
+++ b/packages/components/time-select/src/time-select.ts
@@ -4,7 +4,7 @@ import { useEmptyValuesProps, useSizeProp } from '@element-plus/hooks'
 
 import type { PopperEffect } from '@element-plus/components/popper'
 import type TimeSelect from './time-select.vue'
-import type { Component, ExtractPropTypes } from 'vue'
+import type { Component, ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const timeSelectProps = buildProps({
   /**
@@ -109,5 +109,8 @@ export const timeSelectProps = buildProps({
 } as const)
 
 export type TimeSelectProps = ExtractPropTypes<typeof timeSelectProps>
+export type TimeSelectPropsPublic = __ExtractPublicPropTypes<
+  typeof timeSelectProps
+>
 
 export type TimeSelectInstance = InstanceType<typeof TimeSelect> & unknown

--- a/packages/components/timeline/src/timeline-item.ts
+++ b/packages/components/timeline/src/timeline-item.ts
@@ -1,6 +1,6 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type TimelineItem from './timeline-item.vue'
 
 export const timelineItemProps = buildProps({
@@ -62,5 +62,8 @@ export const timelineItemProps = buildProps({
   hollow: Boolean,
 } as const)
 export type TimelineItemProps = ExtractPropTypes<typeof timelineItemProps>
+export type TimelineItemPropsPublic = __ExtractPublicPropTypes<
+  typeof timelineItemProps
+>
 
 export type TimelineItemInstance = InstanceType<typeof TimelineItem> & unknown

--- a/packages/components/tooltip-v2/src/arrow.ts
+++ b/packages/components/tooltip-v2/src/arrow.ts
@@ -1,7 +1,11 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 import { tooltipV2Sides } from './common'
 
-import type { CSSProperties, ExtractPropTypes } from 'vue'
+import type {
+  CSSProperties,
+  ExtractPropTypes,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type { TooltipV2Sides } from './common'
 
 export const tooltipV2ArrowProps = buildProps({
@@ -28,3 +32,6 @@ export const tooltipV2ArrowSpecialProps = buildProps({
 } as const)
 
 export type TooltipV2ArrowProps = ExtractPropTypes<typeof tooltipV2ArrowProps>
+export type TooltipV2ArrowPropsPublic = __ExtractPublicPropTypes<
+  typeof tooltipV2ArrowProps
+>

--- a/packages/components/tooltip-v2/src/common.ts
+++ b/packages/components/tooltip-v2/src/common.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 /**
  * TODO: make this under constants or tokens
@@ -10,6 +10,9 @@ export const tooltipV2CommonProps = buildProps({
 } as const)
 
 export type TooltipV2CommonProps = ExtractPropTypes<typeof tooltipV2CommonProps>
+export type TooltipV2CommonPropsPublic = __ExtractPublicPropTypes<
+  typeof tooltipV2CommonProps
+>
 
 export enum TooltipV2Sides {
   top = 'top',

--- a/packages/components/tooltip-v2/src/content.ts
+++ b/packages/components/tooltip-v2/src/content.ts
@@ -2,7 +2,7 @@ import { buildProps, definePropType } from '@element-plus/utils'
 import { useAriaProps } from '@element-plus/hooks'
 
 import type { PopperEffect } from '@element-plus/components/popper'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Placement, Strategy, VirtualElement } from '@floating-ui/dom'
 
 const tooltipV2Strategies = ['absolute', 'fixed'] as const
@@ -61,5 +61,9 @@ export const tooltipV2ContentProps = buildProps({
 } as const)
 
 export type TooltipV2ContentProps = ExtractPropTypes<
+  typeof tooltipV2ContentProps
+>
+
+export type TooltipV2ContentPropsPublic = __ExtractPublicPropTypes<
   typeof tooltipV2ContentProps
 >

--- a/packages/components/tooltip-v2/src/forward-ref.tsx
+++ b/packages/components/tooltip-v2/src/forward-ref.tsx
@@ -6,7 +6,11 @@ import {
   ensureOnlyChild,
 } from '@element-plus/utils'
 
-import type { ExtractPropTypes, VNodeArrayChildren } from 'vue'
+import type {
+  ExtractPropTypes,
+  VNodeArrayChildren,
+  __ExtractPublicPropTypes,
+} from 'vue'
 
 export type RefSetter = (el: HTMLElement | null) => void
 
@@ -16,6 +20,9 @@ export const forwardRefProps = buildProps({
 } as const)
 
 export type ForwardRefProps = ExtractPropTypes<typeof forwardRefProps>
+export type ForwardRefPropsPublic = __ExtractPublicPropTypes<
+  typeof forwardRefProps
+>
 
 // TODO: consider make this component a reusable component without the only child feature.
 export default defineComponent({

--- a/packages/components/tooltip-v2/src/root.ts
+++ b/packages/components/tooltip-v2/src/root.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 type StateUpdater = (state: boolean) => void
 
@@ -23,3 +23,6 @@ export const tooltipV2RootProps = buildProps({
 } as const)
 
 export type TooltipV2RootProps = ExtractPropTypes<typeof tooltipV2RootProps>
+export type TooltipV2RootPropsPublic = __ExtractPublicPropTypes<
+  typeof tooltipV2RootProps
+>

--- a/packages/components/tooltip-v2/src/tooltip.ts
+++ b/packages/components/tooltip-v2/src/tooltip.ts
@@ -4,7 +4,11 @@ import { tooltipV2TriggerProps } from './trigger'
 import { tooltipV2ArrowProps } from './arrow'
 import { tooltipV2ContentProps } from './content'
 
-import type { ExtractPropTypes, TransitionProps } from 'vue'
+import type {
+  ExtractPropTypes,
+  TransitionProps,
+  __ExtractPublicPropTypes,
+} from 'vue'
 
 export const tooltipV2Props = buildProps({
   ...tooltipV2RootProps,
@@ -25,3 +29,6 @@ export const tooltipV2Props = buildProps({
 } as const)
 
 export type TooltipV2Props = ExtractPropTypes<typeof tooltipV2Props>
+export type TooltipV2PropsPublic = __ExtractPublicPropTypes<
+  typeof tooltipV2Props
+>

--- a/packages/components/tooltip-v2/src/trigger.ts
+++ b/packages/components/tooltip-v2/src/trigger.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 const EventHandler = {
   type: definePropType<(e: Event) => boolean | void>(Function),
@@ -16,5 +16,9 @@ export const tooltipV2TriggerProps = buildProps({
 } as const)
 
 export type TooltipV2TriggerProps = ExtractPropTypes<
+  typeof tooltipV2TriggerProps
+>
+
+export type TooltipV2TriggerPropsPublic = __ExtractPublicPropTypes<
   typeof tooltipV2TriggerProps
 >

--- a/packages/components/tooltip/src/content.ts
+++ b/packages/components/tooltip/src/content.ts
@@ -4,7 +4,7 @@ import { useAriaProps, useDelayedToggleProps } from '@element-plus/hooks'
 import { teleportProps } from '@element-plus/components/teleport'
 
 import type TooltipContent from './content.vue'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const useTooltipContentProps = buildProps({
   ...useDelayedToggleProps,
@@ -60,6 +60,9 @@ export const useTooltipContentProps = buildProps({
 } as const)
 
 export type ElTooltipContentProps = ExtractPropTypes<
+  typeof useTooltipContentProps
+>
+export type ElTooltipContentPropsPublic = __ExtractPublicPropTypes<
   typeof useTooltipContentProps
 >
 

--- a/packages/components/tooltip/src/tooltip.ts
+++ b/packages/components/tooltip/src/tooltip.ts
@@ -5,7 +5,7 @@ import { useTooltipContentProps } from './content'
 import { useTooltipTriggerProps } from './trigger'
 
 import type Tooltip from './tooltip.vue'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const {
   useModelToggleProps: useTooltipModelToggleProps,
@@ -39,5 +39,8 @@ export const tooltipEmits = [
 ]
 
 export type ElTooltipProps = ExtractPropTypes<typeof useTooltipProps>
+export type ElTooltipPropsPublic = __ExtractPublicPropTypes<
+  typeof useTooltipProps
+>
 
 export type TooltipInstance = InstanceType<typeof Tooltip> & unknown

--- a/packages/components/tooltip/src/trigger.ts
+++ b/packages/components/tooltip/src/trigger.ts
@@ -3,7 +3,7 @@ import { popperTriggerProps } from '@element-plus/components/popper'
 import { EVENT_CODE } from '@element-plus/constants'
 
 import type { Arrayable } from '@element-plus/utils'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export type TooltipTriggerType = 'hover' | 'focus' | 'click' | 'contextmenu'
 
@@ -30,5 +30,9 @@ export const useTooltipTriggerProps = buildProps({
 } as const)
 
 export type ElTooltipTriggerProps = ExtractPropTypes<
+  typeof useTooltipTriggerProps
+>
+
+export type ElTooltipTriggerPropsPublic = __ExtractPublicPropTypes<
   typeof useTooltipTriggerProps
 >

--- a/packages/components/tour/src/content.ts
+++ b/packages/components/tour/src/content.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { Placement, Strategy, VirtualElement } from '@floating-ui/dom'
 
 export const tourStrategies = ['absolute', 'fixed'] as const
@@ -65,6 +65,9 @@ export const tourContentProps = buildProps({
 })
 
 export type TourContentProps = ExtractPropTypes<typeof tourContentProps>
+export type TourContentPropsPublic = __ExtractPublicPropTypes<
+  typeof tourContentProps
+>
 
 export const tourContentEmits = {
   close: () => true,

--- a/packages/components/tour/src/mask.ts
+++ b/packages/components/tour/src/mask.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { PosInfo } from './types'
 
 export const maskProps = buildProps({
@@ -38,3 +38,4 @@ export const maskProps = buildProps({
 })
 
 export type MaskProps = ExtractPropTypes<typeof maskProps>
+export type MaskPropsPublic = __ExtractPublicPropTypes<typeof maskProps>

--- a/packages/components/tour/src/step.ts
+++ b/packages/components/tour/src/step.ts
@@ -1,7 +1,11 @@
 import { buildProps, definePropType, iconPropType } from '@element-plus/utils'
 import { tourContentProps } from './content'
 
-import type { CSSProperties, ExtractPropTypes } from 'vue'
+import type {
+  CSSProperties,
+  ExtractPropTypes,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type { TourBtnProps, TourMask } from './types'
 
 export const tourStepProps = buildProps({
@@ -86,6 +90,7 @@ export const tourStepProps = buildProps({
 })
 
 export type TourStepProps = ExtractPropTypes<typeof tourStepProps>
+export type TourStepPropsPublic = __ExtractPublicPropTypes<typeof tourStepProps>
 
 export const tourStepEmits = {
   close: () => true,

--- a/packages/components/tour/src/tour.ts
+++ b/packages/components/tour/src/tour.ts
@@ -9,7 +9,11 @@ import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { teleportProps } from '@element-plus/components/teleport'
 import { tourContentProps } from './content'
 
-import type { CSSProperties, ExtractPropTypes } from 'vue'
+import type {
+  CSSProperties,
+  ExtractPropTypes,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type Tour from './tour.vue'
 import type { TourGap, TourMask } from './types'
 
@@ -117,6 +121,7 @@ export const tourProps = buildProps({
 })
 
 export type TourProps = ExtractPropTypes<typeof tourProps>
+export type TourPropsPublic = __ExtractPublicPropTypes<typeof tourProps>
 export type TourInstance = InstanceType<typeof Tour> & unknown
 
 export const tourEmits = {

--- a/packages/components/transfer/src/transfer-panel.ts
+++ b/packages/components/transfer/src/transfer-panel.ts
@@ -1,7 +1,7 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 import { transferCheckedChangeFn, transferProps } from './transfer'
 
-import type { ExtractPropTypes, VNode } from 'vue'
+import type { ExtractPropTypes, VNode, __ExtractPublicPropTypes } from 'vue'
 import type { TransferDataItem, TransferKey } from './transfer'
 import type TransferPanel from './transfer-panel.vue'
 
@@ -30,6 +30,9 @@ export const transferPanelProps = buildProps({
   props: transferProps.props,
 } as const)
 export type TransferPanelProps = ExtractPropTypes<typeof transferPanelProps>
+export type TransferPanelPropsPublic = __ExtractPublicPropTypes<
+  typeof transferPanelProps
+>
 
 export const transferPanelEmits = {
   [CHECKED_CHANGE_EVENT]: transferCheckedChangeFn,

--- a/packages/components/transfer/src/transfer.ts
+++ b/packages/components/transfer/src/transfer.ts
@@ -7,7 +7,12 @@ import {
 } from '@element-plus/utils'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
-import type { ExtractPropTypes, h as H, VNode } from 'vue'
+import type {
+  ExtractPropTypes,
+  h as H,
+  VNode,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type Transfer from './transfer.vue'
 
 export type TransferKey = string | number
@@ -140,6 +145,7 @@ export const transferProps = buildProps({
   },
 } as const)
 export type TransferProps = ExtractPropTypes<typeof transferProps>
+export type TransferPropsPublic = __ExtractPublicPropTypes<typeof transferProps>
 
 export const transferCheckedChangeFn = (
   value: TransferKey[],

--- a/packages/components/tree-v2/src/types.ts
+++ b/packages/components/tree-v2/src/types.ts
@@ -2,6 +2,7 @@ import type {
   ComponentInternalInstance,
   ExtractPropTypes,
   SetupContext,
+  __ExtractPublicPropTypes,
 } from 'vue'
 import type { treeEmits, treeProps } from './virtual-tree'
 
@@ -23,6 +24,7 @@ export interface TreeOptionProps {
 }
 
 export type TreeProps = ExtractPropTypes<typeof treeProps>
+export type TreePropsPublic = __ExtractPublicPropTypes<typeof treeProps>
 
 export interface TreeNode {
   key: TreeKey

--- a/packages/components/upload/src/upload-content.ts
+++ b/packages/components/upload/src/upload-content.ts
@@ -1,7 +1,7 @@
 import { NOOP, buildProps, definePropType } from '@element-plus/utils'
 import { uploadBaseProps } from './upload'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type {
   UploadFile,
   UploadHooks,
@@ -53,5 +53,8 @@ export const uploadContentProps = buildProps({
 } as const)
 
 export type UploadContentProps = ExtractPropTypes<typeof uploadContentProps>
+export type UploadContentPropsPublic = __ExtractPublicPropTypes<
+  typeof uploadContentProps
+>
 
 export type UploadContentInstance = InstanceType<typeof UploadContent> & unknown

--- a/packages/components/upload/src/upload-dragger.ts
+++ b/packages/components/upload/src/upload-dragger.ts
@@ -1,6 +1,6 @@
 import { buildProps, isArray } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type UploadDragger from './upload-dragger.vue'
 
 export const uploadDraggerProps = buildProps({
@@ -10,6 +10,9 @@ export const uploadDraggerProps = buildProps({
   },
 } as const)
 export type UploadDraggerProps = ExtractPropTypes<typeof uploadDraggerProps>
+export type UploadDraggerPropsPublic = __ExtractPublicPropTypes<
+  typeof uploadDraggerProps
+>
 
 export const uploadDraggerEmits = {
   file: (file: File[]) => isArray(file),

--- a/packages/components/upload/src/upload-list.ts
+++ b/packages/components/upload/src/upload-list.ts
@@ -1,7 +1,7 @@
 import { NOOP, buildProps, definePropType, mutable } from '@element-plus/utils'
 import { uploadListTypes } from './upload'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { UploadFile, UploadFiles, UploadHooks } from './upload'
 import type UploadList from './upload-list.vue'
 
@@ -32,6 +32,9 @@ export const uploadListProps = buildProps({
 } as const)
 
 export type UploadListProps = ExtractPropTypes<typeof uploadListProps>
+export type UploadListPropsPublic = __ExtractPublicPropTypes<
+  typeof uploadListProps
+>
 export const uploadListEmits = {
   remove: (file: UploadFile) => !!file,
 }

--- a/packages/components/upload/src/upload.ts
+++ b/packages/components/upload/src/upload.ts
@@ -3,7 +3,7 @@ import { ajaxUpload } from './ajax'
 
 import type { Awaitable, Mutable } from '@element-plus/utils'
 import type { UploadAjaxError } from './ajax'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Upload from './upload.vue'
 
 export const uploadListTypes = ['text', 'picture', 'picture-card'] as const
@@ -256,5 +256,6 @@ export const uploadProps = buildProps({
 } as const)
 
 export type UploadProps = ExtractPropTypes<typeof uploadProps>
+export type UploadPropsPublic = __ExtractPublicPropTypes<typeof uploadProps>
 
 export type UploadInstance = InstanceType<typeof Upload> & unknown

--- a/packages/components/virtual-list/src/props.ts
+++ b/packages/components/virtual-list/src/props.ts
@@ -6,7 +6,11 @@ import {
 } from '@element-plus/utils'
 import { VERTICAL } from './defaults'
 
-import type { ExtractPropTypes, StyleValue } from 'vue'
+import type {
+  ExtractPropTypes,
+  StyleValue,
+  __ExtractPublicPropTypes,
+} from 'vue'
 import type { GridItemKeyGetter, ItemSize } from './types'
 
 const itemSize = buildProp({
@@ -187,9 +191,21 @@ export const virtualizedScrollbarProps = buildProps({
 } as const)
 
 export type VirtualizedProps = ExtractPropTypes<typeof virtualizedProps>
+export type VirtualizedPropsPublic = __ExtractPublicPropTypes<
+  typeof virtualizedProps
+>
 export type VirtualizedListProps = ExtractPropTypes<typeof virtualizedListProps>
+export type VirtualizedListPropsPublic = __ExtractPublicPropTypes<
+  typeof virtualizedListProps
+>
 export type VirtualizedGridProps = ExtractPropTypes<typeof virtualizedGridProps>
+export type VirtualizedGridPropsPublic = __ExtractPublicPropTypes<
+  typeof virtualizedGridProps
+>
 
 export type VirtualizedScrollbarProps = ExtractPropTypes<
+  typeof virtualizedScrollbarProps
+>
+export type VirtualizedScrollbarPropsPublic = __ExtractPublicPropTypes<
   typeof virtualizedScrollbarProps
 >

--- a/packages/components/watermark/src/watermark.ts
+++ b/packages/components/watermark/src/watermark.ts
@@ -1,6 +1,6 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Watermark from './watermark.vue'
 
 export interface WatermarkFontType {
@@ -75,4 +75,7 @@ export const watermarkProps = buildProps({
 } as const)
 
 export type WatermarkProps = ExtractPropTypes<typeof watermarkProps>
+export type WatermarkPropsPublic = __ExtractPublicPropTypes<
+  typeof watermarkProps
+>
 export type WatermarkInstance = InstanceType<typeof Watermark> & unknown

--- a/packages/hooks/use-model-toggle/index.ts
+++ b/packages/hooks/use-model-toggle/index.ts
@@ -9,7 +9,12 @@ import {
 
 import type { ExtractPropType } from '@element-plus/utils'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
-import type { ComponentPublicInstance, ExtractPropTypes, Ref } from 'vue'
+import type {
+  ComponentPublicInstance,
+  ExtractPropTypes,
+  Ref,
+  __ExtractPublicPropTypes,
+} from 'vue'
 
 const _prop = buildProp({
   type: definePropType<boolean | null>(Boolean),
@@ -192,6 +197,9 @@ const { useModelToggle, useModelToggleProps, useModelToggleEmits } =
 export { useModelToggle, useModelToggleEmits, useModelToggleProps }
 
 export type UseModelToggleProps = ExtractPropTypes<typeof useModelToggleProps>
+export type UseModelTogglePropsPublic = __ExtractPublicPropTypes<
+  typeof useModelToggleProps
+>
 
 export type ModelToggleParams = {
   indicator: Ref<boolean>

--- a/packages/utils/__tests__/vue/props.test.ts
+++ b/packages/utils/__tests__/vue/props.test.ts
@@ -20,7 +20,7 @@ import type {
   WritableArray,
   epPropKey,
 } from '../..'
-import type { ExtractPropTypes, PropType } from 'vue'
+import type { ExtractPropTypes, PropType, __ExtractPublicPropTypes } from 'vue'
 
 describe('Types', () => {
   it('Writable', () => {
@@ -380,6 +380,21 @@ describe('buildProp', () => {
     expectTypeOf<Extracted>().toEqualTypeOf<{
       readonly key1: string
       readonly key2: string | number
+    }>()
+  })
+
+  it('extract public', () => {
+    const props = {
+      key1: buildProp({
+        type: String,
+        default: 'value',
+      }),
+    } as const
+
+    type ExtractedPublic = __ExtractPublicPropTypes<typeof props>
+
+    expectTypeOf<ExtractedPublic>().toEqualTypeOf<{
+      readonly key1?: string | undefined
     }>()
   })
 })

--- a/packages/utils/vue/props/util.ts
+++ b/packages/utils/vue/props/util.ts
@@ -9,9 +9,8 @@ export type IfUnknown<T, Y, N> = [unknown] extends [T] ? Y : N
 
 export type UnknownToNever<T> = IfUnknown<T, never, T>
 
-// ExtractPublicPropTypes copy from vue 3.3
 // delete when upgrade to vue 3.3 : start
-
+// __ExtractPublicPropTypes copy from vue 3.3
 // If the type T accepts type "any", output type Y, otherwise output type N.
 // https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
 export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
@@ -53,12 +52,12 @@ type PublicOptionalKeys<T> = Exclude<keyof T, PublicRequiredKeys<T>>
  */
 
 declare module 'vue' {
-  export type ExtractPublicPropTypes<O> = {
+  // compatible with higher versions of Vue
+  export type __ExtractPublicPropTypes<O> = {
     [K in keyof Pick<O, PublicRequiredKeys<O>>]: InferPropType<O[K]>
   } & {
     [K in keyof Pick<O, PublicOptionalKeys<O>>]?: InferPropType<O[K]>
   }
 }
 // delete when upgrade to vue 3.3 : end
-
 export {}

--- a/packages/utils/vue/props/util.ts
+++ b/packages/utils/vue/props/util.ts
@@ -1,3 +1,5 @@
+import { Prop } from 'vue'
+
 export type Writable<T> = { -readonly [P in keyof T]: T[P] }
 export type WritableArray<T> = T extends readonly any[] ? Writable<T> : T
 
@@ -6,5 +8,57 @@ export type IfNever<T, Y = true, N = false> = [T] extends [never] ? Y : N
 export type IfUnknown<T, Y, N> = [unknown] extends [T] ? Y : N
 
 export type UnknownToNever<T> = IfUnknown<T, never, T>
+
+// ExtractPublicPropTypes copy from vue 3.3
+// delete when upgrade to vue 3.3 : start
+
+// If the type T accepts type "any", output type Y, otherwise output type N.
+// https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
+export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
+
+type InferPropType<T, NullAsAny = true> = [T] extends [null]
+  ? NullAsAny extends true
+    ? any
+    : null
+  : [T] extends [{ type: null | true }]
+  ? any // As TS issue https://github.com/Microsoft/TypeScript/issues/14829 // somehow `ObjectConstructor` when inferred from { (): T } becomes `any` // `BooleanConstructor` when inferred from PropConstructor(with PropMethod) becomes `Boolean`
+  : [T] extends [ObjectConstructor | { type: ObjectConstructor }]
+  ? Record<string, any>
+  : [T] extends [BooleanConstructor | { type: BooleanConstructor }]
+  ? boolean
+  : [T] extends [DateConstructor | { type: DateConstructor }]
+  ? Date
+  : [T] extends [(infer U)[] | { type: (infer U)[] }]
+  ? U extends DateConstructor
+    ? Date | InferPropType<U, false>
+    : InferPropType<U, false>
+  : [T] extends [Prop<infer V, infer D>]
+  ? unknown extends V
+    ? keyof V extends never
+      ? IfAny<V, V, D>
+      : V
+    : V
+  : T
+
+type PublicRequiredKeys<T> = {
+  [K in keyof T]: T[K] extends { required: true } ? K : never
+}[keyof T]
+
+type PublicOptionalKeys<T> = Exclude<keyof T, PublicRequiredKeys<T>>
+
+/**
+ * Extract prop types from a runtime props options object.
+ * The extracted types are **public** - i.e. the expected props that can be
+ * passed to component.
+ */
+
+declare module 'vue' {
+  export type ExtractPublicPropTypes<O> = {
+    [K in keyof Pick<O, PublicRequiredKeys<O>>]: InferPropType<O[K]>
+  } & {
+    [K in keyof Pick<O, PublicOptionalKeys<O>>]?: InferPropType<O[K]>
+  }
+}
+// delete when upgrade to vue 3.3 : end
 
 export {}

--- a/packages/utils/vue/props/util.ts
+++ b/packages/utils/vue/props/util.ts
@@ -1,4 +1,4 @@
-import { Prop } from 'vue'
+import type { Prop } from 'vue'
 
 export type Writable<T> = { -readonly [P in keyof T]: T[P] }
 export type WritableArray<T> = T extends readonly any[] ? Writable<T> : T

--- a/scripts/gc.sh
+++ b/scripts/gc.sh
@@ -51,10 +51,11 @@ EOF
 cat > $DIRNAME/src/$INPUT_NAME.ts <<EOF
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const ${PROP_NAME}Props = buildProps({} as const)
 export type ${NAME}Props = ExtractPropTypes<typeof ${PROP_NAME}Props>
+export type ${NAME}PropsPublic = __ExtractPublicPropTypes<typeof ${PROP_NAME}Props>
 
 export const ${PROP_NAME}Emits = {}
 export type ${NAME}Emits = typeof ${PROP_NAME}Emits


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


组件的`props类型`有两种，一种组件内部使用，一种暴露给外部声明使用
![image](https://github.com/user-attachments/assets/af55d907-229c-4341-9d22-62eacbed2809)
![image](https://github.com/user-attachments/assets/dcf7c1d1-1779-4fc8-8c68-e432e4d6c0ac)

给所有组件新增public props，供外部使用

由于当前库Vue版本3.2，缺少`ExtractPublicPropTypes`同时为了兼容高版本Vue，临时使用`__ExtractPublicPropTypes`替代。
等Vue依赖升级后可以删除这部分代码，并全局替换`__ExtractPublicPropTypes`->`ExtractPublicPropTypes`。

代码变动：
- 所有组件增加 public props
- packages/utils/vue/props/util.ts 引入__ExtractPublicPropTypes
- 模板调整