### PR TITLE
fix(components): [image] support lazy inside transformed containers

### DIFF
--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -63,7 +63,7 @@ import {
   useAttrs as useRawAttrs,
   watch,
 } from 'vue'
-import { useEventListener, useThrottleFn } from '@vueuse/core'
+import { useIntersectionObserver, useThrottleFn } from '@vueuse/core'
 import { fromPairs } from 'lodash-unified'
 import { useAttrs, useLocale, useNamespace } from '@element-plus/hooks'
 import ImageViewer from '@element-plus/components/image-viewer'
@@ -72,8 +72,8 @@ import {
   isArray,
   isClient,
   isElement,
-  isInContainer,
   isString,
+  isWindow,
 } from '@element-plus/utils'
 import { imageEmits, imageProps } from './image'
 
@@ -111,7 +111,7 @@ const hasLoadError = ref(false)
 const isLoading = ref(true)
 const showViewer = ref(false)
 const container = ref<HTMLElement>()
-const _scrollContainer = ref<HTMLElement | Window>()
+const _scrollContainer = ref<HTMLElement | undefined>()
 
 const supportLoading = isClient && 'loading' in HTMLImageElement.prototype
 let stopScrollListener: (() => void) | undefined
@@ -170,8 +170,8 @@ function handleError(event: Event) {
   emit('error', event)
 }
 
-function handleLazyLoad() {
-  if (isInContainer(container.value, _scrollContainer.value)) {
+function handleLazyLoad(isIntersecting: boolean) {
+  if (isIntersecting) {
     loadImage()
     removeLazyLoadListener()
   }
@@ -191,24 +191,27 @@ async function addLazyLoadListener() {
     _scrollContainer.value =
       document.querySelector<HTMLElement>(scrollContainer) ?? undefined
   } else if (container.value) {
-    _scrollContainer.value = getScrollContainer(container.value)
+    const scrollContainer = getScrollContainer(container.value)
+    _scrollContainer.value = isWindow(scrollContainer)
+      ? undefined
+      : scrollContainer
   }
 
-  if (_scrollContainer.value) {
-    stopScrollListener = useEventListener(
-      _scrollContainer,
-      'scroll',
-      lazyLoadHandler
-    )
-    setTimeout(() => handleLazyLoad(), 100)
-  }
+  const { stop } = useIntersectionObserver(
+    container,
+    ([entry]) => {
+      lazyLoadHandler(entry.isIntersecting)
+    },
+    { root: _scrollContainer }
+  )
+  stopScrollListener = stop
 }
 
 function removeLazyLoadListener() {
-  if (!isClient || !_scrollContainer.value || !lazyLoadHandler) return
+  if (!isClient || !lazyLoadHandler) return
 
   stopScrollListener?.()
-  _scrollContainer.value = undefined
+  stopScrollListener = undefined
 }
 
 function clickHandler() {

--- a/packages/components/image/src/image.vue
+++ b/packages/components/image/src/image.vue
@@ -211,6 +211,7 @@ function removeLazyLoadListener() {
   if (!isClient || !lazyLoadHandler) return
 
   stopScrollListener?.()
+  _scrollContainer.value = undefined
   stopScrollListener = undefined
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Previously, image lazy loading relied on scroll event listeners, which do not work inside containers using CSS transform. This commit replaces scroll-based detection with `IntersectionObserver`, which properly supports lazy loading within transformed contexts.

Transform: 

https://github.com/user-attachments/assets/bd95d1fe-129e-4fc7-be73-9c2c436a1665

Scroll:

https://github.com/user-attachments/assets/61ef1998-c18b-4c2f-ba22-06c62d14830e



fix #21571 

