### PR TITLE
feat(components): [input-number] change the min and max default value

### DIFF
--- a/docs/en-US/component/input-number.md
+++ b/docs/en-US/component/input-number.md
@@ -99,27 +99,27 @@ input-number/with-prefix-suffix
 
 ### Attributes
 
-| Name                        | Description                                      | Type                                          | Default   |
-| --------------------------- | ------------------------------------------------ | --------------------------------------------- | --------- |
-| model-value / v-model       | binding value                                    | ^[number] / ^[null]                           | —         |
-| min                         | the minimum allowed value                        | ^[number]                                     | -Infinity |
-| max                         | the maximum allowed value                        | ^[number]                                     | Infinity  |
-| step                        | incremental step                                 | ^[number]                                     | 1         |
-| step-strictly               | whether input value can only be multiple of step | ^[boolean]                                    | false     |
-| precision                   | precision of input value                         | ^[number]                                     | —         |
-| size                        | size of the component                            | ^[enum]`'large' \| 'default' \| 'small'`      | default   |
-| readonly ^(2.2.16)          | same as `readonly` in native input               | ^[boolean]                                    | false     |
-| disabled                    | whether the component is disabled                | ^[boolean]                                    | false     |
-| controls                    | whether to enable the control buttons            | ^[boolean]                                    | true      |
-| controls-position           | position of the control buttons                  | ^[enum]`'' \| 'right'`                        | —         |
-| name                        | same as `name` in native input                   | ^[string]                                     | —         |
-| aria-label ^(a11y) ^(2.7.2) | same as `aria-label` in native input             | ^[string]                                     | —         |
-| placeholder                 | same as `placeholder` in native input            | ^[string]                                     | —         |
-| id                          | same as `id` in native input                     | ^[string]                                     | —         |
-| value-on-clear ^(2.2.0)     | value should be set when input box is cleared    | ^[number] / ^[null] / ^[enum]`'min' \| 'max'` | —         |
-| validate-event              | whether to trigger form validation               | ^[boolean]                                    | true      |
-| label ^(a11y) ^(deprecated) | same as `aria-label` in native input             | ^[string]                                     | —         |
-| inputmode ^(2.10.3)         | same as `inputmode` in native input              | ^[string]                                     | —         |
+| Name                        | Description                                      | Type                                          | Default                 |
+| --------------------------- | ------------------------------------------------ | --------------------------------------------- | ----------------------- |
+| model-value / v-model       | binding value                                    | ^[number] / ^[null]                           | —                       |
+| min                         | the minimum allowed value                        | ^[number]                                     | Number.MAX_SAFE_INTEGER |
+| max                         | the maximum allowed value                        | ^[number]                                     | Number.MIN_SAFE_INTEGER |
+| step                        | incremental step                                 | ^[number]                                     | 1                       |
+| step-strictly               | whether input value can only be multiple of step | ^[boolean]                                    | false                   |
+| precision                   | precision of input value                         | ^[number]                                     | —                       |
+| size                        | size of the component                            | ^[enum]`'large' \| 'default' \| 'small'`      | default                 |
+| readonly ^(2.2.16)          | same as `readonly` in native input               | ^[boolean]                                    | false                   |
+| disabled                    | whether the component is disabled                | ^[boolean]                                    | false                   |
+| controls                    | whether to enable the control buttons            | ^[boolean]                                    | true                    |
+| controls-position           | position of the control buttons                  | ^[enum]`'' \| 'right'`                        | —                       |
+| name                        | same as `name` in native input                   | ^[string]                                     | —                       |
+| aria-label ^(a11y) ^(2.7.2) | same as `aria-label` in native input             | ^[string]                                     | —                       |
+| placeholder                 | same as `placeholder` in native input            | ^[string]                                     | —                       |
+| id                          | same as `id` in native input                     | ^[string]                                     | —                       |
+| value-on-clear ^(2.2.0)     | value should be set when input box is cleared    | ^[number] / ^[null] / ^[enum]`'min' \| 'max'` | —                       |
+| validate-event              | whether to trigger form validation               | ^[boolean]                                    | true                    |
+| label ^(a11y) ^(deprecated) | same as `aria-label` in native input             | ^[string]                                     | —                       |
+| inputmode ^(2.10.3)         | same as `inputmode` in native input              | ^[string]                                     | —                       |
 
 ### Slots
 

--- a/packages/components/input-number/src/input-number.ts
+++ b/packages/components/input-number/src/input-number.ts
@@ -38,14 +38,14 @@ export const inputNumberProps = buildProps({
    */
   max: {
     type: Number,
-    default: Number.POSITIVE_INFINITY,
+    default: Number.MAX_SAFE_INTEGER,
   },
   /**
    * @description the minimum allowed value
    */
   min: {
     type: Number,
-    default: Number.NEGATIVE_INFINITY,
+    default: Number.MIN_SAFE_INTEGER,
   },
   /**
    * @description binding value


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

![image](https://github.com/user-attachments/assets/66e2e4ff-9ed3-455a-b9a2-9c8e0dc7e563)

When the number exceeds `Number.MAX_SAFE_INTEGER`, further increasing it will produce unexpected results. Therefore, I think it is more reasonable to limit the default maximum value to `Number.MAX_SAFE_INTEGER`. The same is true for min.

Since this change has almost no impact on normal user usage, I don't think it needs to be included in the minor version.
