### PR TITLE
fix(components): auto close panel for daterange type after selection

### DIFF
--- a/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker/src/date-picker-com/panel-date-range.vue
@@ -694,7 +694,9 @@ const handleRangePick = (
 watch(
   [maxDate, minDate],
   ([min, max]) => {
-    if (min && max) handleRangeConfirm(true)
+    if (min && max) {
+      handleRangeConfirm(showTime.value)
+    }
   },
   { flush: 'post' }
 )


### PR DESCRIPTION
- Fix daterange type not auto-closing panel after date selection
- Add conditional logic based on showTime to distinguish daterange and datetimerange
- Ensure daterange closes panel automatically while datetimerange stays open for time selection
- All existing tests pass with this change

Close: #21631 
