### PR TITLE
fix(types): [table] export missing types TableHeader,TreeData,TreeProps

### DIFF
--- a/packages/components/cascader-panel/src/config.ts
+++ b/packages/components/cascader-panel/src/config.ts
@@ -3,14 +3,14 @@ import { NOOP, buildProps, definePropType } from '@element-plus/utils'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
 import type { PropType } from 'vue'
+import type { CascaderProps } from './node'
 import type {
   CascaderConfig,
   CascaderNodePathValue,
   CascaderOption,
-  CascaderProps,
   CascaderValue,
   RenderLabel,
-} from './node'
+} from './types'
 
 export const CommonProps = buildProps({
   /**

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -56,13 +56,13 @@ import {
 import { checkNode, getMenuIndex, sortByOriginalOrder } from './utils'
 import { CASCADER_PANEL_INJECTION_KEY } from './types'
 
+import type { default as CascaderNode } from './node'
 import type {
-  default as CascaderNode,
   CascaderNodeValue,
   CascaderOption,
   CascaderValue,
-} from './node'
-import type { ElCascaderPanelContext } from './types'
+  ElCascaderPanelContext,
+} from './types'
 import type { CascaderMenuInstance } from './instance'
 
 defineOptions({

--- a/packages/components/cascader-panel/src/node.ts
+++ b/packages/components/cascader-panel/src/node.ts
@@ -1,32 +1,16 @@
 import { isArray, isEmpty, isFunction, isUndefined } from '@element-plus/utils'
 
-import type { VNode } from 'vue'
+import type {
+  CascaderConfig,
+  CascaderNodePathValue,
+  CascaderNodeValue,
+  CascaderOption,
+  LazyLoad,
+  isDisabled,
+  isLeaf,
+} from './types'
 
-export type CascaderNodeValue = string | number
-export type CascaderNodePathValue = CascaderNodeValue[]
-export type CascaderValue =
-  | CascaderNodeValue
-  | CascaderNodePathValue
-  | (CascaderNodeValue | CascaderNodePathValue)[]
-export type CascaderConfig = Required<CascaderProps>
 export type ExpandTrigger = 'click' | 'hover'
-export type isDisabled = (data: CascaderOption, node: Node) => boolean
-export type isLeaf = (data: CascaderOption, node: Node) => boolean
-export type Resolve = (dataList?: CascaderOption[]) => void
-export type LazyLoad = (node: Node, resolve: Resolve) => void
-export interface RenderLabelProps {
-  node: Node
-  data: CascaderOption
-}
-export type RenderLabel = (props: RenderLabelProps) => VNode | VNode[]
-export interface CascaderOption extends Record<string, unknown> {
-  label?: string
-  value?: CascaderNodeValue
-  children?: CascaderOption[]
-  disabled?: boolean
-  leaf?: boolean
-}
-
 export interface CascaderProps {
   expandTrigger?: ExpandTrigger
   multiple?: boolean

--- a/packages/components/cascader-panel/src/store.ts
+++ b/packages/components/cascader-panel/src/store.ts
@@ -7,7 +7,7 @@ import type {
   CascaderNodePathValue,
   CascaderNodeValue,
   CascaderOption,
-} from './node'
+} from './types'
 
 const flatNodes = (nodes: Node[], leafOnly: boolean) => {
   return nodes.reduce((res, node) => {

--- a/packages/components/cascader-panel/src/types.ts
+++ b/packages/components/cascader-panel/src/types.ts
@@ -1,12 +1,19 @@
 import type { InjectionKey, VNode } from 'vue'
 import type {
   default as CascaderNode,
-  CascaderOption,
   CascaderProps,
   ExpandTrigger,
 } from './node'
 
-export type { CascaderNode, CascaderOption, CascaderProps, ExpandTrigger }
+export type { CascaderNode, CascaderProps, ExpandTrigger }
+
+export interface CascaderOption extends Record<string, unknown> {
+  label?: string
+  value?: CascaderNodeValue
+  children?: CascaderOption[]
+  disabled?: boolean
+  leaf?: boolean
+}
 
 export type CascaderNodeValue = string | number
 export type CascaderNodePathValue = CascaderNodeValue[]

--- a/packages/components/segmented/src/segmented.ts
+++ b/packages/components/segmented/src/segmented.ts
@@ -8,7 +8,7 @@ import {
 import { useAriaProps, useSizeProp } from '@element-plus/hooks'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
-import type { Option } from './types'
+import type { SegementedOption } from './types'
 import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type Segmented from './segmented.vue'
 
@@ -33,7 +33,7 @@ export const segmentedProps = buildProps({
    * @description options of segmented
    */
   options: {
-    type: definePropType<Option[]>(Array),
+    type: definePropType<SegementedOption[]>(Array),
     default: () => [],
   },
   /**

--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -45,7 +45,7 @@ import { debugWarn, isObject } from '@element-plus/utils'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { defaultProps, segmentedEmits, segmentedProps } from './segmented'
 
-import type { Option } from './types'
+import type { SegementedOption } from './types'
 
 defineOptions({
   name: 'ElSegmented',
@@ -75,7 +75,7 @@ const state = reactive({
   focusVisible: false,
 })
 
-const handleChange = (item: Option) => {
+const handleChange = (item: SegementedOption) => {
   const value = getValue(item)
   emit(UPDATE_MODEL_EVENT, value)
   emit(CHANGE_EVENT, value)
@@ -86,22 +86,22 @@ const aliasProps = computed(() => ({ ...defaultProps, ...props.props }))
 //FIXME: remove this when vue >=3.3
 const intoAny = (item: any) => item
 
-const getValue = (item: Option) => {
+const getValue = (item: SegementedOption) => {
   return isObject(item) ? item[aliasProps.value.value] : item
 }
 
-const getLabel = (item: Option) => {
+const getLabel = (item: SegementedOption) => {
   return isObject(item) ? item[aliasProps.value.label] : item
 }
 
-const getDisabled = (item: Option | undefined) => {
+const getDisabled = (item: SegementedOption | undefined) => {
   return !!(
     _disabled.value ||
     (isObject(item) ? item[aliasProps.value.disabled] : false)
   )
 }
 
-const getSelected = (item: Option) => {
+const getSelected = (item: SegementedOption) => {
   return props.modelValue === getValue(item)
 }
 
@@ -109,7 +109,7 @@ const getOption = (value: any) => {
   return props.options.find((item) => getValue(item) === value)
 }
 
-const getItemCls = (item: Option) => {
+const getItemCls = (item: SegementedOption) => {
   return [
     ns.e('item'),
     ns.is('selected', getSelected(item)),

--- a/packages/components/segmented/src/types.ts
+++ b/packages/components/segmented/src/types.ts
@@ -1,1 +1,1 @@
-export type Option = Record<string, any> | string | number | boolean
+export type SegementedOption = Record<string, any> | string | number | boolean

--- a/packages/components/select-v2/index.ts
+++ b/packages/components/select-v2/index.ts
@@ -7,3 +7,13 @@ export const ElSelectV2: SFCWithInstall<typeof Select> = withInstall(Select)
 export default ElSelectV2
 
 export * from './src/token'
+
+export type {
+  SelectV2Props,
+  SelectV2PropsPublic,
+  OptionV2Props,
+  OptionV2PropsPublic,
+  SelectV2EmitFn,
+  OptionV2EmitFn,
+  SelectV2Instance,
+} from './src/defaults'

--- a/packages/components/select-v2/index.ts
+++ b/packages/components/select-v2/index.ts
@@ -9,11 +9,8 @@ export default ElSelectV2
 export * from './src/token'
 
 export type {
-  SelectV2Props,
   SelectV2PropsPublic,
-  OptionV2Props,
   OptionV2PropsPublic,
   SelectV2EmitFn,
   OptionV2EmitFn,
-  SelectV2Instance,
 } from './src/defaults'

--- a/packages/components/select-v2/src/defaults.ts
+++ b/packages/components/select-v2/src/defaults.ts
@@ -18,7 +18,7 @@ import { tagProps } from '../../tag'
 import { defaultProps } from './useProps'
 import SelectV2 from './select.vue'
 
-import type { Option, OptionType } from './select.types'
+import type { OptionType, OptionV2 } from './select.types'
 import type { Props } from './useProps'
 import type { EmitFn } from '@element-plus/utils/vue/typescript'
 import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
@@ -319,7 +319,7 @@ export const optionV2Props = buildProps({
   disabled: Boolean,
   hovering: Boolean,
   item: {
-    type: definePropType<Option>(Object),
+    type: definePropType<OptionV2>(Object),
     required: true,
   },
   index: Number,
@@ -340,7 +340,7 @@ export const selectV2Emits = {
 }
 export const optionV2Emits = {
   hover: (index?: number) => isNumber(index),
-  select: (val: Option, index?: number) => true,
+  select: (val: OptionV2, index?: number) => true,
 }
 /* eslint-enable @typescript-eslint/no-unused-vars */
 

--- a/packages/components/select-v2/src/select-dropdown.tsx
+++ b/packages/components/select-v2/src/select-dropdown.tsx
@@ -25,7 +25,7 @@ import type {
   FixedSizeListInstance,
   ItemProps,
 } from '@element-plus/components/virtual-list'
-import type { Option, OptionItemProps } from './select.types'
+import type { OptionItemProps, OptionV2 } from './select.types'
 import type {
   ComponentPublicInstance,
   ComputedRef,
@@ -47,7 +47,7 @@ interface SelectDropdownExposed {
   isSized: ComputedRef<boolean>
   isItemDisabled: (modelValue: any[] | any, selected: boolean) => boolean
   isItemHovering: (target: number) => boolean
-  isItemSelected: (modelValue: any[] | any, target: Option) => boolean
+  isItemSelected: (modelValue: any[] | any, target: OptionV2) => boolean
   scrollToItem: (index: number) => void
   resetScrollTop: () => void
 }

--- a/packages/components/select-v2/src/select.types.ts
+++ b/packages/components/select-v2/src/select.types.ts
@@ -1,12 +1,12 @@
 type OptionCommon = Record<string, any>
 
-export type Option = OptionCommon & {
+export type OptionV2 = OptionCommon & {
   created?: boolean
 }
 
 export type OptionGroup = OptionCommon
 
-export type OptionType = Option | OptionGroup
+export type OptionType = OptionV2 | OptionGroup
 
 export type OptionItemProps = {
   item: any
@@ -15,8 +15,8 @@ export type OptionItemProps = {
 }
 export type SelectStates = {
   inputValue: string
-  cachedOptions: Option[]
-  createdOptions: Option[]
+  cachedOptions: OptionV2[]
+  createdOptions: OptionV2[]
   hoveringIndex: number
   inputHovering: boolean
   selectionWidth: number

--- a/packages/components/select-v2/src/token.ts
+++ b/packages/components/select-v2/src/token.ts
@@ -1,13 +1,13 @@
 import type { OptionV2Props, SelectV2Instance, SelectV2Props } from './defaults'
 import type { InjectionKey, Ref } from 'vue'
-import type { Option } from './select.types'
+import type { OptionV2 } from './select.types'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
 
 export interface SelectV2Context {
   props: SelectV2Props
   expanded: Ref<boolean>
   tooltipRef: Ref<TooltipInstance | undefined>
-  onSelect: (option: Option) => void
+  onSelect: (option: OptionV2) => void
   onHover: (idx?: number) => void
   onKeyboardNavigate: (direction: 'forward' | 'backward') => void
   onKeyboardSelect: () => void

--- a/packages/components/select-v2/src/useAllowCreate.ts
+++ b/packages/components/select-v2/src/useAllowCreate.ts
@@ -2,13 +2,13 @@ import { computed, ref, watch } from 'vue'
 import { useProps } from './useProps'
 
 import type { SelectV2Props } from './token'
-import type { Option, SelectStates } from './select.types'
+import type { OptionV2, SelectStates } from './select.types'
 
 export function useAllowCreate(props: SelectV2Props, states: SelectStates) {
   const { aliasProps, getLabel, getValue } = useProps(props)
 
   const createOptionCount = ref(0)
-  const cachedSelectedOption = ref<Option>()
+  const cachedSelectedOption = ref<OptionV2>()
 
   const enableAllowCreateMode = computed(() => {
     return props.allowCreate && props.filterable
@@ -25,14 +25,14 @@ export function useAllowCreate(props: SelectV2Props, states: SelectStates) {
   )
 
   function hasExistingOption(query: string) {
-    const hasOption = (option: Option) => getLabel(option) === query
+    const hasOption = (option: OptionV2) => getLabel(option) === query
     return (
       (props.options && props.options.some(hasOption)) ||
       states.createdOptions.some(hasOption)
     )
   }
 
-  function selectNewOption(option: Option) {
+  function selectNewOption(option: OptionV2) {
     if (!enableAllowCreateMode.value) {
       return
     }
@@ -77,7 +77,7 @@ export function useAllowCreate(props: SelectV2Props, states: SelectStates) {
     }
   }
 
-  function removeNewOption(option: Option) {
+  function removeNewOption(option: OptionV2) {
     if (
       !enableAllowCreateMode.value ||
       !option ||

--- a/packages/components/select-v2/src/useProps.ts
+++ b/packages/components/select-v2/src/useProps.ts
@@ -2,7 +2,7 @@ import { computed } from 'vue'
 import { get } from 'lodash-unified'
 
 import type { SelectV2Props } from './token'
-import type { Option } from './select.types'
+import type { OptionV2 } from './select.types'
 
 export interface Props {
   label?: string
@@ -21,10 +21,11 @@ export const defaultProps: Required<Props> = {
 export function useProps(props: Pick<SelectV2Props, 'props'>) {
   const aliasProps = computed(() => ({ ...defaultProps, ...props.props }))
 
-  const getLabel = (option: Option) => get(option, aliasProps.value.label)
-  const getValue = (option: Option) => get(option, aliasProps.value.value)
-  const getDisabled = (option: Option) => get(option, aliasProps.value.disabled)
-  const getOptions = (option: Option) => get(option, aliasProps.value.options)
+  const getLabel = (option: OptionV2) => get(option, aliasProps.value.label)
+  const getValue = (option: OptionV2) => get(option, aliasProps.value.value)
+  const getDisabled = (option: OptionV2) =>
+    get(option, aliasProps.value.disabled)
+  const getOptions = (option: OptionV2) => get(option, aliasProps.value.options)
 
   return {
     aliasProps,

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -44,7 +44,7 @@ import {
 import { useAllowCreate } from './useAllowCreate'
 import { useProps } from './useProps'
 
-import type { Option, OptionType, SelectStates } from './select.types'
+import type { OptionType, OptionV2, SelectStates } from './select.types'
 import type { SelectV2Props } from './token'
 import type { SelectV2EmitFn } from './defaults'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
@@ -210,7 +210,7 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
   const filterOptions = (query: string) => {
     const regexp = new RegExp(escapeStringRegexp(query), 'i')
 
-    const isValidOption = (o: Option): boolean => {
+    const isValidOption = (o: OptionV2): boolean => {
       if (isFilterMethodValid.value || isRemoteMethodValid.value) return true
       // when query was given, we should test on the label see whether the label contains the given query
       return query ? regexp.test(getLabel(o) || '') : true
@@ -555,7 +555,7 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     tagTooltipRef.value?.updatePopper?.()
   }
 
-  const onSelect = (option: Option) => {
+  const onSelect = (option: OptionV2) => {
     if (props.multiple) {
       let selectedOptions = (props.modelValue as any[]).slice()
 
@@ -594,7 +594,7 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     focus()
   }
 
-  const deleteTag = (event: MouseEvent, option: Option) => {
+  const deleteTag = (event: MouseEvent, option: OptionV2) => {
     let selectedOptions = (props.modelValue as any[]).slice()
 
     const index = getValueIndex(selectedOptions, getValue(option))
@@ -784,7 +784,7 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     menuRef.value!.scrollToItem(index)
   }
 
-  const getOption = (value: unknown, cachedOptions?: Option[]) => {
+  const getOption = (value: unknown, cachedOptions?: OptionV2[]) => {
     // match the option with the given value, if not found, create a new option
     const selectValue = getValueKey(value)
 

--- a/packages/components/table/index.ts
+++ b/packages/components/table/index.ts
@@ -4,9 +4,6 @@ import TableColumn from './src/tableColumn'
 
 import type { SFCWithInstall } from '@element-plus/utils'
 
-export type { TableHeader } from './src/table-header'
-export type { TreeData as TableTreeData } from './src/store/tree'
-
 export const ElTable: SFCWithInstall<typeof Table> & {
   TableColumn: typeof TableColumn
 } = withInstall(Table, {
@@ -29,11 +26,24 @@ export type {
   ColumnStyle,
   CellCls,
   CellStyle,
+  DefaultRow,
   TreeNode,
   RenderRowData,
   Sort,
   Filter,
   TableColumnCtx,
   TableTooltipData,
+  TableSortOrder,
   TreeProps,
 } from './src/table/defaults'
+
+export type {
+  Filters as TableFilters,
+  FilterMethods,
+  TableColumn,
+  ValueOf as TableColumnValueOf,
+} from './src/table-column/defaults'
+export type { TableBodyProps } from './src/table-body/defaults'
+export type { TableFooter } from './src/table-footer/index'
+export type { TableHeader, TableHeaderProps } from './src/table-header/index'
+export type { TreeData as TableTreeData } from './src/store/tree'

--- a/packages/components/table/index.ts
+++ b/packages/components/table/index.ts
@@ -27,7 +27,7 @@ export type {
   CellCls,
   CellStyle,
   DefaultRow,
-  TreeNode,
+  TableTreeNode,
   RenderRowData,
   Sort,
   Filter,

--- a/packages/components/table/index.ts
+++ b/packages/components/table/index.ts
@@ -4,6 +4,9 @@ import TableColumn from './src/tableColumn'
 
 import type { SFCWithInstall } from '@element-plus/utils'
 
+export type { TableHeader } from './src/table-header'
+export type { TreeData as TableTreeData } from './src/store/tree'
+
 export const ElTable: SFCWithInstall<typeof Table> & {
   TableColumn: typeof TableColumn
 } = withInstall(Table, {
@@ -32,4 +35,5 @@ export type {
   Filter,
   TableColumnCtx,
   TableTooltipData,
+  TreeProps,
 } from './src/table/defaults'

--- a/packages/components/table/src/config.ts
+++ b/packages/components/table/src/config.ts
@@ -7,7 +7,7 @@ import { getProp, isBoolean, isFunction, isNumber } from '@element-plus/utils'
 import type { VNode } from 'vue'
 import type { TableColumnCtx } from './table-column/defaults'
 import type { Store } from './store'
-import type { DefaultRow, TreeNode } from './table/defaults'
+import type { DefaultRow, TableTreeNode } from './table/defaults'
 
 const defaultClassNames = {
   selection: 'table-column--selection',
@@ -205,7 +205,7 @@ export function treeCellPrefix<T extends DefaultRow>(
     store,
   }: {
     row: T
-    treeNode: TreeNode
+    treeNode: TableTreeNode
     store: Store<T>
   },
   createPlaceholder = false

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -3,9 +3,14 @@ import { isArray, isUndefined } from '@element-plus/utils'
 import { getRowIdentity, walkTreeNode } from '../util'
 
 import type { WatcherPropsData } from '.'
-import type { DefaultRow, Table, TableProps, TreeNode } from '../table/defaults'
+import type {
+  DefaultRow,
+  Table,
+  TableProps,
+  TableTreeNode,
+} from '../table/defaults'
 
-export interface TreeData extends TreeNode {
+export interface TreeData extends TableTreeNode {
   children?: string[]
   lazy?: boolean
   loaded?: boolean
@@ -201,7 +206,7 @@ function useTree<T extends DefaultRow>(watcherData: WatcherPropsData<T>) {
     }
   }
 
-  const loadData = (row: T, key: string, treeNode: TreeNode) => {
+  const loadData = (row: T, key: string, treeNode: TableTreeNode) => {
     const { load } = instance.props as unknown as TableProps<T>
     if (load && !treeData.value[key].loaded) {
       treeData.value[key].loading = true

--- a/packages/components/table/src/table-body/render-helper.ts
+++ b/packages/components/table/src/table-body/render-helper.ts
@@ -15,7 +15,7 @@ import type {
   Table,
   TableColumnCtx,
   TableProps,
-  TreeNode,
+  TableTreeNode,
 } from '../table/defaults'
 import type { TreeData } from '../store/tree'
 import type { TableOverflowTooltipOptions } from '../util'
@@ -57,7 +57,7 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
   const rowRender = (
     row: T,
     $index: number,
-    treeRowData?: TreeNode,
+    treeRowData?: TableTreeNode,
     expanded = false
   ) => {
     const { tooltipEffect, tooltipOptions, store } = props

--- a/packages/components/table/src/table/defaults.ts
+++ b/packages/components/table/src/table/defaults.ts
@@ -150,7 +150,7 @@ interface TableProps<T extends DefaultRow> {
   indent?: number
   treeProps?: TreeProps
   lazy?: boolean
-  load?: (row: T, treeNode: TreeNode, resolve: (data: T[]) => void) => void
+  load?: (row: T, treeNode: TableTreeNode, resolve: (data: T[]) => void) => void
   className?: string
   style?: CSSProperties
   tableLayout?: Layout
@@ -181,7 +181,7 @@ interface Filter<T extends DefaultRow> {
   silent: any
 }
 
-interface TreeNode {
+interface TableTreeNode {
   expanded?: boolean
   loading?: boolean
   noLazyChildren?: boolean
@@ -197,7 +197,7 @@ interface RenderRowData<T extends DefaultRow> {
   row: T
   $index: number
   cellIndex: number
-  treeNode?: TreeNode
+  treeNode?: TableTreeNode
   expanded: boolean
 }
 
@@ -437,7 +437,7 @@ export type {
   CellCls,
   CellStyle,
   DefaultRow,
-  TreeNode,
+  TableTreeNode,
   RenderRowData,
   Sort,
   Filter,

--- a/packages/components/tree-v2/src/composables/useCheck.ts
+++ b/packages/components/tree-v2/src/composables/useCheck.ts
@@ -7,11 +7,17 @@ import {
 
 import type { CheckboxValueType } from '@element-plus/components/checkbox'
 import type { Ref } from 'vue'
-import type { Tree, TreeKey, TreeNode, TreeNodeData, TreeProps } from '../types'
+import type {
+  TreeV2,
+  TreeV2Key,
+  TreeV2Node,
+  TreeV2NodeData,
+  TreeV2Props,
+} from '../types'
 
-export function useCheck(props: TreeProps, tree: Ref<Tree | undefined>) {
-  const checkedKeys = ref<Set<TreeKey>>(new Set())
-  const indeterminateKeys = ref<Set<TreeKey>>(new Set())
+export function useCheck(props: TreeV2Props, tree: Ref<TreeV2 | undefined>) {
+  const checkedKeys = ref<Set<TreeV2Key>>(new Set())
+  const indeterminateKeys = ref<Set<TreeV2Key>>(new Set())
   const { emit } = getCurrentInstance()!
 
   watch(
@@ -32,7 +38,7 @@ export function useCheck(props: TreeProps, tree: Ref<Tree | undefined>) {
     }
     const { levelTreeNodeMap, maxLevel } = tree.value
     const checkedKeySet = checkedKeys.value
-    const indeterminateKeySet = new Set<TreeKey>()
+    const indeterminateKeySet = new Set<TreeV2Key>()
     // It is easier to determine the indeterminate state by
     // traversing from bottom to top
     // leaf nodes not have indeterminate status and can be skipped
@@ -73,19 +79,19 @@ export function useCheck(props: TreeProps, tree: Ref<Tree | undefined>) {
     indeterminateKeys.value = indeterminateKeySet
   }
 
-  const isChecked = (node: TreeNode) => checkedKeys.value.has(node.key)
+  const isChecked = (node: TreeV2Node) => checkedKeys.value.has(node.key)
 
-  const isIndeterminate = (node: TreeNode) =>
+  const isIndeterminate = (node: TreeV2Node) =>
     indeterminateKeys.value.has(node.key)
 
   const toggleCheckbox = (
-    node: TreeNode,
+    node: TreeV2Node,
     isChecked: CheckboxValueType,
     nodeClick = true,
     immediateUpdate = true
   ) => {
     const checkedKeySet = checkedKeys.value
-    const toggle = (node: TreeNode, checked: CheckboxValueType) => {
+    const toggle = (node: TreeV2Node, checked: CheckboxValueType) => {
       checkedKeySet[checked ? SetOperationEnum.ADD : SetOperationEnum.DELETE](
         node.key
       )
@@ -107,7 +113,7 @@ export function useCheck(props: TreeProps, tree: Ref<Tree | undefined>) {
     }
   }
 
-  const afterNodeCheck = (node: TreeNode, checked: CheckboxValueType) => {
+  const afterNodeCheck = (node: TreeV2Node, checked: CheckboxValueType) => {
     const { checkedNodes, checkedKeys } = getChecked()
     const { halfCheckedNodes, halfCheckedKeys } = getHalfChecked()
     emit(NODE_CHECK, node.data, {
@@ -120,28 +126,28 @@ export function useCheck(props: TreeProps, tree: Ref<Tree | undefined>) {
   }
 
   // expose
-  function getCheckedKeys(leafOnly = false): TreeKey[] {
+  function getCheckedKeys(leafOnly = false): TreeV2Key[] {
     return getChecked(leafOnly).checkedKeys
   }
 
-  function getCheckedNodes(leafOnly = false): TreeNodeData[] {
+  function getCheckedNodes(leafOnly = false): TreeV2NodeData[] {
     return getChecked(leafOnly).checkedNodes
   }
 
-  function getHalfCheckedKeys(): TreeKey[] {
+  function getHalfCheckedKeys(): TreeV2Key[] {
     return getHalfChecked().halfCheckedKeys
   }
 
-  function getHalfCheckedNodes(): TreeNodeData[] {
+  function getHalfCheckedNodes(): TreeV2NodeData[] {
     return getHalfChecked().halfCheckedNodes
   }
 
   function getChecked(leafOnly = false): {
-    checkedKeys: TreeKey[]
-    checkedNodes: TreeNodeData[]
+    checkedKeys: TreeV2Key[]
+    checkedNodes: TreeV2NodeData[]
   } {
-    const checkedNodes: TreeNodeData[] = []
-    const keys: TreeKey[] = []
+    const checkedNodes: TreeV2NodeData[] = []
+    const keys: TreeV2Key[] = []
     if (tree?.value && props.showCheckbox) {
       const { treeNodeMap } = tree.value
       checkedKeys.value.forEach((key) => {
@@ -159,11 +165,11 @@ export function useCheck(props: TreeProps, tree: Ref<Tree | undefined>) {
   }
 
   function getHalfChecked(): {
-    halfCheckedKeys: TreeKey[]
-    halfCheckedNodes: TreeNodeData[]
+    halfCheckedKeys: TreeV2Key[]
+    halfCheckedNodes: TreeV2NodeData[]
   } {
-    const halfCheckedNodes: TreeNodeData[] = []
-    const halfCheckedKeys: TreeKey[] = []
+    const halfCheckedNodes: TreeV2NodeData[] = []
+    const halfCheckedKeys: TreeV2Key[] = []
     if (tree?.value && props.showCheckbox) {
       const { treeNodeMap } = tree.value
       indeterminateKeys.value.forEach((key) => {
@@ -180,7 +186,7 @@ export function useCheck(props: TreeProps, tree: Ref<Tree | undefined>) {
     }
   }
 
-  function setCheckedKeys(keys: TreeKey[]) {
+  function setCheckedKeys(keys: TreeV2Key[]) {
     checkedKeys.value.clear()
     indeterminateKeys.value.clear()
     nextTick(() => {
@@ -188,7 +194,7 @@ export function useCheck(props: TreeProps, tree: Ref<Tree | undefined>) {
     })
   }
 
-  function setChecked(key: TreeKey, isChecked: boolean) {
+  function setChecked(key: TreeV2Key, isChecked: boolean) {
     if (tree?.value && props.showCheckbox) {
       const node = tree.value.treeNodeMap.get(key)
       if (node) {
@@ -197,7 +203,7 @@ export function useCheck(props: TreeProps, tree: Ref<Tree | undefined>) {
     }
   }
 
-  function _setCheckedKeys(keys: TreeKey[]) {
+  function _setCheckedKeys(keys: TreeV2Key[]) {
     if (tree?.value) {
       const { treeNodeMap } = tree.value
       if (props.showCheckbox && treeNodeMap && keys?.length > 0) {

--- a/packages/components/tree-v2/src/composables/useFilter.ts
+++ b/packages/components/tree-v2/src/composables/useFilter.ts
@@ -2,14 +2,14 @@ import { computed, ref } from 'vue'
 import { isFunction } from '@element-plus/utils'
 
 import type { Ref } from 'vue'
-import type { Tree, TreeKey, TreeNode, TreeProps } from '../types'
+import type { TreeV2, TreeV2Key, TreeV2Node, TreeV2Props } from '../types'
 
 // When the data volume is very large using filter will cause lag
 // I haven't found a better way to optimize it for now
 // Maybe this problem should be left to the server side
-export function useFilter(props: TreeProps, tree: Ref<Tree | undefined>) {
-  const hiddenNodeKeySet = ref<Set<TreeKey>>(new Set([]))
-  const hiddenExpandIconKeySet = ref<Set<TreeKey>>(new Set([]))
+export function useFilter(props: TreeV2Props, tree: Ref<TreeV2 | undefined>) {
+  const hiddenNodeKeySet = ref<Set<TreeV2Key>>(new Set([]))
+  const hiddenExpandIconKeySet = ref<Set<TreeV2Key>>(new Set([]))
 
   const filterable = computed(() => {
     return isFunction(props.filterMethod)
@@ -19,14 +19,14 @@ export function useFilter(props: TreeProps, tree: Ref<Tree | undefined>) {
     if (!filterable.value) {
       return
     }
-    const expandKeySet = new Set<TreeKey>()
+    const expandKeySet = new Set<TreeV2Key>()
     const hiddenExpandIconKeys = hiddenExpandIconKeySet.value
     const hiddenKeys = hiddenNodeKeySet.value
-    const family: TreeNode[] = []
+    const family: TreeV2Node[] = []
     const nodes = tree.value?.treeNodes || []
     const filter = props.filterMethod
     hiddenKeys.clear()
-    function traverse(nodes: TreeNode[]) {
+    function traverse(nodes: TreeV2Node[]) {
       nodes.forEach((node) => {
         family.push(node)
         if (filter?.(query, node.data, node)) {
@@ -66,7 +66,7 @@ export function useFilter(props: TreeProps, tree: Ref<Tree | undefined>) {
     return expandKeySet
   }
 
-  function isForceHiddenExpandIcon(node: TreeNode): boolean {
+  function isForceHiddenExpandIcon(node: TreeV2Node): boolean {
     return hiddenExpandIconKeySet.value.has(node.key)
   }
 

--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -6,7 +6,7 @@ import {
   NODE_COLLAPSE,
   NODE_DROP,
   NODE_EXPAND,
-  TreeOptionsEnum,
+  TreeV2OptionsEnum,
 } from '../virtual-tree'
 import { useCheck } from './useCheck'
 import { useFilter } from './useFilter'
@@ -19,21 +19,21 @@ import type { SetupContext } from 'vue'
 import type { treeEmits } from '../virtual-tree'
 import type { CheckboxValueType } from '@element-plus/components/checkbox'
 import type {
-  Tree,
-  TreeData,
-  TreeKey,
-  TreeNode,
-  TreeNodeData,
-  TreeProps,
+  TreeV2,
+  TreeV2Data,
+  TreeV2Key,
+  TreeV2Node,
+  TreeV2NodeData,
+  TreeV2Props,
 } from '../types'
 
 export function useTree(
-  props: TreeProps,
+  props: TreeV2Props,
   emit: SetupContext<typeof treeEmits>['emit']
 ) {
-  const expandedKeySet = ref<Set<TreeKey>>(new Set())
-  const currentKey = ref<TreeKey | undefined>()
-  const tree = shallowRef<Tree | undefined>()
+  const expandedKeySet = ref<Set<TreeV2Key>>(new Set())
+  const currentKey = ref<TreeV2Key | undefined>()
+  const tree = shallowRef<TreeV2 | undefined>()
   const listRef = ref<typeof FixedSizeList | undefined>()
 
   const {
@@ -54,25 +54,25 @@ export function useTree(
   )
 
   const valueKey = computed(() => {
-    return props.props?.value || TreeOptionsEnum.KEY
+    return props.props?.value || TreeV2OptionsEnum.KEY
   })
   const childrenKey = computed(() => {
-    return props.props?.children || TreeOptionsEnum.CHILDREN
+    return props.props?.children || TreeV2OptionsEnum.CHILDREN
   })
   const disabledKey = computed(() => {
-    return props.props?.disabled || TreeOptionsEnum.DISABLED
+    return props.props?.disabled || TreeV2OptionsEnum.DISABLED
   })
   const labelKey = computed(() => {
-    return props.props?.label || TreeOptionsEnum.LABEL
+    return props.props?.label || TreeV2OptionsEnum.LABEL
   })
 
   const flattenTree = computed(() => {
     const expandedKeys = expandedKeySet.value
     const hiddenKeys = hiddenNodeKeySet.value
-    const flattenNodes: TreeNode[] = []
+    const flattenNodes: TreeV2Node[] = []
     const nodes = tree.value?.treeNodes || []
 
-    const stack: TreeNode[] = []
+    const stack: TreeV2Node[] = []
     for (let i = nodes.length - 1; i >= 0; --i) {
       stack.push(nodes[i])
     }
@@ -95,19 +95,19 @@ export function useTree(
     return flattenTree.value.length > 0
   })
 
-  function createTree(data: TreeData): Tree {
-    const treeNodeMap: Map<TreeKey, TreeNode> = new Map()
-    const levelTreeNodeMap: Map<number, TreeNode[]> = new Map()
+  function createTreeV2(data: TreeV2Data): TreeV2 {
+    const treeNodeMap: Map<TreeV2Key, TreeV2Node> = new Map()
+    const levelTreeNodeMap: Map<number, TreeV2Node[]> = new Map()
     let maxLevel = 1
     function traverse(
-      nodes: TreeData,
+      nodes: TreeV2Data,
       level = 1,
-      parent: TreeNode | undefined = undefined
+      parent: TreeV2Node | undefined = undefined
     ) {
-      const siblings: TreeNode[] = []
+      const siblings: TreeV2Node[] = []
       for (const rawNode of nodes) {
         const value = getKey(rawNode)
-        const node: TreeNode = {
+        const node: TreeV2Node = {
           level,
           key: value,
           data: rawNode,
@@ -133,7 +133,7 @@ export function useTree(
       }
       return siblings
     }
-    const treeNodes: TreeNode[] = traverse(data)
+    const treeNodes: TreeV2Node[] = traverse(data)
     return {
       treeNodeMap,
       levelTreeNodeMap,
@@ -149,26 +149,26 @@ export function useTree(
     }
   }
 
-  function getChildren(node: TreeNodeData): TreeNodeData[] {
+  function getChildren(node: TreeV2NodeData): TreeV2NodeData[] {
     return node[childrenKey.value]
   }
 
-  function getKey(node: TreeNodeData): TreeKey {
+  function getKey(node: TreeV2NodeData): TreeV2Key {
     if (!node) {
       return ''
     }
     return node[valueKey.value]
   }
 
-  function getDisabled(node: TreeNodeData): boolean {
+  function getDisabled(node: TreeV2NodeData): boolean {
     return node[disabledKey.value]
   }
 
-  function getLabel(node: TreeNodeData): string {
+  function getLabel(node: TreeV2NodeData): string {
     return node[labelKey.value]
   }
 
-  function toggleExpand(node: TreeNode) {
+  function toggleExpand(node: TreeV2Node) {
     const expandedKeys = expandedKeySet.value
     if (expandedKeys.has(node.key)) {
       collapseNode(node)
@@ -177,8 +177,8 @@ export function useTree(
     }
   }
 
-  function setExpandedKeys(keys: TreeKey[]) {
-    const expandedKeys = new Set<TreeKey>()
+  function setExpandedKeys(keys: TreeV2Key[]) {
+    const expandedKeys = new Set<TreeV2Key>()
     const nodeMap = tree.value!.treeNodeMap
 
     keys.forEach((k) => {
@@ -193,7 +193,7 @@ export function useTree(
     expandedKeySet.value = expandedKeys
   }
 
-  function handleNodeClick(node: TreeNode, e: MouseEvent) {
+  function handleNodeClick(node: TreeV2Node, e: MouseEvent) {
     emit(NODE_CLICK, node.data, node, e)
     handleCurrentChange(node)
     if (props.expandOnClickNode) {
@@ -208,22 +208,22 @@ export function useTree(
     }
   }
 
-  function handleNodeDrop(node: TreeNode, e: DragEvent) {
+  function handleNodeDrop(node: TreeV2Node, e: DragEvent) {
     emit(NODE_DROP, node.data, node, e)
   }
 
-  function handleCurrentChange(node: TreeNode) {
+  function handleCurrentChange(node: TreeV2Node) {
     if (!isCurrent(node)) {
       currentKey.value = node.key
       emit(CURRENT_CHANGE, node.data, node)
     }
   }
 
-  function handleNodeCheck(node: TreeNode, checked: CheckboxValueType) {
+  function handleNodeCheck(node: TreeV2Node, checked: CheckboxValueType) {
     toggleCheckbox(node, checked)
   }
 
-  function expandNode(node: TreeNode) {
+  function expandNode(node: TreeV2Node) {
     const keySet = expandedKeySet.value
     if (tree.value && props.accordion) {
       // whether only one node among the same level can be expanded at one time
@@ -241,44 +241,44 @@ export function useTree(
     emit(NODE_EXPAND, node.data, node)
   }
 
-  function collapseNode(node: TreeNode) {
+  function collapseNode(node: TreeV2Node) {
     expandedKeySet.value.delete(node.key)
     node.expanded = false
     emit(NODE_COLLAPSE, node.data, node)
   }
 
-  function isDisabled(node: TreeNode): boolean {
+  function isDisabled(node: TreeV2Node): boolean {
     return !!node.disabled
   }
 
-  function isCurrent(node: TreeNode): boolean {
+  function isCurrent(node: TreeV2Node): boolean {
     const current = currentKey.value
     return current !== undefined && current === node.key
   }
 
-  function getCurrentNode(): TreeNodeData | undefined {
+  function getCurrentNode(): TreeV2NodeData | undefined {
     if (!currentKey.value) return undefined
     return tree.value?.treeNodeMap.get(currentKey.value)?.data
   }
 
-  function getCurrentKey(): TreeKey | undefined {
+  function getCurrentKey(): TreeV2Key | undefined {
     return currentKey.value
   }
 
-  function setCurrentKey(key: TreeKey): void {
+  function setCurrentKey(key: TreeV2Key): void {
     currentKey.value = key
   }
 
-  function setData(data: TreeData) {
-    tree.value = createTree(data)
+  function setData(data: TreeV2Data) {
+    tree.value = createTreeV2(data)
   }
 
-  function getNode(data: TreeKey | TreeNodeData) {
+  function getNode(data: TreeV2Key | TreeV2NodeData) {
     const key = isObject(data) ? getKey(data) : data
     return tree.value?.treeNodeMap.get(key)
   }
 
-  function scrollToNode(key: TreeKey, strategy: ScrollStrategy = 'auto') {
+  function scrollToNode(key: TreeV2Key, strategy: ScrollStrategy = 'auto') {
     const node = getNode(key)
     if (node && listRef.value) {
       listRef.value.scrollToItem(flattenTree.value.indexOf(node), strategy)
@@ -302,7 +302,7 @@ export function useTree(
   watch(
     () => props.defaultExpandedKeys,
     (key) => {
-      expandedKeySet.value = new Set<TreeKey>(key)
+      expandedKeySet.value = new Set<TreeV2Key>(key)
     },
     {
       immediate: true,
@@ -311,7 +311,7 @@ export function useTree(
 
   watch(
     () => props.data,
-    (data: TreeData) => {
+    (data: TreeV2Data) => {
       setData(data)
     },
     {

--- a/packages/components/tree-v2/src/tree-node.vue
+++ b/packages/components/tree-v2/src/tree-node.vue
@@ -71,7 +71,7 @@ import {
 } from './virtual-tree'
 
 import type { CheckboxValueType } from '@element-plus/components/checkbox'
-import type { TreeNode } from './types'
+import type { TreeV2Node } from './types'
 
 defineOptions({
   name: 'ElTreeNode',
@@ -86,7 +86,7 @@ const ns = useNamespace('tree')
 const indent = computed(() => tree?.props.indent ?? 16)
 const icon = computed(() => tree?.props.icon ?? CaretRight)
 
-const getNodeClass = (node: TreeNode) => {
+const getNodeClass = (node: TreeV2Node) => {
   const nodeClassFunc = tree?.props.props.class
   if (!nodeClassFunc) return {}
 

--- a/packages/components/tree-v2/src/types.ts
+++ b/packages/components/tree-v2/src/types.ts
@@ -6,60 +6,60 @@ import type {
 } from 'vue'
 import type { treeEmits, treeProps } from './virtual-tree'
 
-export type TreeNodeData = Record<string, any>
+export type TreeV2NodeData = Record<string, any>
 
-export type TreeData = TreeNodeData[]
+export type TreeV2Data = TreeV2NodeData[]
 
-export type TreeKey = string | number
+export type TreeV2Key = string | number
 
-export interface TreeOptionProps {
+export interface TreeV2OptionProps {
   children?: string
   label?: string
   value?: string
   disabled?: string
   class?: (
-    data: TreeNodeData,
-    node: TreeNode
+    data: TreeV2NodeData,
+    node: TreeV2Node
   ) => string | { [key: string]: boolean }
 }
 
-export type TreeProps = ExtractPropTypes<typeof treeProps>
-export type TreePropsPublic = __ExtractPublicPropTypes<typeof treeProps>
+export type TreeV2Props = ExtractPropTypes<typeof treeProps>
+export type TreeV2PropsPublic = __ExtractPublicPropTypes<typeof treeProps>
 
-export interface TreeNode {
-  key: TreeKey
+export interface TreeV2Node {
+  key: TreeV2Key
   level: number
-  parent?: TreeNode
-  children?: TreeNode[]
-  data: TreeNodeData
+  parent?: TreeV2Node
+  children?: TreeV2Node[]
+  data: TreeV2NodeData
   disabled?: boolean
   label?: string
   isLeaf?: boolean
   expanded?: boolean
 }
 
-export interface TreeContext {
+export interface TreeV2Context {
   ctx: Omit<SetupContext<typeof treeEmits>, 'expose' | 'attrs'>
   instance: ComponentInternalInstance
-  props: TreeProps
+  props: TreeV2Props
 }
 
-export interface Tree {
-  treeNodeMap: Map<TreeKey, TreeNode>
-  levelTreeNodeMap: Map<number, TreeNode[]>
-  treeNodes: TreeNode[]
+export interface TreeV2 {
+  treeNodeMap: Map<TreeV2Key, TreeV2Node>
+  levelTreeNodeMap: Map<number, TreeV2Node[]>
+  treeNodes: TreeV2Node[]
   maxLevel: number
 }
 
 export type FilterMethod = (
   query: string,
-  data: TreeNodeData,
-  node: TreeNode
+  data: TreeV2NodeData,
+  node: TreeV2Node
 ) => boolean
 
 export interface CheckedInfo {
-  checkedKeys: TreeKey[]
-  checkedNodes: TreeData
-  halfCheckedKeys: TreeKey[]
-  halfCheckedNodes: TreeData
+  checkedKeys: TreeV2Key[]
+  checkedNodes: TreeV2Data
+  halfCheckedKeys: TreeV2Key[]
+  halfCheckedNodes: TreeV2Data
 }

--- a/packages/components/tree-v2/src/virtual-tree.ts
+++ b/packages/components/tree-v2/src/virtual-tree.ts
@@ -8,19 +8,19 @@ import {
 
 import type { CheckboxValueType } from '@element-plus/components/checkbox'
 import type { InjectionKey } from 'vue'
-import type { TreeNodeData } from '@element-plus/components/tree/src/tree.type'
 import type {
   CheckedInfo,
   FilterMethod,
-  TreeContext,
-  TreeData,
-  TreeKey,
-  TreeNode,
-  TreeOptionProps,
+  TreeV2Context,
+  TreeV2Data,
+  TreeV2Key,
+  TreeV2Node,
+  TreeV2NodeData,
+  TreeV2OptionProps,
 } from './types'
 
 // constants
-export const ROOT_TREE_INJECTION_KEY: InjectionKey<TreeContext> = Symbol()
+export const ROOT_TREE_INJECTION_KEY: InjectionKey<TreeV2Context> = Symbol()
 const EMPTY_NODE = {
   key: -1,
   level: -1,
@@ -28,7 +28,7 @@ const EMPTY_NODE = {
 } as const
 
 // enums
-export enum TreeOptionsEnum {
+export enum TreeV2OptionsEnum {
   KEY = 'id',
   LABEL = 'label',
   CHILDREN = 'children',
@@ -49,7 +49,7 @@ const itemSize = {
 // props
 export const treeProps = buildProps({
   data: {
-    type: definePropType<TreeData>(Array),
+    type: definePropType<TreeV2Data>(Array),
     default: () => mutable([] as const),
   },
   emptyText: {
@@ -60,27 +60,27 @@ export const treeProps = buildProps({
     default: 200,
   },
   props: {
-    type: definePropType<TreeOptionProps>(Object),
+    type: definePropType<TreeV2OptionProps>(Object),
     default: () =>
       mutable({
-        children: TreeOptionsEnum.CHILDREN,
-        label: TreeOptionsEnum.LABEL,
-        disabled: TreeOptionsEnum.DISABLED,
-        value: TreeOptionsEnum.KEY,
-        class: TreeOptionsEnum.CLASS,
+        children: TreeV2OptionsEnum.CHILDREN,
+        label: TreeV2OptionsEnum.LABEL,
+        disabled: TreeV2OptionsEnum.DISABLED,
+        value: TreeV2OptionsEnum.KEY,
+        class: TreeV2OptionsEnum.CLASS,
       } as const),
   },
   highlightCurrent: Boolean,
   showCheckbox: Boolean,
   defaultCheckedKeys: {
-    type: definePropType<TreeKey[]>(Array),
+    type: definePropType<TreeV2Key[]>(Array),
     default: () => mutable([] as const),
   },
   // Whether checked state of a node not affects its father and
   // child nodes when show-checkbox is true
   checkStrictly: Boolean,
   defaultExpandedKeys: {
-    type: definePropType<TreeKey[]>(Array),
+    type: definePropType<TreeV2Key[]>(Array),
     default: () => mutable([] as const),
   },
   indent: {
@@ -101,7 +101,7 @@ export const treeProps = buildProps({
     default: true,
   },
   currentNodeKey: {
-    type: definePropType<TreeKey>([String, Number]),
+    type: definePropType<TreeV2Key>([String, Number]),
   },
   // TODO need to optimization
   accordion: Boolean,
@@ -121,7 +121,7 @@ export const treeProps = buildProps({
 
 export const treeNodeProps = buildProps({
   node: {
-    type: definePropType<TreeNode>(Object),
+    type: definePropType<TreeV2Node>(Object),
     default: () => mutable(EMPTY_NODE),
   },
   expanded: Boolean,
@@ -136,7 +136,7 @@ export const treeNodeProps = buildProps({
 
 export const treeNodeContentProps = buildProps({
   node: {
-    type: definePropType<TreeNode>(Object),
+    type: definePropType<TreeV2Node>(Object),
     required: true,
   },
 } as const)
@@ -152,25 +152,25 @@ export const NODE_CHECK_CHANGE = 'check-change'
 export const NODE_CONTEXTMENU = 'node-contextmenu'
 
 export const treeEmits = {
-  [NODE_CLICK]: (data: TreeNodeData, node: TreeNode, e: MouseEvent) =>
+  [NODE_CLICK]: (data: TreeV2NodeData, node: TreeV2Node, e: MouseEvent) =>
     data && node && e,
-  [NODE_DROP]: (data: TreeNodeData, node: TreeNode, e: DragEvent) =>
+  [NODE_DROP]: (data: TreeV2NodeData, node: TreeV2Node, e: DragEvent) =>
     data && node && e,
-  [NODE_EXPAND]: (data: TreeNodeData, node: TreeNode) => data && node,
-  [NODE_COLLAPSE]: (data: TreeNodeData, node: TreeNode) => data && node,
-  [CURRENT_CHANGE]: (data: TreeNodeData, node: TreeNode) => data && node,
-  [NODE_CHECK]: (data: TreeNodeData, checkedInfo: CheckedInfo) =>
+  [NODE_EXPAND]: (data: TreeV2NodeData, node: TreeV2Node) => data && node,
+  [NODE_COLLAPSE]: (data: TreeV2NodeData, node: TreeV2Node) => data && node,
+  [CURRENT_CHANGE]: (data: TreeV2NodeData, node: TreeV2Node) => data && node,
+  [NODE_CHECK]: (data: TreeV2NodeData, checkedInfo: CheckedInfo) =>
     data && checkedInfo,
-  [NODE_CHECK_CHANGE]: (data: TreeNodeData, checked: boolean) =>
+  [NODE_CHECK_CHANGE]: (data: TreeV2NodeData, checked: boolean) =>
     data && isBoolean(checked),
-  [NODE_CONTEXTMENU]: (evt: Event, data: TreeNodeData, node: TreeNode) =>
+  [NODE_CONTEXTMENU]: (evt: Event, data: TreeV2NodeData, node: TreeV2Node) =>
     evt && data && node,
 }
 
 export const treeNodeEmits = {
-  click: (node: TreeNode, e: MouseEvent) => !!(node && e),
-  drop: (node: TreeNode, e: DragEvent) => !!(node && e),
-  toggle: (node: TreeNode) => !!node,
-  check: (node: TreeNode, checked: CheckboxValueType) =>
+  click: (node: TreeV2Node, e: MouseEvent) => !!(node && e),
+  drop: (node: TreeV2Node, e: DragEvent) => !!(node && e),
+  toggle: (node: TreeV2Node) => !!node,
+  check: (node: TreeV2Node, checked: CheckboxValueType) =>
     node && isBoolean(checked),
 }

--- a/packages/components/tree/src/model/useDragNode.ts
+++ b/packages/components/tree/src/model/useDragNode.ts
@@ -10,16 +10,16 @@ import type {
   NodeDropType,
 } from '../tree.type'
 import type TreeStore from './tree-store'
-import type Node from './node'
+import type TreeNode from './node'
 
-interface TreeNode {
-  node: Node
+interface TreeNodeEl {
+  node: TreeNode
   $el?: HTMLElement
 }
 
 interface DragOptions {
   event: DragEvent
-  treeNode: TreeNode
+  treeNode: TreeNodeEl
 }
 
 interface Props {
@@ -52,9 +52,9 @@ export function useDragNodeHandler({
   const dragState = ref<{
     allowDrop: boolean
     dropType: NodeDropType | null
-    draggingNode: TreeNode | null
+    draggingNode: TreeNodeEl | null
     showDropIndicator: boolean
-    dropNode: TreeNode | null
+    dropNode: TreeNodeEl | null
   }>({
     showDropIndicator: false,
     draggingNode: null,

--- a/packages/components/tree/src/model/useNodeExpandEventBroadcast.ts
+++ b/packages/components/tree/src/model/useNodeExpandEventBroadcast.ts
@@ -1,15 +1,15 @@
 import { inject, provide } from 'vue'
 import { TREE_NODE_MAP_INJECTION_KEY } from '../tokens'
 
-import type Node from '../model/node'
+import type TreeNode from '../model/node'
 
 interface NodeMap {
-  treeNodeExpand(node?: Node): void
+  treeNodeExpand(node?: TreeNode): void
   children: NodeMap[]
 }
 
 interface Props {
-  node?: Node
+  node?: TreeNode
   accordion: boolean
 }
 
@@ -34,7 +34,7 @@ export function useNodeExpandEventBroadcast(props: Props) {
   provide(TREE_NODE_MAP_INJECTION_KEY, currentNodeMap)
 
   return {
-    broadcastExpanded: (node?: Node): void => {
+    broadcastExpanded: (node?: TreeNode): void => {
       if (!props.accordion) return
       for (const childNode of currentNodeMap.children) {
         childNode.treeNodeExpand(node)

--- a/packages/components/tree/src/model/util.ts
+++ b/packages/components/tree/src/model/util.ts
@@ -1,11 +1,11 @@
 import type { SetupContext } from 'vue'
-import type Node from './node'
+import type TreeNode from './node'
 import type { RootTreeType, TreeKey, TreeNodeData } from '../tree.type'
 
 export const NODE_KEY = '$treeNodeId'
 
 export const markNodeData = function (
-  node: Node,
+  node: TreeNode,
   data: TreeNodeData | null
 ): void {
   if (!data || data[NODE_KEY]) return

--- a/packages/components/tree/src/tree-node.vue
+++ b/packages/components/tree/src/tree-node.vue
@@ -103,7 +103,7 @@ import NodeContent from './tree-node-content.vue'
 import { getNodeKey as getNodeKeyUtil, handleCurrentChange } from './model/util'
 import { useNodeExpandEventBroadcast } from './model/useNodeExpandEventBroadcast'
 import { dragEventsKey } from './model/useDragNode'
-import Node from './model/node'
+import TreeNode from './model/node'
 import { NODE_INSTANCE_INJECTION_KEY, ROOT_TREE_INJECTION_KEY } from './tokens'
 
 import type { ComponentInternalInstance, PropType } from 'vue'
@@ -121,7 +121,7 @@ export default defineComponent({
   },
   props: {
     node: {
-      type: Node,
+      type: TreeNode,
       default: () => ({}),
     },
     props: {
@@ -196,11 +196,11 @@ export default defineComponent({
       }
     )
 
-    const getNodeKey = (node: Node): any => {
+    const getNodeKey = (node: TreeNode): any => {
       return getNodeKeyUtil(tree.props.nodeKey, node.data)
     }
 
-    const getNodeClass = (node: Node) => {
+    const getNodeClass = (node: TreeNode) => {
       const nodeClassFunc = props.props.class
       if (!nodeClassFunc) {
         return {}
@@ -300,7 +300,7 @@ export default defineComponent({
 
     const handleChildNodeExpand = (
       nodeData: TreeNodeData,
-      node: Node,
+      node: TreeNode,
       instance: ComponentInternalInstance
     ) => {
       broadcastExpanded(node)

--- a/packages/components/tree/src/tree.type.ts
+++ b/packages/components/tree/src/tree.type.ts
@@ -6,15 +6,15 @@ import type {
   VNode,
   h,
 } from 'vue'
-import type Node from './model/node'
+import type TreeNode from './model/node'
 import type TreeStore from './model/tree-store'
 
 export interface RootTreeType {
   ctx: SetupContext<any>
   props: TreeComponentProps
   store: Ref<TreeStore>
-  root: Ref<Node>
-  currentNode: Ref<Node>
+  root: Ref<TreeNode>
+  currentNode: Ref<TreeNode>
   instance: ComponentInternalInstance
 }
 
@@ -37,10 +37,10 @@ export interface TreeNodeChildState {
 export interface TreeNodeOptions {
   data: TreeNodeData
   store: TreeStore
-  parent?: Node
+  parent?: TreeNode
 }
 export interface TreeStoreNodesMap {
-  [key: string]: Node
+  [key: string]: TreeNode
 }
 export interface TreeStoreOptions {
   key?: TreeKey
@@ -59,12 +59,12 @@ export interface TreeStoreOptions {
 }
 export interface TreeOptionProps {
   children?: string
-  label?: string | ((data: TreeNodeData, node: Node) => string)
-  disabled?: string | ((data: TreeNodeData, node: Node) => boolean)
-  isLeaf?: string | ((data: TreeNodeData, node: Node) => boolean)
+  label?: string | ((data: TreeNodeData, node: TreeNode) => string)
+  disabled?: string | ((data: TreeNodeData, node: TreeNode) => boolean)
+  isLeaf?: string | ((data: TreeNodeData, node: TreeNode) => boolean)
   class?: (
     data: TreeNodeData,
-    node: Node
+    node: TreeNode
   ) => string | { [key: string]: boolean }
 }
 export type RenderContentFunction = (
@@ -73,19 +73,19 @@ export type RenderContentFunction = (
 ) => VNode | VNode[]
 export interface RenderContentContext {
   _self: ComponentInternalInstance
-  node: Node
+  node: TreeNode
   data: TreeNodeData
   store: TreeStore
 }
-export type AllowDragFunction = (node: Node) => boolean
+export type AllowDragFunction = (node: TreeNode) => boolean
 export type AllowDropType = 'inner' | 'prev' | 'next'
 export type AllowDropFunction = (
-  draggingNode: Node,
-  dropNode: Node,
+  draggingNode: TreeNode,
+  dropNode: TreeNode,
   type: AllowDropType
 ) => boolean
 export type LoadFunction = (
-  rootNode: Node,
+  rootNode: TreeNode,
   loadedCallback: (data: TreeData) => void,
   stopLoading: () => void
 ) => void
@@ -93,7 +93,7 @@ export type FilterValue = any
 export type FilterNodeMethodFunction = (
   value: FilterValue,
   data: TreeNodeData,
-  child: Node
+  child: TreeNode
 ) => boolean
 export interface TreeComponentProps {
   data: TreeData
@@ -126,5 +126,3 @@ export interface TreeComponentProps {
 }
 
 export type NodeDropType = 'before' | 'after' | 'inner' | 'none'
-
-export type { Node }

--- a/packages/components/tree/src/tree.type.ts
+++ b/packages/components/tree/src/tree.type.ts
@@ -126,3 +126,5 @@ export interface TreeComponentProps {
 }
 
 export type NodeDropType = 'before' | 'after' | 'inner' | 'none'
+
+export type { Node }

--- a/packages/components/tree/src/tree.vue
+++ b/packages/components/tree/src/tree.vue
@@ -59,7 +59,7 @@ import { useKeydown } from './model/useKeydown'
 import { ROOT_TREE_INJECTION_KEY } from './tokens'
 import { isEqual } from 'lodash-unified'
 
-import type Node from './model/node'
+import type TreeNode from './model/node'
 import type { ComponentInternalInstance, PropType } from 'vue'
 import type { Nullable } from '@element-plus/utils'
 import type {
@@ -186,7 +186,7 @@ export default defineComponent({
 
     store.value.initialize()
 
-    const root = ref<Node>(store.value.root)
+    const root = ref<TreeNode>(store.value.root)
     const currentNode = ref<Node | null>(null)
     const el$ = ref<Nullable<HTMLElement>>(null)
     const dropIndicator$ = ref<Nullable<HTMLElement>>(null)
@@ -260,7 +260,7 @@ export default defineComponent({
       store.value.filter(value)
     }
 
-    const getNodeKey = (node: Node) => {
+    const getNodeKey = (node: TreeNode) => {
       return getNodeKeyUtil(props.nodeKey, node.data)
     }
 
@@ -301,7 +301,7 @@ export default defineComponent({
       return currentNode ? currentNode[props.nodeKey] : null
     }
 
-    const setCheckedNodes = (nodes: Node[], leafOnly?: boolean) => {
+    const setCheckedNodes = (nodes: TreeNode[], leafOnly?: boolean) => {
       if (!props.nodeKey)
         throw new Error('[Tree] nodeKey is required in setCheckedNodes')
       store.value.setCheckedNodes(nodes, leafOnly)
@@ -329,7 +329,7 @@ export default defineComponent({
       return store.value.getHalfCheckedKeys()
     }
 
-    const setCurrentNode = (node: Node, shouldAutoExpandParent = true) => {
+    const setCurrentNode = (node: TreeNode, shouldAutoExpandParent = true) => {
       if (!props.nodeKey)
         throw new Error('[Tree] nodeKey is required in setCurrentNode')
 
@@ -349,7 +349,7 @@ export default defineComponent({
       })
     }
 
-    const getNode = (data: TreeKey | TreeNodeData): Node => {
+    const getNode = (data: TreeKey | TreeNodeData): TreeNode => {
       return store.value.getNode(data)
     }
 
@@ -380,7 +380,7 @@ export default defineComponent({
 
     const handleNodeExpand = (
       nodeData: TreeNodeData,
-      node: Node,
+      node: TreeNode,
       instance: ComponentInternalInstance
     ) => {
       broadcastExpanded(node)


### PR DESCRIPTION
When building a custom library that uses ElTable as a dependency:

Adding a ref to the ElTable component and using vite-plugin-dts to generate dts files will cause errors:

 "error TS4082: Default export of the module has or is using private name 'TableHeader'". 
 “error TS4082: Default export of the module has or is using private name 'TreeData_2'.”
 “error TS4082: Default export of the module has or is using private name 'TreeProps'.”

This commit fixes this issue.

related #21816

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
