### PR TITLE
docs: format warning tip

### DIFF
--- a/docs/en-US/component/tree-select.md
+++ b/docs/en-US/component/tree-select.md
@@ -38,8 +38,10 @@ tree-select/check-strictly
 :::
 
 :::warning
+
 When using show-checkbox, since `check-on-click-leaf` is true by default,
 last tree children's can be checked by clicking their nodes.
+
 :::
 
 ## Multiple Selection

--- a/docs/en-US/component/tree-v2.md
+++ b/docs/en-US/component/tree-v2.md
@@ -28,8 +28,10 @@ tree-v2/selectable
 :::
 
 :::warning
+
 When using show-checkbox, since `check-on-click-leaf` is true by default,
 last tree children's can be checked by clicking their nodes.
+
 :::
 
 ## Disabled checkbox

--- a/docs/en-US/component/tree.md
+++ b/docs/en-US/component/tree.md
@@ -28,8 +28,10 @@ tree/selectable
 :::
 
 :::warning
+
 When using show-checkbox, since `check-on-click-leaf` is true by default,
 last tree children's can be checked by clicking their nodes.
+
 :::
 
 ## Custom leaf node in lazy mode


### PR DESCRIPTION
### Description

1. Ensured correct automatic text parsing in [Crowdin](https://crowdin.com/editor/element-plus/883/en-zhcn?view=comfortable&filter=basic&value=0).

2. [Unified](https://github.com/element-plus/element-plus/blob/docs/warn-tip-foramt/docs/en-US/component/button.md?plain=1#L30-L36).

### Now

 | [US](https://element-plus.org/en-US/component/tree.html#selectable) | [ZH](https://element-plus.org/zh-CN/component/tree.html#%E5%8F%AF%E9%80%89%E6%8B%A9) |
| ------- | ----- |
 |      <img width="1278" height="1270" alt="image" src="https://github.com/user-attachments/assets/1977973b-2920-47cb-9f9e-eac79da1d56a" />      |     <img width="1278" height="1270" alt="image" src="https://github.com/user-attachments/assets/3d400cb5-6996-4df0-ac7e-bc39bbc63e75" />  |

<hr />

<img width="1278" height="1270" alt="image" src="https://github.com/user-attachments/assets/aeb583ce-4317-463b-ac94-46774ab48747" />



