### PR TITLE
Revert "fix(components): [table] render default slot only when it returns valid vnodes (#21651)"

### DIFF
--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -7,12 +7,7 @@ import {
   unref,
   watchEffect,
 } from 'vue'
-import {
-  debugWarn,
-  ensureValidVNode,
-  isArray,
-  isUndefined,
-} from '@element-plus/utils'
+import { debugWarn, isArray, isUndefined } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import {
   cellForced,
@@ -164,7 +159,9 @@ function useRender<T extends DefaultRow>(
         let children: VNode | VNode[] | null = null
         if (slots.default) {
           const vnodes = slots.default(data)
-          children = ensureValidVNode(vnodes) ? vnodes : originRenderCell(data)
+          children = vnodes.some((v) => v.type !== Comment)
+            ? vnodes
+            : originRenderCell(data)
         } else {
           children = originRenderCell(data)
         }

--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -1,4 +1,5 @@
 import {
+  Comment,
   computed,
   getCurrentInstance,
   h,

--- a/packages/utils/vue/vnode.ts
+++ b/packages/utils/vue/vnode.ts
@@ -170,21 +170,3 @@ export const flattedChildren = (
   })
   return result
 }
-
-// Copyied from https://github.com/vuejs/core/blob/c875019d49b4c36a88d929ccadc31ad414747c7b/packages/runtime-core/src/helpers/renderSlot.ts#L102
-export function ensureValidVNode(
-  vnodes: VNodeArrayChildren
-): VNodeArrayChildren | null {
-  return vnodes.some((child) => {
-    if (!isVNode(child)) return true
-    if (child.type === Comment) return false
-    if (
-      child.type === Fragment &&
-      !ensureValidVNode(child.children as VNodeArrayChildren)
-    )
-      return false
-    return true
-  })
-    ? vnodes
-    : null
-}


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

This PR is to fix https://github.com/element-plus/element-plus/issues/21708.

The issue is caused by https://github.com/element-plus/element-plus/pull/21651

I think the default slot unpassed value should be judged when the component is encapsulated twice, and should not affect normal use. Normal use of default slot unpassed values is expected to be null in most cases, not the original value of the data, which is not expected.