### PR TITLE
chore: update crowdin translate link

### DIFF
--- a/docs/.vitepress/vitepress/utils/index.ts
+++ b/docs/.vitepress/vitepress/utils/index.ts
@@ -46,6 +46,6 @@ export function createGitHubUrl(
 }
 
 export function createCrowdinUrl(/** zh-CN、es-ES... */ targetLang: string) {
-  // Direct project language URL format: https://crowdin.com/project/element-plus/{language}
+  // example: https://crowdin.com/project/element-plus/zh-CN
   return `https://crowdin.com/project/element-plus/${targetLang}`
 }

--- a/docs/.vitepress/vitepress/utils/index.ts
+++ b/docs/.vitepress/vitepress/utils/index.ts
@@ -45,14 +45,7 @@ export function createGitHubUrl(
   }${folder || ''}${path}${ext || ''}`
 }
 
-export function createCrowdinUrl(targetLang: string) {
-  let translateLang = ''
-  // for zh-CN zh-HK zh-TW, maybe later we will have cases like Chinese lang
-  // for now we just keep it as simple as possible.
-  if (targetLang.startsWith('zh-')) {
-    translateLang = targetLang.split('-').join('').toLocaleLowerCase()
-  } else {
-    translateLang = targetLang.split('-').shift()!.toLocaleLowerCase()
-  }
-  return `https://crowdin.com/translate/element-plus/all/en-${translateLang}`
+export function createCrowdinUrl(/** zh-CN、es-ES... */ targetLang: string) {
+  // Direct project language URL format: https://crowdin.com/project/element-plus/{language}
+  return `https://crowdin.com/project/element-plus/${targetLang}`
 }


### PR DESCRIPTION

<img width="1241" height="393" alt="image" src="https://github.com/user-attachments/assets/03777597-d480-45a1-9fd6-55c08c4e8637" />


### Now

In fact, there is no specific page located. It is very messy and I don’t know where it is.
https://crowdin.com/translate/element-plus/all/en-zhcn

<img width="1278" height="1270" alt="image" src="https://github.com/user-attachments/assets/387fccc6-617d-4103-af9d-4c22fdbd77f3" />


### After

https://crowdin.com/project/element-plus/zh-CN

<img width="1278" height="1270" alt="image" src="https://github.com/user-attachments/assets/b3180c48-04d9-4bad-b632-09194a620457" />
