### PR TITLE
refactor(components): [cascader] adjust the ts type

### DIFF
--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -247,7 +247,7 @@ import {
 import { ArrowDown, Check } from '@element-plus/icons-vue'
 import { cascaderEmits, cascaderProps } from './cascader'
 
-import type { Options, State } from '@element-plus/components/popper'
+import type { Options } from '@element-plus/components/popper'
 import type { ComputedRef, Ref, StyleValue } from 'vue'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
 import type { InputInstance } from '@element-plus/components/input'
@@ -265,7 +265,7 @@ const popperOptions: Partial<Options> = {
       name: 'arrowPosition',
       enabled: true,
       phase: 'main',
-      fn: ({ state }: { state: State }) => {
+      fn: ({ state }) => {
         const { modifiersData, placement } = state
         if (['right', 'left', 'bottom', 'top'].includes(placement)) return
         if (modifiersData.arrow) {

--- a/packages/components/popper/index.ts
+++ b/packages/components/popper/index.ts
@@ -17,4 +17,4 @@ export * from './src/content'
 export * from './src/arrow'
 export * from './src/constants'
 
-export type { Placement, Options, State } from '@popperjs/core'
+export type { Placement, Options } from '@popperjs/core'


### PR DESCRIPTION
It seems that the automatic deduction can be done normally.

<img width="754" height="378" alt="image" src="https://github.com/user-attachments/assets/267e82ed-e778-4e23-a05a-3ac999f26e6d" />
