### PR TITLE
fix(types): [other] cannot find declare module types from installed packages

### DIFF
--- a/internal/build/src/tasks/types-definitions.ts
+++ b/internal/build/src/tasks/types-definitions.ts
@@ -71,7 +71,7 @@ export const generateTypesDefinitions = async () => {
 
   // delete when upgrade to vue 3.3
   // insert import statement at the beginning of the file
-  formattedText = `import "./utils/vue/props/util";\n${formattedText}`
+  formattedText = `import "./utils/vue3.3.polyfill";\n${formattedText}`
 
   await writeFile(entryFilePath, formattedText, 'utf8')
 

--- a/internal/build/src/tasks/types-definitions.ts
+++ b/internal/build/src/tasks/types-definitions.ts
@@ -67,7 +67,11 @@ export const generateTypesDefinitions = async () => {
   )
 
   const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed })
-  const formattedText = printer.printFile(sourceFile)
+  let formattedText = printer.printFile(sourceFile)
+
+  // delete when upgrade to vue 3.3
+  // insert import statement at the beginning of the file
+  formattedText = `import "./utils/vue/props/util";\n${formattedText}`
 
   await writeFile(entryFilePath, formattedText, 'utf8')
 

--- a/packages/utils/vue/props/util.ts
+++ b/packages/utils/vue/props/util.ts
@@ -1,5 +1,3 @@
-import type { Prop } from 'vue'
-
 export type Writable<T> = { -readonly [P in keyof T]: T[P] }
 export type WritableArray<T> = T extends readonly any[] ? Writable<T> : T
 
@@ -9,54 +7,4 @@ export type IfUnknown<T, Y, N> = [unknown] extends [T] ? Y : N
 
 export type UnknownToNever<T> = IfUnknown<T, never, T>
 
-// delete when upgrade to vue 3.3 : start
-// __ExtractPublicPropTypes copy from vue 3.3
-// If the type T accepts type "any", output type Y, otherwise output type N.
-// https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
-export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
-
-type InferPropType<T, NullAsAny = true> = [T] extends [null]
-  ? NullAsAny extends true
-    ? any
-    : null
-  : [T] extends [{ type: null | true }]
-  ? any // As TS issue https://github.com/Microsoft/TypeScript/issues/14829 // somehow `ObjectConstructor` when inferred from { (): T } becomes `any` // `BooleanConstructor` when inferred from PropConstructor(with PropMethod) becomes `Boolean`
-  : [T] extends [ObjectConstructor | { type: ObjectConstructor }]
-  ? Record<string, any>
-  : [T] extends [BooleanConstructor | { type: BooleanConstructor }]
-  ? boolean
-  : [T] extends [DateConstructor | { type: DateConstructor }]
-  ? Date
-  : [T] extends [(infer U)[] | { type: (infer U)[] }]
-  ? U extends DateConstructor
-    ? Date | InferPropType<U, false>
-    : InferPropType<U, false>
-  : [T] extends [Prop<infer V, infer D>]
-  ? unknown extends V
-    ? keyof V extends never
-      ? IfAny<V, V, D>
-      : V
-    : V
-  : T
-
-type PublicRequiredKeys<T> = {
-  [K in keyof T]: T[K] extends { required: true } ? K : never
-}[keyof T]
-
-type PublicOptionalKeys<T> = Exclude<keyof T, PublicRequiredKeys<T>>
-
-declare module 'vue' {
-  // compatible with higher versions of Vue
-  /**
-   * Extract prop types from a runtime props options object.
-   * The extracted types are **public** - i.e. the expected props that can be
-   * passed to component.
-   */
-  export type __ExtractPublicPropTypes<O> = {
-    [K in keyof Pick<O, PublicRequiredKeys<O>>]: InferPropType<O[K]>
-  } & {
-    [K in keyof Pick<O, PublicOptionalKeys<O>>]?: InferPropType<O[K]>
-  }
-}
-// delete when upgrade to vue 3.3 : end
 export {}

