### PR TITLE
fix(components): [message-box] Prevent event propagation when the Ent…

### DIFF
--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -101,7 +101,7 @@
                   :placeholder="inputPlaceholder"
                   :aria-invalid="validateError"
                   :class="{ invalid: validateError }"
-                  @keydown.enter="handleInputEnter"
+                  @keydown.prevent.enter="handleInputEnter"
                 />
                 <div
                   :class="ns.e('errormsg')"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

message-box 里面其他的enter事件都加了prevent，但是el-input的enter没加，导致enter触发的时候冒泡到组件外面，才导致了bug

#21228 
