### PR TITLE
fix(components): [date-picker] keep datetimerange close on value change

### DIFF
--- a/docs/en-US/component/date-picker.md
+++ b/docs/en-US/component/date-picker.md
@@ -201,7 +201,7 @@ Note, date time locale (month name, first day of the week ...) are also configur
 
 | Name            | Description                                                           | Type                                                                                      |
 | --------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| change          | triggers when user confirms the value                                 | ^[Function]`(val: typeof v-model) => void`                                                |
+| change          | triggers when user confirms the value or click outside                | ^[Function]`(val: typeof v-model) => void`                                                |
 | blur            | triggers when Input blurs                                             | ^[Function]`(e: FocusEvent) => void`                                                      |
 | focus           | triggers when Input focuses                                           | ^[Function]`(e: FocusEvent) => void`                                                      |
 | clear ^(2.7.7)  | triggers when the clear icon is clicked in a clearable DatePicker     | ^[Function]`() => void`                                                                   |

--- a/docs/en-US/component/datetime-picker.md
+++ b/docs/en-US/component/datetime-picker.md
@@ -122,7 +122,7 @@ datetime-picker/custom-icon
 
 | Name            | Description                                                           | Parameters                                                                                |
 | --------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| change          | triggers when user confirms the value                                 | ^[Function]`(val: typeof v-model) => void`                                                |
+| change          | triggers when user confirms the value or click outside                | ^[Function]`(val: typeof v-model) => void`                                                |
 | blur            | triggers when Input blurs                                             | ^[Function]`(e: FocusEvent) => void`                                                      |
 | focus           | triggers when Input focuses                                           | ^[Function]`(e: FocusEvent) => void`                                                      |
 | clear ^(2.7.7)  | triggers when the clear icon is clicked in a clearable DateTimePicker | ^[Function]`() => void`                                                                   |

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -17,6 +17,8 @@ import { EVENT_CODE } from '@element-plus/constants'
 import { ElFormItem } from '@element-plus/components/form'
 import DatePicker from '../src/date-picker'
 
+import type DatePickerRange from '../src/date-picker-com/panel-date-range.vue'
+
 const _mount = (template: string, data = () => ({}), otherObj?) =>
   mount(
     {
@@ -1999,6 +2001,32 @@ describe('DateRangePicker', () => {
       '9',
       '10',
     ])
+  })
+  it('should not be visible after input two dates', async () => {
+    const wrapper = _mount(
+      `<el-date-picker
+        v-model="value"
+        type="daterange"
+        show-week-number
+      />`,
+      () => ({ value: [new Date(2025, 0, 1), new Date(2025, 1, 1)] })
+    )
+    const input = wrapper.find('input')
+    await input.trigger('blur')
+    await input.trigger('focus')
+
+    const rangePanelWrapper = wrapper.findComponent(
+      '.el-date-range-picker'
+    ) as VueWrapper<InstanceType<typeof DatePickerRange>>
+    expect(rangePanelWrapper.exists()).toBe(true)
+    expect(rangePanelWrapper.vm.visible).toBe(true)
+    const cells = document.querySelectorAll('.available .el-date-table-cell')
+    ;(cells[0] as HTMLElement).click()
+    await nextTick()
+    ;(cells[1] as HTMLElement).click()
+    await nextTick()
+
+    expect(rangePanelWrapper.vm.visible).toBe(false)
   })
 })
 

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1970,7 +1970,7 @@ describe('DateRangePicker', () => {
   })
 
   it('range, shows weekNumber', async () => {
-    _mount(
+    const wrapper = _mount(
       `<el-date-picker
         v-model="value"
         type="daterange"
@@ -1978,6 +1978,10 @@ describe('DateRangePicker', () => {
       />`,
       () => ({ value: [new Date(2025, 0, 1), new Date(2025, 1, 1)] })
     )
+    const input = wrapper.find('input')
+    input.trigger('blur')
+    input.trigger('focus')
+
     await nextTick()
     const weeks = document.querySelectorAll('td.week')
     expect(weeks.length).toBe(12)
@@ -2035,6 +2039,9 @@ describe('MonthRange', () => {
     // input text is something like date string
     expect(inputs[0].element.value.length).toBe(7)
     expect(inputs[1].element.value.length).toBe(7)
+    inputs[0].trigger('blur')
+    inputs[0].trigger('focus')
+    await nextTick()
     // reverse selection
     p1.click()
     await nextTick()

--- a/packages/components/date-picker/src/composables/use-range-picker.ts
+++ b/packages/components/date-picker/src/composables/use-range-picker.ts
@@ -128,8 +128,18 @@ export const useRangePicker = (
   watch(
     () => props.parsedValue,
     (parsedValue) => {
-      if (!props.visible || !parsedValue?.length) {
+      if (!parsedValue?.length) {
         onReset(parsedValue)
+      }
+    },
+    { immediate: true }
+  )
+
+  watch(
+    () => props.visible,
+    () => {
+      if (props.visible) {
+        onReset(props.parsedValue)
       }
     },
     { immediate: true }

--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -438,6 +438,7 @@ const defaultValue = toRef(pickerBase.props, 'defaultValue')
 const { lang } = useLocale()
 const leftDate = ref<Dayjs>(dayjs().locale(lang.value))
 const rightDate = ref<Dayjs>(dayjs().locale(lang.value).add(1, unit))
+let shouldBeVisible = true
 
 const {
   minDate,
@@ -688,16 +689,17 @@ const handleRangePick = (
   maxDate.value = maxDate_
   minDate.value = minDate_
 
-  handleRangeConfirm(close)
+  if (!showTime.value && close) {
+    close = !minDate_ || !maxDate_
+  }
+  shouldBeVisible = close
 }
 
-watch(
-  [maxDate, minDate],
-  ([min, max]) => {
-    if (min && max) handleRangeConfirm(true)
-  },
-  { flush: 'post' }
-)
+watch([maxDate, minDate], ([max, min]) => {
+  if (max && min) {
+    handleRangeConfirm(shouldBeVisible)
+  }
+})
 
 const minTimePickerVisible = ref(false)
 const maxTimePickerVisible = ref(false)


### PR DESCRIPTION
It will may break a part of the date-picker-panel. I will ensure it will not in the date-picker-panel PR.

fix #21603 fix #21631 fix #21635