### PR TITLE
fix(components): [cascader-panel] ensure set null after clear

### DIFF
--- a/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
+++ b/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
@@ -806,4 +806,25 @@ describe('CascaderPanel.vue', () => {
     await nextTick()
     expect(node!.classes('is-active')).toBe(true)
   })
+
+  test('getCheckedNodes and clearCheckedNodes2', async () => {
+    const handleChange = vi.fn()
+    const wrapper = mount(() => (
+      <CascaderPanel options={NORMAL_OPTIONS} onChange={handleChange} />
+    ))
+    const vm = wrapper.findComponent(CascaderPanel).vm
+    const firstColumnItems = wrapper.findAll('.el-cascader-node')
+    const bjNode = firstColumnItems.find((node) =>
+      node.text().includes('Beijing')
+    )
+    await bjNode?.trigger('click')
+    await nextTick()
+    expect(handleChange).toHaveBeenCalledTimes(1)
+    expect(handleChange).toHaveBeenCalledWith(['beijing'])
+    vm.clearCheckedNodes()
+    await nextTick()
+    expect(handleChange).toHaveBeenCalledTimes(2)
+    expect(handleChange).toHaveBeenLastCalledWith(null)
+    expect(vm.getCheckedNodes(false)?.length).toBe(0)
+  })
 })

--- a/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
+++ b/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
@@ -827,4 +827,64 @@ describe('CascaderPanel.vue', () => {
     expect(handleChange).toHaveBeenLastCalledWith(null)
     expect(vm.getCheckedNodes(false)?.length).toBe(0)
   })
+
+  test('ensure only one update model value is fired on single mode', async () => {
+    const onChange = vi.fn()
+    const onUpdateModelValue = vi.fn()
+    const options = [
+      {
+        value: 'guide',
+        label: 'Guide',
+      },
+    ]
+    const wrapper = mount(() => (
+      <CascaderPanel
+        options={options}
+        onUpdate:modelValue={onUpdateModelValue}
+        onChange={onChange}
+      />
+    ))
+    const node = wrapper.find(NODE)
+    await node.trigger('click')
+    expect(onChange).toHaveBeenCalledOnce()
+    expect(onUpdateModelValue).toHaveBeenCalledOnce()
+    expect(onChange).toHaveBeenCalledWith(['guide'])
+    expect(onUpdateModelValue).toHaveBeenCalledWith(['guide'])
+  })
+
+  test('ensure only one update model value is fired on multiple mode', async () => {
+    const onChange = vi.fn()
+    const onUpdateModelValue = vi.fn()
+    const options = [
+      {
+        value: 'guide',
+        label: 'Guide',
+      },
+      {
+        value: 'guide1',
+        label: 'Guide1',
+      },
+    ]
+    const value = ref([])
+    const props = {
+      multiple: true,
+    }
+    const wrapper = mount(() => (
+      <CascaderPanel
+        v-model={value.value}
+        options={options}
+        props={props}
+        onUpdate:modelValue={onUpdateModelValue}
+        onChange={onChange}
+      />
+    ))
+
+    const node = wrapper.find('.el-cascader-node__label')
+    await node.trigger('click')
+    await nextTick()
+    expect(onChange).toHaveBeenCalledOnce()
+    expect(onUpdateModelValue).toHaveBeenCalledOnce()
+    expect(onChange).toHaveBeenCalledWith([['guide']])
+    expect(onUpdateModelValue).toHaveBeenCalledWith([['guide']])
+  })
 })

--- a/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
+++ b/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
@@ -807,7 +807,7 @@ describe('CascaderPanel.vue', () => {
     expect(node!.classes('is-active')).toBe(true)
   })
 
