### PR TITLE
fix(components): [select/v2] width of drop-down panel exceeds the input

### DIFF
--- a/packages/components/popper/src/utils.ts
+++ b/packages/components/popper/src/utils.ts
@@ -43,10 +43,10 @@ function genModifiers(options: PopperCoreConfigProps) {
       name: 'preventOverflow',
       options: {
         padding: {
-          top: 2,
-          bottom: 2,
-          left: 5,
-          right: 5,
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
         },
       },
     },

--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -257,7 +257,7 @@
         <el-select-menu
           ref="menuRef"
           :data="filteredOptions"
-          :width="popperSize - 2"
+          :width="popperSize - BORDER_HORIZONTAL_WIDTH"
           :hovering-index="states.hoveringIndex"
           :scrollbar-always-on="scrollbarAlwaysOn"
         >
@@ -304,6 +304,7 @@ import ElSelectMenu from './select-dropdown'
 import useSelect from './useSelect'
 import { selectV2Emits, selectV2Props } from './defaults'
 import { selectV2InjectionKey } from './token'
+import { BORDER_HORIZONTAL_WIDTH } from '@element-plus/constants'
 
 export default defineComponent({
   name: 'ElSelectV2',
@@ -364,6 +365,7 @@ export default defineComponent({
       selectedLabel,
       calculatorRef,
       inputStyle,
+      BORDER_HORIZONTAL_WIDTH,
     }
   },
 })

--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -257,7 +257,7 @@
         <el-select-menu
           ref="menuRef"
           :data="filteredOptions"
-          :width="popperSize"
+          :width="popperSize - 2"
           :hovering-index="states.hoveringIndex"
           :scrollbar-always-on="scrollbarAlwaysOn"
         >

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -2,7 +2,7 @@
 import { defineComponent, markRaw, nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, test, vi } from 'vitest'
-import { EVENT_CODE } from '@element-plus/constants'
+import { BORDER_HORIZONTAL_WIDTH, EVENT_CODE } from '@element-plus/constants'
 import { ArrowDown, CaretTop, CircleClose } from '@element-plus/icons-vue'
 import { usePopperContainerId } from '@element-plus/hooks'
 import { hasClass } from '@element-plus/utils'
@@ -1128,7 +1128,7 @@ describe('Select', () => {
       .mockReturnValue(selectRect as DOMRect)
     const dropdown = wrapper.findComponent({ name: 'ElSelectDropdown' })
     dropdown.vm.minWidth = `${
-      selectRef.element.getBoundingClientRect().width - 2
+      selectRef.element.getBoundingClientRect().width - BORDER_HORIZONTAL_WIDTH
     }px`
     await nextTick()
     expect(dropdown.element.style.width).toBe('219px')

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -1128,10 +1128,10 @@ describe('Select', () => {
       .mockReturnValue(selectRect as DOMRect)
     const dropdown = wrapper.findComponent({ name: 'ElSelectDropdown' })
     dropdown.vm.minWidth = `${
-      selectRef.element.getBoundingClientRect().width
+      selectRef.element.getBoundingClientRect().width - 2
     }px`
     await nextTick()
-    expect(dropdown.element.style.width).toBe('221px')
+    expect(dropdown.element.style.width).toBe('219px')
     mockSelectWidth.mockRestore()
   })
 

--- a/packages/components/select/src/select-dropdown.vue
+++ b/packages/components/select/src/select-dropdown.vue
@@ -18,6 +18,7 @@ import { computed, defineComponent, inject, onMounted, ref } from 'vue'
 import { useResizeObserver } from '@vueuse/core'
 import { useNamespace } from '@element-plus/hooks'
 import { selectKey } from './token'
+import { BORDER_HORIZONTAL_WIDTH } from '@element-plus/constants'
 
 export default defineComponent({
   name: 'ElSelectDropdown',
@@ -36,7 +37,9 @@ export default defineComponent({
 
     function updateMinWidth() {
       if (select.selectRef?.offsetWidth) {
-        minWidth.value = `${select.selectRef?.offsetWidth - 2}px`
+        minWidth.value = `${
+          select.selectRef?.offsetWidth - BORDER_HORIZONTAL_WIDTH
+        }px`
       } else {
         minWidth.value = ''
       }

--- a/packages/components/select/src/select-dropdown.vue
+++ b/packages/components/select/src/select-dropdown.vue
@@ -35,7 +35,11 @@ export default defineComponent({
     const minWidth = ref('')
 
     function updateMinWidth() {
-      minWidth.value = `${select.selectRef?.offsetWidth! - 2}px`
+      if (select.selectRef?.offsetWidth) {
+        minWidth.value = `${select.selectRef?.offsetWidth - 2}px`
+      } else {
+        minWidth.value = ''
+      }
     }
 
     onMounted(() => {

--- a/packages/components/select/src/select-dropdown.vue
+++ b/packages/components/select/src/select-dropdown.vue
@@ -35,7 +35,7 @@ export default defineComponent({
     const minWidth = ref('')
 
     function updateMinWidth() {
-      minWidth.value = `${select.selectRef?.offsetWidth}px`
+      minWidth.value = `${select.selectRef?.offsetWidth! - 2}px`
     }
 
     onMounted(() => {

--- a/packages/components/select/src/select-dropdown.vue
+++ b/packages/components/select/src/select-dropdown.vue
@@ -36,10 +36,9 @@ export default defineComponent({
     const minWidth = ref('')
 
     function updateMinWidth() {
-      if (select.selectRef?.offsetWidth) {
-        minWidth.value = `${
-          select.selectRef?.offsetWidth - BORDER_HORIZONTAL_WIDTH
-        }px`
+      const offsetWidth = select.selectRef?.offsetWidth
+      if (offsetWidth) {
+        minWidth.value = `${offsetWidth - BORDER_HORIZONTAL_WIDTH}px`
       } else {
         minWidth.value = ''
       }

--- a/packages/constants/form.ts
+++ b/packages/constants/form.ts
@@ -1,1 +1,2 @@
 export const MINIMUM_INPUT_WIDTH = 11
+export const BORDER_HORIZONTAL_WIDTH = 2


### PR DESCRIPTION
fix #21901 

It is caused by 2 reasons

1.popper.js has been passed the position to prevent overflow boundaries `top:2 bottom:2 left:5 right:5`, and the width of min-width has been set equal to the width of the input.

2.The 1px border of the popper results in the actual dropdown width being 2px wider than the input.


因为2个原因导致的

1.popper.js传入了防止溢出边界的参数`top:2 bottom:2 left:5 right:5`,会导致下拉面板的左右位置至少距离屏幕5px，同时设置了min-width的宽度等于input的宽度。

2.popper边框的1px导致实际弹出的下拉框宽度会比inpu多2px。

<img width="1153" height="422" alt="269cfef98b311968d848921a1e912a18" src="https://github.com/user-attachments/assets/4bea2280-e080-4bde-94c1-8f454f47cd45" />
