### PR TITLE
feat(components): [tour] support keyboard switching steps

### DIFF
--- a/packages/components/tour/src/step.vue
+++ b/packages/components/tour/src/step.vue
@@ -156,7 +156,7 @@ const onClose = () => {
 
 const handleKeydown = (e: KeyboardEvent) => {
   const target = e.target as HTMLElement | null
-  if (!!target && target.isContentEditable) return
+  if (target?.isContentEditable) return
 
   const actions: Record<string, () => void> = {
     [EVENT_CODE.left]: () => current.value > 0 && onPrev(),

--- a/packages/components/tour/src/step.vue
+++ b/packages/components/tour/src/step.vue
@@ -65,7 +65,8 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, watch } from 'vue'
+import { computed, inject, onBeforeUnmount, onMounted, watch } from 'vue'
+import { EVENT_CODE } from '@element-plus/constants'
 import { omit } from 'lodash-unified'
 import { ElButton } from '@element-plus/components/button'
 import { ElIcon } from '@element-plus/components/icon'
@@ -152,4 +153,28 @@ const onClose = () => {
   tourOnClose()
   emit('close')
 }
+
+const handleKeydown = (e: KeyboardEvent) => {
+  const target = e.target as HTMLElement | null
+  if (!!target && target.isContentEditable) return
+
+  const actions: Record<string, () => void> = {
+    [EVENT_CODE.left]: () => current.value > 0 && onPrev(),
+    [EVENT_CODE.right]: onNext,
+  }
+
+  const action = actions[e.code]
+  if (action) {
+    e.preventDefault()
+    action()
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', handleKeydown)
+})
 </script>


### PR DESCRIPTION
This will help us better experience feature previews, as the focus points of different steps can be far apart, making switching with the mouse somewhat cumbersome.

Being able to use the keyboard would certainly be a significant convenience.
