### PR TITLE
style(components): remove unused icon class & autocomplete tweaks

### DIFF
--- a/packages/components/autocomplete/__tests__/autocomplete.test.tsx
+++ b/packages/components/autocomplete/__tests__/autocomplete.test.tsx
@@ -279,9 +279,9 @@ describe('Autocomplete.vue', () => {
     vi.runAllTimers()
     await nextTick()
 
-    expect(document.body.querySelector('.el-icon-loading')).toBeDefined()
+    expect(document.body.querySelector('.el-icon.is-loading')).toBeDefined()
     await wrapper.setProps({ hideLoading: true })
-    expect(document.body.querySelector('.el-icon-loading')).toBeNull()
+    expect(document.body.querySelector('.el-icon.is-loading')).toBeNull()
   })
 
   test('selectWhenUnmatched', async () => {

--- a/packages/theme-chalk/src/autocomplete.scss
+++ b/packages/theme-chalk/src/autocomplete.scss
@@ -82,11 +82,5 @@
         background-color: getCssVar('bg-color', 'overlay');
       }
     }
-
-    @include b(icon) {
-      @include when(loading) {
-        vertical-align: middle;
-      }
-    }
   }
 }

--- a/packages/theme-chalk/src/autocomplete.scss
+++ b/packages/theme-chalk/src/autocomplete.scss
@@ -71,6 +71,7 @@
   @include when(loading) {
     li {
       text-align: center;
+      cursor: default;
       height: 100px;
       line-height: 100px;
       font-size: 20px;
@@ -82,8 +83,10 @@
       }
     }
 
-    & .#{$namespace}-icon-loading {
-      vertical-align: middle;
+    @include b(icon) {
+      @include when(loading) {
+        vertical-align: middle;
+      }
     }
   }
 }

--- a/packages/theme-chalk/src/icon.scss
+++ b/packages/theme-chalk/src/icon.scss
@@ -1,10 +1,6 @@
 @use 'mixins/mixins' as *;
 @use 'common/var' as *;
 
-.#{$namespace}-icon-loading {
-  animation: rotating 2s linear infinite;
-}
-
 .#{$namespace}-icon--right {
   margin-left: 5px;
 }


### PR DESCRIPTION
- removed `.el-icon-loading` as it is not used. `.is-loading` is the right one.
- it now enable the class vertical-align of autocomplete (very slight difference):
![Peek 2025-07-31 23-36](https://github.com/user-attachments/assets/a6129c78-6b28-4617-abb9-bf7daa5ef621)
- cursor to default in the popper when the autocomplete is loading.