### PR TITLE
fix(components): [data-picker] cellClassName ineffective when not date

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/basic-month-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-month-table.vue
@@ -33,7 +33,7 @@
 
 <script lang="ts" setup>
 import { computed, nextTick, ref, watch } from 'vue'
-import dayjs from 'dayjs'
+import dayjs, { type Dayjs } from 'dayjs'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { castArray, hasClass } from '@element-plus/utils'
 import { basicMonthTableProps } from '../props/basic-month-table'
@@ -49,6 +49,7 @@ type MonthCell = {
   text: number
   type: 'normal' | 'today'
   inRange: boolean
+  dayjs?: Dayjs
 }
 
 const props = defineProps(basicMonthTableProps)
@@ -132,6 +133,7 @@ const rows = computed<MonthCell[][]>(() => {
 
       cell.text = index
       cell.disabled = props.disabledDate?.(calTime.toDate()) || false
+      cell.dayjs = calTime
     }
   }
   return rows
@@ -169,6 +171,11 @@ const getCellStyle = (cell: MonthCell) => {
     if (cell.end) {
       style['end-date'] = true
     }
+  }
+
+  const customClass = props.cellClassName?.(cell.dayjs!.toDate())
+  if (customClass) {
+    style[customClass] = true
   }
   return style
 }

--- a/packages/components/date-picker/src/date-picker-com/basic-year-table.vue
+++ b/packages/components/date-picker/src/date-picker-com/basic-year-table.vue
@@ -29,7 +29,7 @@
 
 <script lang="ts" setup>
 import { computed, nextTick, ref, watch } from 'vue'
-import dayjs from 'dayjs'
+import dayjs, { type Dayjs } from 'dayjs'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { rangeArr } from '@element-plus/components/time-picker'
 import { castArray, hasClass } from '@element-plus/utils'
@@ -46,6 +46,7 @@ type YearCell = {
   text: number
   type: 'normal' | 'today'
   inRange: boolean
+  dayjs?: Dayjs
 }
 
 const datesInYear = (year: number, lang: string) => {
@@ -133,6 +134,7 @@ const rows = computed(() => {
       const cellDate = calTime.toDate()
       cell.disabled =
         (props.disabledDate && props.disabledDate(cellDate)) || false
+      cell.dayjs = calTime
       row[j] = cell
     }
   }
@@ -166,6 +168,11 @@ const getCellKls = (cell: YearCell) => {
     if (cell.end) {
       kls['end-date'] = true
     }
+  }
+
+  const customClass = props.cellClassName?.(cell.dayjs!.toDate())
+  if (customClass) {
+    kls[customClass] = true
   }
   return kls
 }

--- a/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-pick.vue
@@ -154,6 +154,7 @@
             :selection-mode="selectionMode"
             :date="innerDate"
             :disabled-date="disabledDate"
+            :cell-class-name="cellClassName"
             :parsed-value="parsedValue"
             @pick="handleYearPick"
           />
@@ -164,6 +165,7 @@
             :date="innerDate"
             :parsed-value="parsedValue"
             :disabled-date="disabledDate"
+            :cell-class-name="cellClassName"
             @pick="handleMonthPick"
           />
         </div>

--- a/packages/components/date-picker/src/date-picker-com/panel-month-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-month-range.vue
@@ -58,6 +58,7 @@
             :max-date="maxDate"
             :range-state="rangeState"
             :disabled-date="disabledDate"
+            :cell-class-name="cellClassName"
             @changerange="handleChangeRange"
             @pick="handleRangePick"
             @select="onSelect"
@@ -96,6 +97,7 @@
             :max-date="maxDate"
             :range-state="rangeState"
             :disabled-date="disabledDate"
+            :cell-class-name="cellClassName"
             @changerange="handleChangeRange"
             @pick="handleRangePick"
             @select="onSelect"
@@ -143,7 +145,7 @@ const pickerBase = inject(PICKER_BASE_INJECTION_KEY) as any
 const isDefaultFormat = inject(
   ROOT_PICKER_IS_DEFAULT_FORMAT_INJECTION_KEY
 ) as any
-const { shortcuts, disabledDate } = pickerBase.props
+const { shortcuts, disabledDate, cellClassName } = pickerBase.props
 const format = toRef(pickerBase.props, 'format')
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 const leftDate = ref(dayjs().locale(lang.value))

--- a/packages/components/date-picker/src/date-picker-com/panel-year-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-year-range.vue
@@ -45,6 +45,7 @@
             :max-date="maxDate"
             :range-state="rangeState"
             :disabled-date="disabledDate"
+            :cell-class-name="cellClassName"
             @changerange="handleChangeRange"
             @pick="handleRangePick"
             @select="onSelect"
@@ -81,6 +82,7 @@
             :max-date="maxDate"
             :range-state="rangeState"
             :disabled-date="disabledDate"
+            :cell-class-name="cellClassName"
             @changerange="handleChangeRange"
             @pick="handleRangePick"
             @select="onSelect"
@@ -131,7 +133,7 @@ const isDefaultFormat = inject(
   ROOT_PICKER_IS_DEFAULT_FORMAT_INJECTION_KEY
 ) as any
 const pickerBase = inject(PICKER_BASE_INJECTION_KEY) as any
-const { shortcuts, disabledDate } = pickerBase.props
+const { shortcuts, disabledDate, cellClassName } = pickerBase.props
 const format = toRef(pickerBase.props, 'format')
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 

--- a/packages/components/date-picker/src/props/basic-month-table.ts
+++ b/packages/components/date-picker/src/props/basic-month-table.ts
@@ -1,10 +1,13 @@
-import { buildProps } from '@element-plus/utils'
+import { buildProps, definePropType } from '@element-plus/utils'
 import { datePickerSharedProps, selectionModeWithDefault } from './shared'
 
 import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const basicMonthTableProps = buildProps({
   ...datePickerSharedProps,
+  cellClassName: {
+    type: definePropType<(date: Date) => string>(Function),
+  },
   selectionMode: selectionModeWithDefault('month'),
 })
 

--- a/packages/components/date-picker/src/props/basic-year-table.ts
+++ b/packages/components/date-picker/src/props/basic-year-table.ts
@@ -1,10 +1,13 @@
-import { buildProps } from '@element-plus/utils'
+import { buildProps, definePropType } from '@element-plus/utils'
 import { datePickerSharedProps, selectionModeWithDefault } from './shared'
 
 import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 
 export const basicYearTableProps = buildProps({
   ...datePickerSharedProps,
+  cellClassName: {
+    type: definePropType<(date: Date) => string>(Function),
+  },
   selectionMode: selectionModeWithDefault('year'),
 } as const)
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Fix an issue where the `cellClassName` prop did not work when `type` was set to values like `year`, `month`, or `week`. Now `cellClassName` works correctly for all supported types.

fix #21373