### PR TITLE
fix(components): [splitter] preserve fixed size ratio in useSize

### DIFF
--- a/docs/examples/splitter/size.vue
+++ b/docs/examples/splitter/size.vue
@@ -3,7 +3,6 @@
     style="height: 250px; box-shadow: var(--el-border-color-light) 0px 0px 10px"
   >
     <el-splitter
-      :key="splitKey"
       @resize-start="handleResizeStart"
       @resize-end="handleResizeEnd"
       @resize="handleResize"
@@ -11,20 +10,20 @@
       <el-splitter-panel>
         <div class="demo-panel">1</div>
       </el-splitter-panel>
-      <el-splitter-panel v-model:size="size" :max="900" :min="50">
+      <el-splitter-panel v-model:size="size" :max="200" :min="50">
         <div class="demo-panel">{{ size }}px</div>
+      </el-splitter-panel>
+      <el-splitter-panel>
+        <div class="demo-panel">3</div>
       </el-splitter-panel>
     </el-splitter>
   </div>
-
-  <el-button @click="changeSize">点我设置成100px</el-button>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
 
 const size = ref(100)
-const splitKey = ref(0)
 
 const handleResizeStart = (index: number, sizes: number[]) => {
   console.log('resizeStart', index, sizes)
@@ -36,9 +35,6 @@ const handleResize = (index: number, sizes: number[]) => {
 
 const handleResizeEnd = (index: number, sizes: number[]) => {
   console.log('resizeEnd', index, sizes)
-}
-const changeSize = () => {
-  size.value = 100
 }
 </script>
 

--- a/docs/examples/splitter/size.vue
+++ b/docs/examples/splitter/size.vue
@@ -3,6 +3,7 @@
     style="height: 250px; box-shadow: var(--el-border-color-light) 0px 0px 10px"
   >
     <el-splitter
+      :key="splitKey"
       @resize-start="handleResizeStart"
       @resize-end="handleResizeEnd"
       @resize="handleResize"
@@ -10,20 +11,20 @@
       <el-splitter-panel>
         <div class="demo-panel">1</div>
       </el-splitter-panel>
-      <el-splitter-panel v-model:size="size" :max="200" :min="50">
+      <el-splitter-panel v-model:size="size" :max="900" :min="50">
         <div class="demo-panel">{{ size }}px</div>
-      </el-splitter-panel>
-      <el-splitter-panel>
-        <div class="demo-panel">3</div>
       </el-splitter-panel>
     </el-splitter>
   </div>
+
+  <el-button @click="changeSize">点我设置成100px</el-button>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
 
 const size = ref(100)
+const splitKey = ref(0)
 
 const handleResizeStart = (index: number, sizes: number[]) => {
   console.log('resizeStart', index, sizes)
@@ -35,6 +36,9 @@ const handleResize = (index: number, sizes: number[]) => {
 
 const handleResizeEnd = (index: number, sizes: number[]) => {
   console.log('resizeEnd', index, sizes)
+}
+const changeSize = () => {
+  size.value = 100
 }
 </script>
 

--- a/packages/components/splitter/src/hooks/useSize.ts
+++ b/packages/components/splitter/src/hooks/useSize.ts
@@ -60,8 +60,8 @@ export function useSize(
     const totalPtg = ptgList.reduce<number>((acc, ptg) => acc + (ptg || 0), 0)
     const hasRawSize = panels.value.some((p) => p.rawSize !== undefined)
     if (hasRawSize && !emptyCount) {
-      const fixedIndexs = []
-      const flexIndexs = []
+      const fixedIndexs: number[] = []
+      const flexIndexs: number[] = []
       panels.value.forEach((panel, index) => {
         if (panel.rawSize != null) {
           fixedIndexs.push(index)

--- a/packages/components/splitter/src/hooks/useSize.ts
+++ b/packages/components/splitter/src/hooks/useSize.ts
@@ -69,11 +69,17 @@ export function useSize(
           flexIndexs.push(index)
         }
       })
-      const fixedTotal = fixedIndexs.reduce((sum, i) => sum + ptgList[i], 0)
+      const fixedTotal = fixedIndexs.reduce(
+        (sum, i) => sum + (ptgList[i] ?? 0),
+        0
+      )
       const restTotal = 1 - fixedTotal
-      const flexTotal = flexIndexs.reduce((sum, i) => sum + ptgList[i], 0)
+      const flexTotal = flexIndexs.reduce(
+        (sum, i) => sum + (ptgList[i] ?? 0),
+        0
+      )
       flexIndexs.forEach((i) => {
-        ptgList[i] = (ptgList[i] / flexTotal) * restTotal
+        ptgList[i] = ((ptgList[i] ?? 0) / flexTotal) * restTotal
       })
     } else {
       if (totalPtg > 1 || !emptyCount) {

--- a/packages/components/splitter/src/hooks/useSize.ts
+++ b/packages/components/splitter/src/hooks/useSize.ts
@@ -41,7 +41,7 @@ export function useSize(
     // Convert the passed props size to a percentage
     for (let i = 0; i < panelCounts.value; i += 1) {
       const itemSize = panels.value[i]?.size
-      
+
       if (isPct(itemSize)) {
         ptgList[i] = getPct(itemSize)
       } else if (isPx(itemSize)) {

--- a/packages/components/splitter/src/hooks/useSize.ts
+++ b/packages/components/splitter/src/hooks/useSize.ts
@@ -41,6 +41,7 @@ export function useSize(
     // Convert the passed props size to a percentage
     for (let i = 0; i < panelCounts.value; i += 1) {
       const itemSize = panels.value[i]?.size
+      
       if (isPct(itemSize)) {
         ptgList[i] = getPct(itemSize)
       } else if (isPx(itemSize)) {

--- a/packages/components/splitter/src/split-panel.vue
+++ b/packages/components/splitter/src/split-panel.vue
@@ -163,6 +163,7 @@ const _panel = reactive({
   getVnode: () => instance.vnode,
   setIndex,
   ...props,
+  rawSize: props.size,
   collapsible: computed(() => getCollapsible(props.collapsible)),
 })
 

--- a/packages/components/splitter/src/type.ts
+++ b/packages/components/splitter/src/type.ts
@@ -11,6 +11,7 @@ export type PanelItemState = UnwrapRef<{
   min?: number | string
   resizable: boolean
   size?: number | string
+  rawSize?: number | string
   setIndex: (val: number) => void
 }>
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fixed: #21953 

[demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZGl2XG4gICAgc3R5bGU9XCJoZWlnaHQ6IDI1MHB4OyBib3gtc2hhZG93OiB2YXIoLS1lbC1ib3JkZXItY29sb3ItbGlnaHQpIDBweCAwcHggMTBweFwiXG4gID5cbiAgICA8ZWwtc3BsaXR0ZXJcbiAgICAgIDprZXk9XCJzcGxpdEtleVwiXG4gICAgICBAcmVzaXplLXN0YXJ0PVwiaGFuZGxlUmVzaXplU3RhcnRcIlxuICAgICAgQHJlc2l6ZS1lbmQ9XCJoYW5kbGVSZXNpemVFbmRcIlxuICAgICAgQHJlc2l6ZT1cImhhbmRsZVJlc2l6ZVwiXG4gICAgPlxuICAgICAgPGVsLXNwbGl0dGVyLXBhbmVsPlxuICAgICAgICA8ZGl2IGNsYXNzPVwiZGVtby1wYW5lbFwiPjE8L2Rpdj5cbiAgICAgIDwvZWwtc3BsaXR0ZXItcGFuZWw+XG4gICAgICA8ZWwtc3BsaXR0ZXItcGFuZWwgdi1tb2RlbDpzaXplPVwic2l6ZVwiIDptYXg9XCI5MDBcIiA6bWluPVwiNTBcIj5cbiAgICAgICAgPGRpdiBjbGFzcz1cImRlbW8tcGFuZWxcIj57eyBzaXplIH19cHg8L2Rpdj5cbiAgICAgIDwvZWwtc3BsaXR0ZXItcGFuZWw+XG4gICAgPC9lbC1zcGxpdHRlcj5cbiAgPC9kaXY+XG5cbiAgPGVsLWJ1dHRvbiBAY2xpY2s9XCJjaGFuZ2VTaXplXCI+54K55oiR6K6+572u5oiQMTAwcHg8L2VsLWJ1dHRvbj5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgc2V0dXAgbGFuZz1cInRzXCI+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5cbmNvbnN0IHNpemUgPSByZWYoMTAwKVxuY29uc3Qgc3BsaXRLZXkgPSByZWYoMCk7XG5cbmNvbnN0IGhhbmRsZVJlc2l6ZVN0YXJ0ID0gKGluZGV4OiBudW1iZXIsIHNpemVzOiBudW1iZXJbXSkgPT4ge1xuICBjb25zb2xlLmxvZygncmVzaXplU3RhcnQnLCBpbmRleCwgc2l6ZXMpXG59XG5cbmNvbnN0IGhhbmRsZVJlc2l6ZSA9IChpbmRleDogbnVtYmVyLCBzaXplczogbnVtYmVyW10pID0+IHtcbiAgY29uc29sZS5sb2coJ3Jlc2l6ZScsIGluZGV4LCBzaXplcylcbn1cblxuY29uc3QgaGFuZGxlUmVzaXplRW5kID0gKGluZGV4OiBudW1iZXIsIHNpemVzOiBudW1iZXJbXSkgPT4ge1xuICBjb25zb2xlLmxvZygncmVzaXplRW5kJywgaW5kZXgsIHNpemVzKVxuXG59XG5jb25zdCBjaGFuZ2VTaXplID0gKCk9PntcbiAgc2l6ZS52YWx1ZSA9IDEwMDtcbn07XG48L3NjcmlwdD5cblxuPHN0eWxlIHNjb3BlZD5cbi5kZW1vLXBhbmVsIHtcbiAgZGlzcGxheTogZmxleDtcbiAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAganVzdGlmeS1jb250ZW50OiBjZW50ZXI7XG4gIGhlaWdodDogMTAwJTtcbn1cbjwvc3R5bGU+XG4iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgY29uc3Qgc3R5bGVzID0gWydodHRwczovL3ByZXZpZXctMjE5NjAtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmNzcycsICdodHRwczovL3ByZXZpZXctMjE5NjAtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS90aGVtZS1jaGFsay9kYXJrL2Nzcy12YXJzLmNzcyddLm1hcCgoc3R5bGUpID0+IHtcbiAgICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICAgIGxpbmsuaHJlZiA9IHN0eWxlXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2xvYWQnLCByZXNvbHZlKVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdlcnJvcicsIHJlamVjdClcbiAgICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gICAgfSlcbiAgfSlcbiAgcmV0dXJuIFByb21pc2UuYWxsU2V0dGxlZChzdHlsZXMpXG59XG4iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcbiAgICBcImpzeFwiOiBcInByZXNlcnZlXCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJ0eXBlc1wiOiBbXCJlbGVtZW50LXBsdXMvZ2xvYmFsLmQudHNcIl0sXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwiUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3J1bnRpbWUtZG9tQGxhdGVzdC9kaXN0L3J1bnRpbWUtZG9tLmVzbS1icm93c2VyLmpzXCIsXG4gICAgXCJAdnVlL3NoYXJlZFwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9zaGFyZWRAbGF0ZXN0L2Rpc3Qvc2hhcmVkLmVzbS1idW5kbGVyLmpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL3ByZXZpZXctMjE5NjAtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcInVuc3VwcG9ydGVkXCIsXG4gICAgXCJAZWxlbWVudC1wbHVzL2ljb25zLXZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQGVsZW1lbnQtcGx1cy9pY29ucy12dWVAMi9kaXN0L2luZGV4Lm1pbi5qc1wiXG4gIH0sXG4gIFwic2NvcGVzXCI6IHt9XG59IiwiX28iOnsic2hvd0hpZGRlbiI6dHJ1ZSwic3R5bGVTb3VyY2UiOiJodHRwczovL3ByZXZpZXctMjE5NjAtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmNzcyJ9fQ==)

The useSize method previously [scaled ](https://github.com/element-plus/element-plus/blob/dev/packages/components/splitter/src/hooks/useSize.ts#L63C5-L67C7)all ratios without distinguishing fixed sizes.This caused fixed size ratios to change unexpectedly. 

This PR ensures that:
1.Fixed size ratios remain unchanged.
2.Only flexible sizes are rescaled to fit the remaining space.