### PR TITLE
ci: add locale:sync scripts

### DIFF
--- a/docs/en-US/guide/dev-guide.md
+++ b/docs/en-US/guide/dev-guide.md
@@ -50,3 +50,28 @@ will start the local development environment.
 ```
 
 Modify `App.vue` file per your needs to get things work.
+
+## The following commands are also useful during development
+
+### Generate component template
+
+With command
+
+```shell
+pnpm gen <component-name>
+# eg.
+pnpm gen awesome
+pnpm gen awesome-button
+```
+
+will generate a component template in `packages/components/awesome` and `packages/components/awesome-button` directory.
+
+### Sync locale files
+
+With command
+
+```shell
+pnpm locale:sync
+```
+
+will sync the new fields from the `en.ts` locale file to other locale files and add the comment `// to be translated`.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "gen:version": "tsx scripts/gen-version.ts",
     "diff:table": "tsx scripts/build-table.ts",
     "update:version": "tsx scripts/update-version.ts",
+    "locale:sync": "tsx scripts/sync-locale.ts && pnpm run locale:lint",
+    "locale:lint": "eslint --ext .ts --max-warnings 0 --cache --fix packages/locale/lang",
     "clean": "pnpm run clean:dist && pnpm run -r --parallel clean",
     "clean:dist": "rimraf dist",
     "build": "pnpm run -C internal/build start",

--- a/packages/locale/lang/af.ts
+++ b/packages/locale/lang/af.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Bevestig',
       clear: 'Maak skoon',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Nou',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Kanselleer',
       clear: 'Maak skoon',
       confirm: 'Bevestig',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Kies datum',
       selectTime: 'Kies tyd',
       startDate: 'Begindatum',
