### PR TITLE
feat(components): [el-cascader] add beforeChange prop to CascaderProps

### DIFF
--- a/packages/components/cascader-panel/src/config.ts
+++ b/packages/components/cascader-panel/src/config.ts
@@ -5,6 +5,7 @@ import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import type { PropType } from 'vue'
 import type {
   CascaderConfig,
+  default as CascaderNode,
   CascaderNodePathValue,
   CascaderOption,
   CascaderProps,
@@ -100,6 +101,14 @@ export const DefaultProps: CascaderConfig = {
 
 export const cascaderPanelProps = buildProps({
   ...CommonProps,
+  /**
+   * @description before-change hook before the binding value changes. If false is returned or a Promise is returned and then is rejected, changing will be aborted
+   */
+  beforeChange: {
+    type: definePropType<
+      (node: CascaderNode, checked: boolean) => Promise<boolean> | boolean
+    >(Function),
+  },
   border: {
     type: Boolean,
     default: true,

--- a/packages/components/cascader/src/cascader.ts
+++ b/packages/components/cascader/src/cascader.ts
@@ -94,6 +94,14 @@ export const cascaderProps = buildProps({
     default: () => true,
   },
   /**
+   * @description before-change hook before the binding value changes. If false is returned or a Promise is returned and then is rejected, changing will be aborted
+   */
+  beforeChange: {
+    type: definePropType<
+      (node: CascaderNode, checked: boolean) => Promise<boolean> | boolean
+    >(Function),
+  },
+  /**
    * @description position of dropdown
    */
   placement: {

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -158,6 +158,7 @@
         v-model="checkedValue"
         :options="options"
         :props="props.props"
+        :before-change="props.beforeChange"
         :border="false"
         :render-label="$slots.default"
         @expand-change="handleExpandChange"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

Add “beforeChange” prop to CascaderProps, You can handle some business logic before the change event occurs, and control whether the change is triggered by returning true or false. At the same time, it can solve the application scenario of #21351

