### PR TITLE
fix(components):[el-input-number] change default 'align' prop to 'left'

### DIFF
--- a/packages/components/input-number/src/input-number.ts
+++ b/packages/components/input-number/src/input-number.ts
@@ -125,7 +125,7 @@ export const inputNumberProps = buildProps({
    */
   align: {
     type: definePropType<'left' | 'right' | 'center'>(String),
-    default: 'center',
+    default: 'left',
   },
   /**
    * @description whether to disable scientific notation input (e.g. 'e', 'E')


### PR DESCRIPTION
When the align prop is not supported, the default alignment is left-justified. I believe developers who previously needed center alignment would have already implemented corresponding styles themselves. However, after adding center alignment as the new default, those who don’t need it will now be forced to explicitly configure align="left".

fix [#21291](https://github.com/element-plus/element-plus/pull/21291)


Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
