### PR TITLE
fix(components): [input-tag] add missing Tooltip style

### DIFF
--- a/packages/components/input-tag/style/css.ts
+++ b/packages/components/input-tag/style/css.ts
@@ -1,3 +1,4 @@
 import '@element-plus/components/base/style/css'
 import '@element-plus/components/tag/style/css'
+import '@element-plus/components/tooltip/style/css'
 import '@element-plus/theme-chalk/el-input-tag.css'

--- a/packages/components/input-tag/style/index.ts
+++ b/packages/components/input-tag/style/index.ts
@@ -1,3 +1,4 @@
 import '@element-plus/components/base/style'
-import '@element-plus/components/tag/style/index'
+import '@element-plus/components/tag/style'
+import '@element-plus/components/tooltip/style'
 import '@element-plus/theme-chalk/src/input-tag.scss'


### PR DESCRIPTION
Since `style/index.ts` and `style/css.ts` did not import the Tooltip styles, the related Tooltip styles were missing when importing InputTag on demand.

<img width="430" height="147" alt="image" src="https://github.com/user-attachments/assets/767258a0-22ee-4958-82bc-25a2c26a0f45" />

[Reproduction Repo](https://github.com/cszhjh/ep-input-tag-demo)