### PR TITLE
fix(components): [date-picker-panel] remove duplicate panels on inner date input change

### DIFF
--- a/packages/components/date-picker-panel/__tests__/date-picker-panel.test.tsx
+++ b/packages/components/date-picker-panel/__tests__/date-picker-panel.test.tsx
@@ -837,6 +837,40 @@ describe('DatePickerPanel', () => {
           '10',
         ])
       })
+
+      it('should not duplicate panels on update inner input nor change panels', async () => {
+        const value = ref([new Date(2025, 0, 1), new Date(2025, 0, 5)])
+        const wrapper = mount(() => (
+          <DatePickerPanel v-model={value.value} type="datetimerange" />
+        ))
+        await nextTick()
+        let pickerss = wrapper.findAll(
+          '.el-date-range-picker__time-header .el-date-range-picker__editors-wrap'
+        )
+        const leftDateInput = pickerss[0].find(
+          '.el-date-range-picker__time-picker-wrap:nth-child(1) input'
+        ).element as HTMLInputElement
+        const rightDateInput = pickerss[1].find(
+          '.el-date-range-picker__time-picker-wrap:nth-child(1) input'
+        ).element as HTMLInputElement
+        expect(leftDateInput.value).toBe('2025-01-01')
+        expect(rightDateInput.value).toBe('2025-01-05')
+        rightDateInput.value = '2025-01-06'
+        rightDateInput.dispatchEvent(new Event('input'))
+        rightDateInput.dispatchEvent(new Event('change'))
+        await nextTick()
+        expect(value.value[1]).toStrictEqual(new Date(2025, 0, 6))
+        pickerss = wrapper.findAll('.el-date-range-picker__header')
+        const leftHeader = pickerss[0].findAll(
+          '.el-date-range-picker__header-label'
+        )[1]
+        const rightHeader = pickerss[1].findAll(
+          '.el-date-range-picker__header-label'
+        )[1]
+
+        expect(leftHeader.text()).toBe('January')
+        expect(rightHeader.text()).toBe('February')
+      })
     })
   })
 })

--- a/packages/components/date-picker-panel/src/composables/use-range-picker.ts
+++ b/packages/components/date-picker-panel/src/composables/use-range-picker.ts
@@ -12,10 +12,7 @@ import type { PanelRangeSharedProps, RangeState } from '../props/shared'
 import type { DefaultValue } from '../utils'
 
 type UseRangePickerProps = {
-  onParsedValueChanged: (
-    minDate: Dayjs | undefined,
-    maxDate: Dayjs | undefined
-  ) => void
+  sortDates: (minDate: Dayjs | undefined, maxDate: Dayjs | undefined) => void
   defaultValue: Ref<DefaultValue>
   defaultTime?: Ref<DefaultValue>
   leftDate: Ref<Dayjs>
@@ -34,7 +31,7 @@ export const useRangePicker = (
     step,
     unit,
 
-    onParsedValueChanged,
+    sortDates,
   }: UseRangePickerProps
 ) => {
   const { emit } = getCurrentInstance()!
@@ -70,13 +67,13 @@ export const useRangePicker = (
     }
   }
 
