### PR TITLE
fix(components): [segmented] wrap options item slot to any

### DIFF
--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -24,7 +24,7 @@
           @change="handleChange(item)"
         />
         <div :class="ns.e('item-label')">
-          <slot :item="item">{{ getLabel(item) }}</slot>
+          <slot :item="intoAny(item)">{{ getLabel(item) }}</slot>
         </div>
       </label>
     </div>
@@ -82,6 +82,8 @@ const handleChange = (item: Option) => {
 }
 
 const aliasProps = computed(() => ({ ...defaultProps, ...props.props }))
+
+const intoAny = (item: any) => item
 
 const getValue = (item: Option) => {
   return isObject(item) ? item[aliasProps.value.value] : item

--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -83,6 +83,7 @@ const handleChange = (item: Option) => {
 
 const aliasProps = computed(() => ({ ...defaultProps, ...props.props }))
 
+//FIXME: remove this when vue >=3.3
 const intoAny = (item: any) => item
 
 const getValue = (item: Option) => {


### PR DESCRIPTION
closed #21791

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

```ts
export type Option = Record<string, any> | string | number | boolean
```
We can't resolve the passed type in options without a generic.
It's a workaround before vue >= 3.3.