### PR TITLE
docs(components): [dialog] smoother `custom-animation` example

### DIFF
--- a/docs/.vitepress/vitepress/components/dev/version-tag.vue
+++ b/docs/.vitepress/vitepress/components/dev/version-tag.vue
@@ -5,7 +5,7 @@ defineProps<{
 </script>
 
 <template>
-  <el-tag size="small" effect="plain" hit round class="!ml-2">
+  <el-tag size="small" effect="plain" hit round>
     {{ version }}
   </el-tag>
 </template>

--- a/docs/.vitepress/vitepress/components/dev/version-tag.vue
+++ b/docs/.vitepress/vitepress/components/dev/version-tag.vue
@@ -9,3 +9,9 @@ defineProps<{
     {{ version }}
   </el-tag>
 </template>
+
+<style scoped>
+.el-tag {
+  margin-left: 0.5rem;
+}
+</style>

--- a/docs/.vitepress/vitepress/components/dev/version-tag.vue
+++ b/docs/.vitepress/vitepress/components/dev/version-tag.vue
@@ -9,9 +9,3 @@ defineProps<{
     {{ version }}
   </el-tag>
 </template>
-
-<style scoped>
-.el-tag {
-  margin-left: 0.5rem;
-}
-</style>

--- a/docs/.vitepress/vitepress/components/dev/version-tag.vue
+++ b/docs/.vitepress/vitepress/components/dev/version-tag.vue
@@ -5,7 +5,7 @@ defineProps<{
 </script>
 
 <template>
-  <el-tag size="small" effect="plain" hit round class="ml-2">
+  <el-tag size="small" effect="plain" hit round class="!ml-2">
     {{ version }}
   </el-tag>
 </template>

--- a/docs/.vitepress/vitepress/components/sidebar/vp-sidebar-link.vue
+++ b/docs/.vitepress/vitepress/components/sidebar/vp-sidebar-link.vue
@@ -38,12 +38,7 @@ watch([activeLink, sidebarItem], ([active, el]) => {
     @click="$emit('close')"
   >
     <p class="link-text">{{ item.text }}</p>
-    <!-- eslint-disable-next-line vue/html-self-closing -->
-    <VersionTag
-      v-if="item.promotion"
-      :version="item.promotion"
-      class="ml-2"
-    ></VersionTag>
+    <VersionTag v-if="item.promotion" :version="item.promotion" />
   </a>
 </template>
 

--- a/docs/.vitepress/vitepress/components/sidebar/vp-sidebar-link.vue
+++ b/docs/.vitepress/vitepress/components/sidebar/vp-sidebar-link.vue
@@ -38,7 +38,7 @@ watch([activeLink, sidebarItem], ([active, el]) => {
     @click="$emit('close')"
   >
     <p class="link-text">{{ item.text }}</p>
-    <VersionTag v-if="item.promotion" class="ml-2" :version="item.promotion" />
+    <VersionTag v-if="item.promotion" :version="item.promotion" />
   </a>
 </template>
 

--- a/docs/.vitepress/vitepress/components/sidebar/vp-sidebar-link.vue
+++ b/docs/.vitepress/vitepress/components/sidebar/vp-sidebar-link.vue
@@ -38,7 +38,12 @@ watch([activeLink, sidebarItem], ([active, el]) => {
     @click="$emit('close')"
   >
     <p class="link-text">{{ item.text }}</p>
-    <VersionTag v-if="item.promotion" :version="item.promotion" />
+    <!-- eslint-disable-next-line vue/html-self-closing -->
+    <VersionTag
+      v-if="item.promotion"
+      :version="item.promotion"
+      class="!ml-2"
+    ></VersionTag>
   </a>
 </template>
 

--- a/docs/.vitepress/vitepress/components/sidebar/vp-sidebar-link.vue
+++ b/docs/.vitepress/vitepress/components/sidebar/vp-sidebar-link.vue
@@ -42,7 +42,7 @@ watch([activeLink, sidebarItem], ([active, el]) => {
     <VersionTag
       v-if="item.promotion"
       :version="item.promotion"
-      class="!ml-2"
+      class="ml-2"
     ></VersionTag>
   </a>
 </template>

--- a/docs/.vitepress/vitepress/components/sidebar/vp-sidebar-link.vue
+++ b/docs/.vitepress/vitepress/components/sidebar/vp-sidebar-link.vue
@@ -56,6 +56,10 @@ watch([activeLink, sidebarItem], ([active, el]) => {
   .link-text {
     margin: 0;
   }
+
+  .link-text + * {
+    margin-left: 0.5rem;
+  }
 }
 
 .link:hover .link-text {

--- a/docs/examples/dialog/custom-animation.vue
+++ b/docs/examples/dialog/custom-animation.vue
@@ -1,43 +1,38 @@
 <template>
-  <div class="demo-block">
-    <div class="demo-buttons">
-      <el-button plain @click="openDialog('fade')"> Default </el-button>
-      <el-button plain @click="openDialog('scale')"> Scale </el-button>
-      <el-button plain @click="openDialog('slide')"> Slide </el-button>
-      <el-button plain @click="openDialog('bounce')"> Bounce </el-button>
-      <el-button plain @click="openDialogWithObject"> Object Config </el-button>
-    </div>
-
-    <el-dialog
-      ref="dialogRef"
-      v-model="dialogVisible"
-      class="custom-transition-dialog"
-      :title="`${currentAnimation} Animation Dialog`"
-      width="30%"
-      :transition="transitionConfig"
-    >
-      <div class="dialog-content">
-        <p>
-          Current animation: <strong>{{ currentAnimation }}</strong>
-        </p>
-        <p>
-          This dialog demonstrates the {{ currentAnimation }} animation effect.
-        </p>
-        <p v-if="isObjectConfig">
-          <strong>Using object configuration:</strong><br />
-          <code>{{ JSON.stringify(transitionConfig, null, 2) }}</code>
-        </p>
-      </div>
-      <template #footer>
-        <span class="dialog-footer">
-          <el-button @click="dialogVisible = false">Cancel</el-button>
-          <el-button type="primary" @click="dialogVisible = false">
-            Confirm
-          </el-button>
-        </span>
-      </template>
-    </el-dialog>
+  <div>
+    <el-button plain @click="openDialog('fade')"> Default </el-button>
+    <el-button plain @click="openDialog('scale')"> Scale </el-button>
+    <el-button plain @click="openDialog('slide')"> Slide </el-button>
+    <el-button plain @click="openDialog('bounce')"> Bounce </el-button>
+    <el-button plain @click="openDialogWithObject"> Object Config </el-button>
   </div>
+
+  <el-dialog
+    v-model="dialogVisible"
+    class="custom-transition-dialog"
+    :title="`${currentAnimation} Animation Dialog`"
+    width="30%"
+    :transition="transitionConfig"
+  >
+    <div>
+      <p>
+        Current animation: <strong>{{ currentAnimation }}</strong>
+      </p>
+      <p>
+        This dialog demonstrates the {{ currentAnimation }} animation effect.
+      </p>
+      <p v-if="isObjectConfig">
+        <strong>Using object configuration:</strong><br />
+        <code>{{ JSON.stringify(transitionConfig, null, 2) }}</code>
+      </p>
+    </div>
+    <template #footer>
+      <el-button @click="dialogVisible = false">Cancel</el-button>
+      <el-button type="primary" @click="dialogVisible = false">
+        Confirm
+      </el-button>
+    </template>
+  </el-dialog>
 </template>
 
 <script lang="ts" setup>
@@ -47,7 +42,6 @@ import type { DialogTransition } from 'element-plus'
 
 const dialogVisible = ref(false)
 const currentAnimation = ref('fade')
-const dialogRef = ref()
 const isObjectConfig = ref(false)
 
 const transitionConfig = computed<DialogTransition>(() => {
@@ -76,27 +70,6 @@ const openDialogWithObject = () => {
 </script>
 
 <style scoped>
-.demo-buttons {
-  display: flex;
-  gap: 12px;
-  margin-bottom: 20px;
-  flex-wrap: wrap;
-}
-
-.dialog-content {
-  line-height: 1.6;
-}
-
-.dialog-content p {
-  margin: 8px 0;
-}
-
-.dialog-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
 code {
   background: var(--el-bg-color-page);
   padding: 4px 8px;
@@ -110,20 +83,18 @@ code {
 <style>
 /* Scale Animation */
 .dialog-scale-enter-active,
-.dialog-scale-leave-active {
-  transition: all 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
-}
-
+.dialog-scale-leave-active,
 .dialog-scale-enter-active .el-dialog,
 .dialog-scale-leave-active .el-dialog {
   transition: all 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
-.dialog-scale-enter-from .el-dialog {
-  transform: scale(0.5);
+.dialog-scale-enter-from,
+.dialog-scale-leave-to {
   opacity: 0;
 }
 
+.dialog-scale-enter-from .el-dialog,
 .dialog-scale-leave-to .el-dialog {
   transform: scale(0.5);
   opacity: 0;
@@ -131,20 +102,18 @@ code {
 
 /* Slide Animation */
 .dialog-slide-enter-active,
-.dialog-slide-leave-active {
-  transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-}
-
+.dialog-slide-leave-active,
 .dialog-slide-enter-active .el-dialog,
 .dialog-slide-leave-active .el-dialog {
-  transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-.dialog-slide-enter-from .el-dialog {
-  transform: translateY(-100px);
+.dialog-slide-enter-from,
+.dialog-slide-leave-to {
   opacity: 0;
 }
 
+.dialog-slide-enter-from .el-dialog,
 .dialog-slide-leave-to .el-dialog {
   transform: translateY(-100px);
   opacity: 0;
@@ -152,20 +121,18 @@ code {
 
 /* Bounce Animation */
 .dialog-bounce-enter-active,
-.dialog-bounce-leave-active {
-  transition: all 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-}
-
+.dialog-bounce-leave-active,
 .dialog-bounce-enter-active .el-dialog,
 .dialog-bounce-leave-active .el-dialog {
-  transition: all 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  transition: all 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
 
-.dialog-bounce-enter-from .el-dialog {
-  transform: scale(0.3) translateY(-50px);
+.dialog-bounce-enter-from,
+.dialog-bounce-leave-to {
   opacity: 0;
 }
 
+.dialog-bounce-enter-from .el-dialog,
 .dialog-bounce-leave-to .el-dialog {
   transform: scale(0.3) translateY(-50px);
   opacity: 0;
@@ -173,22 +140,20 @@ code {
 
 /* Object Configuration Animation */
 .dialog-custom-object-enter-active,
-.dialog-custom-object-leave-active {
-  transition: all 0.5s cubic-bezier(0.25, 0.8, 0.25, 1);
-}
-
+.dialog-custom-object-leave-active,
 .dialog-custom-object-enter-active .el-dialog,
 .dialog-custom-object-leave-active .el-dialog {
   transition: all 0.5s cubic-bezier(0.25, 0.8, 0.25, 1);
 }
 
-.dialog-custom-object-enter-from .el-dialog {
-  transform: rotate(180deg) scale(0.5);
+.dialog-custom-object-enter-from,
+.dialog-custom-object-leave-to {
   opacity: 0;
 }
 
+.dialog-custom-object-enter-from .el-dialog,
 .dialog-custom-object-leave-to .el-dialog {
-  transform: rotate(-180deg) scale(0.5);
+  transform: rotate(180deg) scale(0.5);
   opacity: 0;
 }
 </style>


### PR DESCRIPTION
###  1. [staging.element-plus.org](https://staging.element-plus.org)  Sidebar version tag `ml-2` style missing. I suspect it's due to [duplicate styles](https://github.com/element-plus/element-plus/blob/docs/update-tag--dialog-example/docs/.vitepress/vitepress/components/dev/version-tag.vue#L8).

<img width="1278" height="1263" alt="image" src="https://github.com/user-attachments/assets/c05e81f7-4c13-4cfa-8bad-b1621418f3a4" />

<hr />

### 2. update **custom-animation** example.

#### Rel:

- https://github.com/element-plus/element-plus/pull/21479


| [Before](https://preview-21479-element-plus.surge.sh/en-US/component/dialog.html#custom-animation) | [After](https://preview-21555-element-plus.surge.sh/en-US/component/dialog.html#custom-animation) |
| ------- | ----- |
 |      ![screenshots](https://github.com/user-attachments/assets/4dca106e-b3d9-454f-8d35-70f100bef7fe)      |       ![screenshots](https://github.com/user-attachments/assets/bcbcf0d5-30a5-41cf-a620-f651c63579af)   |

