### PR TITLE
refactor(components): [drawer] improve slot template

### DIFF
--- a/packages/components/drawer/src/drawer.vue
+++ b/packages/components/drawer/src/drawer.vue
@@ -55,26 +55,28 @@
                   v-if="withHeader"
                   :class="[ns.e('header'), headerClass]"
                 >
-                  <slot
-                    v-if="!$slots.title"
-                    name="header"
-                    :close="handleClose"
-                    :title-id="titleId"
-                    :title-class="ns.e('title')"
-                  >
-                    <span
-                      v-if="!$slots.title"
-                      :id="titleId"
-                      role="heading"
-                      :aria-level="headerAriaLevel"
-                      :class="ns.e('title')"
+                  <template v-if="!$slots.title">
+                    <slot
+                      name="header"
+                      :close="handleClose"
+                      :title-id="titleId"
+                      :title-class="ns.e('title')"
                     >
-                      {{ title }}
-                    </span>
-                  </slot>
-                  <slot v-else name="title">
-                    <!-- DEPRECATED SLOT -->
-                  </slot>
+                      <span
+                        :id="titleId"
+                        role="heading"
+                        :aria-level="headerAriaLevel"
+                        :class="ns.e('title')"
+                      >
+                        {{ title }}
+                      </span>
+                    </slot>
+                  </template>
+                  <template v-else>
+                    <slot name="title">
+                      <!-- DEPRECATED SLOT -->
+                    </slot>
+                  </template>
                   <button
                     v-if="showClose"
                     :aria-label="t('el.drawer.close')"


### PR DESCRIPTION
- Readability: Reduces repeated conditional checks, resulting in cleaner templates.

- Performance: Avoids repeated evaluation of the same condition.
<img width="472" height="265" alt="image" src="https://github.com/user-attachments/assets/4bcd647a-ab9f-4ef1-ae4f-87a14931b84b" />


In fact, it should be possible to just delete the ```v-if="!$slots.title"``` inside the span, but it seems clearer to use `template`, and it is also done in other places.

<img width="768" height="130" alt="image" src="https://github.com/user-attachments/assets/2c69c5fe-9821-4cc1-874a-7546283e5e16" />
