### PR TITLE
fix(components): [segmented] correct size calculation in scaled elements

### DIFF
--- a/packages/components/segmented/__tests__/segmented.test.tsx
+++ b/packages/components/segmented/__tests__/segmented.test.tsx
@@ -209,4 +209,38 @@ describe('Segmented.vue', () => {
         .includes('is-disabled')
     ).toBeTruthy()
   })
+
+  test('should calculate correct size when value changes inside a dynamically scaled container', async () => {
+    const scale = ref(1)
+    const value = ref('Banana')
+    const options = ref(['Banana', 'Apple'])
+
+    const wrapper = mount(() => (
+      <div style={{ transform: `scale(${scale.value})` }}>
+        <Segmented v-model={value.value} options={options.value} />
+      </div>
+    ))
+
+    await nextTick()
+
+    let indicator = wrapper.find('.el-segmented__item-selected')
+      .element as HTMLElement
+    let selectedItem = wrapper.find('.el-segmented__item.is-selected')
+      .element as HTMLElement
+
+    // Initial check at scale: 1
+    expect(indicator.style.width).toBe(`${selectedItem.offsetWidth}px`)
+
+    // Change scale dynamically
+    scale.value = 0.5
+    await nextTick()
+
+    indicator = wrapper.find('.el-segmented__item-selected')
+      .element as HTMLElement
+    selectedItem = wrapper.find('.el-segmented__item.is-selected')
+      .element as HTMLElement
+
+    // Check width is still correct after scale and value have changed
+    expect(indicator.style.width).toBe(`${selectedItem.offsetWidth}px`)
+  })
 })

--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -130,13 +130,12 @@ const updateSelect = () => {
     state.focusVisible = false
     return
   }
-  const rect = selectedItem.getBoundingClientRect()
   state.isInit = true
   if (props.direction === 'vertical') {
-    state.height = rect.height
+    state.height = selectedItem.offsetHeight
     state.translateY = selectedItem.offsetTop
   } else {
-    state.width = rect.width
+    state.width = selectedItem.offsetWidth
     state.translateX = selectedItem.offsetLeft
   }
   try {


### PR DESCRIPTION
closed #21374

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

https://github.com/user-attachments/assets/9ec42add-d726-44aa-a425-3effdbd98fc0

Prefer `offsetWidth` and `offsetHeight` over `getBoundingClientRect()`; they return the layout size independent of transforms, ensuring an accurate width measurement.




