### PR TITLE
fix(components): [pagination] reset icon hover state when page changes

### DIFF
--- a/packages/components/pagination/__tests__/pagination.test.tsx
+++ b/packages/components/pagination/__tests__/pagination.test.tsx
@@ -245,14 +245,15 @@ describe('Pagination', () => {
     })
 
     test('test more icon', async () => {
-      const wrapper = mount(
+      const currentPage = ref(5)
+      const wrapper = mount(() => (
         <Pagination
+          v-model:current-page={currentPage.value}
           layout="pager"
           total={100}
           pageSize={10}
-          defaultCurrentPage={5}
         />
-      )
+      ))
 
       assertCurrent(wrapper, 5)
       expect(wrapper.find('.btn-quickprev').exists()).toBeTruthy()
@@ -260,13 +261,11 @@ describe('Pagination', () => {
       expect(wrapper.findComponent(DArrowLeft).exists()).toBeFalsy()
       expect(wrapper.findComponent(DArrowRight).exists()).toBeFalsy()
 
+      // quick prev
       const quickPrev = wrapper.find('.btn-quickprev')
-
-      // Trigger hover
       await quickPrev.trigger('mouseenter')
       expect(wrapper.findComponent(DArrowLeft).exists()).toBeTruthy()
 
-      // Trigger click
       await quickPrev.trigger('click')
       assertCurrent(wrapper, 1)
       expect(wrapper.find('.btn-quickprev').exists()).toBeFalsy()
@@ -276,13 +275,11 @@ describe('Pagination', () => {
       expect(wrapper.find('.btn-quickprev').exists()).toBeTruthy()
       expect(wrapper.findComponent(DArrowLeft).exists()).toBeFalsy()
 
+      // quick next
       const quickNext = wrapper.find('.btn-quicknext')
-
-      // Trigger hover
       await quickNext.trigger('mouseenter')
       expect(wrapper.findComponent(DArrowRight).exists()).toBeTruthy()
 
-      // Trigger click
       await quickNext.trigger('click')
       assertCurrent(wrapper, 10)
       expect(wrapper.find('.btn-quicknext').exists()).toBeFalsy()
@@ -291,6 +288,17 @@ describe('Pagination', () => {
       assertCurrent(wrapper, 5)
       expect(wrapper.find('.btn-quicknext').exists()).toBeTruthy()
       expect(wrapper.findComponent(DArrowRight).exists()).toBeFalsy()
+
+      // While hovering over the icon
+      // switching pages does not change the icon's display state or the position of the more button
+      await wrapper.find('.btn-quickprev').trigger('mouseenter')
+      expect(wrapper.findComponent(DArrowLeft).exists()).toBeTruthy()
+
+      currentPage.value = 6
+      await nextTick()
+      assertCurrent(wrapper, 6)
+      expect(wrapper.find('.btn-quickprev').exists()).toBeTruthy()
+      expect(wrapper.findComponent(DArrowLeft).exists()).toBeTruthy()
     })
 
     test('test pageCount change and side effect', async () => {

--- a/packages/components/pagination/__tests__/pagination.test.tsx
+++ b/packages/components/pagination/__tests__/pagination.test.tsx
@@ -1,7 +1,12 @@
 import { nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { CaretLeft, CaretRight } from '@element-plus/icons-vue'
+import {
+  CaretLeft,
+  CaretRight,
+  DArrowLeft,
+  DArrowRight,
+} from '@element-plus/icons-vue'
 import Pagination from '../src/pagination'
 import selectDropdownVue from '../../select/src/select-dropdown.vue'
 
@@ -237,6 +242,55 @@ describe('Pagination', () => {
       pageSize.value = 50
       await nextTick()
       assertCurrent(wrapper, 2)
+    })
+
+    test('test more icon', async () => {
+      const wrapper = mount(
+        <Pagination
+          layout="pager"
+          total={100}
+          pageSize={10}
+          defaultCurrentPage={5}
+        />
+      )
+
+      assertCurrent(wrapper, 5)
+      expect(wrapper.find('.btn-quickprev').exists()).toBeTruthy()
+      expect(wrapper.find('.btn-quicknext').exists()).toBeTruthy()
+      expect(wrapper.findComponent(DArrowLeft).exists()).toBeFalsy()
+      expect(wrapper.findComponent(DArrowRight).exists()).toBeFalsy()
+
+      const quickPrev = wrapper.find('.btn-quickprev')
+
+      // Trigger hover
+      await quickPrev.trigger('mouseenter')
+      expect(wrapper.findComponent(DArrowLeft).exists()).toBeTruthy()
+
+      // Trigger click
+      await quickPrev.trigger('click')
+      assertCurrent(wrapper, 1)
+      expect(wrapper.find('.btn-quickprev').exists()).toBeFalsy()
+
+      await wrapper.find('.el-pager li:nth-child(5)').trigger('click')
+      assertCurrent(wrapper, 5)
+      expect(wrapper.find('.btn-quickprev').exists()).toBeTruthy()
+      expect(wrapper.findComponent(DArrowLeft).exists()).toBeFalsy()
+
+      const quickNext = wrapper.find('.btn-quicknext')
+
+      // Trigger hover
+      await quickNext.trigger('mouseenter')
+      expect(wrapper.findComponent(DArrowRight).exists()).toBeTruthy()
+
+      // Trigger click
+      await quickNext.trigger('click')
+      assertCurrent(wrapper, 10)
+      expect(wrapper.find('.btn-quicknext').exists()).toBeFalsy()
+
+      await wrapper.find('.el-pager li:nth-child(3)').trigger('click')
+      assertCurrent(wrapper, 5)
+      expect(wrapper.find('.btn-quicknext').exists()).toBeTruthy()
+      expect(wrapper.findComponent(DArrowRight).exists()).toBeFalsy()
     })
 
     test('test pageCount change and side effect', async () => {

--- a/packages/components/pagination/src/components/pager.vue
+++ b/packages/components/pagination/src/components/pager.vue
@@ -147,6 +147,8 @@ watchEffect(() => {
   const halfPagerCount = (props.pagerCount - 1) / 2
   showPrevMore.value = false
   showNextMore.value = false
+  quickPrevHover.value = false
+  quickNextHover.value = false
   if (props.pageCount! > props.pagerCount) {
     if (props.currentPage > props.pagerCount - halfPagerCount) {
       showPrevMore.value = true

--- a/packages/components/pagination/src/components/pager.vue
+++ b/packages/components/pagination/src/components/pager.vue
@@ -70,7 +70,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watchEffect } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { DArrowLeft, DArrowRight, MoreFilled } from '@element-plus/icons-vue'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { CHANGE_EVENT } from '@element-plus/constants'
@@ -143,21 +143,29 @@ const nextMoreKls = computed(() => [
 ])
 
 const tabindex = computed(() => (props.disabled ? -1 : 0))
-watchEffect(() => {
-  const halfPagerCount = (props.pagerCount - 1) / 2
-  showPrevMore.value = false
-  showNextMore.value = false
-  quickPrevHover.value = false
-  quickNextHover.value = false
-  if (props.pageCount! > props.pagerCount) {
-    if (props.currentPage > props.pagerCount - halfPagerCount) {
-      showPrevMore.value = true
+watch(
+  () => [props.pageCount, props.pagerCount, props.currentPage],
+  ([pageCount, pagerCount, currentPage]) => {
+    const halfPagerCount = (props.pagerCount - 1) / 2
+    let showPrev = false
+    let showNext = false
+
+    if (pageCount! > pagerCount) {
+      if (currentPage > pagerCount - halfPagerCount) {
+        showPrev = true
+      }
+      if (currentPage < pageCount! - halfPagerCount) {
+        showNext = true
+      }
     }
-    if (props.currentPage < props.pageCount! - halfPagerCount) {
-      showNextMore.value = true
-    }
-  }
-})
+
+    quickPrevHover.value &&= showPrevMore.value
+    quickNextHover.value &&= showNextMore.value
+    showPrevMore.value = showPrev
+    showNextMore.value = showNext
+  },
+  { immediate: true }
+)
 function onMouseEnter(forward = false) {
   if (props.disabled) return
   if (forward) {

--- a/packages/components/pagination/src/components/pager.vue
+++ b/packages/components/pagination/src/components/pager.vue
@@ -146,21 +146,17 @@ const tabindex = computed(() => (props.disabled ? -1 : 0))
 watch(
   () => [props.pageCount, props.pagerCount, props.currentPage],
   ([pageCount, pagerCount, currentPage]) => {
-    const halfPagerCount = (props.pagerCount - 1) / 2
+    const halfPagerCount = (pagerCount - 1) / 2
     let showPrev = false
     let showNext = false
 
-    if (pageCount! > pagerCount) {
-      if (currentPage > pagerCount - halfPagerCount) {
-        showPrev = true
-      }
-      if (currentPage < pageCount! - halfPagerCount) {
-        showNext = true
-      }
+    if (pageCount > pagerCount) {
+      showPrev = currentPage > pagerCount - halfPagerCount
+      showNext = currentPage < pageCount - halfPagerCount
     }
 
-    quickPrevHover.value &&= showPrevMore.value
-    quickNextHover.value &&= showNextMore.value
+    quickPrevHover.value &&= showPrev
+    quickNextHover.value &&= showNext
     showPrevMore.value = showPrev
     showNextMore.value = showNext
   },


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

When switching pages, the icon's hover state was not properly reset, causing the icon to retain its previous hover effect after pagination. This fix ensures that the hover state is reset correctly whenever the page changes.

fix #21370