### PR TITLE
fix(components): [option] delete newly created option

### DIFF
--- a/packages/components/select/src/option.vue
+++ b/packages/components/select/src/option.vue
@@ -30,11 +30,7 @@ import { useId, useNamespace } from '@element-plus/hooks'
 import { useOption } from './useOption'
 import { COMPONENT_NAME, optionProps } from './option'
 
-import type {
-  OptionExposed,
-  OptionInternalInstance,
-  OptionStates,
-} from './type'
+import type { OptionExposed, OptionInternalInstance, OptionStates } from './type'
 
 export default defineComponent({
   name: COMPONENT_NAME,

--- a/packages/components/select/src/option.vue
+++ b/packages/components/select/src/option.vue
@@ -30,7 +30,11 @@ import { useId, useNamespace } from '@element-plus/hooks'
 import { useOption } from './useOption'
 import { COMPONENT_NAME, optionProps } from './option'
 
-import type { OptionExposed, OptionInternalInstance, OptionStates } from './type'
+import type {
+  OptionExposed,
+  OptionInternalInstance,
+  OptionStates,
+} from './type'
 
 export default defineComponent({
   name: COMPONENT_NAME,
@@ -73,12 +77,13 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       const key = vm.value
-      const { selected: selectedOptions } = select.states
-      const doesSelected = selectedOptions.some((item) => {
-        return item.value === vm.value
-      })
+
       // if option is not selected, remove it from cache
       nextTick(() => {
+        const { selected: selectedOptions } = select.states
+        const doesSelected = selectedOptions.some((item) => {
+          return item.value === vm.value
+        })
         if (select.states.cachedOptions.get(key) === vm && !doesSelected) {
           select.states.cachedOptions.delete(key)
         }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

This bug is caused by an async timing issue — onBeforeUnmount runs before the selected state updates, leading to the created option being removed from the cache incorrectly.

Fixes #21323