### PR TITLE
fix(components): [scrollbar] resize according to container size

### DIFF
--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -61,6 +61,7 @@ const emit = defineEmits(scrollbarEmits)
 const ns = useNamespace('scrollbar')
 
 let stopResizeObserver: (() => void) | undefined = undefined
+let stopWrapResizeObserver: (() => void) | undefined = undefined
 let stopResizeListener: (() => void) | undefined = undefined
 let wrapScrollTop = 0
 let wrapScrollLeft = 0
@@ -199,9 +200,11 @@ watch(
   (noresize) => {
     if (noresize) {
       stopResizeObserver?.()
+      stopWrapResizeObserver?.()
       stopResizeListener?.()
     } else {
       ;({ stop: stopResizeObserver } = useResizeObserver(resizeRef, update))
+      ;({ stop: stopWrapResizeObserver } = useResizeObserver(wrapRef, update))
       stopResizeListener = useEventListener('resize', update)
     }
   },


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


scrollbar updates on external container height change.  
fixed #21693
[demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IHJlZn0gZnJvbSAndnVlJ1xuXG5jb25zdCBoID0gcmVmKDIwMClcbmNvbnN0IHcgPSByZWYoMTAwKVxuXG5jb25zdCBsYXJnZT0oKT0+e1xuICBoLnZhbHVlPTQwMDtcbn1cbmNvbnN0IHNtYWxsPSgpPT57XG4gIGgudmFsdWU9MjAwO1xufVxuY29uc3QgbWlkPSgpPT57XG4gIGgudmFsdWU9MjUwO1xufVxuY29uc3QgY2hhbmdldz0oKT0+e1xuICB3LnZhbHVlPTIwMS13LnZhbHVlO1xufVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGVsLWJ1dHRvbiBAY2xpY2s9XCJsYXJnZVwiPnNldCBsYXJnZSBoZWlnaHQ8L2VsLWJ1dHRvbj5cbiAgPGVsLWJ1dHRvbiBAY2xpY2s9XCJtaWRcIj5zZXQgc21hbGwgaGVpZ2h0PC9lbC1idXR0b24+XG4gIDxlbC1idXR0b24gQGNsaWNrPVwic21hbGxcIj5zZXQgc21hbGwgaGVpZ2h0PC9lbC1idXR0b24+XG4gIDxlbC1idXR0b24gQGNsaWNrPVwiY2hhbmdld1wiPmNoYW5nZSB3aWR0aChmb3IgdXBkYXRlKTwvZWwtYnV0dG9uPlxuICA8ZGl2IGNsYXNzPVwidFwiIDpzdHlsZT1cInsnaGVpZ2h0JzogaCsncHgnLCd3aWR0aCc6dysncHgnfVwiPlxuICAgIDxlbC1zY3JvbGxiYXIgY2xhc3M9XCJ1c2Vyc1wiPlxuICAgICAgPHA+MTExPC9wPlxuICAgICAgPHA+MTExPC9wPlxuICAgICAgPHA+MTExPC9wPlxuICAgICAgPHA+MTExPC9wPlxuICAgICAgPHA+MTExPC9wPlxuICAgICAgPHA+MTExPC9wPlxuICAgICAgPHA+MTExPC9wPlxuICAgICAgPHA+MTExPC9wPlxuICAgICAgPHA+MTExPC9wPlxuICAgIDwvZWwtc2Nyb2xsYmFyPlxuICA8L2Rpdj5cbjwvdGVtcGxhdGU+XG5cbjxzdHlsZT5cbi50IHtcbiAgYm9yZGVyOiAxcHggc29saWQ7XG59XG5cbi51c2VycyB7XG4gIGhlaWdodDogMTAwJTtcbiAgd2lkdGg6MTAwJTtcbn1cbjwvc3R5bGU+XG4iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgY29uc3Qgc3R5bGVzID0gWydodHRwczovL3ByZXZpZXctMjE2OTQtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmNzcycsICdodHRwczovL3ByZXZpZXctMjE2OTQtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS90aGVtZS1jaGFsay9kYXJrL2Nzcy12YXJzLmNzcyddLm1hcCgoc3R5bGUpID0+IHtcbiAgICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICAgIGxpbmsuaHJlZiA9IHN0eWxlXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2xvYWQnLCByZXNvbHZlKVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdlcnJvcicsIHJlamVjdClcbiAgICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gICAgfSlcbiAgfSlcbiAgcmV0dXJuIFByb21pc2UuYWxsU2V0dGxlZChzdHlsZXMpXG59XG4iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcbiAgICBcImpzeFwiOiBcInByZXNlcnZlXCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJ0eXBlc1wiOiBbXCJlbGVtZW50LXBsdXMvZ2xvYmFsLmQudHNcIl0sXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwiUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3J1bnRpbWUtZG9tQGxhdGVzdC9kaXN0L3J1bnRpbWUtZG9tLmVzbS1icm93c2VyLmpzXCIsXG4gICAgXCJAdnVlL3NoYXJlZFwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9zaGFyZWRAbGF0ZXN0L2Rpc3Qvc2hhcmVkLmVzbS1idW5kbGVyLmpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL3ByZXZpZXctMjE2OTQtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcInVuc3VwcG9ydGVkXCIsXG4gICAgXCJAZWxlbWVudC1wbHVzL2ljb25zLXZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQGVsZW1lbnQtcGx1cy9pY29ucy12dWVAMi9kaXN0L2luZGV4Lm1pbi5qc1wiXG4gIH0sXG4gIFwic2NvcGVzXCI6IHt9XG59IiwiX28iOnsic2hvd0hpZGRlbiI6dHJ1ZSwic3R5bGVTb3VyY2UiOiJodHRwczovL3ByZXZpZXctMjE2OTQtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmNzcyJ9fQ==)

![PixPin_2025-08-10_21-30-46](https://github.com/user-attachments/assets/32e41210-1049-4e37-866f-d62f61369fce)
