### PR TITLE
feat(components): [table-v2] Export the tableLocation to default slot

### DIFF
--- a/packages/components/table-v2/src/components/row.tsx
+++ b/packages/components/table-v2/src/components/row.tsx
@@ -157,6 +157,7 @@ const TableV2Row = defineComponent({
         rowData,
         rowIndex,
         style,
+        tableLocation,
       } = props
 
       let ColumnCells: ColumnCellsType = columns.map((column, columnIndex) => {
@@ -194,6 +195,7 @@ const TableV2Row = defineComponent({
           }),
           style,
           columns,
+          tableLocation,
           depth,
           rowData,
           rowIndex,

--- a/packages/components/table-v2/src/grid.ts
+++ b/packages/components/table-v2/src/grid.ts
@@ -64,6 +64,10 @@ export const tableV2GridProps = buildProps({
   },
   rowKey: tableV2RowProps.rowKey,
 
+  tableLocation: {
+    type: definePropType<'main' | 'left' | 'right'>(String),
+  },
+
   /**
    * Event handlers
    */

--- a/packages/components/table-v2/src/renderers/left-table.tsx
+++ b/packages/components/table-v2/src/renderers/left-table.tsx
@@ -14,7 +14,7 @@ const LeftTable: FunctionalComponent<LeftTableProps> = (props, { slots }) => {
   const { leftTableRef, ...rest } = props
 
   return (
-    <Table ref={leftTableRef} {...rest}>
+    <Table table-location="left" ref={leftTableRef} {...rest}>
       {slots}
     </Table>
   )

--- a/packages/components/table-v2/src/renderers/main-table.tsx
+++ b/packages/components/table-v2/src/renderers/main-table.tsx
@@ -14,7 +14,7 @@ const MainTable: FunctionalComponent<MainTableRendererProps> = (
 ) => {
   const { mainTableRef, ...rest } = props
   return (
-    <Table ref={mainTableRef} {...rest}>
+    <Table table-location="main" ref={mainTableRef} {...rest}>
       {slots}
     </Table>
   )

--- a/packages/components/table-v2/src/renderers/right-table.tsx
+++ b/packages/components/table-v2/src/renderers/right-table.tsx
@@ -4,20 +4,20 @@ import type { FunctionalComponent, Ref } from 'vue'
 import type { TableV2GridProps } from '../grid'
 import type { TableGridInstance } from '../table-grid'
 
-type LeftTableProps = TableV2GridProps & {
+type RightTableProps = TableV2GridProps & {
   rightTableRef: Ref<TableGridInstance | undefined>
 }
 
-const LeftTable: FunctionalComponent<LeftTableProps> = (props, { slots }) => {
+const RightTable: FunctionalComponent<RightTableProps> = (props, { slots }) => {
   if (!props.columns.length) return
 
   const { rightTableRef, ...rest } = props
 
   return (
-    <Table ref={rightTableRef} {...rest}>
+    <Table table-location="right" ref={rightTableRef} {...rest}>
       {slots}
     </Table>
   )
 }
 
-export default LeftTable
+export default RightTable

--- a/packages/components/table-v2/src/renderers/row.tsx
+++ b/packages/components/table-v2/src/renderers/row.tsx
@@ -34,6 +34,7 @@ type RowRendererProps = TableGridRowSlotParams &
   > & {
     ns: UseNamespaceReturn
     tableInstance?: ComponentInternalInstance
+    tableLocation: 'main' | 'left' | 'right'
   }
 
 const RowRenderer: FunctionalComponent<RowRendererProps> = (
@@ -59,6 +60,7 @@ const RowRenderer: FunctionalComponent<RowRendererProps> = (
     ns,
     onRowHovered,
     onRowExpanded,
+    tableLocation,
   } = props
 
   const rowKls = tryCall(rowClass, { columns, rowData, rowIndex }, '')
@@ -98,6 +100,7 @@ const RowRenderer: FunctionalComponent<RowRendererProps> = (
     rowKey: _rowKey,
     rowEventHandlers,
     style,
+    tableLocation,
   }
 
   const handlerMouseEnter = (e: MouseEvent) => {

--- a/packages/components/table-v2/src/row.ts
+++ b/packages/components/table-v2/src/row.ts
@@ -81,6 +81,9 @@ export const tableV2RowProps = buildProps({
     type: Number,
     required: true,
   },
+  tableLocation: {
+    type: definePropType<'main' | 'left' | 'right'>(String),
+  },
   /**
    * Unique item key
    */

--- a/packages/components/table-v2/src/table-grid.tsx
+++ b/packages/components/table-v2/src/table-grid.tsx
@@ -228,6 +228,7 @@ const TableGrid = defineComponent({
         headerWidth,
         height,
         width,
+        tableLocation,
 
         getRowHeight,
         onScroll,
@@ -265,6 +266,7 @@ const TableGrid = defineComponent({
             onScroll={onScroll}
             onItemRendered={onItemRendered}
             perfMode={false}
+            table-location={tableLocation}
           >
             {{
               default: (params: GridDefaultSlotParams) => {
@@ -307,6 +309,7 @@ export default TableGrid
 export type TableGridRowSlotParams = {
   columns: TableV2GridProps['columns']
   rowData: any
+  tableLocation: 'main' | 'left' | 'right'
 } & GridDefaultSlotParams
 
 export type TableGridInstance = InstanceType<typeof TableGrid> &

--- a/packages/components/virtual-list/src/builders/build-grid.ts
+++ b/packages/components/virtual-list/src/builders/build-grid.ts
@@ -587,7 +587,14 @@ const createGrid = ({
       const renderItems = () => {
         const [columnStart, columnEnd] = unref(columnsToRender)
         const [rowStart, rowEnd] = unref(rowsToRender)
-        const { data, totalColumn, totalRow, useIsScrolling, itemKey } = props
+        const {
+          data,
+          totalColumn,
+          totalRow,
+          useIsScrolling,
+          itemKey,
+          tableLocation,
+        } = props
         const children: VNodeChild[] = []
         if (totalRow > 0 && totalColumn > 0) {
           for (let row = rowStart; row <= rowEnd; row++) {
@@ -598,6 +605,7 @@ const createGrid = ({
                   Fragment,
                   { key },
                   slots.default?.({
+                    tableLocation,
                     columnIndex: column,
                     data,
                     isScrolling: useIsScrolling

--- a/packages/components/virtual-list/src/props.ts
+++ b/packages/components/virtual-list/src/props.ts
@@ -138,6 +138,9 @@ export const virtualizedGridProps = buildProps({
   estimatedRowHeight: estimatedItemSize,
   initScrollLeft: initScrollOffset,
   initScrollTop: initScrollOffset,
+  tableLocation: {
+    type: definePropType<'main' | 'left' | 'right'>(String),
+  },
   itemKey: {
     type: definePropType<GridItemKeyGetter>(Function),
     default: ({


### PR DESCRIPTION
closed #20876

Export the tableLocation variable to the default slot.

<img width="2266" height="362" alt="image" src="https://github.com/user-attachments/assets/a9fe7d0a-676d-4ebc-841f-d81246346854" />

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
