### PR TITLE
style(components): [input] prevent slot element width squeeze

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -406,7 +406,7 @@
     .#{$namespace}-select,
     .#{$namespace}-button {
       display: inline-block;
-      flex-grow: 1;
+      flex: 1;
       margin: 0 -20px;
     }
 

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -406,6 +406,7 @@
     .#{$namespace}-select,
     .#{$namespace}-button {
       display: inline-block;
+      flex-grow: 1;
       margin: 0 -20px;
     }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

This PR is to fix #21474 

Comparison of effects:

Before modification
<img width="469" height="116" alt="{46F56B9C-8B28-4169-828A-3DDB60D44965}" src="https://github.com/user-attachments/assets/8954490f-1ecf-4e61-ad5f-0d228a53a93d" />

After modification
<img width="468" height="110" alt="{E4973753-D4C1-424A-B11D-3BCB353B49AB}" src="https://github.com/user-attachments/assets/2f9312aa-dbd5-47c2-a50c-6822a08bce79" />

