### PR TITLE
fix(components): [select] dropdown should always display when focused

### DIFF
--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -2461,7 +2461,26 @@ describe('Select', () => {
     expect(wrapper.find(`.${PLACEHOLDER_CLASS_NAME}`).text()).toBe(placeholder)
   })
 
-  test('should close popper when click icon twice', async () => {
+  // [true, false].forEach((filterableValue) => {
+  //   test('should toggle popper when click icon', async () => {
+  //     wrapper = getSelectVm({
+  //       filterable: filterableValue,
+  //       clearable: true,
+  //     })
+  //     const select = wrapper.findComponent({ name: 'ElSelect' })
+
+  //     const iconWhenDropdownClose = wrapper.findComponent(ArrowDown)
+  //     await iconWhenDropdownClose.trigger('click')
+  //     expect((select.vm as any).expanded).toBe(true)
+
+  //     await wrapper.setProps({ suffixIcon: markRaw(CaretTop) })
+  //     const iconWhenDropdownOpen = wrapper.findComponent(CaretTop)
+  //     await iconWhenDropdownOpen.trigger('click')
+  //     expect((select.vm as any).expanded).toBe(false)
+  //   })
+  // })
+
+  test('mouseenter click should keep dropdown open when filterable', async () => {
     wrapper = getSelectVm({
       filterable: true,
       clearable: true,
@@ -2470,13 +2489,14 @@ describe('Select', () => {
     const trigger = wrapper.find(`.${WRAPPER_CLASS_NAME}`)
     await trigger.trigger('click')
     expect((select.vm as any).expanded).toBe(true)
+
     await trigger.trigger('click')
-    expect((select.vm as any).expanded).toBe(false)
+    expect((select.vm as any).expanded).toBe(true)
   })
 
-  test('mouseenter click', async () => {
+  test('mouseenter click should toggle dropdown when non-filterable', async () => {
     wrapper = getSelectVm({
-      filterable: true,
+      filterable: false,
       clearable: true,
     })
     const select = wrapper.findComponent({ name: 'ElSelect' })

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -684,15 +684,12 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
 
   const toggleMenu = (event?: Event) => {
     if (selectDisabled.value) return
-
     // We only set the inputHovering state to true on mouseenter event on iOS devices
     // To keep the state updated we set it here to true
     if (isIOS) states.inputHovering = true
 
-    const clickedSuffix =
-      event && suffixRef.value?.contains(event.target as Node)
-
-    if (clickedSuffix) {
+    // non-filterable
+    if (!props.filterable) {
       if (states.menuVisibleOnFocus) {
         states.menuVisibleOnFocus = false
       } else {
@@ -701,14 +698,16 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
       return
     }
 
-    const shouldToggle = !isFocused.value && !states.menuVisibleOnFocus
-
-    if (isFocused.value || shouldToggle) {
-      expanded.value = isFocused.value ? true : !expanded.value
+    // filterable
+    const clickedSuffix =
+      event && suffixRef.value?.contains(event.target as Node)
+    if (clickedSuffix) {
+      expanded.value = !expanded.value
+      return
     }
 
-    if (states.menuVisibleOnFocus) {
-      states.menuVisibleOnFocus = false
+    if (isFocused.value) {
+      expanded.value = true
     }
   }
 

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -682,12 +682,24 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
     }
   }
 
-  const toggleMenu = () => {
+  const toggleMenu = (event?: Event) => {
     if (selectDisabled.value) return
 
     // We only set the inputHovering state to true on mouseenter event on iOS devices
     // To keep the state updated we set it here to true
     if (isIOS) states.inputHovering = true
+
+    const clickedSuffix =
+      event && suffixRef.value?.contains(event.target as Node)
+
+    if (clickedSuffix) {
+      if (states.menuVisibleOnFocus) {
+        states.menuVisibleOnFocus = false
+      } else {
+        expanded.value = !expanded.value
+      }
+      return
+    }
 
     const shouldToggle = !isFocused.value && !states.menuVisibleOnFocus
 

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -689,11 +689,14 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
     // To keep the state updated we set it here to true
     if (isIOS) states.inputHovering = true
 
+    const shouldToggle = !isFocused.value && !states.menuVisibleOnFocus
+
+    if (isFocused.value || shouldToggle) {
+      expanded.value = isFocused.value ? true : !expanded.value
+    }
+
     if (states.menuVisibleOnFocus) {
-      // controlled by automaticDropdown
       states.menuVisibleOnFocus = false
-    } else {
-      expanded.value = !expanded.value
     }
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### Description

When the select component's input is focused, the dropdown should always be displayed for better user experience (unified with the other components).

[Ref](https://github.com/element-plus/element-plus/pull/21959)

### Preview

Before:
![select-collapse](https://github.com/user-attachments/assets/f194db42-d1b9-4ed5-b100-20e6f377aaa5)

After:
![select-focus-open](https://github.com/user-attachments/assets/12056cd8-a412-48f4-8e1d-a24c640eb9c7)

