### PR TITLE
docs: select use minimum base examples & delete input tip

### DIFF
--- a/docs/en-US/component/input.md
+++ b/docs/en-US/component/input.md
@@ -7,16 +7,6 @@ lang: en-US
 
 Input data using mouse or keyboard.
 
-:::warning
-
-Input is a controlled component, it **always shows Vue binding value**.
-
-Under normal circumstances, `input` event should be handled. Its handler should update component's binding value (or use `v-model`). Otherwise, input box's value will not change.
-
-Do not support `v-model` modifiers.
-
-:::
-
 ## Basic usage
 
 :::demo

--- a/docs/en-US/component/select-v2.md
+++ b/docs/en-US/component/select-v2.md
@@ -37,6 +37,14 @@ select-v2/multiple
 
 :::
 
+## Sizes
+
+:::demo Add `size` attribute to change the size of Select-V2. In addition to the default size, there are two other options: `large`, `small`.
+
+select-v2/size
+
+:::
+
 ## Hide extra tags when the selected items are too many
 
 You can collapse tags to a text by using `collapse-tags` attribute. You can check them when mouse hover collapse text by using `collapse-tags-tooltip` attribute.

--- a/docs/en-US/component/select.md
+++ b/docs/en-US/component/select.md
@@ -49,6 +49,14 @@ select/clearable
 
 :::
 
+## Sizes
+
+:::demo Add `size` attribute to change the size of Select. In addition to the default size, there are two other options: `large`, `small`.
+
+select/size
+
+:::
+
 ## Basic multiple select
 
 Multiple select uses tags to display selected options.

--- a/docs/examples/select-v2/basic-usage.vue
+++ b/docs/examples/select-v2/basic-usage.vue
@@ -1,26 +1,10 @@
 <template>
-  <div class="flex flex-wrap gap-4 items-center">
-    <el-select-v2
-      v-model="value"
-      :options="options"
-      placeholder="Please select"
-      size="large"
-      style="width: 240px"
-    />
-    <el-select-v2
-      v-model="value"
-      :options="options"
-      placeholder="Please select"
-      style="width: 240px"
-    />
-    <el-select-v2
-      v-model="value"
-      :options="options"
-      placeholder="Please select"
-      size="small"
-      style="width: 240px"
-    />
-  </div>
+  <el-select-v2
+    v-model="value"
+    :options="options"
+    placeholder="Please select"
+    style="width: 240px"
+  />
 </template>
 
 <script lang="ts" setup>
@@ -34,9 +18,3 @@ const options = Array.from({ length: 1000 }).map((_, idx) => ({
   label: `${initials[idx % 10]}${idx}`,
 }))
 </script>
-
-<style scoped>
-.example-showcase .el-select-v2 {
-  margin-right: 20px;
-}
-</style>

--- a/docs/examples/select-v2/size.vue
+++ b/docs/examples/select-v2/size.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="flex flex-wrap gap-4 items-center">
+    <el-select-v2
+      v-model="value"
+      :options="options"
+      placeholder="Please select"
+      size="large"
+      style="width: 240px"
+    />
+    <el-select-v2
+      v-model="value"
+      :options="options"
+      placeholder="Please select"
+      style="width: 240px"
+    />
+    <el-select-v2
+      v-model="value"
+      :options="options"
+      placeholder="Please select"
+      size="small"
+      style="width: 240px"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+const initials = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
+
+const value = ref()
+const options = Array.from({ length: 1000 }).map((_, idx) => ({
+  value: `Option ${idx + 1}`,
+  label: `${initials[idx % 10]}${idx}`,
+}))
+</script>
+
+<style scoped>
+.example-showcase .el-select-v2 {
+  margin-right: 20px;
+}
+</style>

--- a/docs/examples/select/basic-usage.vue
+++ b/docs/examples/select/basic-usage.vue
@@ -1,40 +1,12 @@
 <template>
-  <div class="flex flex-wrap gap-4 items-center">
-    <el-select
-      v-model="value"
-      placeholder="Select"
-      size="large"
-      style="width: 240px"
-    >
-      <el-option
-        v-for="item in options"
-        :key="item.value"
-        :label="item.label"
-        :value="item.value"
-      />
-    </el-select>
-    <el-select v-model="value" placeholder="Select" style="width: 240px">
-      <el-option
-        v-for="item in options"
-        :key="item.value"
-        :label="item.label"
-        :value="item.value"
-      />
-    </el-select>
-    <el-select
-      v-model="value"
-      placeholder="Select"
-      size="small"
-      style="width: 240px"
-    >
-      <el-option
-        v-for="item in options"
-        :key="item.value"
-        :label="item.label"
-        :value="item.value"
-      />
-    </el-select>
-  </div>
+  <el-select v-model="value" placeholder="Select" style="width: 240px">
+    <el-option
+      v-for="item in options"
+      :key="item.value"
+      :label="item.label"
+      :value="item.value"
+    />
+  </el-select>
 </template>
 
 <script lang="ts" setup>

--- a/docs/examples/select/size.vue
+++ b/docs/examples/select/size.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="flex flex-wrap gap-4 items-center">
+    <el-select
+      v-model="value"
+      placeholder="Select"
+      size="large"
+      style="width: 240px"
+    >
+      <el-option
+        v-for="item in options"
+        :key="item.value"
+        :label="item.label"
+        :value="item.value"
+      />
+    </el-select>
+    <el-select v-model="value" placeholder="Select" style="width: 240px">
+      <el-option
+        v-for="item in options"
+        :key="item.value"
+        :label="item.label"
+        :value="item.value"
+      />
+    </el-select>
+    <el-select
+      v-model="value"
+      placeholder="Select"
+      size="small"
+      style="width: 240px"
+    >
+      <el-option
+        v-for="item in options"
+        :key="item.value"
+        :label="item.label"
+        :value="item.value"
+      />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+const value = ref('')
+
+const options = [
+  {
+    value: 'Option1',
+    label: 'Option1',
+  },
+  {
+    value: 'Option2',
+    label: 'Option2',
+  },
+  {
+    value: 'Option3',
+    label: 'Option3',
+  },
+  {
+    value: 'Option4',
+    label: 'Option4',
+  },
+  {
+    value: 'Option5',
+    label: 'Option5',
+  },
+]
+</script>


### PR DESCRIPTION
- select、select-v2 use minimum base examples.
  - _Because it is a commonly used component, it is changed to facilitate user use, [refer to input](https://element-plus.org/en-US/component/input.html#basic-usage)._ 
- delete input warning tip.
  - _This is the most basic usage of vue, I think it can be deleted._ 


| -        | Before | After |
| ------ | ------- | ----- |
| select、select-v2        |     ![image](https://github.com/user-attachments/assets/328fc888-aa00-452e-ad03-15d2f14a1325)  |     ![image](https://github.com/user-attachments/assets/d29f8121-1985-4d7e-b14b-92816561eebe)     |
|  input tip | ![image](https://github.com/user-attachments/assets/bcf32376-d1af-4a94-b754-3f03c177ccbe)  | ![image](https://github.com/user-attachments/assets/8be4bbe2-5831-41c6-a66b-7f0552bfd83b) |

