### PR TITLE
refactor(components): [message] use `MessageType` replace `messageType`

### DIFF
--- a/packages/components/message/src/message.ts
+++ b/packages/components/message/src/message.ts
@@ -25,7 +25,7 @@ export const messageTypes = [
 
 export type MessageType = typeof messageTypes[number]
 /** @deprecated please use `MessageType` instead */
-export type messageType = MessageType
+export type messageType = MessageType // will be removed in 3.0.0.
 
 export interface MessageConfigContext {
   max?: number

--- a/packages/components/message/src/message.ts
+++ b/packages/components/message/src/message.ts
@@ -23,7 +23,9 @@ export const messageTypes = [
   'error',
 ] as const
 
-export type messageType = typeof messageTypes[number]
+export type MessageType = typeof messageTypes[number]
+/** @deprecated please use `MessageType` instead */
+export type messageType = MessageType
 
 export interface MessageConfigContext {
   max?: number
@@ -195,7 +197,7 @@ export interface MessageHandler {
 
 export type MessageFn = {
   (options?: MessageParams, appContext?: null | AppContext): MessageHandler
-  closeAll(type?: messageType): void
+  closeAll(type?: MessageType): void
 }
 export type MessageTypedFn = (
   options?: MessageParamsWithType,

--- a/packages/components/message/src/method.ts
+++ b/packages/components/message/src/method.ts
@@ -22,7 +22,7 @@ import type {
   MessageOptions,
   MessageParams,
   MessageParamsNormalized,
-  messageType,
+  MessageType,
 } from './message'
 
 let seed = 1
@@ -190,7 +190,7 @@ messageTypes.forEach((type) => {
   }
 })
 
-export function closeAll(type?: messageType): void {
+export function closeAll(type?: MessageType): void {
   // Create a copy of instances to avoid modification during iteration
   const instancesToClose = [...instances]
 


### PR DESCRIPTION
Follow TypeScript type naming conventions, use PascalCase, and provide backwards-compatible deprecated types.