-  const onReset = (parsedValue: PanelRangeSharedProps['parsedValue']) => {
+  const parseValue = (parsedValue: PanelRangeSharedProps['parsedValue']) => {
     if (isArray(parsedValue) && parsedValue.length === 2) {
       const [start, end] = parsedValue
       minDate.value = start
       leftDate.value = start
       maxDate.value = end
-      onParsedValueChanged(unref(minDate), unref(maxDate))
+      sortDates(unref(minDate), unref(maxDate))
     } else {
       restoreDefault()
     }
@@ -129,7 +126,7 @@ export const useRangePicker = (
     () => props.parsedValue,
     (parsedValue) => {
       if (!(parsedValue as [Dayjs, Dayjs])?.length) {
-        onReset(parsedValue)
+        parseValue(parsedValue)
       }
     },
     {
@@ -141,7 +138,7 @@ export const useRangePicker = (
     () => props.visible,
     () => {
       if (props.visible) {
-        onReset(props.parsedValue)
+        parseValue(props.parsedValue)
       }
     },
     { immediate: true }
@@ -159,7 +156,7 @@ export const useRangePicker = (
     handleRangeConfirm,
     handleShortcutClick,
     onSelect,
-    onReset,
+    parseValue,
     t,
   }
 }

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
@@ -476,7 +476,7 @@ const {
   handleRangeConfirm,
   handleShortcutClick,
   onSelect,
-  onReset,
+  parseValue,
   t,
 } = useRangePicker(props, {
   defaultValue,
@@ -484,14 +484,14 @@ const {
   leftDate,
   rightDate,
   unit,
-  onParsedValueChanged,
+  sortDates,
 })
 
 watch(
   () => props.visible,
   (visible) => {
     if (!visible && rangeState.value.selecting) {
-      onReset(props.parsedValue)
+      parseValue(props.parsedValue)
       onSelect(false)
     }
   }
@@ -781,6 +781,7 @@ const handleDateInput = (value: string | null, type: ChangeType) => {
         minDate.value = maxDate.value.subtract(1, 'month')
       }
     }
+    sortDates(minDate.value, maxDate.value)
   }
 }
 
@@ -845,7 +846,7 @@ const handleMinTimePick = (value: Dayjs, visible: boolean, first: boolean) => {
     maxDate.value = minDate.value
     rightDate.value = value
     nextTick(() => {
-      onReset(props.parsedValue)
+      parseValue(props.parsedValue)
     })
   }
 }
@@ -900,10 +901,7 @@ const parseUserInput = (value: Dayjs | Dayjs[]) => {
   )
 }
 
-function onParsedValueChanged(
-  minDate: Dayjs | undefined,
-  maxDate: Dayjs | undefined
-) {
+function sortDates(minDate: Dayjs | undefined, maxDate: Dayjs | undefined) {
   if (props.unlinkPanels && maxDate) {
     const minDateYear = minDate?.year() || 0
     const minDateMonth = minDate?.month() || 0

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-month-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-month-range.vue
@@ -170,13 +170,13 @@ const {
   handleRangeConfirm,
   handleShortcutClick,
   onSelect,
-  onReset,
+  parseValue,
 } = useRangePicker(props, {
   defaultValue,
   leftDate,
   rightDate,
   unit,
-  onParsedValueChanged,
+  sortDates,
 })
 
 const hasShortcuts = computed(() => !!shortcuts.length)
@@ -248,10 +248,7 @@ const parseUserInput = (value: Dayjs | Dayjs[]) => {
   )
 }
 
-function onParsedValueChanged(
-  minDate: Dayjs | undefined,
-  maxDate: Dayjs | undefined
-) {
+function sortDates(minDate: Dayjs | undefined, maxDate: Dayjs | undefined) {
   if (props.unlinkPanels && maxDate) {
     const minDateYear = minDate?.year() || 0
     const maxDateYear = maxDate.year()
@@ -266,7 +263,7 @@ watch(
   () => props.visible,
   (visible) => {
     if (!visible && rangeState.value.selecting) {
-      onReset(props.parsedValue)
+      parseValue(props.parsedValue)
       onSelect(false)
     }
   }

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-year-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-year-range.vue
@@ -154,14 +154,14 @@ const {
   handleRangeConfirm,
   handleShortcutClick,
   onSelect,
-  onReset,
+  parseValue,
 } = useRangePicker(props, {
   defaultValue,
   leftDate,
   rightDate,
   step,
   unit,
-  onParsedValueChanged,
+  sortDates,
 })
 
 const {
@@ -273,10 +273,7 @@ const handleClear = () => {
   emit('pick', null)
 }
 
-function onParsedValueChanged(
-  minDate: Dayjs | undefined,
-  maxDate: Dayjs | undefined
-) {
+function sortDates(minDate: Dayjs | undefined, maxDate: Dayjs | undefined) {
   if (props.unlinkPanels && maxDate) {
     const minDateYear = minDate?.year() || 0
     const maxDateYear = maxDate.year()
@@ -292,7 +289,7 @@ watch(
   () => props.visible,
   (visible) => {
     if (!visible && rangeState.value.selecting) {
-      onReset(props.parsedValue)
+      parseValue(props.parsedValue)
       onSelect(false)
     }
   }


### PR DESCRIPTION
1. pretty much same as this bug https://github.com/element-plus/element-plus/pull/21420#issuecomment-3121655805 where the date picker duplicate his panels on date input change.
demo issue:
![Peek 2025-08-25 00-08](https://github.com/user-attachments/assets/cc14f615-2a8c-4e91-8f0e-dfad0dc92568).
2. I renamed 2 functions because there were not really defining what there doing.

[shortcut demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtZGF0ZS1waWNrZXItcGFuZWwgdi1tb2RlbD1cInZhbHVlXCIgdHlwZT1cImRhdGV0aW1lcmFuZ2VcIiAvPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3QgdmFsdWUgPSByZWYoKVxuPC9zY3JpcHQ+XG4iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgY29uc3Qgc3R5bGVzID0gWydodHRwczovL3ByZXZpZXctMjE4ODgtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmNzcycsICdodHRwczovL3ByZXZpZXctMjE4ODgtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS90aGVtZS1jaGFsay9kYXJrL2Nzcy12YXJzLmNzcyddLm1hcCgoc3R5bGUpID0+IHtcbiAgICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICAgIGxpbmsuaHJlZiA9IHN0eWxlXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2xvYWQnLCByZXNvbHZlKVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdlcnJvcicsIHJlamVjdClcbiAgICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gICAgfSlcbiAgfSlcbiAgcmV0dXJuIFByb21pc2UuYWxsU2V0dGxlZChzdHlsZXMpXG59XG4iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcbiAgICBcImpzeFwiOiBcInByZXNlcnZlXCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJ0eXBlc1wiOiBbXCJlbGVtZW50LXBsdXMvZ2xvYmFsLmQudHNcIl0sXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwiUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly9mYXN0bHkuanNkZWxpdnIubmV0L25wbS9AdnVlL3J1bnRpbWUtZG9tQGxhdGVzdC9kaXN0L3J1bnRpbWUtZG9tLmVzbS1icm93c2VyLmpzXCIsXG4gICAgXCJAdnVlL3NoYXJlZFwiOiBcImh0dHBzOi8vZmFzdGx5LmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9zaGFyZWRAbGF0ZXN0L2Rpc3Qvc2hhcmVkLmVzbS1idW5kbGVyLmpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL3ByZXZpZXctMjE4ODgtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcInVuc3VwcG9ydGVkXCIsXG4gICAgXCJAZWxlbWVudC1wbHVzL2ljb25zLXZ1ZVwiOiBcImh0dHBzOi8vZmFzdGx5LmpzZGVsaXZyLm5ldC9ucG0vQGVsZW1lbnQtcGx1cy9pY29ucy12dWVAMi9kaXN0L2luZGV4Lm1pbi5qc1wiXG4gIH0sXG4gIFwic2NvcGVzXCI6IHt9XG59IiwiX28iOnsic2hvd0hpZGRlbiI6dHJ1ZSwic3R5bGVTb3VyY2UiOiJodHRwczovL3ByZXZpZXctMjE4ODgtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmNzcyJ9fQ==).