### PR TITLE
fix(components): [color-picker-panel] sync bg-color with date-picker-panel

### DIFF
--- a/packages/theme-chalk/src/color-picker-panel.scss
+++ b/packages/theme-chalk/src/color-picker-panel.scss
@@ -68,6 +68,7 @@
   width: 300px;
   padding: 12px;
   box-sizing: content-box;
+  background: getCssVar('bg-color', 'overlay');
 
   @include when(border) {
     border: solid 1px getCssVar('border-color-lighter');


### PR DESCRIPTION


| Before | After |
|--------|-------|
| <img width="481" height="309" alt="image" src="https://github.com/user-attachments/assets/88c4eb26-2b9a-4dff-bb5c-b86692355935" /> | <img width="481" height="309" alt="image" src="https://github.com/user-attachments/assets/d30880bd-4148-4c6d-952d-eb29844f5105" /> |