### PR TITLE
fix(components): [date-picker] window focus causes the panel to pop up

### DIFF
--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -255,9 +255,7 @@ const { isFocused, handleFocus, handleBlur } = useFocusController(inputRef, {
   beforeFocus() {
     return props.readonly
   },
-  afterFocus() {
-    pickerVisible.value = true
-  },
+
   beforeBlur(event) {
     return (
       !hasJustTabExitedInput && refPopper.value?.isFocusInsideContent(event)


### PR DESCRIPTION
Fix the time picker to automatically expand when switching browser tabs while it is focused

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
[#21749]