### PR TITLE
refactor(components): [message-box] remove duplicates conditional

### DIFF
--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -80,9 +80,8 @@
                       :is="showInput ? 'label' : 'p'"
                       v-if="!dangerouslyUseHTMLString"
                       :for="showInput ? inputId : undefined"
-                    >
-                      {{ !dangerouslyUseHTMLString ? message : '' }}
-                    </component>
+                      v-text="message"
+                    />
                     <component
                       :is="showInput ? 'label' : 'p'"
                       v-else


### PR DESCRIPTION
- Remove duplicate conditionals: The original code's `{{ !dangerouslyUseHTMLString ? message : '' }} `is redundant because the outer conditional already has a `v-if="!dangerouslyUseHTMLString"` conditional.

- Use the v-text directive: Change {{ message }} to v-text="message" for a cleaner, more concise look.

- Keep the logic clear: Use v-text for safe rendering and v-html for HTML rendering.