### PR TITLE
feat(components): [popConfirm] support effect

### DIFF
--- a/docs/en-US/component/popconfirm.md
+++ b/docs/en-US/component/popconfirm.md
@@ -54,6 +54,7 @@ popconfirm/trigger-event
 | Name                | Description                                                                         | Type                                                                         | Default        |
 | ------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------------- |
 | title               | Title                                                                               | ^[string]                                                                    | —              |
+| effect ^(2.11.2)    | Tooltip theme, built-in theme: `dark` / `light`                                     | ^[enum]`'dark' \| 'light'` / ^[string]                                       | light          |
 | confirm-button-text | Confirm button text                                                                 | ^[string]                                                                    | —              |
 | cancel-button-text  | Cancel button text                                                                  | ^[string]                                                                    | —              |
 | confirm-button-type | Confirm button type                                                                 | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info' \| 'text'` | primary        |

--- a/packages/components/popconfirm/src/popconfirm.ts
+++ b/packages/components/popconfirm/src/popconfirm.ts
@@ -61,6 +61,13 @@ export const popconfirmProps = buildProps({
     default: 200,
   },
   /**
+   * @description Tooltip theme, built-in theme: `dark` / `light`
+   */
+  effect: {
+    ...useTooltipContentProps.effect,
+    default: 'light',
+  },
+  /**
    * @description whether popconfirm is teleported to the body
    */
   teleported: useTooltipContentProps.teleported,

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -2,7 +2,7 @@
   <el-tooltip
     ref="tooltipRef"
     trigger="click"
-    effect="light"
+    :effect="effect"
     v-bind="$attrs"
     :popper-class="`${ns.namespace.value}-popover`"
     :popper-style="style"


### PR DESCRIPTION
popconfirm also needs effect custom background.

<img width="1218" height="815" alt="image" src="https://github.com/user-attachments/assets/a176a4a5-0675-4049-97ee-2892d507a260" />

