### PR TITLE
fix(components): [radio-group] prop-value cause ivalidate loop

### DIFF
--- a/packages/components/radio/src/radio-group.vue
+++ b/packages/components/radio/src/radio-group.vue
@@ -28,6 +28,7 @@ import { useId, useNamespace } from '@element-plus/hooks'
 import { debugWarn } from '@element-plus/utils'
 import { radioGroupEmits, radioGroupProps } from './radio-group'
 import { radioGroupKey } from './constants'
+import { isEqual } from 'lodash-unified'
 
 import type { RadioGroupProps } from './radio-group'
 
@@ -75,8 +76,8 @@ provide(
 
 watch(
   () => props.modelValue,
-  () => {
-    if (props.validateEvent) {
+  (newVal, oldValue) => {
+    if (props.validateEvent && !isEqual(newVal, oldValue)) {
       formItem?.validate('change').catch((err) => debugWarn(err))
     }
   }


### PR DESCRIPTION
fix el-radio-group in el-form-item  would trigger invalid updates and potential infinite loops when model-value is a reference type (e.g., object/array) similar to el-checkbox-group https://github.com/element-plus/element-plus/pull/21309.
Fixes https://github.com/element-plus/element-plus/issues/21305
Why is isEqual needed? When users pass in types that do not meet expectations, the component should not crash or get stuck in an infinite loop; instead, it should handle them gracefully.
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