@@ -37,7 +46,6 @@ export default {
       month10: 'Okt',
       month11: 'Nov',
       month12: 'Des',
-      // week: 'week',
       weeks: {
         sun: 'So',
         mon: 'Ma',
@@ -46,6 +54,15 @@ export default {
         thu: 'Do',
         fri: 'Vr',
         sat: 'Sa',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Jan',
@@ -62,6 +79,10 @@ export default {
         dec: 'Des',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Laai',
       noMatch: 'Geen toepaslike data',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Laai',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Geen toepaslike data',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Boodskap',
       confirm: 'Bevestig',
       cancel: 'Kanselleer',
       error: 'Ongeldige invoer',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'press delete to remove', // to be translated
@@ -101,12 +134,22 @@ export default {
       preview: 'Voorskou',
       continue: 'Gaan voort',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Geen Data',
       confirmFilter: 'Bevestig',
       resetFilter: 'Herstel',
       clearFilter: 'Alles',
       sumText: 'Som',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Geen Data',

--- a/packages/locale/lang/ar-eg.ts
+++ b/packages/locale/lang/ar-eg.ts
@@ -43,7 +43,6 @@ export default {
       month10: 'أكتوبر',
       month11: 'نوفمبر',
       month12: 'ديسمبر',
-      week: 'أسبوع',
       weeks: {
         sun: 'الأحد',
         mon: 'الأثنين',

--- a/packages/locale/lang/ar-eg.ts
+++ b/packages/locale/lang/ar-eg.ts
@@ -9,6 +9,7 @@ export default {
       clear: 'إزالة',
       defaultLabel: 'إختر اللون',
       description: 'اللون الحالي هو {color}. اضفط انتر لاختيار لون جديد',
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'الآن',
@@ -20,6 +21,7 @@ export default {
         'استخدم مفاتيح الاسهم و اضغط انتر لاختيار اليوم المراد من الشهر',
       monthTablePrompt: 'استخدم مفاتيح الاسهم واضغط انتر لاختيار الشهر',
       yearTablePrompt: 'استخدم مفاتيح الاسهم واضغط انتر لاختيار السنة',
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'إختر التاريخ',
       selectTime: 'إختر الوقت',
       startDate: 'تاريخ البدء',
@@ -51,6 +53,15 @@ export default {
         thu: 'الخميس',
         fri: 'الجمعة',
         sat: 'السبت',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'يناير',
@@ -100,6 +111,8 @@ export default {
       currentPage: 'صفحة رقم {pager}',
       prevPages: 'صفحات {pager} السابقة',
       nextPages: 'صفحات {pager} التالية',
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
     },
     dialog: {
       close: 'أغلق هذا التبويب',
@@ -131,6 +144,11 @@ export default {
       resetFilter: 'حذف',
       clearFilter: 'الكل',
       sumText: 'المجموع',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'لايوجد بيانات',

--- a/packages/locale/lang/ar.ts
+++ b/packages/locale/lang/ar.ts
@@ -43,7 +43,6 @@ export default {
       month10: 'تشرين الاول',
       month11: 'تشرين الثاني',
       month12: 'كانون الاول',
-      week: 'أسبوع',
       weeks: {
         sun: 'الأحد',
         mon: 'الأثنين',

--- a/packages/locale/lang/ar.ts
+++ b/packages/locale/lang/ar.ts
@@ -9,6 +9,7 @@ export default {
       clear: 'إزالة',
       defaultLabel: 'إختر اللون',
       description: 'اللون الحالي هو {color}. اضفط انتر لاختيار لون جديد',
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'الآن',
@@ -20,6 +21,7 @@ export default {
         'استخدم مفاتيح الاسهم و اضغط انتر لاختيار اليوم المراد من الشهر',
       monthTablePrompt: 'استخدم مفاتيح الاسهم واضغط انتر لاختيار الشهر',
       yearTablePrompt: 'استخدم مفاتيح الاسهم واضغط انتر لاختيار السنة',
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'إختر التاريخ',
       selectTime: 'إختر الوقت',
       startDate: 'تاريخ البدء',
@@ -51,6 +53,15 @@ export default {
         thu: 'الخميس',
         fri: 'الجمعة',
         sat: 'السبت',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'كانون الثاني',
@@ -100,6 +111,8 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
     },
     dialog: {
       close: 'أغلق هذا التبويب',
@@ -120,12 +133,22 @@ export default {
       preview: 'عرض',
       continue: 'إستمرار',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'لايوجد بيانات',
       confirmFilter: 'تأكيد',
       resetFilter: 'حذف',
       clearFilter: 'الكل',
       sumText: 'المجموع',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'لايوجد بيانات',

--- a/packages/locale/lang/az.ts
+++ b/packages/locale/lang/az.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Təsdiqlə',
       clear: 'Təmizlə',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'İndi',
@@ -14,6 +18,11 @@ export default {
       cancel: 'İmtina',
       clear: 'Təmizlə',
       confirm: 'Təsdiqlə',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Tarix seç',
       selectTime: 'Saat seç',
       startDate: 'Başlanğıc Tarixi',
@@ -46,6 +55,15 @@ export default {
         fri: 'Cüm',
         sat: 'Şən',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Yan',
         feb: 'Fev',
@@ -61,6 +79,10 @@ export default {
         dec: 'Dek',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Yüklənir',
       noMatch: 'Nəticə tapılmadı',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Yüklənir',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Nəticə tapılmadı',
@@ -87,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Mesaj',
       confirm: 'Təsdiqlə',
       cancel: 'İmtina',
       error: 'Səhv',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Sürüşdürmədən sonra sil',
@@ -100,12 +134,22 @@ export default {
       preview: 'Ön izlə',
       continue: 'Davam et',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Məlumat yoxdur',
       confirmFilter: 'Təsdiqlə',
       resetFilter: 'Sıfırla',
       clearFilter: 'Bütün',
       sumText: 'Cəmi',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Məlumat yoxdur',
@@ -128,13 +172,13 @@ export default {
       confirmButtonText: 'Bəli',
       cancelButtonText: 'Xeyr',
     },
-    empty: {
-      description: 'Məlumat yoxdur',
-    },
     carousel: {
       leftArrow: 'Carousel arrow left', // to be translated
       rightArrow: 'Carousel arrow right', // to be translated
       indicator: 'Carousel switch to index {index}', // to be translated
+    },
+    empty: {
+      description: 'Məlumat yoxdur',
     },
   },
 }

--- a/packages/locale/lang/az.ts
+++ b/packages/locale/lang/az.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Oktyabr',
       month11: 'Noyabr',
       month12: 'Dekabr',
-      week: 'həftə',
       weeks: {
         sun: 'Baz',
         mon: 'B.e',
@@ -120,14 +119,14 @@ export default {
       hasCheckedFormat: '{checked}/{total} seçildi',
     },
     image: {
-      error: 'SƏHV', // to be translated
+      error: 'SƏHV',
     },
     pageHeader: {
-      title: 'Geri', // to be translated
+      title: 'Geri',
     },
     popconfirm: {
-      confirmButtonText: 'Bəli', // to be translated
-      cancelButtonText: 'Xeyr', // to be translated
+      confirmButtonText: 'Bəli',
+      cancelButtonText: 'Xeyr',
     },
     empty: {
       description: 'Məlumat yoxdur',

--- a/packages/locale/lang/bg.ts
+++ b/packages/locale/lang/bg.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Изчисти',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Сега',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Откажи',
       clear: 'Изчисти',
       confirm: 'ОК',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Избери дата',
       selectTime: 'Избери час',
       startDate: 'Начална дата',
@@ -37,7 +46,6 @@ export default {
       month10: 'Октомври',
       month11: 'Ноември',
       month12: 'Декември',
-      // week: 'Седмица',
       weeks: {
         sun: 'Нед',
         mon: 'Пон',
@@ -46,6 +54,15 @@ export default {
         thu: 'Чет',
         fri: 'Пет',
         sat: 'Съб',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Яну',
@@ -62,6 +79,10 @@ export default {
         dec: 'Дек',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Зареждане',
       noMatch: 'Няма намерени',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Зареждане',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Няма намерени',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Съобщение',
       confirm: 'ОК',
       cancel: 'Откажи',
       error: 'Невалидни данни',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'press delete to remove', // to be translated
@@ -101,12 +134,22 @@ export default {
       preview: 'Прегледай',
       continue: 'Продължи',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Няма данни',
       confirmFilter: 'Потвърди',
       resetFilter: 'Изчисти',
       clearFilter: 'Всички',
       sumText: 'Sum', // to be translated
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Няма данни',

--- a/packages/locale/lang/bn.ts
+++ b/packages/locale/lang/bn.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'ঠিক আছে',
       clear: 'ক্লিয়ার',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'এখন',
@@ -14,6 +18,11 @@ export default {
       cancel: 'বাতিল',
       clear: 'ক্লিয়ার',
       confirm: 'ঠিক আছে',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'তারিখ নির্বাচন করুন',
       selectTime: 'সময় নির্বাচন করুন',
       startDate: 'যে তারিখ থেকে',
@@ -46,6 +55,15 @@ export default {
         fri: 'শুক্র',
         sat: 'শনি',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'জানু',
         feb: 'ফেব্রু',
@@ -61,6 +79,10 @@ export default {
         dec: 'ডিসে',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'লোড হচ্ছে',
       noMatch: 'কোন মিল পওয়া যায়নি',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'লোড হচ্ছে',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'কোন মিল পওয়া যায়নি',
@@ -90,11 +115,18 @@ export default {
       deprecationWarning:
         'অপ্রচলিত (Deprecated) ব্যাবহার পওয়া গেছে, আরও জানতে চাইলে, দয়া করে el-pagination এর ডকুমেন্টেশন দেখুন',
     },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
+    },
     messagebox: {
       title: 'বার্তা',
       confirm: 'ঠিক আছে',
       cancel: 'বাতিল',
       error: 'ইনপুট ডাটা গ্রহনযোগ্য নয়',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'অপসারণ করতে "ডিলিট" এ ক্লিক করুন',
@@ -102,12 +134,22 @@ export default {
       preview: 'প্রিভিউ',
       continue: 'চালিয়ে যান',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'কোন ডাটা নেই',
       confirmFilter: 'নিশ্চিত করুন',
       resetFilter: 'রিসেট',
       clearFilter: 'সব',
       sumText: 'সারাংশ',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'কোন ডাটা নেই',

--- a/packages/locale/lang/bn.ts
+++ b/packages/locale/lang/bn.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'অক্টোবর',
       month11: 'নভেম্বর',
       month12: 'ডিসেম্বর',
-      week: 'সাপ্তাহ',
       weeks: {
         sun: 'রবি',
         mon: 'সোম',

--- a/packages/locale/lang/ca.ts
+++ b/packages/locale/lang/ca.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Confirmar',
       clear: 'Netejar',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Ara',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Cancel·lar',
       clear: 'Netejar',
       confirm: 'Confirmar',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Seleccionar data',
       selectTime: 'Seleccionar hora',
       startDate: 'Data Inici',
@@ -37,7 +46,6 @@ export default {
       month10: 'Octubre',
       month11: 'Novembre',
       month12: 'Desembre',
-      // week: 'setmana',
       weeks: {
         sun: 'Dg',
         mon: 'Dl',
@@ -46,6 +54,15 @@ export default {
         thu: 'Dj',
         fri: 'Dv',
         sat: 'Ds',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Gen',
@@ -62,6 +79,10 @@ export default {
         dec: 'Des',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Carregant',
       noMatch: 'No hi ha dades que coincideixin',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Carregant',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'No hi ha dades que coincideixin',
@@ -88,11 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
+      title: 'Message', // to be translated
       confirm: 'Acceptar',
       cancel: 'Cancel·lar',
       error: 'Entrada invàlida',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'premi eliminar per descartar',
@@ -100,12 +134,22 @@ export default {
       preview: 'Vista Prèvia',
       continue: 'Continuar',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Sense Dades',
       confirmFilter: 'Confirmar',
       resetFilter: 'Netejar',
       clearFilter: 'Tot',
       sumText: 'Tot',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Sense Dades',

--- a/packages/locale/lang/ckb.ts
+++ b/packages/locale/lang/ckb.ts
@@ -45,7 +45,6 @@ export default {
       month10: 'گەڵاڕێزان',
       month11: 'سەرماوەز',
       month12: 'بەفرانبار',
-      week: 'هەفت',
       weeks: {
         sun: 'یەکشەممە',
         mon: 'دووشەممە',
@@ -152,16 +151,16 @@ export default {
     transfer: {
       noMatch: 'هیچ داتای هاوتا نیە',
       noData: 'هیچ داتا نیە',
-      titles: ['لیستی 1', 'لیستی 2'], // to be translated
-      filterPlaceholder: 'کلیلەوشە داخڵ بکە', // to be translated
-      noCheckedFormat: '{total} دانە', // to be translated
-      hasCheckedFormat: '{checked}/{total} هەڵبژێردراوە', // to be translated
+      titles: ['لیستی 1', 'لیستی 2'],
+      filterPlaceholder: 'کلیلەوشە داخڵ بکە',
+      noCheckedFormat: '{total} دانە',
+      hasCheckedFormat: '{checked}/{total} هەڵبژێردراوە',
     },
     image: {
       error: 'شکستی هێنا',
     },
     pageHeader: {
-      title: 'گەڕانەوە', // to be translated
+      title: 'گەڕانەوە',
     },
     popconfirm: {
       confirmButtonText: 'بەڵێ',

--- a/packages/locale/lang/ckb.ts
+++ b/packages/locale/lang/ckb.ts
@@ -10,6 +10,7 @@ export default {
       defaultLabel: 'هەڵبژاردنی ڕەنگ',
       description:
         'ڕەنگی ئێستا {color}. ئینتەر دابگرە بۆ هەڵبژاردنی ڕەنگی نوێ.',
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'ئێستا',
@@ -144,6 +145,11 @@ export default {
       resetFilter: 'جێگیرکردنەوە',
       clearFilter: 'هەموو',
       sumText: 'کۆ',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'هیچ داتا نیە',

--- a/packages/locale/lang/cs.ts
+++ b/packages/locale/lang/cs.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Vymazat',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Teď',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Zrušit',
       clear: 'Vymazat',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Vybrat datum',
       selectTime: 'Vybrat čas',
       startDate: 'Datum začátku',
@@ -24,8 +33,6 @@ export default {
       nextYear: 'Příští rok',
       prevMonth: 'Předchozí měsíc',
       nextMonth: 'Příští měsíc',
-      day: 'Den',
-      month: 'Měsíc',
       year: 'Rok',
       month1: 'Leden',
       month2: 'Únor',
@@ -48,6 +55,15 @@ export default {
         fri: 'Pá',
         sat: 'So',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Led',
         feb: 'Úno',
@@ -62,6 +78,12 @@ export default {
         nov: 'Lis',
         dec: 'Pro',
       },
+      day: 'Den',
+      month: 'Měsíc',
+    },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
     },
     select: {
       loading: 'Načítání',
@@ -71,6 +93,9 @@ export default {
     },
     mention: {
       loading: 'Načítání',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Žádná shoda',
@@ -89,12 +114,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Zpráva',
       confirm: 'OK',
       cancel: 'Zrušit',
       error: 'Neplatný vstup',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Stisknout pro smazání',
@@ -102,12 +136,22 @@ export default {
       preview: 'Náhled',
       continue: 'Pokračovat',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Žádná data',
       confirmFilter: 'Potvrdit',
       resetFilter: 'Resetovat',
       clearFilter: 'Vše',
       sumText: 'Celkem',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Žádná data',

--- a/packages/locale/lang/cs.ts
+++ b/packages/locale/lang/cs.ts
@@ -25,7 +25,6 @@ export default {
       prevMonth: 'Předchozí měsíc',
       nextMonth: 'Příští měsíc',
       day: 'Den',
-      week: 'Týden',
       month: 'Měsíc',
       year: 'Rok',
       month1: 'Leden',

--- a/packages/locale/lang/da.ts
+++ b/packages/locale/lang/da.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Oktober',
       month11: 'November',
       month12: 'December',
-      week: 'uge',
       weeks: {
         sun: 'Søn',
         mon: 'Man',

--- a/packages/locale/lang/da.ts
+++ b/packages/locale/lang/da.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Ryd',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Nu',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Annuller',
       clear: 'Ryd',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Vælg dato',
       selectTime: 'Vælg tidspunkt',
       startDate: 'Startdato',
@@ -46,6 +55,15 @@ export default {
         fri: 'Fre',
         sat: 'Lør',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Jan',
         feb: 'Feb',
@@ -61,6 +79,10 @@ export default {
         dec: 'Dec',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Henter',
       noMatch: 'Ingen matchende data',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Henter',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Ingen matchende data',
@@ -87,11 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
+      title: 'Message', // to be translated
       confirm: 'OK',
       cancel: 'Annuller',
       error: 'Ugyldig input',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'tryk slet for at fjerne',
@@ -99,12 +134,22 @@ export default {
       preview: 'Forhåndsvisning',
       continue: 'Fortsæt',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Ingen data',
       confirmFilter: 'Bekræft',
       resetFilter: 'Nulstil',
       clearFilter: 'Alle',
       sumText: 'Sum',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Ingen data',

--- a/packages/locale/lang/de.ts
+++ b/packages/locale/lang/de.ts
@@ -25,7 +25,6 @@ export default {
       prevMonth: 'Letzter Monat',
       nextMonth: 'Nächster Monat',
       day: 'Tag',
-      week: 'Woche',
       month: 'Monat',
       year: '',
       month1: 'Januar',

--- a/packages/locale/lang/de.ts
+++ b/packages/locale/lang/de.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Leeren',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Jetzt',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Abbrechen',
       clear: 'Leeren',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Datum wählen',
       selectTime: 'Uhrzeit wählen',
       startDate: 'Startdatum',
@@ -24,8 +33,6 @@ export default {
       nextYear: 'Nächtes Jahr',
       prevMonth: 'Letzter Monat',
       nextMonth: 'Nächster Monat',
-      day: 'Tag',
-      month: 'Monat',
       year: '',
       month1: 'Januar',
       month2: 'Februar',
@@ -48,6 +55,15 @@ export default {
         fri: 'Fr',
         sat: 'Sa',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Jan',
         feb: 'Feb',
@@ -62,6 +78,12 @@ export default {
         nov: 'Nov',
         dec: 'Dez',
       },
+      day: 'Tag',
+      month: 'Monat',
+    },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
     },
     select: {
       loading: 'Lädt.',
@@ -71,6 +93,9 @@ export default {
     },
     mention: {
       loading: 'Lädt.',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Nichts gefunden.',
@@ -89,17 +114,32 @@ export default {
       currentPage: 'Seite {pager}',
       prevPages: 'Vorherige {pager} Seiten',
       nextPages: 'Nächste {pager} Seiten',
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
+      title: 'Message', // to be translated
       confirm: 'OK',
       cancel: 'Abbrechen',
       error: 'Fehler',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Klicke löschen zum entfernen',
       delete: 'Löschen',
       preview: 'Vorschau',
       continue: 'Fortsetzen',
+    },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
     },
     table: {
       emptyText: 'Keine Daten',

--- a/packages/locale/lang/el.ts
+++ b/packages/locale/lang/el.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Εντάξει',
       clear: 'Καθαρισμός',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Τώρα',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Ακύρωση',
       clear: 'Καθαρισμός',
       confirm: 'Εντάξει',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Επιλέξτε ημέρα',
       selectTime: 'Επιλέξτε ώρα',
       startDate: 'Ημερομηνία Έναρξης',
@@ -37,7 +46,6 @@ export default {
       month10: 'Οκτώβριος',
       month11: 'Νοέμβριος',
       month12: 'Δεκέμβριος',
-      // week: 'εβδομάδα',
       weeks: {
         sun: 'Κυρ',
         mon: 'Δευ',
@@ -46,6 +54,15 @@ export default {
         thu: 'Πεμ',
         fri: 'Παρ',
         sat: 'Σαβ',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Ιαν',
@@ -62,6 +79,10 @@ export default {
         dec: 'Δεκ',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Φόρτωση',
       noMatch: 'Δεν βρέθηκαν αποτελέσματα',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Φόρτωση',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Δεν βρέθηκαν αποτελέσματα',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Μήνυμα',
       confirm: 'Εντάξει',
       cancel: 'Ακύρωση',
       error: 'Άκυρη εισαγωγή',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Πάτησε Διαγραφή για αφαίρεση',
@@ -101,12 +134,22 @@ export default {
       preview: 'Προεπισκόπηση',
       continue: 'Συνέχεια',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Χωρίς Δεδομένα',
       confirmFilter: 'Επιβεβαίωση',
       resetFilter: 'Επαναφορά',
       clearFilter: 'Όλα',
       sumText: 'Σύνολο',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Χωρίς Δεδομένα',

--- a/packages/locale/lang/en.ts
+++ b/packages/locale/lang/en.ts
@@ -2,7 +2,7 @@ export default {
   name: 'en',
   el: {
     breadcrumb: {
-      label: 'Breadcrumb', // to be translated
+      label: 'Breadcrumb',
     },
     colorpicker: {
       confirm: 'OK',
@@ -46,7 +46,6 @@ export default {
       month10: 'October',
       month11: 'November',
       month12: 'December',
-      week: 'week',
       weeks: {
         sun: 'Sun',
         mon: 'Mon',
@@ -158,16 +157,16 @@ export default {
     transfer: {
       noMatch: 'No matching data',
       noData: 'No data',
-      titles: ['List 1', 'List 2'], // to be translated
-      filterPlaceholder: 'Enter keyword', // to be translated
-      noCheckedFormat: '{total} items', // to be translated
-      hasCheckedFormat: '{checked}/{total} checked', // to be translated
+      titles: ['List 1', 'List 2'],
+      filterPlaceholder: 'Enter keyword',
+      noCheckedFormat: '{total} items',
+      hasCheckedFormat: '{checked}/{total} checked',
     },
     image: {
       error: 'FAILED',
     },
     pageHeader: {
-      title: 'Back', // to be translated
+      title: 'Back',
     },
     popconfirm: {
       confirmButtonText: 'Yes',

--- a/packages/locale/lang/eo.ts
+++ b/packages/locale/lang/eo.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Oktobro',
       month11: 'Novembro',
       month12: 'Decembro',
-      week: 'Semajno',
       weeks: {
         sun: 'Dim',
         mon: 'Lun',

--- a/packages/locale/lang/eo.ts
+++ b/packages/locale/lang/eo.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Bone',
       clear: 'Malplenigi',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Nun',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Nuligi',
       clear: 'Malplenigi',
       confirm: 'Bone',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Elektu daton',
       selectTime: 'Elektu horon',
       startDate: 'Komenca Dato',
@@ -46,6 +55,15 @@ export default {
         fri: 'Ven',
         sat: 'Sab',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Jan',
         feb: 'Feb',
@@ -61,6 +79,10 @@ export default {
         dec: 'Dec',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Ŝarĝante',
       noMatch: 'Neniuj kongruaj datumoj',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Ŝarĝante',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Neniuj kongruaj datumoj',
@@ -87,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Mesaĝo',
       confirm: 'Bone',
       cancel: 'Nuligi',
       error: 'Nevalida Enigo!',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Premu "Delete" por forigi',
@@ -100,12 +134,22 @@ export default {
       preview: 'Antaŭrigardi',
       continue: 'Daŭrigi',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Neniuj datumoj',
       confirmFilter: 'Konfirmi',
       resetFilter: 'Restarigi',
       clearFilter: 'Ĉiuj',
       sumText: 'Sumo',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Neniuj datumoj',

--- a/packages/locale/lang/es.ts
+++ b/packages/locale/lang/es.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Confirmar',
       clear: 'Despejar',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Ahora',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Cancelar',
       clear: 'Despejar',
       confirm: 'Confirmar',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Seleccionar fecha',
       selectTime: 'Seleccionar hora',
       startDate: 'Fecha Incial',
@@ -37,7 +46,6 @@ export default {
       month10: 'octubre',
       month11: 'noviembre',
       month12: 'diciembre',
-      // week: 'semana',
       weeks: {
         sun: 'dom',
         mon: 'lun',
@@ -46,6 +54,15 @@ export default {
         thu: 'jue',
         fri: 'vie',
         sat: 'sáb',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'ene',
@@ -62,6 +79,10 @@ export default {
         dec: 'dic',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Cargando',
       noMatch: 'No hay datos que coincidan',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Cargando',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'No hay datos que coincidan',
@@ -88,11 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
+      title: 'Message', // to be translated
       confirm: 'Aceptar',
       cancel: 'Cancelar',
       error: 'Entrada inválida',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Pulse Eliminar para retirar',
@@ -100,12 +134,22 @@ export default {
       preview: 'Vista Previa',
       continue: 'Continuar',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Sin Datos',
       confirmFilter: 'Confirmar',
       resetFilter: 'Reiniciar',
       clearFilter: 'Despejar',
       sumText: 'Suma',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Sin Datos',

--- a/packages/locale/lang/et.ts
+++ b/packages/locale/lang/et.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Tühjenda',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Praegu',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Tühista',
       clear: 'Tühjenda',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Vali kuupäev',
       selectTime: 'Vali kellaaeg',
       startDate: 'Alguskuupäev',
@@ -37,7 +46,6 @@ export default {
       month10: 'Oktoober',
       month11: 'November',
       month12: 'Detsember',
-      // week: 'nädal',
       weeks: {
         sun: 'P',
         mon: 'E',
@@ -46,6 +54,15 @@ export default {
         thu: 'N',
         fri: 'R',
         sat: 'L',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Jaan',
@@ -62,6 +79,10 @@ export default {
         dec: 'Dets',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Laadimine',
       noMatch: 'Sobivad andmed puuduvad',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Laadimine',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Sobivad andmed puuduvad',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Teade',
       confirm: 'OK',
       cancel: 'Tühista',
       error: 'Vigane sisend',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Vajuta "Kustuta", et eemaldada',
@@ -101,12 +134,22 @@ export default {
       preview: 'Eelvaate',
       continue: 'Jätka',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Andmed puuduvad',
       confirmFilter: 'Kinnita',
       resetFilter: 'Taasta',
       clearFilter: 'Kõik',
       sumText: 'Summa',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Andmed puuduvad',

--- a/packages/locale/lang/eu.ts
+++ b/packages/locale/lang/eu.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Ados',
       clear: 'Garbitu',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Orain',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Utzi',
       clear: 'Garbitu',
       confirm: 'Ados',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Hautatu data',
       selectTime: 'Hautatu ordua',
       startDate: 'Hasierako data',
@@ -37,7 +46,6 @@ export default {
       month10: 'Urria',
       month11: 'Azaroa',
       month12: 'Abendua',
-      // week: 'astea',
       weeks: {
         sun: 'ig.',
         mon: 'al.',
@@ -46,6 +54,15 @@ export default {
         thu: 'og.',
         fri: 'ol.',
         sat: 'lr.',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'urt',
@@ -62,6 +79,10 @@ export default {
         dec: 'abe',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Kargatzen',
       noMatch: 'Bat datorren daturik ez',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Kargatzen',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Bat datorren daturik ez',
@@ -88,18 +112,32 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Mezua',
       confirm: 'Ados',
       cancel: 'Utzi',
       error: 'Sarrera baliogabea',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'sakatu Ezabatu kentzeko',
       delete: 'Ezabatu',
       preview: 'Aurrebista',
       continue: 'Jarraitu',
+    },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
     },
     table: {
       emptyText: 'Daturik ez',

--- a/packages/locale/lang/eu.ts
+++ b/packages/locale/lang/eu.ts
@@ -119,10 +119,10 @@ export default {
     transfer: {
       noMatch: 'Bat datorren daturik ez',
       noData: 'Daturik ez',
-      titles: ['Zerrenda 1', 'Zerrenda 2'], // to be translated
-      filterPlaceholder: 'Sartu gako-hitza', // to be translated
-      noCheckedFormat: '{total} elementu', // to be translated
-      hasCheckedFormat: '{checked}/{total} hautatuta', // to be translated
+      titles: ['Zerrenda 1', 'Zerrenda 2'],
+      filterPlaceholder: 'Sartu gako-hitza',
+      noCheckedFormat: '{total} elementu',
+      hasCheckedFormat: '{checked}/{total} hautatuta',
     },
     image: {
       error: 'FAILED', // to be translated

--- a/packages/locale/lang/fa.ts
+++ b/packages/locale/lang/fa.ts
@@ -48,7 +48,6 @@ export default {
       month10: 'اکتبر',
       month11: 'نوامبر',
       month12: 'دسامبر',
-      week: 'هفته',
       weeks: {
         sun: 'یک‌شنبه',
         mon: 'دوشنبه',

--- a/packages/locale/lang/fi.ts
+++ b/packages/locale/lang/fi.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Tyhjennä',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Nyt',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Peruuta',
       clear: 'Tyhjennä',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Valitse päivä',
       selectTime: 'Valitse aika',
       startDate: 'Aloituspäivä',
@@ -37,7 +46,6 @@ export default {
       month10: 'lokakuu',
       month11: 'marraskuu',
       month12: 'joulukuu',
-      // week: 'week',
       weeks: {
         sun: 'su',
         mon: 'ma',
@@ -46,6 +54,15 @@ export default {
         thu: 'to',
         fri: 'pe',
         sat: 'la',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'tammi',
@@ -62,6 +79,10 @@ export default {
         dec: 'joulu',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Lataa',
       noMatch: 'Ei vastaavia tietoja',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Lataa',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Ei vastaavia tietoja',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Viesti',
       confirm: 'OK',
       cancel: 'Peruuta',
       error: 'Virheellinen syöte',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Poista Delete-näppäimellä',
@@ -101,12 +134,22 @@ export default {
       preview: 'Esikatsele',
       continue: 'Jatka',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Ei tietoja',
       confirmFilter: 'Vahvista',
       resetFilter: 'Tyhjennä',
       clearFilter: 'Kaikki',
       sumText: 'Summa',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Ei tietoja',

--- a/packages/locale/lang/fr.ts
+++ b/packages/locale/lang/fr.ts
@@ -2,7 +2,7 @@ export default {
   name: 'fr',
   el: {
     breadcrumb: {
-      label: `Fil d'Ariane`,
+      label: "Fil d'Ariane",
     },
     colorpicker: {
       confirm: 'Confirmer',
@@ -10,6 +10,7 @@ export default {
       defaultLabel: 'color picker',
       description:
         'La couleur actuelle est {color}. Appuyer sur Entrée pour sélectionner une nouvelle couleur.',
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Maintenant',
@@ -34,7 +35,7 @@ export default {
       nextYear: 'Année suivante',
       prevMonth: 'Mois précédent',
       nextMonth: 'Mois suivant',
-      year: '', // In french, like in english, we don't say "Année" after the year number.
+      year: '',
       month1: 'Janvier',
       month2: 'Février',
       month3: 'Mars',
@@ -92,6 +93,9 @@ export default {
     },
     mention: {
       loading: 'Chargement',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Aucune correspondance',

--- a/packages/locale/lang/fr.ts
+++ b/packages/locale/lang/fr.ts
@@ -47,7 +47,6 @@ export default {
       month10: 'Octobre',
       month11: 'Novembre',
       month12: 'Décembre',
-      week: 'Semaine',
       weeks: {
         sun: 'Dim',
         mon: 'Lun',

--- a/packages/locale/lang/he.ts
+++ b/packages/locale/lang/he.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'אישור',
       clear: 'נקה',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'כעת',
@@ -14,6 +18,11 @@ export default {
       cancel: 'בטל',
       clear: 'נקה',
       confirm: 'אישור',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'בחר תאריך',
       selectTime: 'בחר זמן',
       startDate: 'תאריך התחלה',
@@ -46,6 +55,15 @@ export default {
         fri: 'ו׳',
         sat: 'שבת',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'ינואר',
         feb: 'פברואר',
@@ -61,6 +79,10 @@ export default {
         dec: 'דצמבר',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'טוען',
       noMatch: 'לא נמצאה התאמה',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'טוען',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'לא נמצאה התאמה',
@@ -87,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'הודעה',
       confirm: 'אישור',
       cancel: 'בטל',
       error: 'קלט לא תקין',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'לחץ כדי למחוק',
@@ -100,12 +134,22 @@ export default {
       preview: 'תצוגה מקדימה',
       continue: 'המשך',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'אין נתונים',
       confirmFilter: 'אישור',
       resetFilter: 'נקה',
       clearFilter: 'הכל',
       sumText: 'סך הכל',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'אין נתונים',

--- a/packages/locale/lang/he.ts
+++ b/packages/locale/lang/he.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'אוקטובר',
       month11: 'נובמבר',
       month12: 'דצמבר',
-      week: 'שבוע',
       weeks: {
         sun: 'א׳',
         mon: 'ב׳',

--- a/packages/locale/lang/hi.ts
+++ b/packages/locale/lang/hi.ts
@@ -48,7 +48,6 @@ export default {
       month10: 'अक्टूबर',
       month11: 'नवंबर',
       month12: 'दिसंबर',
-      week: 'सप्ताह',
       weeks: {
         sun: 'रवि',
         mon: 'सोम',

--- a/packages/locale/lang/hr.ts
+++ b/packages/locale/lang/hr.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Listopad',
       month11: 'Studeni',
       month12: 'Prosinac',
-      week: 'tjedan',
       weeks: {
         sun: 'Ned',
         mon: 'Pon',
@@ -114,10 +113,10 @@ export default {
     transfer: {
       noMatch: 'Nema pronađenih podataka',
       noData: 'Nema podataka',
-      titles: ['Lista 1', 'Lista 2'], // to be translated
-      filterPlaceholder: 'Unesite ključnu riječ', // to be translated
-      noCheckedFormat: '{total} stavki', // to be translated
-      hasCheckedFormat: '{checked}/{total} checked', // to be translated
+      titles: ['Lista 1', 'Lista 2'],
+      filterPlaceholder: 'Unesite ključnu riječ',
+      noCheckedFormat: '{total} stavki',
+      hasCheckedFormat: '{checked}/{total} checked',
     },
     image: {
       error: 'FAILED', // to be translated

--- a/packages/locale/lang/hr.ts
+++ b/packages/locale/lang/hr.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Očisti',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Sada',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Otkaži',
       clear: 'Očisti',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Odaberi datum',
       selectTime: 'Odaberi vrijeme',
       startDate: 'Datum početka',
@@ -46,6 +55,15 @@ export default {
         fri: 'Pet',
         sat: 'Sub',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Jan',
         feb: 'Feb',
@@ -61,6 +79,10 @@ export default {
         dec: 'Dec',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Učitavanje',
       noMatch: 'Nema pronađenih podataka',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Učitavanje',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Nema pronađenih podataka',
@@ -87,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Poruka',
       confirm: 'OK',
       cancel: 'Otkaži',
       error: 'Pogrešan unos',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'pritisnite izbriši za brisanje',
@@ -100,12 +134,22 @@ export default {
       preview: 'Pregled',
       continue: 'Nastavak',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Nema podataka',
       confirmFilter: 'Potvrdi',
       resetFilter: 'Resetiraj',
       clearFilter: 'Sve',
       sumText: 'Suma',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Nema podataka',

--- a/packages/locale/lang/hu.ts
+++ b/packages/locale/lang/hu.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Törlés',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Most',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Mégse',
       clear: 'Törlés',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Dátum',
       selectTime: 'Időpont',
       startDate: 'Dátum-tól',
@@ -46,6 +55,15 @@ export default {
         fri: 'Pén',
         sat: 'Szo',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Jan',
         feb: 'Feb',
@@ -61,6 +79,10 @@ export default {
         dec: 'Dec',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Betöltés',
       noMatch: 'Nincs találat',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Betöltés',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Nincs találat',
@@ -87,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Üzenet',
       confirm: 'OK',
       cancel: 'Mégse',
       error: 'Hibás adat',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'kattints a törléshez',
@@ -100,12 +134,22 @@ export default {
       preview: 'Előnézet',
       continue: 'Tovább',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Nincs adat',
       confirmFilter: 'Megerősít',
       resetFilter: 'Alaphelyet',
       clearFilter: 'Mind',
       sumText: 'Összeg',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Nincs adat',

--- a/packages/locale/lang/hy-am.ts
+++ b/packages/locale/lang/hy-am.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Լաւ',
       clear: 'Մաքրել',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Հիմա',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Չեղարկել',
       clear: 'Մաքրել',
       confirm: 'Լաւ',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Ընտրեք ամսաթիւը',
       selectTime: 'Ընտրեք ժամանակը',
       startDate: 'Սկզբ. ամսաթիւը',
@@ -46,6 +55,15 @@ export default {
         fri: 'Ուրբ',
         sat: 'Շաբ',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Յունվ',
         feb: 'Փետ',
@@ -61,6 +79,10 @@ export default {
         dec: 'Դեկ',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Բեռնում',
       noMatch: 'Համապատասխան տուեալներ չկան',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Բեռնում',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Համապատասխան տուեալներ չկան',
@@ -87,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Հաղորդագրութիւն',
       confirm: 'Լաւ',
       cancel: 'Չեղարկել',
       error: 'Անվաւեր տուեալների մուտք',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Սեղմեք [Ջնջել] ջնջելու համար',
@@ -100,12 +134,22 @@ export default {
       preview: 'Նախադիտում',
       continue: 'Շարունակել',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Տուեալներ չկան',
       confirmFilter: 'Յաստատել',
       resetFilter: 'Վերագործարկել',
       clearFilter: 'Բոլորը',
       sumText: 'Գումարը',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Տուեալներ չկան',

--- a/packages/locale/lang/hy-am.ts
+++ b/packages/locale/lang/hy-am.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Յոկտեմբեր',
       month11: 'Նոյեմբեր',
       month12: 'Դեկտեմբեր',
-      week: 'Շաբաթ',
       weeks: {
         sun: 'Կիր',
         mon: 'Երկ',

--- a/packages/locale/lang/id.ts
+++ b/packages/locale/lang/id.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Pilih',
       clear: 'Kosongkan',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Sekarang',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Batal',
       clear: 'Kosongkan',
       confirm: 'Ya',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Pilih tanggal',
       selectTime: 'Pilih waktu',
       startDate: 'Tanggal Mulai',
@@ -46,6 +55,15 @@ export default {
         fri: 'Jum',
         sat: 'Sab',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Jan',
         feb: 'Feb',
@@ -61,6 +79,10 @@ export default {
         dec: 'Des',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Memuat',
       noMatch: 'Tidak ada data yg cocok',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Memuat',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Tidak ada data yg cocok',
@@ -90,11 +115,18 @@ export default {
       deprecationWarning:
         'Penggunaan yang tidak akan digunakan lagi terdeteksi, silakan lihat dokumentasi el-pagination untuk lebih jelasnya',
     },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
+    },
     messagebox: {
       title: 'Pesan',
       confirm: 'Ya',
       cancel: 'Batal',
       error: 'Masukan ilegal',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Tekan hapus untuk melanjutkan',
@@ -102,12 +134,22 @@ export default {
       preview: 'Pratinjau',
       continue: 'Lanjutkan',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Tidak ada data',
       confirmFilter: 'Konfirmasi',
       resetFilter: 'Atur ulang',
       clearFilter: 'Semua',
       sumText: 'Jumlah',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Tidak ada data',

--- a/packages/locale/lang/id.ts
+++ b/packages/locale/lang/id.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Oktober',
       month11: 'November',
       month12: 'Desember',
-      week: 'Minggu',
       weeks: {
         sun: 'Min',
         mon: 'Sen',

--- a/packages/locale/lang/it.ts
+++ b/packages/locale/lang/it.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Pulisci',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Ora',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Cancella',
       clear: 'Pulisci',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Seleziona data',
       selectTime: 'Seleziona ora',
       startDate: 'Data inizio',
@@ -37,7 +46,6 @@ export default {
       month10: 'Ottobre',
       month11: 'Novembre',
       month12: 'Dicembre',
-      // week: 'settimana',
       weeks: {
         sun: 'Dom',
         mon: 'Lun',
@@ -46,6 +54,15 @@ export default {
         thu: 'Gio',
         fri: 'Ven',
         sat: 'Sab',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Gen',
@@ -62,6 +79,10 @@ export default {
         dec: 'Dic',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Caricamento',
       noMatch: 'Nessuna corrispondenza',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Caricamento',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Nessuna corrispondenza',
@@ -88,11 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
+      title: 'Message', // to be translated
       confirm: 'OK',
       cancel: 'Cancella',
       error: 'Input non valido',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Premi cancella per rimuovere',
@@ -100,12 +134,22 @@ export default {
       preview: 'Anteprima',
       continue: 'Continua',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Nessun dato',
       confirmFilter: 'Conferma',
       resetFilter: 'Reset',
       clearFilter: 'Tutti',
       sumText: 'Somma',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Nessun dato',

--- a/packages/locale/lang/ja.ts
+++ b/packages/locale/lang/ja.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'クリア',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: '現在',
@@ -14,6 +18,11 @@ export default {
       cancel: 'キャンセル',
       clear: 'クリア',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: '日付を選択',
       selectTime: '時間を選択',
       startDate: '開始日',
@@ -37,7 +46,6 @@ export default {
       month10: '10月',
       month11: '11月',
       month12: '12月',
-      // week: '週次',
       weeks: {
         sun: '日',
         mon: '月',
@@ -46,6 +54,15 @@ export default {
         thu: '木',
         fri: '金',
         sat: '土',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: '1月',
@@ -62,6 +79,10 @@ export default {
         dec: '12月',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'ロード中',
       noMatch: 'データなし',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'ロード中',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'データなし',
@@ -88,18 +112,32 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'メッセージ',
       confirm: 'OK',
       cancel: 'キャンセル',
       error: '正しくない入力',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Delキーを押して削除する',
       delete: '削除する',
       preview: 'プレビュー',
       continue: '続行する',
+    },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
     },
     table: {
       emptyText: 'データなし',

--- a/packages/locale/lang/kk.ts
+++ b/packages/locale/lang/kk.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Қабылдау',
       clear: 'Тазалау',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Қазір',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Болдырмау',
       clear: 'Тазалау',
       confirm: 'Қабылдау',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Күнді таңдаңыз',
       selectTime: 'Сағатты таңдаңыз',
       startDate: 'Басталу күні',
@@ -46,6 +55,15 @@ export default {
         fri: 'Жұм',
         sat: 'Сен',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Қаң',
         feb: 'Ақп',
@@ -61,6 +79,10 @@ export default {
         dec: 'Жел',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Жүктелуде',
       noMatch: 'Сәйкес деректер жоқ',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Жүктелуде',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Сәйкес деректер жоқ',
@@ -87,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Хабар',
       confirm: 'Қабылдау',
       cancel: 'Болдырмау',
       error: 'Жарамсыз енгізулер',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Өшіруді басып өшіріңіз',
@@ -100,12 +134,22 @@ export default {
       preview: 'Алдын ала қарау',
       continue: 'Жалғастыру',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Деректер жоқ',
       confirmFilter: 'Қабылдау',
       resetFilter: 'Қалпына келтіру',
       clearFilter: 'Барлығы',
       sumText: 'Сомасы',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Деректер жоқ',

--- a/packages/locale/lang/kk.ts
+++ b/packages/locale/lang/kk.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Қазан',
       month11: 'Қараша',
       month12: 'Желтоқсан',
-      week: 'Апта',
       weeks: {
         sun: 'Жек',
         mon: 'Дүй',

--- a/packages/locale/lang/ko.ts
+++ b/packages/locale/lang/ko.ts
@@ -10,6 +10,7 @@ export default {
       defaultLabel: '색상 선택기',
       description:
         '현재 색상은 {color}입니다. Enter 키를 눌러 새 색상을 선택합니다.',
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: '지금',
@@ -21,6 +22,7 @@ export default {
       monthTablePrompt: '화살표 키를 사용하고 Enter를 눌러 월을 선택합니다.',
       yearTablePrompt:
         '화살표 키를 사용하고 Enter 키를 눌러 연도를 선택합니다.',
+      selectedDate: 'Selected date', // to be translated
       selectDate: '날짜 선택',
       selectTime: '시간 선택',
       startDate: '시작 날짜',
@@ -44,7 +46,6 @@ export default {
       month10: '10월',
       month11: '11월',
       month12: '12월',
-      // week: 'week',
       weeks: {
         sun: '일',
         mon: '월',
@@ -53,6 +54,15 @@ export default {
         thu: '목',
         fri: '금',
         sat: '토',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: '1월',

--- a/packages/locale/lang/ku.ts
+++ b/packages/locale/lang/ku.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Temam',
       clear: 'Paqij bike',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Niha',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Betal bike',
       clear: 'Paqij bike',
       confirm: 'Temam',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Dîrokê bibijêre',
       selectTime: 'Demê bibijêre',
       startDate: 'Dîroka Destpêkê',
@@ -37,7 +46,6 @@ export default {
       month10: 'Kewçêr',
       month11: 'Sarmawaz',
       month12: 'Berfanbar',
-      // week: 'week',
       weeks: {
         sun: 'Yek',
         mon: 'Duş',
@@ -46,6 +54,15 @@ export default {
         thu: 'Pên',
         fri: 'În',
         sat: 'Şem',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Rêb',
@@ -62,6 +79,10 @@ export default {
         dec: 'Ber',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Bardibe',
       noMatch: 'Li hembere ve agahî tune',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Bardibe',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Li hembere ve agahî tune',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Peyam',
       confirm: 'Temam',
       cancel: 'Betal bike',
       error: 'Beyana çewt',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'ji bo rake pêl "delete" bike',
@@ -101,12 +134,22 @@ export default {
       preview: 'Pêşdîtin',
       continue: 'Berdewam',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Agahî tune',
       confirmFilter: 'Piştrast bike',
       resetFilter: 'Jê bibe',
       clearFilter: 'Hemû',
       sumText: 'Kom',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Agahî tune',

--- a/packages/locale/lang/ky.ts
+++ b/packages/locale/lang/ky.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Мурунку',
       clear: 'ачык',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'азыр',
@@ -14,6 +18,11 @@ export default {
       cancel: 'жокко чыгарылды',
       clear: 'ачык',
       confirm: 'белгилөө',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'дата',
       selectTime: 'тандоо убактысы',
       startDate: 'Башталган датасы',
@@ -37,7 +46,6 @@ export default {
       month10: 'онунчу айда',
       month11: 'он биринчи ай',
       month12: 'он экинчи айда',
-      // week: '周次',
       weeks: {
         sun: 'жети жума',
         mon: 'дүйшөмбү',
@@ -46,6 +54,15 @@ export default {
         thu: 'бейшемби',
         fri: 'жума',
         sat: 'ишемби',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'биринчи ай',
@@ -62,6 +79,10 @@ export default {
         dec: 'он экинчи айда',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Жүктөлүүдө',
       noMatch: 'Дал келген маалыматтар',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Жүктөлүүдө',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Дал келген маалыматтар',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'тез',
       confirm: 'белгилөө',
       cancel: 'жокко чыгарылды',
       error: 'Маалыматтарды киргизүү мыйзамдуу эмес!',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Жок кылуу баскычын басуу жок',
@@ -101,12 +134,22 @@ export default {
       preview: 'ЖМКнын картинки',
       continue: 'жүктөп бер',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'маалымат жок',
       confirmFilter: 'чыпка',
       resetFilter: 'кайра орнотуу',
       clearFilter: 'бүткөн',
       sumText: 'Бардыгы болуп',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'маалымат жок',

--- a/packages/locale/lang/lo.ts
+++ b/packages/locale/lang/lo.ts
@@ -44,7 +44,6 @@ export default {
       month10: 'ຕຸລາ',
       month11: 'ພະຈິກ',
       month12: 'ທັນວາ',
-      week: 'ອາທິດ',
       weeks: {
         sun: 'ອາ',
         mon: 'ຈ',

--- a/packages/locale/lang/lt.ts
+++ b/packages/locale/lang/lt.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Valyti',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Dabar',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Atšaukti',
       clear: 'Valyti',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Pasirink datą',
       selectTime: 'Pasirink laiką',
       startDate: 'Data nuo',
@@ -37,7 +46,6 @@ export default {
       month10: 'Spalis',
       month11: 'Lapkritis',
       month12: 'Gruodis',
-      // week: 'savaitė',
       weeks: {
         sun: 'S.',
         mon: 'Pr.',
@@ -46,6 +54,15 @@ export default {
         thu: 'K.',
         fri: 'Pn.',
         sat: 'Š.',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Sau',
@@ -62,6 +79,10 @@ export default {
         dec: 'Gruo',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Kraunasi',
       noMatch: 'Duomenų nerasta',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Kraunasi',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Duomenų nerasta',
@@ -88,18 +112,32 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Žinutė',
       confirm: 'OK',
       cancel: 'Atšaukti',
       error: 'Klaida įvestuose duomenyse',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'spauskite "Trinti" norėdami pašalinti',
       delete: 'Trinti',
       preview: 'Peržiūrėti',
       continue: 'Toliau',
+    },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
     },
     table: {
       emptyText: 'Duomenų nerasta',

--- a/packages/locale/lang/lv.ts
+++ b/packages/locale/lang/lv.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Labi',
       clear: 'Notīrīt',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Tagad',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Atcelt',
       clear: 'Notīrīt',
       confirm: 'Labi',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Izvēlēties datumu',
       selectTime: 'Izvēlēties laiku',
       startDate: 'Sākuma datums',
@@ -37,7 +46,6 @@ export default {
       month10: 'Oktobris',
       month11: 'Novembris',
       month12: 'Decembris',
-      // week: 'nedēļa',
       weeks: {
         sun: 'Sv',
         mon: 'Pr',
@@ -46,6 +54,15 @@ export default {
         thu: 'Ce',
         fri: 'Pk',
         sat: 'Se',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Jan',
@@ -62,6 +79,10 @@ export default {
         dec: 'Dec',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Ielādē',
       noMatch: 'Nav atbilstošu datu',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Ielādē',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Nav atbilstošu datu',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Paziņojums',
       confirm: 'Labi',
       cancel: 'Atcelt',
       error: 'Nederīga ievade',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Nospiediet dzēst lai izņemtu',
@@ -101,12 +134,22 @@ export default {
       preview: 'Priekšskatīt',
       continue: 'Turpināt',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Nav datu',
       confirmFilter: 'Apstiprināt',
       resetFilter: 'Atiestatīt',
       clearFilter: 'Visi',
       sumText: 'Summa',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Nav datu',

--- a/packages/locale/lang/mg.ts
+++ b/packages/locale/lang/mg.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Oktobra',
       month11: 'Novambra',
       month12: 'Desambra',
-      week: 'herinandro',
       weeks: {
         sun: 'Lad',
         mon: 'Ala',
@@ -116,16 +115,16 @@ export default {
     transfer: {
       noMatch: 'Tsy misy angona mifanentana',
       noData: 'Tsy misy angona',
-      titles: ['Lisitra 1', 'Lisitra 2'], // to be translated
-      filterPlaceholder: 'Ampidiro teny fanalahidy', // to be translated
-      noCheckedFormat: '{total} zavatra', // to be translated
-      hasCheckedFormat: '{checked}/{total} voamarina', // to be translated
+      titles: ['Lisitra 1', 'Lisitra 2'],
+      filterPlaceholder: 'Ampidiro teny fanalahidy',
+      noCheckedFormat: '{total} zavatra',
+      hasCheckedFormat: '{checked}/{total} voamarina',
     },
     image: {
       error: 'TSY NAHOMBY',
     },
     pageHeader: {
-      title: 'Miverina', // to be translated
+      title: 'Miverina',
     },
     popconfirm: {
       confirmButtonText: 'Eny',

--- a/packages/locale/lang/mg.ts
+++ b/packages/locale/lang/mg.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'ENY',
       clear: 'Fafana',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Zao',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Hanafoana',
       clear: 'Fafana',
       confirm: 'ENY',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Misafidy daty',
       selectTime: 'Misafidy ora',
       startDate: 'Daty fanombohana',
@@ -46,6 +55,15 @@ export default {
         fri: 'Zom',
         sat: 'Sab',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Jan',
         feb: 'Feb',
@@ -61,6 +79,10 @@ export default {
         dec: 'Des',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Eo ampiandrasana',
       noMatch: 'Tsy misy angona mifanentana',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Eo ampiandrasana',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Tsy misy angona mifanentana',
@@ -90,11 +115,18 @@ export default {
       deprecationWarning:
         'Fampiasana tsy ampiasaina intsony no hita, azafady mba jereo ny tahirin-kevitra el-pagination raha mila fanazavana fanampiny',
     },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
+    },
     messagebox: {
       title: 'Hafatra',
       confirm: 'ENY',
       cancel: 'Hanafoana',
       error: 'Fampidirana tsy ara-dalàna',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'tsindrio fafana raha hanala',
@@ -102,12 +134,22 @@ export default {
       preview: 'Topi-maso',
       continue: 'Hanoy',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Tsy misy angona',
       confirmFilter: 'Manamarina',
       resetFilter: 'Averina',
       clearFilter: 'Rehetra',
       sumText: 'Atambatra',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Tsy misy angona',

--- a/packages/locale/lang/mn.ts
+++ b/packages/locale/lang/mn.ts
@@ -37,7 +37,6 @@ export default {
       month10: '10 сар',
       month11: '11 сар',
       month12: '12 сар',
-      week: 'Долоо хоног',
       weeks: {
         sun: 'Ням',
         mon: 'Дав',

--- a/packages/locale/lang/mn.ts
+++ b/packages/locale/lang/mn.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Тийм',
       clear: 'Цэвэрлэх',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Одоо',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Болих',
       clear: 'Цэвэрлэх',
       confirm: 'Тийм',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Огноог сонго',
       selectTime: 'Цагийг сонго',
       startDate: 'Эхлэх огноо',
@@ -46,6 +55,15 @@ export default {
         fri: 'Баа',
         sat: 'Бям',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: '1 сар',
         feb: '2 сар',
@@ -61,6 +79,10 @@ export default {
         dec: '12 сар',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Ачаалж байна',
       noMatch: 'Тохирох өгөгдөл байхгүй',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Ачаалж байна',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Тохирох өгөгдөл байхгүй',
@@ -87,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Зурвас',
       confirm: 'Тийм',
       cancel: 'Болих',
       error: 'Буруу утга',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Устгахын дарж арилга',
@@ -100,12 +134,22 @@ export default {
       preview: 'Өмнөх',
       continue: 'Үргэлжлүүлэх',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Өгөгдөл байхгүй',
       confirmFilter: 'Зөвшөөрөх',
       resetFilter: 'Цэвэрлэх',
       clearFilter: 'Бүгд',
       sumText: 'Нийт',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Өгөгдөл байхгүй',

--- a/packages/locale/lang/ms.ts
+++ b/packages/locale/lang/ms.ts
@@ -48,7 +48,6 @@ export default {
       month10: 'Oktober',
       month11: 'November',
       month12: 'Disember',
-      week: 'minggu',
       weeks: {
         sun: 'Ahd',
         mon: 'Isn',

--- a/packages/locale/lang/ms.ts
+++ b/packages/locale/lang/ms.ts
@@ -126,9 +126,10 @@ export default {
     messagebox: {
       title: 'Mesej',
       confirm: 'OK',
-      Batal: 'Dibatalkan',
+      cancel: 'Cancel', // to be translated
       error: 'Input haram',
       close: 'Tutup dialog ini',
+      Batal: 'Dibatalkan',
     },
     upload: {
       deleteTip: 'tekan padam untuk mengalih keluar',
@@ -172,6 +173,7 @@ export default {
     },
     popconfirm: {
       confirmButtonText: 'Ya',
+      cancelButtonText: 'No', // to be translated
       BatalButtonText: 'Tidak',
     },
     carousel: {

--- a/packages/locale/lang/my.ts
+++ b/packages/locale/lang/my.ts
@@ -48,7 +48,6 @@ export default {
       month10: 'အောက်တိုဘာ',
       month11: 'နိုဝင်ဘာ',
       month12: 'ဒီဇင်ဘာ',
-      week: 'ရက်သတ္တပတ်',
       weeks: {
         sun: 'နွေ',
         mon: 'လာ',

--- a/packages/locale/lang/nb-no.ts
+++ b/packages/locale/lang/nb-no.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Tøm',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Nå',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Avbryt',
       clear: 'Tøm',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Velg dato',
       selectTime: 'Velg tidspunkt',
       startDate: 'Startdato',
@@ -46,6 +55,15 @@ export default {
         fri: 'Fre',
         sat: 'Lør',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Jan',
         feb: 'Feb',
@@ -61,6 +79,10 @@ export default {
         dec: 'Des',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Laster',
       noMatch: 'Ingen samsvarende resulater',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Laster',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Ingen samsvarende resultater',
@@ -87,11 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
+      title: 'Message', // to be translated
       confirm: 'OK',
       cancel: 'Avbryt',
       error: 'Ugyldig input',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'trykk på x for å slette',
@@ -99,12 +134,22 @@ export default {
       preview: 'Forhåndsvisning',
       continue: 'Fortsett',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Ingen Data',
       confirmFilter: 'Bekreft',
       resetFilter: 'Tilbakestill',
       clearFilter: 'Alle',
       sumText: 'Sum',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Ingen Data',

--- a/packages/locale/lang/nb-no.ts
+++ b/packages/locale/lang/nb-no.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Oktober',
       month11: 'November',
       month12: 'Desember',
-      week: 'uke',
       weeks: {
         sun: 'Søn',
         mon: 'Man',

--- a/packages/locale/lang/nl.ts
+++ b/packages/locale/lang/nl.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Bevestig',
       clear: 'Wissen',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Nu',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Annuleren',
       clear: 'Legen',
       confirm: 'Bevestig',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Selecteer datum',
       selectTime: 'Selecteer tijd',
       startDate: 'Startdatum',
@@ -37,7 +46,6 @@ export default {
       month10: 'oktober',
       month11: 'november',
       month12: 'december',
-      // week: 'week',
       weeks: {
         sun: 'Zo',
         mon: 'Ma',
@@ -46,6 +54,15 @@ export default {
         thu: 'Do',
         fri: 'Vr',
         sat: 'Za',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'jan',
@@ -62,6 +79,10 @@ export default {
         dec: 'dec',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Laden',
       noMatch: 'Geen overeenkomende resultaten',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Laden',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Geen overeenkomende resultaten',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Bericht',
       confirm: 'Bevestig',
       cancel: 'Annuleren',
       error: 'Ongeldige invoer',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Kies verwijder om te wissen',
@@ -101,12 +134,22 @@ export default {
       preview: 'Voorbeeld',
       continue: 'Doorgaan',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Geen data',
       confirmFilter: 'Bevestigen',
       resetFilter: 'Reset',
       clearFilter: 'Alles',
       sumText: 'Som',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Geen data',

--- a/packages/locale/lang/pa.ts
+++ b/packages/locale/lang/pa.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'تایید',
       clear: 'پاکول',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'اوس',
@@ -14,6 +18,11 @@ export default {
       cancel: 'ردول',
       clear: 'پاکول',
       confirm: 'تایید',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'نیټه وټاکئ',
       selectTime: 'وخت وټاکئ',
       startDate: 'پیل نیټه',
@@ -37,7 +46,6 @@ export default {
       month10: 'اکتوبر',
       month11: 'نومبر',
       month12: 'دسمبر',
-      // week: 'week',
       weeks: {
         sun: 'یکشنبه',
         mon: 'دوشنبه',
@@ -46,6 +54,15 @@ export default {
         thu: 'پنج​شنبه',
         fri: 'جمعه',
         sat: 'شنبه',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'جنوري',
@@ -62,6 +79,10 @@ export default {
         dec: 'دسمبر',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'بار کول',
       noMatch: 'هیڅه ونه موندل شول',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'بار کول',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'هیڅه ونه موندل شول',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'عنوان',
       confirm: 'تایید',
       cancel: 'لغوه کول',
       error: 'تيروتنه',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'د حذف کولو لپاره پاکه تڼۍ فشار کړئ',
@@ -101,12 +134,22 @@ export default {
       preview: 'مخکتنه',
       continue: 'ادامه',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'هیڅ معلومات ونه موندل شول',
       confirmFilter: 'تایید',
       resetFilter: 'پاکول',
       clearFilter: 'ټول',
       sumText: 'مجموعه',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'هیڅ معلومات ونه موندل شول',

--- a/packages/locale/lang/pl.ts
+++ b/packages/locale/lang/pl.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'październik',
       month11: 'listopad',
       month12: 'grudzień',
-      week: 'tydzień',
       weeks: {
         sun: 'niedz.',
         mon: 'pon.',

--- a/packages/locale/lang/pl.ts
+++ b/packages/locale/lang/pl.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Wyczyść',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Teraz',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Anuluj',
       clear: 'Wyczyść',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Wybierz datę',
       selectTime: 'Wybierz godzinę',
       startDate: 'Data początkowa',
@@ -46,6 +55,15 @@ export default {
         fri: 'pt.',
         sat: 'sob.',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'STY',
         feb: 'LUT',
@@ -61,6 +79,10 @@ export default {
         dec: 'GRU',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Ładowanie',
       noMatch: 'Brak dopasowań',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Ładowanie',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Brak dopasowań',
@@ -87,18 +112,32 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Wiadomość',
       confirm: 'OK',
       cancel: 'Anuluj',
       error: 'Wiadomość zawiera niedozwolone znaki',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'kliknij kasuj aby usunąć',
       delete: 'Kasuj',
       preview: 'Podgląd',
       continue: 'Kontynuuj',
+    },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
     },
     table: {
       emptyText: 'Brak danych',

--- a/packages/locale/lang/pt-br.ts
+++ b/packages/locale/lang/pt-br.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Confirmar',
       clear: 'Limpar',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Agora',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Cancelar',
       clear: 'Limpar',
       confirm: 'Confirmar',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Selecione a data',
       selectTime: 'Selecione a hora',
       startDate: 'Data inicial',
@@ -37,7 +46,6 @@ export default {
       month10: 'Outubro',
       month11: 'Novembro',
       month12: 'Dezembro',
-      // week: 'semana',
       weeks: {
         sun: 'Dom',
         mon: 'Seg',
@@ -46,6 +54,15 @@ export default {
         thu: 'Qui',
         fri: 'Sex',
         sat: 'Sab',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Jan',
@@ -62,6 +79,10 @@ export default {
         dec: 'Dez',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Carregando',
       noMatch: 'Sem resultados',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Carregando',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Sem resultados',
@@ -88,18 +112,32 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Mensagem',
       confirm: 'Confirmar',
       cancel: 'Cancelar',
       error: 'Erro!',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'aperte delete para apagar',
       delete: 'Apagar',
       preview: 'Pré-visualizar',
       continue: 'Continuar',
+    },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
     },
     table: {
       emptyText: 'Sem dados',

--- a/packages/locale/lang/pt.ts
+++ b/packages/locale/lang/pt.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Confirmar',
       clear: 'Limpar',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Agora',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Cancelar',
       clear: 'Limpar',
       confirm: 'Confirmar',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Selecione a data',
       selectTime: 'Selecione a hora',
       startDate: 'Data de inicio',
@@ -37,7 +46,6 @@ export default {
       month10: 'Outubro',
       month11: 'Novembro',
       month12: 'Dezembro',
-      // week: 'semana',
       weeks: {
         sun: 'Dom',
         mon: 'Seg',
@@ -46,6 +54,15 @@ export default {
         thu: 'Qui',
         fri: 'Sex',
         sat: 'Sab',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Jan',
@@ -62,6 +79,10 @@ export default {
         dec: 'Dez',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'A carregar',
       noMatch: 'Sem correspondência',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'A carregar',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Sem correspondência',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Mensagem',
       confirm: 'Confirmar',
       cancel: 'Cancelar',
       error: 'Erro!',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'press delete to remove', // to be translated
@@ -101,12 +134,22 @@ export default {
       preview: 'Previsualizar',
       continue: 'Continuar',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Sem dados',
       confirmFilter: 'Confirmar',
       resetFilter: 'Limpar',
       clearFilter: 'Todos',
       sumText: 'Sum', // to be translated
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Sem dados',

--- a/packages/locale/lang/ro.ts
+++ b/packages/locale/lang/ro.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Șterge',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Acum',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Anulează',
       clear: 'Șterge',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Selectează data',
       selectTime: 'Selectează ora',
       startDate: 'Data de început',
@@ -37,7 +46,6 @@ export default {
       month10: 'Octombrie',
       month11: 'Noiembrie',
       month12: 'Decembrie',
-      // week: 'week',
       weeks: {
         sun: 'Du',
         mon: 'Lu',
@@ -46,6 +54,15 @@ export default {
         thu: 'Jo',
         fri: 'Vi',
         sat: 'Sâ',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Ian',
@@ -62,6 +79,10 @@ export default {
         dec: 'Dec',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Se încarcă',
       noMatch: 'Nu există date potrivite',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Se încarcă',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Nu există date potrivite',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Mesaj',
       confirm: 'OK',
       cancel: 'Anulează',
       error: 'Date introduse eronate',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'apăsați pe ștergeți pentru a elimina',
@@ -101,12 +134,22 @@ export default {
       preview: 'previzualizare',
       continue: 'continuă',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Nu există date',
       confirmFilter: 'Confirmă',
       resetFilter: 'Resetează',
       clearFilter: 'Tot',
       sumText: 'Suma',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Nu există date',

--- a/packages/locale/lang/ru.ts
+++ b/packages/locale/lang/ru.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Ок',
       clear: 'Очистить',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Сейчас',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Отмена',
       clear: 'Очистить',
       confirm: 'Ок',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Выбрать дату',
       selectTime: 'Выбрать время',
       startDate: 'Дата начала',
@@ -46,6 +55,15 @@ export default {
         fri: 'Пт',
         sat: 'Сб',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Янв',
         feb: 'Фев',
@@ -61,6 +79,10 @@ export default {
         dec: 'Дек',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Загрузка',
       noMatch: 'Совпадений не найдено',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Загрузка',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Совпадений не найдено',
@@ -87,18 +112,32 @@ export default {
       currentPage: 'страница {pager}',
       prevPages: 'Предыдущие {pager} страниц',
       nextPages: 'Следующие {pager} страниц',
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Сообщение',
       confirm: 'Ок',
       cancel: 'Отмена',
       error: 'Недопустимый ввод данных',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Нажмите [Удалить] для удаления',
       delete: 'Удалить',
       preview: 'Превью',
       continue: 'Продолжить',
+    },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
     },
     table: {
       emptyText: 'Нет данных',

--- a/packages/locale/lang/ru.ts
+++ b/packages/locale/lang/ru.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Октябрь',
       month11: 'Ноябрь',
       month12: 'Декабрь',
-      week: 'неделя',
       weeks: {
         sun: 'Вс',
         mon: 'Пн',

--- a/packages/locale/lang/sk.ts
+++ b/packages/locale/lang/sk.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Zmazať',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Teraz',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Zrušiť',
       clear: 'Zmazať',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Vybrať dátum',
       selectTime: 'Vybrať čas',
       startDate: 'Dátum začiatku',
@@ -24,8 +33,6 @@ export default {
       nextYear: 'Ďalší rok',
       prevMonth: 'Predošlý mesiac',
       nextMonth: 'Ďalší mesiac',
-      day: 'Deň',
-      month: 'Mesiac',
       year: 'Rok',
       month1: 'Január',
       month2: 'Február',
@@ -48,6 +55,15 @@ export default {
         fri: 'Pi',
         sat: 'So',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Jan',
         feb: 'Feb',
@@ -62,6 +78,12 @@ export default {
         nov: 'Nov',
         dec: 'Dec',
       },
+      day: 'Deň',
+      month: 'Mesiac',
+    },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
     },
     select: {
       loading: 'Načítavanie',
@@ -71,6 +93,9 @@ export default {
     },
     mention: {
       loading: 'Načítavanie',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Žiadna zhoda',
@@ -89,12 +114,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Správa',
       confirm: 'OK',
       cancel: 'Zrušiť',
       error: 'Neplatný vstup',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'pre odstránenie stisni klávesu Delete',
@@ -102,12 +136,22 @@ export default {
       preview: 'Prehliadať',
       continue: 'Pokračovať',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Žiadne dáta',
       confirmFilter: 'Potvrdiť',
       resetFilter: 'Zresetovať',
       clearFilter: 'Všetko',
       sumText: 'Spolu',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Žiadne dáta',

--- a/packages/locale/lang/sk.ts
+++ b/packages/locale/lang/sk.ts
@@ -25,7 +25,6 @@ export default {
       prevMonth: 'Predošlý mesiac',
       nextMonth: 'Ďalší mesiac',
       day: 'Deň',
-      week: 'Týždeň',
       month: 'Mesiac',
       year: 'Rok',
       month1: 'Január',

--- a/packages/locale/lang/sl.ts
+++ b/packages/locale/lang/sl.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Okt',
       month11: 'Nov',
       month12: 'Dec',
-      week: 'teden',
       weeks: {
         sun: 'Ned',
         mon: 'Pon',

--- a/packages/locale/lang/sl.ts
+++ b/packages/locale/lang/sl.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'V redu',
       clear: 'Počisti',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Zdaj',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Prekliči',
       clear: 'Počisti',
       confirm: 'Potrdi',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Izberi datum',
       selectTime: 'Izberi čas',
       startDate: 'Začetni datum',
@@ -46,6 +55,15 @@ export default {
         fri: 'Pet',
         sat: 'Sob',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Jan',
         feb: 'Feb',
@@ -61,6 +79,10 @@ export default {
         dec: 'Dec',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Nalaganje',
       noMatch: 'Ni ustreznih podatkov',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Nalaganje',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Ni ustreznih podatkov',
@@ -87,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Sporočilo',
       confirm: 'V redu',
       cancel: 'Prekliči',
       error: 'Nedovoljen vnos',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'press delete to remove', // to be translated
@@ -100,12 +134,22 @@ export default {
       preview: 'Predogled',
       continue: 'Nadaljuj',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Ni podatkov',
       confirmFilter: 'Potrdi',
       resetFilter: 'Ponastavi',
       clearFilter: 'Vse',
       sumText: 'Skupno',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Ni podatkov',

--- a/packages/locale/lang/sr.ts
+++ b/packages/locale/lang/sr.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Поништи',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Сада',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Откажи',
       clear: 'Бриши',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Изабери датум',
       selectTime: 'Изабери време',
       startDate: 'Датум почетка',
@@ -46,6 +55,15 @@ export default {
         fri: 'Пет',
         sat: 'Суб',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'јан',
         feb: 'феб',
@@ -61,6 +79,10 @@ export default {
         dec: 'дец',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Учитавање',
       noMatch: 'Нема резултата',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Учитавање',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Нема резултата',
@@ -87,12 +112,21 @@ export default {
       currentPage: 'страна {pager}',
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Порука',
       confirm: 'OK',
       cancel: 'Откажи',
       error: 'Неисправан унос',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'притисни БРИШИ да обришеш',
@@ -100,12 +134,22 @@ export default {
       preview: 'Види',
       continue: 'Настави',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Нема података',
       confirmFilter: 'Потврди',
       resetFilter: 'Ресетуј',
       clearFilter: 'Све',
       sumText: 'Збир',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Нема података',

--- a/packages/locale/lang/sr.ts
+++ b/packages/locale/lang/sr.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'октобар',
       month11: 'новембар',
       month12: 'децембар',
-      week: 'седмица',
       weeks: {
         sun: 'Нед',
         mon: 'Пон',
@@ -114,7 +113,7 @@ export default {
     transfer: {
       noMatch: 'Нема резултата',
       noData: 'Нема података',
-      titles: ['Листа 1', 'Листа 2'], // to be translated
+      titles: ['Листа 1', 'Листа 2'],
       filterPlaceholder: 'Унеси кључну реч',
       noCheckedFormat: '{total} ставки',
       hasCheckedFormat: '{checked}/{total} обележених',

--- a/packages/locale/lang/sv.ts
+++ b/packages/locale/lang/sv.ts
@@ -128,7 +128,7 @@ export default {
       error: 'FAILED', // to be translated
     },
     pageHeader: {
-      title: 'Bakåt', // to be translated
+      title: 'Bakåt',
     },
     popconfirm: {
       confirmButtonText: 'Ja',

--- a/packages/locale/lang/sv.ts
+++ b/packages/locale/lang/sv.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Töm',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Nu',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Avbryt',
       clear: 'Töm',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Välj datum',
       selectTime: 'Välj tid',
       startDate: 'Startdatum',
@@ -37,7 +46,6 @@ export default {
       month10: 'Oktober',
       month11: 'November',
       month12: 'December',
-      // week: 'week',
       weeks: {
         sun: 'Sön',
         mon: 'Mån',
@@ -46,6 +54,15 @@ export default {
         thu: 'Tor',
         fri: 'Fre',
         sat: 'Lör',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Jan',
@@ -62,6 +79,10 @@ export default {
         dec: 'Dec',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Laddar',
       noMatch: 'Hittade inget',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Laddar',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Hittade inget',
@@ -88,18 +112,32 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Meddelande',
       confirm: 'OK',
       cancel: 'Avbryt',
       error: 'Felaktig inmatning',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'press delete to remove', // to be translated
       delete: 'Radera',
       preview: 'Förhandsvisa',
       continue: 'Fortsätt',
+    },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
     },
     table: {
       emptyText: 'Inga Data',

--- a/packages/locale/lang/sw.ts
+++ b/packages/locale/lang/sw.ts
@@ -46,7 +46,6 @@ export default {
       month10: 'mwezi wa kumi',
       month11: 'mwezi wa kumi na moja',
       month12: 'mwezi wa kumi na mbili',
-      week: 'siku saba',
       weeks: {
         sun: 'jpili',
         mon: 'jtatu',

--- a/packages/locale/lang/sw.ts
+++ b/packages/locale/lang/sw.ts
@@ -10,6 +10,7 @@ export default {
       defaultLabel: 'kichagua rangi',
       description:
         'rangi ya sasa ni {color}. bonyeza kitufe cha kuingia ili kuchagua rangi mpya.',
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'sasa',
@@ -145,6 +146,11 @@ export default {
       resetFilter: 'weka upya',
       clearFilter: 'zote',
       sumText: 'jumla',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'hakuna data',

--- a/packages/locale/lang/ta.ts
+++ b/packages/locale/lang/ta.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'உறுதி செய்',
       clear: 'தெளிவாக்கு',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'தற்போது',
@@ -14,6 +18,11 @@ export default {
       cancel: 'ரத்து செய்',
       clear: 'சரி',
       confirm: 'உறுதி செய்',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'தேதியை தேர்வு செய்',
       selectTime: 'நேரத்தை தேர்வு செய்',
       startDate: 'தொடங்கும் நாள்',
@@ -46,6 +55,15 @@ export default {
         fri: 'வெள்ளி',
         sat: 'சனி',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'ஜனவரி',
         feb: 'பிப்ரவரி',
@@ -61,6 +79,10 @@ export default {
         dec: 'டிசம்பர்',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'தயாராகிக்கொண்டிருக்கிறது',
       noMatch: 'பொருத்தமான தரவு கிடைக்கவில்லை',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'தயாராகிக்கொண்டிருக்கிறது',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'பொருத்தமான தரவு கிடைக்கவில்லை',
@@ -87,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'செய்தி',
       confirm: 'உறுதி செய்',
       cancel: 'ரத்து செய்',
       error: 'பொருத்தாமில்லாத உள்ளீடு',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'press delete to remove', // to be translated
@@ -100,12 +134,22 @@ export default {
       preview: 'முன்னோட்டம் பார்',
       continue: 'தொடரு',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'தரவு இல்லை',
       confirmFilter: 'உறுதி செய்',
       resetFilter: 'புதுமாற்றம் செய்',
       clearFilter: 'அனைத்தும்',
       sumText: 'கூட்டு',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'தரவு இல்லை',

--- a/packages/locale/lang/te.ts
+++ b/packages/locale/lang/te.ts
@@ -47,7 +47,6 @@ export default {
       month10: 'అక్టోబర్',
       month11: 'నవంబర్',
       month12: 'డిసెంబర్',
-      week: 'వారం',
       weeks: {
         sun: 'ఆది',
         mon: 'సోమ',

--- a/packages/locale/lang/th.ts
+++ b/packages/locale/lang/th.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'ตกลง',
       clear: 'ล้างข้อมูล',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'ตอนนี้',
@@ -14,6 +18,11 @@ export default {
       cancel: 'ยกเลิก',
       clear: 'ล้างข้อมูล',
       confirm: 'ตกลง',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'เลือกวันที่',
       selectTime: 'เลือกเวลา',
       startDate: 'วันที่เริ่มต้น',
@@ -37,7 +46,6 @@ export default {
       month10: 'ตุลาคม',
       month11: 'พฤศจิกายน',
       month12: 'ธันวาคม',
-      // week: 'week',
       weeks: {
         sun: 'อา',
         mon: 'จ',
@@ -46,6 +54,15 @@ export default {
         thu: 'พฤ',
         fri: 'ศ',
         sat: 'ส',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'ม.ค.',
@@ -62,6 +79,10 @@ export default {
         dec: 'ธ.ค.',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'กำลังโหลด',
       noMatch: 'ไม่พบข้อมูลที่ตรงกัน',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'กำลังโหลด',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'ไม่พบข้อมูลที่ตรงกัน',
@@ -88,18 +112,32 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'ข้อความ',
       confirm: 'ตกลง',
       cancel: 'ยกเลิก',
       error: 'คุณป้อนข้อมูลไม่ถูกต้อง',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'กดปุ่ม "ลบ" เพื่อลบออก',
       delete: 'ลบ',
       preview: 'ตัวอย่าง',
       continue: 'ทำต่อ',
+    },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
     },
     table: {
       emptyText: 'ไม่พบข้อมูล',

--- a/packages/locale/lang/tk.ts
+++ b/packages/locale/lang/tk.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Arassala',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Şuwagt',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Bes et',
       clear: 'Arassala',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Güni saýlaň',
       selectTime: 'Wagty saýlaň',
       startDate: 'Başlaýan güni',
@@ -37,7 +46,6 @@ export default {
       month10: 'Okt',
       month11: 'Noý',
       month12: 'Dek',
-      // week: 'week',
       weeks: {
         sun: 'Ýek',
         mon: 'Duş',
@@ -46,6 +54,15 @@ export default {
         thu: 'Pen',
         fri: 'Ann',
         sat: 'Şen',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Ýan',
@@ -62,6 +79,10 @@ export default {
         dec: 'Dek',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Indirilýär',
       noMatch: 'Hiçzat tapylmady',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Indirilýär',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Hiçzat tapylmady',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Hat',
       confirm: 'OK',
       cancel: 'Bes et',
       error: 'Ýalňyş girizme',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Pozmak üçin "poz" düwmä basyň',
@@ -101,12 +134,22 @@ export default {
       preview: 'Gör',
       continue: 'Dowam et',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Maglumat ýok',
       confirmFilter: 'Tassykla',
       resetFilter: 'Arassala',
       clearFilter: 'Hemmesi',
       sumText: 'Jemi',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Maglumat ýok',

--- a/packages/locale/lang/tr.ts
+++ b/packages/locale/lang/tr.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Onayla',
       clear: 'Temizle',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Şimdi',
@@ -14,6 +18,11 @@ export default {
       cancel: 'İptal',
       clear: 'Temizle',
       confirm: 'Onayla',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Tarih seç',
       selectTime: 'Saat seç',
       startDate: 'Başlangıç Tarihi',
@@ -37,7 +46,6 @@ export default {
       month10: 'Ekim',
       month11: 'Kasım',
       month12: 'Aralık',
-      // week: 'week',
       weeks: {
         sun: 'Paz',
         mon: 'Pzt',
@@ -46,6 +54,15 @@ export default {
         thu: 'Per',
         fri: 'Cum',
         sat: 'Cmt',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Oca',
@@ -62,6 +79,10 @@ export default {
         dec: 'Ara',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Yükleniyor',
       noMatch: 'Eşleşen veri bulunamadı',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Yükleniyor',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Eşleşen veri bulunamadı',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Mesaj',
       confirm: 'Onayla',
       cancel: 'İptal',
       error: 'İllegal giriş',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'kaldırmak için delete tuşuna bas',
@@ -101,12 +134,22 @@ export default {
       preview: 'Görüntüle',
       continue: 'Devam',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Veri yok',
       confirmFilter: 'Onayla',
       resetFilter: 'Sıfırla',
       clearFilter: 'Hepsi',
       sumText: 'Sum',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Veri yok',

--- a/packages/locale/lang/ug-cn.ts
+++ b/packages/locale/lang/ug-cn.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'جەزملەش',
       clear: 'قۇرۇقداش',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'ھازىرقى ۋاقىت',
@@ -14,6 +18,11 @@ export default {
       cancel: 'بىكار قىلىش',
       clear: 'قۇرۇقداش',
       confirm: 'جەزملەش',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'چىسلا تاللاڭ',
       selectTime: 'ۋاقىت تاللاڭ',
       startDate: 'باشلانغان چىسلا',
@@ -37,7 +46,6 @@ export default {
       month10: '10-ئاي',
       month11: '11-ئاي',
       month12: '12-ئاي',
-      // week: '周次',
       weeks: {
         sun: 'يەكشەنبە',
         mon: 'دۈشەنبە',
@@ -46,6 +54,15 @@ export default {
         thu: 'پەيشەنبە',
         fri: 'جۈمە',
         sat: 'شەنبە',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: '1-ئاي',
@@ -62,6 +79,10 @@ export default {
         dec: '12-ئاي',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'يۈكلىنىۋاتىدۇ',
       noMatch: 'ئۇچۇر تېپىلمىدى',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'يۈكلىنىۋاتىدۇ',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'ئۇچۇر تېپىلمىدى',
@@ -88,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'ئەسكەرتىش',
       confirm: 'جەزملەش',
       cancel: 'بىكار قىلىش',
       error: 'كىرگۈزگەن ئۇچۇرىڭىزدا خاتالىق بار!',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'delete كۇنپكىسىنى بېسىپ ئۆچۈرەلەيسىز',
@@ -101,12 +134,22 @@ export default {
       preview: 'رەسىمنى كۆرۈش',
       continue: 'رەسىم يوللاش',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'ئۇچۇر يوق',
       confirmFilter: 'سۈزگۈچ',
       resetFilter: 'قايتا تولدۇرۇش',
       clearFilter: 'ھەممە',
       sumText: 'جەمئىي',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'ئۇچۇر يوق',

--- a/packages/locale/lang/uk.ts
+++ b/packages/locale/lang/uk.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Жовтень',
       month11: 'Листопад',
       month12: 'Грудень',
-      week: 'тиждень',
       weeks: {
         sun: 'Нд',
         mon: 'Пн',

--- a/packages/locale/lang/uk.ts
+++ b/packages/locale/lang/uk.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Очистити',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Зараз',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Відміна',
       clear: 'Очистити',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Вибрати дату',
       selectTime: 'Вибрати час',
       startDate: 'Дата початку',
@@ -46,6 +55,15 @@ export default {
         fri: 'Пт',
         sat: 'Сб',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Січ',
         feb: 'Лют',
@@ -61,6 +79,10 @@ export default {
         dec: 'Гру',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Завантаження',
       noMatch: 'Співпадінь не знайдено',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Завантаження',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Співпадінь не знайдено',
@@ -87,18 +112,32 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Повідомлення',
       confirm: 'OK',
       cancel: 'Відміна',
       error: 'Неприпустимий ввід даних',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'натисніть кнопку щоб видалити',
       delete: 'Видалити',
       preview: 'Перегляд',
       continue: 'Продовжити',
+    },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
     },
     table: {
       emptyText: 'Немає даних',

--- a/packages/locale/lang/uz-uz.ts
+++ b/packages/locale/lang/uz-uz.ts
@@ -37,7 +37,6 @@ export default {
       month10: 'Oktabr',
       month11: 'Noyabr',
       month12: 'Dekabr',
-      week: 'Hafta',
       weeks: {
         sun: 'Yak',
         mon: 'Dush',

--- a/packages/locale/lang/uz-uz.ts
+++ b/packages/locale/lang/uz-uz.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'Qabul qilish',
       clear: 'Tozalash',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Hozir',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Bekor qilish',
       clear: 'Tozalash',
       confirm: 'Qabul qilish',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Kunni tanlash',
       selectTime: 'Soatni tanlash',
       startDate: 'Boshlanish sanasi',
@@ -46,6 +55,15 @@ export default {
         fri: 'Jum',
         sat: 'Shan',
       },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
+      },
       months: {
         jan: 'Yan',
         feb: 'Fev',
@@ -61,6 +79,10 @@ export default {
         dec: 'Dek',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Yuklanmoqda',
       noMatch: 'Mos maʼlumot yoʻq',
@@ -69,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Yuklanmoqda',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Mos maʼlumot topilmadi',
@@ -87,12 +112,21 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Xabar',
       confirm: 'Qabul qilish',
       cancel: 'Bekor qilish',
       error: 'Xatolik',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Oʻchirish tugmasini bosib oʻchiring',
@@ -100,12 +134,22 @@ export default {
       preview: 'Oldin koʻrish',
       continue: 'Davom qilish',
     },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
+    },
     table: {
       emptyText: 'Boʻsh',
       confirmFilter: 'Qabul qilish',
       resetFilter: 'Oldingi holatga qaytarish',
       clearFilter: 'Jami',
       sumText: 'Summasi',
+    },
+    tour: {
+      next: 'Next', // to be translated
+      previous: 'Previous', // to be translated
+      finish: 'Finish', // to be translated
     },
     tree: {
       emptyText: 'Maʼlumot yoʻq',

--- a/packages/locale/lang/vi.ts
+++ b/packages/locale/lang/vi.ts
@@ -7,6 +7,10 @@ export default {
     colorpicker: {
       confirm: 'OK',
       clear: 'Xóa',
+      defaultLabel: 'color picker', // to be translated
+      description:
+        'current color is {color}. press enter to select a new color.', // to be translated
+      alphaLabel: 'pick alpha value', // to be translated
     },
     datepicker: {
       now: 'Hiện tại',
@@ -14,6 +18,11 @@ export default {
       cancel: 'Hủy',
       clear: 'Xóa',
       confirm: 'OK',
+      dateTablePrompt:
+        'Use the arrow keys and enter to select the day of the month', // to be translated
+      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
+      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
+      selectedDate: 'Selected date', // to be translated
       selectDate: 'Chọn ngày',
       selectTime: 'Chọn giờ',
       startDate: 'Ngày bắt đầu',
@@ -37,7 +46,6 @@ export default {
       month10: 'Tháng 10',
       month11: 'Tháng 11',
       month12: 'Tháng 12',
-      // week: 'week',
       weeks: {
         sun: 'CN',
         mon: 'T2',
@@ -46,6 +54,15 @@ export default {
         thu: 'T5',
         fri: 'T6',
         sat: 'T7',
+      },
+      weeksFull: {
+        sun: 'Sunday', // to be translated
+        mon: 'Monday', // to be translated
+        tue: 'Tuesday', // to be translated
+        wed: 'Wednesday', // to be translated
+        thu: 'Thursday', // to be translated
+        fri: 'Friday', // to be translated
+        sat: 'Saturday', // to be translated
       },
       months: {
         jan: 'Th.1',
@@ -62,6 +79,10 @@ export default {
         dec: 'Th.12',
       },
     },
+    inputNumber: {
+      decrease: 'decrease number', // to be translated
+      increase: 'increase number', // to be translated
+    },
     select: {
       loading: 'Đang tải',
       noMatch: 'Dữ liệu không phù hợp',
@@ -70,6 +91,9 @@ export default {
     },
     mention: {
       loading: 'Đang tải',
+    },
+    dropdown: {
+      toggleDropdown: 'Toggle Dropdown', // to be translated
     },
     cascader: {
       noMatch: 'Dữ liệu không phù hợp',
@@ -88,18 +112,32 @@ export default {
       currentPage: 'page {pager}', // to be translated
       prevPages: 'Previous {pager} pages', // to be translated
       nextPages: 'Next {pager} pages', // to be translated
+      deprecationWarning:
+        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+    },
+    dialog: {
+      close: 'Close this dialog', // to be translated
+    },
+    drawer: {
+      close: 'Close this dialog', // to be translated
     },
     messagebox: {
       title: 'Thông báo',
       confirm: 'OK',
       cancel: 'Hủy',
       error: 'Dữ liệu không hợp lệ',
+      close: 'Close this dialog', // to be translated
     },
     upload: {
       deleteTip: 'Nhấn xoá để xoá',
       delete: 'Xóa',
       preview: 'Xem trước',
       continue: 'Tiếp tục',
+    },
+    slider: {
+      defaultLabel: 'slider between {min} and {max}', // to be translated
+      defaultRangeStartLabel: 'pick start value', // to be translated
+      defaultRangeEndLabel: 'pick end value', // to be translated
     },
     table: {
       emptyText: 'Không có dữ liệu',

--- a/scripts/sync-locale.ts
+++ b/scripts/sync-locale.ts
@@ -1,0 +1,243 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { basename, resolve } from 'node:path'
+import glob from 'fast-glob'
+import consola from 'consola'
+import { isArray, isObject, isString } from 'lodash-unified'
+import { localeRoot, normalizePath } from '@element-plus/build-utils'
+
+interface LocaleObject {
+  [key: string]: LocaleObject | string | Array<string>
+}
+
+const langRoot = resolve(localeRoot, 'lang')
+const enFile = normalizePath(resolve(langRoot, 'en.ts'))
+const localePath = normalizePath(resolve(`${langRoot}/!(en).ts`))
+const commentInfo = '// to be translated'
+
+function parseLocaleFile(content: string): LocaleObject {
+  try {
+    const untranslatedRexExp = new RegExp(
+      `\\w+:(\\s+|\\n\\s+).*,?\\s*${commentInfo}$`,
+      'gm'
+    )
+    const objectContent = content
+      .replace(/^export\s+default\s+/, '')
+      .replace(/;\s*$/, '')
+      .replaceAll(untranslatedRexExp, '')
+
+    return new Function(`return ${objectContent}`)()
+  } catch (error) {
+    consola.error('Failed to parse locale file:', error)
+    return {}
+  }
+}
+
+function mergeLocaleObjects(
+  source: LocaleObject,
+  target: LocaleObject,
+  path = ''
+): LocaleObject {
+  const result: LocaleObject = {}
+
+  Object.entries(source).forEach(([key, value]) => {
+    const currentPath = path ? `${path}.${key}` : key
+
+    if (isArray(value)) {
+      if (isArray(target[key])) {
+        result[key] = mergeLocaleArrays(
+          value as Array<string>,
+          target[key] as Array<string>,
+          currentPath
+        )
+      } else {
+        result[key] = value.map((item, index) => {
+          consola.log(`📝 Added new array: ${currentPath}[${index}]`)
+          return `${item} ${commentInfo}`
+        })
+      }
+    } else if (isObject(value)) {
+      if (isObject(target[key]) && !isArray(target[key])) {
+        result[key] = mergeLocaleObjects(
+          value as LocaleObject,
+          target[key] as LocaleObject,
+          currentPath
+        )
+      } else {
+        result[key] = addTranslationComments(value)
+      }
+    } else if (key in target) {
+      result[key] = target[key]
+    } else if (isString(value)) {
+      result[key] = `${value} ${commentInfo}`
+      consola.log(`📝 Added new field: ${currentPath}`)
+    }
+  })
+
+  Object.entries(target).forEach(([key, value]) => {
+    if (!(key in source)) {
+      result[key] = value
+      consola.warn(
+        `Found extra field in target: ${path ? `${path}.${key}` : key}`
+      )
+    }
+  })
+
+  return result
+}
+
+function mergeLocaleArrays(
+  sourceArray: Array<string>,
+  targetArray: Array<string>,
+  path: string
+): Array<string> {
+  const result: Array<string> = []
+
+  sourceArray.forEach((sourceItem, index) => {
+    if (index < targetArray.length) {
+      result[index] = targetArray[index]
+    } else {
+      result[index] = `${sourceItem} ${commentInfo}`
+      consola.log(`📝 Added new array item: ${path}[${index}]`)
+    }
+  })
+
+  if (targetArray.length > sourceArray.length) {
+    for (let i = sourceArray.length; i < targetArray.length; i++) {
+      result[i] = targetArray[i]
+      consola.warn(`Found extra array item in target: ${path}[${i}]`)
+    }
+  }
+
+  return result
+}
+
+function addTranslationComments(obj: LocaleObject): LocaleObject {
+  return Object.entries(obj).reduce((all, [key, value]) => {
+    if (isArray(value)) {
+      all[key] = value.map((item) => `${item} ${commentInfo}`)
+    } else if (isObject(value)) {
+      all[key] = addTranslationComments(value)
+    } else if (isString(value)) {
+      all[key] = `${value} ${commentInfo}`
+    }
+
+    return all
+  }, {} as LocaleObject)
+}
+
+function objectToTypescript(obj: LocaleObject, indent = 0): string {
+  const spaces = '  '.repeat(indent)
+  const items: string[] = []
+
+  Object.entries(obj).forEach(([key, value]) => {
+    if (isArray(value)) {
+      let needComment = false
+      const arrayItems = value.map((item) => {
+        if (item.includes(commentInfo)) {
+          const [actualValue] = item.split(commentInfo)
+          const escapedValue = actualValue.trim().replace(/'/g, "\\'")
+
+          needComment = true
+          return `'${escapedValue}'`
+        } else {
+          const escapedValue = item.replace(/'/g, "\\'")
+          return `'${escapedValue}'`
+        }
+      })
+
+      items.push(
+        `${spaces}  ${key}: [${arrayItems.join(', ')}],${
+          needComment ? ` ${commentInfo}` : ''
+        }`
+      )
+    } else if (isObject(value)) {
+      items.push(
+        `${spaces}  ${key}: {\n${objectToTypescript(
+          value as LocaleObject,
+          indent + 1
+        )}\n${spaces}  },`
+      )
+    } else if (isString(value)) {
+      if (value.includes(commentInfo)) {
+        const [actualValue] = value.split(commentInfo)
+        const escapedValue = actualValue.trim().replace(/'/g, "\\'")
+        items.push(`${spaces}  ${key}: '${escapedValue}', ${commentInfo}`)
+      } else {
+        const escapedValue = value.replace(/'/g, "\\'")
+        items.push(`${spaces}  ${key}: '${escapedValue}',`)
+      }
+    }
+  })
+
+  return items.join('\n')
+}
+
+function generateTypescriptFile(obj: LocaleObject): string {
+  return `export default {\n${objectToTypescript(obj)}\n}\n`
+}
+
+function countKeys(obj: LocaleObject): number {
+  return Object.values(obj).reduce((all, value) => {
+    if (isObject(value) && !isArray(value)) {
+      all += countKeys(value)
+    } else {
+      all++
+    }
+
+    return all
+  }, 0)
+}
+
+function main() {
+  consola.start('Starting English additions synchronization...')
+
+  const enContent = readFileSync(enFile, 'utf-8')
+  const enObject = parseLocaleFile(enContent)
+  const localeFiles = glob.sync(localePath)
+  let totalUpdated = 0
+  let totalAdded = 0
+
+  consola.info(`Found ${localeFiles.length} locale files to process`)
+
+  localeFiles.forEach((filePath) => {
+    const fileName = basename(filePath)
+
+    consola.start(`Processing ${fileName}...`)
+
+    try {
+      const content = readFileSync(filePath, 'utf-8')
+      const targetObject = parseLocaleFile(content)
+      const originalKeys = countKeys(targetObject.el as LocaleObject)
+
+      targetObject.el = mergeLocaleObjects(
+        enObject.el as LocaleObject,
+        targetObject.el as LocaleObject
+      )
+
+      const newKeys = countKeys(targetObject.el as LocaleObject)
+      const addedKeys = newKeys - originalKeys
+
+      if (addedKeys > 0) {
+        const newContent = generateTypescriptFile(targetObject)
+        writeFileSync(filePath, newContent, 'utf-8')
+
+        consola.success(
+          `Updated ${fileName} - ${addedKeys} fields waiting to be translated`
+        )
+        totalUpdated++
+        totalAdded += addedKeys
+      } else {
+        consola.success(`${fileName} is up to date`)
+      }
+    } catch (error) {
+      consola.error(`Failed to process ${fileName}:`, error)
+    }
+  })
+
+  consola.log(`🎉 Synchronization completed!`)
+  consola.log(
+    `📊 Updated ${totalUpdated} files - ${totalAdded} fields waiting to be translated`
+  )
+}
+
+main()


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

Every time a multilingual field is added, it needs to be manually added to other languages, which is too tedious. Add a script to automatically synchronize the content of `en.ts` files to other languages

```shell
pnpm locale:sync
```
