### PR TITLE
fix(components): [table] if children row-key repeat use index

### DIFF
--- a/packages/components/table/src/table-body/render-helper.ts
+++ b/packages/components/table/src/table-body/render-helper.ts
@@ -47,10 +47,13 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
       ({ type }) => type === 'default'
     )
   })
+  const rowIdSet = new Set<string>()
   const getKeyOfRow = (row: T, index: number) => {
     const rowKey = (parent?.props as Partial<TableProps<T>>)?.rowKey
     if (rowKey) {
-      return getRowIdentity(row, rowKey)
+      const rowId = getRowIdentity(row, rowKey)
+      rowIdSet.add(rowId)
+      return !rowIdSet.has(rowId) ? rowId : index
     }
     return index
   }
@@ -160,6 +163,7 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
   }
 
   const wrappedRowRender = (row: T, $index: number) => {
+    rowIdSet.clear()
     const store = props.store!
     const { isRowExpanded, assertRowKey } = store
     const { treeData, lazyTreeNodeMap, childrenColumnName, rowKey } =


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

The phenomenon is as follows. If the row-key of a child node is repeated, re-rendering may cause problems when the data is updated.

https://github.com/user-attachments/assets/077f656a-937c-4f0d-8f45-403aed6302d5

Now when we getKeyOfRow, we determine whether the child node is repeated. If it is repeated, we use index


https://github.com/user-attachments/assets/e278d3f1-53aa-41a4-abae-396bdb065aaf



