### PR TITLE
docs(components): [popover] update examples

### DIFF
--- a/docs/examples/popover/directive-usage.vue
+++ b/docs/examples/popover/directive-usage.vue
@@ -1,7 +1,5 @@
 <template>
-  <el-button v-popover="popoverRef" v-click-outside="onClickOutside">
-    Click me
-  </el-button>
+  <el-button v-popover="popoverRef"> Click me </el-button>
 
   <el-popover
     ref="popoverRef"
@@ -15,11 +13,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, unref } from 'vue'
-import { ClickOutside as vClickOutside } from 'element-plus'
+import { ref } from 'vue'
 
 const popoverRef = ref()
-const onClickOutside = () => {
-  unref(popoverRef).popperRef?.delayHide?.()
-}
 </script>

--- a/docs/examples/popover/directive-usage.vue
+++ b/docs/examples/popover/directive-usage.vue
@@ -1,5 +1,7 @@
 <template>
-  <el-button v-popover="popoverRef"> Click me </el-button>
+  <el-button v-popover="popoverRef" v-click-outside="onClickOutside">
+    Click me
+  </el-button>
 
   <el-popover
     ref="popoverRef"
@@ -14,6 +16,12 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import { ClickOutside as vClickOutside } from 'element-plus'
 
-const popoverRef = ref()
+import type { PopoverInstance } from 'element-plus'
+
+const popoverRef = ref<PopoverInstance>()
+const onClickOutside = () => {
+  popoverRef.value?.hide()
+}
 </script>

--- a/docs/examples/popover/virtual-triggering.vue
+++ b/docs/examples/popover/virtual-triggering.vue
@@ -1,7 +1,5 @@
 <template>
-  <el-button ref="buttonRef" v-click-outside="onClickOutside">
-    Click me
-  </el-button>
+  <el-button ref="buttonRef"> Click me </el-button>
 
   <el-popover
     ref="popoverRef"
@@ -15,12 +13,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, unref } from 'vue'
-import { ClickOutside as vClickOutside } from 'element-plus'
+import { ref } from 'vue'
 
 const buttonRef = ref()
 const popoverRef = ref()
-const onClickOutside = () => {
-  unref(popoverRef).popperRef?.delayHide?.()
-}
 </script>

--- a/docs/examples/popover/virtual-triggering.vue
+++ b/docs/examples/popover/virtual-triggering.vue
@@ -1,5 +1,7 @@
 <template>
-  <el-button ref="buttonRef"> Click me </el-button>
+  <el-button ref="buttonRef" v-click-outside="onClickOutside">
+    Click me
+  </el-button>
 
   <el-popover
     ref="popoverRef"
@@ -14,7 +16,13 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import { ClickOutside as vClickOutside } from 'element-plus'
+
+import type { PopoverInstance } from 'element-plus'
 
 const buttonRef = ref()
-const popoverRef = ref()
+const popoverRef = ref<PopoverInstance>()
+const onClickOutside = () => {
+  popoverRef.value?.hide()
+}
 </script>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

It seems that `popperRef` has never exposed `delayHide`, and the [click-outside closing](https://github.com/element-plus/element-plus/blob/a2884da5f80cc865fdc5aeb298fb30fd90887f1f/packages/components/tooltip/src/content.vue#L175) behavior is already handled internally, without requiring additional control from the user.

close #21782