-  test('getCheckedNodes and clearCheckedNodes2', async () => {
+  test('ensure set null after clear', async () => {
     const handleChange = vi.fn()
     const wrapper = mount(() => (
       <CascaderPanel options={NORMAL_OPTIONS} onChange={handleChange} />

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -196,7 +196,6 @@ const calculateCheckedValue = () => {
   const nodes = sortByOriginalOrder(oldNodes, newNodes)
   const values = nodes.map((node) => node.valueByOption)
   checkedNodes.value = nodes
-  //rebuild
   checkedValue.value = multiple ? values : values[0] ?? null
 }
 

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -196,6 +196,7 @@ const calculateCheckedValue = () => {
   const nodes = sortByOriginalOrder(oldNodes, newNodes)
   const values = nodes.map((node) => node.valueByOption)
   checkedNodes.value = nodes
+  //rebuild
   checkedValue.value = multiple ? values : values[0] ?? null
 }
 

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -196,7 +196,7 @@ const calculateCheckedValue = () => {
   const nodes = sortByOriginalOrder(oldNodes, newNodes)
   const values = nodes.map((node) => node.valueByOption)
   checkedNodes.value = nodes
-  checkedValue.value = multiple ? values : values[0]
+  checkedValue.value = multiple ? values : values[0] ?? null
 }
 
 const syncCheckedValue = (loaded = false, forced = false) => {

--- a/packages/components/cascader-panel/src/node-content.tsx
+++ b/packages/components/cascader-panel/src/node-content.tsx
@@ -24,7 +24,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const ns = useNamespace('cascader-node')
     const { config, renderLabelFn } = inject(CASCADER_PANEL_INJECTION_KEY)!
-    const { checkOnClickNode, checkOnClickLeaf } = config
+    const { checkOnClickNode, checkOnClickLeaf, multiple } = config
     const { node, disabled } = props
     const { data, label: nodeLabel } = node
 
@@ -34,7 +34,7 @@ export default defineComponent({
     }
     function handleClick() {
       if (
-        (checkOnClickNode || (node.isLeaf && checkOnClickLeaf)) &&
+        (checkOnClickNode || (node.isLeaf && checkOnClickLeaf && multiple)) &&
         !disabled
       ) {
         emit('handleSelectCheck', !node.checked)

--- a/packages/components/cascader-panel/src/node-content.tsx
+++ b/packages/components/cascader-panel/src/node-content.tsx
@@ -24,7 +24,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const ns = useNamespace('cascader-node')
     const { config, renderLabelFn } = inject(CASCADER_PANEL_INJECTION_KEY)!
-    const { checkOnClickNode, checkOnClickLeaf, multiple } = config
+    const { checkOnClickNode, checkOnClickLeaf } = config
     const { node, disabled } = props
     const { data, label: nodeLabel } = node
 
@@ -32,11 +32,12 @@ export default defineComponent({
       const renderLabel = renderLabelFn?.({ node, data })
       return isVNodeEmpty(renderLabel) ? nodeLabel : renderLabel ?? nodeLabel
     }
-    function handleClick() {
+    function handleClick(e: Event) {
       if (
-        (checkOnClickNode || (node.isLeaf && checkOnClickLeaf && multiple)) &&
+        (checkOnClickNode || (node.isLeaf && checkOnClickLeaf)) &&
         !disabled
       ) {
+        e.stopPropagation()
         emit('handleSelectCheck', !node.checked)
       }
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
fixed #21650 

After clearing, explicitly return null.  [demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtY2FzY2FkZXItcGFuZWwgQGNoYW5nZT1cImhhbmRsZUNoYW5nZVwiIHN0eWxlPVwid2lkdGg6IGZpdC1jb250ZW50XCIgOm9wdGlvbnM9XCJvcHRpb25zXCIgcmVmPVwiY2FzY2FkZXJQYW5lbFwiIC8+XG48L3RlbXBsYXRlPlxuXG48c2NyaXB0IGxhbmc9XCJ0c1wiIHNldHVwPlxuXG5pbXBvcnQge3JlZn0gZnJvbSd2dWUnXG5jb25zdCBjYXNjYWRlclBhbmVsID0gcmVmKG51bGwpXG5jb25zdCBvcHRpb25zID0gW1xuICB7XG4gICAgdmFsdWU6ICdndWlkZScsXG4gICAgbGFiZWw6ICdHdWlkZSdcbiAgfSxcbiAge1xuICAgIHZhbHVlOiAnY29tcG9uZW50JyxcbiAgICBsYWJlbDogJ0NvbXBvbmVudCdcbiAgfSxcbiAge1xuICAgIHZhbHVlOiAncmVzb3VyY2UnLFxuICAgIGxhYmVsOiAnUmVzb3VyY2UnXG4gIH1cbl1cblxuXG5jb25zdCBoYW5kbGVDaGFuZ2UgPSAodmFsKSA9PiB7XG4gIGNvbnNvbGUubG9nKHZhbClcbiAgaWYgKHZhbCkge1xuICAgIC8vIOa4hemZpOmAieS4reiKgueCuVxuICAgIGNhc2NhZGVyUGFuZWwudmFsdWUuY2xlYXJDaGVja2VkTm9kZXMoKVxuICB9XG59XG48L3NjcmlwdD5cbiIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vcHJldmlldy0yMTY1Mi1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2Rpc3QvaW5kZXguY3NzJywgJ2h0dHBzOi8vcHJldmlldy0yMTY1Mi1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL3RoZW1lLWNoYWxrL2RhcmsvY3NzLXZhcnMuY3NzJ10ubWFwKChzdHlsZSkgPT4ge1xuICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgICAgbGluay5ocmVmID0gc3R5bGVcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgICB9KVxuICB9KVxuICByZXR1cm4gUHJvbWlzZS5hbGxTZXR0bGVkKHN0eWxlcylcbn1cbiIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AbGF0ZXN0L2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvc2hhcmVkXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vcHJldmlldy0yMTY1Mi1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2Rpc3QvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AZWxlbWVudC1wbHVzL2ljb25zLXZ1ZUAyL2Rpc3QvaW5kZXgubWluLmpzXCJcbiAgfSxcbiAgXCJzY29wZXNcIjoge31cbn0iLCJfbyI6eyJzaG93SGlkZGVuIjp0cnVlLCJzdHlsZVNvdXJjZSI6Imh0dHBzOi8vcHJldmlldy0yMTY1Mi1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2Rpc3QvaW5kZXguY3NzIn19)