### PR TITLE
fix(components): [select-v2] resolve invalid filter and remote methods

### DIFF
--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -913,13 +913,9 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
   // fix the problem that scrollTop is not reset in filterable mode
   watch(
     () => filteredOptions.value,
-    (newValue, oldValue) => {
+    () => {
       calculatePopperSize()
-      return (
-        menuRef.value &&
-        !isEqual(newValue, oldValue) &&
-        nextTick(menuRef.value.resetScrollTop)
-      )
+      return menuRef.value && nextTick(menuRef.value.resetScrollTop)
     }
   )
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


1. 修复 `filter-method` 和 `remote-method` 失效的问题，原因是 `isFunction(toRaw(props).filterMethod)` 始终返回 `false`。
Fix issue with `filter-method` and `remote-method` not working, caused by `isFunction(toRaw(props).filterMethod)` always returning `false`.
2. 我认为 #21225 的问题出在 [这里](https://github.com/element-plus/element-plus/blob/7b6858374aa4fe8dbd930dffa3854356110eddfa/packages/components/select-v2/src/useSelect.ts#L915)，每次更新时都会重置滚动位置，即使新旧数组数据一致。
I believe the issue in #21225 is caused by [this](https://github.com/element-plus/element-plus/blob/7b6858374aa4fe8dbd930dffa3854356110eddfa/packages/components/select-v2/src/useSelect.ts#L915), where the scroll position gets reset on every update, even when the old and new array data are the same.
3. 经过 [#21257](https://github.com/element-plus/element-plus/pull/21257#issuecomment-3045926887) 的提醒，我认为可以将 `isFilterMethodValid` 和 `isRemoteMethodValid` 提取为 `computed`，这样即使外部传入的是箭头函数，也只会重新执行 `computed` 的 `getter`，而不会重复执行 `filterOptions`（只要返回值没有变化）。
After the suggestion in [#21257](https://github.com/element-plus/element-plus/pull/21257#issuecomment-3045926887), I think we can refactor `isFilterMethodValid` and `isRemoteMethodValid` as `computed`. This way, even if the external function is an arrow function, only the `computed` getter will be re-executed, and `filterOptions` won't run again (as long as the return value doesn't change).
4. 我在本地测试了 #19964 提到的问题，在 `CPU: 4x slowdown` 和 `no throttling` 的情况下表现良好。
I tested the issue mentioned in #19964 locally, and it performed well under `CPU: 4x slowdown` and `no throttling` conditions.


<img width="812" height="569" alt="image" src="https://github.com/user-attachments/assets/eb942de0-20f7-4c77-a92e-16615f2d2bd2" />


context #21225, #21257, #19964
fix #21406