### PR TITLE
fix(components): [onlyChild] no warning when there are multiple child

### DIFF
--- a/packages/components/slot/__tests__/only-child.test.tsx
+++ b/packages/components/slot/__tests__/only-child.test.tsx
@@ -119,7 +119,7 @@ describe('ElOnlyChild', () => {
     await nextTick()
 
     expect(debugWarn).toHaveBeenCalledTimes(1)
-    expect(wrapper.text()).toBe('')
+    expect(wrapper.text()).toBe(AXIOM)
   })
 
   it('should render nothing when no children provided', async () => {
@@ -128,5 +128,13 @@ describe('ElOnlyChild', () => {
 
     expect(debugWarn).not.toHaveBeenCalled()
     expect(wrapper.text()).toBe('')
+  })
+
+  it('should warns about having multiple children', async () => {
+    wrapper = createComponent(() => [h(Fragment, null, [AXIOM, AXIOM])])
+    await nextTick()
+
+    expect(debugWarn).toHaveBeenCalledTimes(1)
+    expect(wrapper.text()).toBe(AXIOM)
   })
 })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

link #18359

```diff
if (defaultSlot.length > 1) {
    debugWarn(NAME, 'requires exact only one valid child.')
-   return null
}
```

This modification is consistent with the previous rendering result, avoid content that cannot be displayed.