### PR TITLE
fix(components): scrollbar fix thumb size calculation error

### DIFF
--- a/packages/components/virtual-list/__tests__/scrollbar.test.ts
+++ b/packages/components/virtual-list/__tests__/scrollbar.test.ts
@@ -75,11 +75,11 @@ describe('virtual scrollbar', () => {
     /**
      *  layout: vertical; width: auto; height: 100px; scrollHeight: 400px;
      *  thumb ratio: (100 / 400) * 100 -> 25   // (clientHeight / scrollHeight) * 100
-     *  thumbSize: 32   // scrollbar.ts computed thumbSize
+     *  thumbSize: 24   // scrollbar.ts computed thumbSize
      *  thumb translateY: (0 / (400 - 100)) * (100 - 25) -> 0  // (scrollTop / (scrollHeight - clientHeight)) * (clientHeight - thumbSize)
      */
     const initializeStyle =
-      'height: 32px; transform: translateY(0px); width: 100%;'
+      'height: 24px; transform: translateY(0px); width: 100%;'
 
     expect(wrapper.find('.el-scrollbar__thumb').attributes('style')).toContain(
       initializeStyle

--- a/packages/components/virtual-list/src/components/scrollbar.ts
+++ b/packages/components/virtual-list/src/components/scrollbar.ts
@@ -78,7 +78,7 @@ const ScrollBar = defineComponent({
       const SCROLLBAR_MAX_SIZE = trackSize.value / 3
       return Math.floor(
         Math.min(
-          Math.max(ratio * trackSize.value, SCROLLBAR_MIN_SIZE),
+          Math.max((ratio * trackSize.value) / 100, SCROLLBAR_MIN_SIZE),
           SCROLLBAR_MAX_SIZE
         )
       )


### PR DESCRIPTION
Fix scrollbar thumb size calculation error

closed #20793

Please make sure these boxes are checked before submitting your PR, thank you!

- [ - ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ - ] Make sure you are merging your commits to `dev` branch.
- [ - ] Add some descriptions and refer to relative issues for your PR.