--- a/packages/utils/vue/props/util.ts
+++ b/packages/utils/vue/props/util.ts
@@ -45,14 +45,13 @@ type PublicRequiredKeys<T> = {
 
 type PublicOptionalKeys<T> = Exclude<keyof T, PublicRequiredKeys<T>>
 
-/**
- * Extract prop types from a runtime props options object.
- * The extracted types are **public** - i.e. the expected props that can be
- * passed to component.
- */
-
 declare module 'vue' {
   // compatible with higher versions of Vue
+  /**
+   * Extract prop types from a runtime props options object.
+   * The extracted types are **public** - i.e. the expected props that can be
+   * passed to component.
+   */
   export type __ExtractPublicPropTypes<O> = {
     [K in keyof Pick<O, PublicRequiredKeys<O>>]: InferPropType<O[K]>
   } & {

--- a/packages/utils/vue3.3.polyfill.ts
+++ b/packages/utils/vue3.3.polyfill.ts
@@ -1,0 +1,51 @@
+import type { Prop } from 'vue'
+// delete when upgrade to vue 3.3 : start
+// __ExtractPublicPropTypes copy from vue 3.3
+// If the type T accepts type "any", output type Y, otherwise output type N.
+// https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
+type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
+
+type InferPropType<T, NullAsAny = true> = [T] extends [null]
+  ? NullAsAny extends true
+    ? any
+    : null
+  : [T] extends [{ type: null | true }]
+  ? any // As TS issue https://github.com/Microsoft/TypeScript/issues/14829 // somehow `ObjectConstructor` when inferred from { (): T } becomes `any` // `BooleanConstructor` when inferred from PropConstructor(with PropMethod) becomes `Boolean`
+  : [T] extends [ObjectConstructor | { type: ObjectConstructor }]
+  ? Record<string, any>
+  : [T] extends [BooleanConstructor | { type: BooleanConstructor }]
+  ? boolean
+  : [T] extends [DateConstructor | { type: DateConstructor }]
+  ? Date
+  : [T] extends [(infer U)[] | { type: (infer U)[] }]
+  ? U extends DateConstructor
+    ? Date | InferPropType<U, false>
+    : InferPropType<U, false>
+  : [T] extends [Prop<infer V, infer D>]
+  ? unknown extends V
+    ? keyof V extends never
+      ? IfAny<V, V, D>
+      : V
+    : V
+  : T
+
+type PublicRequiredKeys<T> = {
+  [K in keyof T]: T[K] extends { required: true } ? K : never
+}[keyof T]
+
+type PublicOptionalKeys<T> = Exclude<keyof T, PublicRequiredKeys<T>>
+
+declare module 'vue' {
+  // compatible with higher versions of Vue
+  /**
+   * Extract prop types from a runtime props options object.
+   * The extracted types are **public** - i.e. the expected props that can be
+   * passed to component.
+   */
+  export type __ExtractPublicPropTypes<O> = {
+    [K in keyof Pick<O, PublicRequiredKeys<O>>]: InferPropType<O[K]>
+  } & {
+    [K in keyof Pick<O, PublicOptionalKeys<O>>]?: InferPropType<O[K]>
+  }
+}
+// delete when upgrade to vue 3.3 : end

--- a/tsconfig.play.json
+++ b/tsconfig.play.json
@@ -5,6 +5,7 @@
     "lib": ["ESNext", "DOM", "DOM.Iterable"]
   },
   "include": [
+    "packages/utils/vue3.3.polyfill.ts",
     "packages",
     "typings/global.d.ts",
     "typings/env.d.ts",

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -6,6 +6,11 @@
     "types": ["node", "jsdom", "unplugin-vue-macros/macros-global"],
     "skipLibCheck": true
   },
-  "include": ["packages", "vitest.setup.ts", "typings/env.d.ts"],
+  "include": [
+    "packages/utils/vue3.3.polyfill.ts",
+    "packages",
+    "vitest.setup.ts",
+    "typings/env.d.ts"
+  ],
   "exclude": ["node_modules", "dist", "**/*.md"]
 }

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -7,7 +7,11 @@
     "types": ["unplugin-vue-macros/macros-global"],
     "skipLibCheck": true
   },
-  "include": ["packages", "typings/env.d.ts"],
+  "include": [
+    "packages/utils/vue3.3.polyfill.ts",
+    "packages",
+    "typings/env.d.ts"
+  ],
   "exclude": [
     "node_modules",
     "**/dist",


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


`@microsoft/api-extractor` breaks TypeScript's recognition of declare module 'vue'.
​**fix**:​​ Temporarily resolve this by manually importing it. 
 
Test it with pnpm, it's working now

A better fix may exist.
