### PR TITLE
fix(components): [cascader] allow object type in modelValue

### DIFF
--- a/docs/en-US/component/cascader.md
+++ b/docs/en-US/component/cascader.md
@@ -199,7 +199,7 @@ cascader/custom-header-footer
 
 | Name                                       | Description                                                                                                                                                                      | Type                                                                                                                                                                        | Default      |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| model-value / v-model                      | binding value                                                                                                                                                                    | ^[string] / ^[number]`string[] \| number[] \| any`                                                                                                                          | —            |
+| model-value / v-model                      | binding value                                                                                                                                                                    | ^[string] / ^[number] /^[object]`string[] \| number[] \| any`                                                                                                               | —            |
 | options                                    | data of the options, the key of `value` and `label` can be customize by `CascaderProps`.                                                                                         | ^[object]`CascaderOption[]`                                                                                                                                                 | —            |
 | [props](#cascaderprops)                    | configuration options, see the following `CascaderProps` table.                                                                                                                  | ^[object]`CascaderProps`                                                                                                                                                    | —            |
 | size                                       | size of input                                                                                                                                                                    | ^[enum]`'large' \| 'default' \| 'small'`                                                                                                                                    | —            |
@@ -270,11 +270,11 @@ cascader/custom-header-footer
 
 ### CascaderPanel Attributes
 
-| Name                    | Description                                                                              | Type                                             | Default |
-| ----------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------ | ------- |
-| model-value / v-model   | binding value                                                                            | ^[string]/^[number]`string[] \| number[] \| any` | —       |
-| options                 | data of the options, the key of `value` and `label` can be customize by `CascaderProps`. | ^[object]`CascaderOption[]`                      | —       |
-| [props](#cascaderprops) | configuration options, see the following `CascaderProps` table.                          | ^[object]`CascaderProps`                         | —       |
+| Name                    | Description                                                                              | Type                                                       | Default |
+| ----------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------- |
+| model-value / v-model   | binding value                                                                            | ^[string]/^[number]/^[object]`string[] \| number[] \| any` | —       |
+| options                 | data of the options, the key of `value` and `label` can be customize by `CascaderProps`. | ^[object]`CascaderOption[]`                                | —       |
+| [props](#cascaderprops) | configuration options, see the following `CascaderProps` table.                          | ^[object]`CascaderProps`                                   | —       |
 
 ### CascaderPanel Events
 

--- a/packages/components/cascader-panel/src/config.ts
+++ b/packages/components/cascader-panel/src/config.ts
@@ -17,7 +17,7 @@ export const CommonProps = buildProps({
    * @description specify which key of node object is used as the node's value
    */
   modelValue: {
-    type: definePropType<CascaderValue | null>([Number, String, Array]),
+    type: definePropType<CascaderValue | null>([Number, String, Array, Object]),
   },
   /**
    * @description data of the options, the key of `value` and `label` can be customize by `CascaderProps`.

--- a/packages/components/cascader-panel/src/node.ts
+++ b/packages/components/cascader-panel/src/node.ts
@@ -2,7 +2,7 @@ import { isArray, isEmpty, isFunction, isUndefined } from '@element-plus/utils'
 
 import type { VNode } from 'vue'
 
-export type CascaderNodeValue = string | number
+export type CascaderNodeValue = string | number | Record<string, any>
 export type CascaderNodePathValue = CascaderNodeValue[]
 export type CascaderValue =
   | CascaderNodeValue

--- a/packages/components/cascader-panel/src/types.ts
+++ b/packages/components/cascader-panel/src/types.ts
@@ -8,7 +8,7 @@ import type {
 
 export type { CascaderNode, CascaderOption, CascaderProps, ExpandTrigger }
 
-export type CascaderNodeValue = string | number
+export type CascaderNodeValue = string | number | Record<string, any>
 export type CascaderNodePathValue = CascaderNodeValue[]
 export type CascaderValue =
   | CascaderNodeValue

--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -191,6 +191,26 @@ describe('Cascader.vue', () => {
     expect(isClear.value).toBe(true)
   })
 
+  test('should support object as value', async () => {
+    const options = [
+      {
+        label: 'label1',
+        children: [
+          {
+            label: 'label2',
+            value: { val: 'val2' },
+          },
+        ],
+      },
+    ]
+    const wrapper = mount(() => (
+      <Cascader modelValue={{ val: 'val2' }} options={options} />
+    ))
+
+    await nextTick()
+    expect(wrapper.find('input').element.value).toBe('label1 / label2')
+  })
+
   test('should show clear btn on focus', async () => {
     const wrapper = _mount(() => (
       <Cascader


### PR DESCRIPTION
closed #21868

In fact cascader was intended to work with object, https://github.com/element-plus/element-plus/issues/2312.
The test might be useless since the cascader already handle object, but didn't find any test of it in this file.