### PR TITLE
style(components): [popper] avoid incorrect word wrapping

### DIFF
--- a/packages/theme-chalk/src/popper.scss
+++ b/packages/theme-chalk/src/popper.scss
@@ -15,7 +15,7 @@
   line-height: 20px;
   min-width: 10px;
   overflow-wrap: break-word;
-  word-break: break-all;
+  word-break: normal;
   visibility: visible;
 
   $arrow-selector: #{& + '__arrow'};


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

This PR is to fix #21381 

I changed the value of the **word-break** from **break-all** to **normal**,comparison of effects:

Before modification
<img width="193" height="273" alt="image" src="https://github.com/user-attachments/assets/9304293d-c5c0-4c22-a357-9a842a2fba41" />

After modification
<img width="237" height="356" alt="image" src="https://github.com/user-attachments/assets/2be03413-184f-4c90-b025-34be6de153d5" />

When the word length does not exceed the container width, break the line at the spaces between words; otherwise, force a line break to prevent overflow, just like **truncated**.

It might be better to add an attribute to the component in the future that allows users to decide how text should wrap.