### PR TITLE
feat(components): [popConfirm] add `close-on-press-escape` prop

### DIFF
--- a/docs/en-US/component/popconfirm.md
+++ b/docs/en-US/component/popconfirm.md
@@ -51,21 +51,22 @@ popconfirm/trigger-event
 
 ### Attributes
 
-| Name                | Description                                                                         | Type                                                                         | Default        |
-| ------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------------- |
-| title               | Title                                                                               | ^[string]                                                                    | —              |
-| effect ^(2.11.2)    | Tooltip theme, built-in theme: `dark` / `light`                                     | ^[enum]`'dark' \| 'light'` / ^[string]                                       | light          |
-| confirm-button-text | Confirm button text                                                                 | ^[string]                                                                    | —              |
-| cancel-button-text  | Cancel button text                                                                  | ^[string]                                                                    | —              |
-| confirm-button-type | Confirm button type                                                                 | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info' \| 'text'` | primary        |
-| cancel-button-type  | Cancel button type                                                                  | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info' \| 'text'` | text           |
-| icon                | Icon Component                                                                      | ^[string] / ^[Component]                                                     | QuestionFilled |
-| icon-color          | Icon color                                                                          | ^[string]                                                                    | #f90           |
-| hide-icon           | is hide Icon                                                                        | ^[boolean]                                                                   | false          |
-| hide-after          | delay of disappear, in millisecond                                                  | ^[number]                                                                    | 200            |
-| teleported          | whether popconfirm is teleported to the body                                        | ^[boolean]                                                                   | true           |
-| persistent          | when popconfirm inactive and `persistent` is `false` , popconfirm will be destroyed | ^[boolean]                                                                   | false          |
-| width               | popconfirm width, min width 150px                                                   | ^[string] / ^[number]                                                        | 150            |
+| Name                            | Description                                                                         | Type                                                                         | Default        |
+| ------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------------- |
+| title                           | Title                                                                               | ^[string]                                                                    | —              |
+| effect ^(2.11.2)                | Tooltip theme, built-in theme: `dark` / `light`                                     | ^[enum]`'dark' \| 'light'` / ^[string]                                       | light          |
+| close-on-press-escape ^(2.11.2) | whether the popConfirm can be closed by pressing ESC                                | ^[boolean]                                                                   | true           |
+| confirm-button-text             | Confirm button text                                                                 | ^[string]                                                                    | —              |
+| cancel-button-text              | Cancel button text                                                                  | ^[string]                                                                    | —              |
+| confirm-button-type             | Confirm button type                                                                 | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info' \| 'text'` | primary        |
+| cancel-button-type              | Cancel button type                                                                  | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info' \| 'text'` | text           |
+| icon                            | Icon Component                                                                      | ^[string] / ^[Component]                                                     | QuestionFilled |
+| icon-color                      | Icon color                                                                          | ^[string]                                                                    | #f90           |
+| hide-icon                       | is hide Icon                                                                        | ^[boolean]                                                                   | false          |
+| hide-after                      | delay of disappear, in millisecond                                                  | ^[number]                                                                    | 200            |
+| teleported                      | whether popconfirm is teleported to the body                                        | ^[boolean]                                                                   | true           |
+| persistent                      | when popconfirm inactive and `persistent` is `false` , popconfirm will be destroyed | ^[boolean]                                                                   | false          |
+| width                           | popconfirm width, min width 150px                                                   | ^[string] / ^[number]                                                        | 150            |
 
 ### Events
 

--- a/packages/components/popconfirm/__tests__/popconfirm.test.tsx
+++ b/packages/components/popconfirm/__tests__/popconfirm.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { rAF } from '@element-plus/test-utils/tick'
 import { usePopperContainerId } from '@element-plus/hooks'
 import Popconfirm from '../src/popconfirm.vue'
+import triggerEvent from '@element-plus/test-utils/trigger-event'
+import { EVENT_CODE } from '@element-plus/constants'
 
 const AXIOM = 'rem is the best girl'
 const FUN = 'dQw4w9WgXcQ'
@@ -38,6 +40,39 @@ describe('Popconfirm.vue', () => {
     expect(
       document.querySelector(selector)!.getAttribute('style')
     ).not.toContain('display: none')
+  })
+
+  it('should close the Popconfirm when pressing Escape', async () => {
+    const onCancel = vi.fn()
+
+    const wrapper = mount({
+      setup() {
+        return () => (
+          <Popconfirm
+            closeOnPressEscape={false}
+            onCancel={onCancel}
+            v-slots={{
+              reference: () => <div class="reference">{AXIOM}</div>,
+            }}
+          />
+        )
+      },
+    })
+
+    await wrapper.find('.reference').trigger('click')
+    await nextTick()
+    await rAF()
+
+    triggerEvent(document.body, 'keydown', EVENT_CODE.esc)
+    await nextTick()
+    expect(onCancel).toHaveBeenCalledTimes(0)
+
+    await wrapper.setProps({ closeOnPressEscape: true })
+
+    triggerEvent(document.body, 'keydown', EVENT_CODE.esc)
+    await nextTick()
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
   describe('teleported API', () => {

--- a/packages/components/popconfirm/__tests__/popconfirm.test.tsx
+++ b/packages/components/popconfirm/__tests__/popconfirm.test.tsx
@@ -71,7 +71,6 @@ describe('Popconfirm.vue', () => {
 
     triggerEvent(document.body, 'keydown', EVENT_CODE.esc)
     await nextTick()
-
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 

--- a/packages/components/popconfirm/src/popconfirm.ts
+++ b/packages/components/popconfirm/src/popconfirm.ts
@@ -82,6 +82,13 @@ export const popconfirmProps = buildProps({
     type: [String, Number],
     default: 150,
   },
+  /**
+   * @description whether the popConfirm can be closed by pressing ESC
+   */
+  closeOnPressEscape: {
+    type: Boolean,
+    default: true,
+  },
 } as const)
 
 export const popconfirmEmits = {
@@ -92,7 +99,8 @@ export const popconfirmEmits = {
   /**
    * @description triggers when click cancel button
    */
-  cancel: (e: MouseEvent) => e instanceof MouseEvent,
+  cancel: (e: MouseEvent | KeyboardEvent) =>
+    e instanceof MouseEvent || e instanceof KeyboardEvent,
 }
 
 export type PopconfirmEmits = typeof popconfirmEmits

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -100,7 +100,7 @@ const cancel = (e: MouseEvent | KeyboardEvent) => {
 }
 
 const onCloseRequested = (event: KeyboardEvent) => {
-  if (props.closeOnPressEscape && event.code === EVENT_CODE.esc) {
+  if (props.closeOnPressEscape) {
     cancel(event)
   }
 }

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -101,8 +101,7 @@ const cancel = (e: MouseEvent | KeyboardEvent) => {
 
 const onCloseRequested = (event: KeyboardEvent) => {
   if (props.closeOnPressEscape && event.code === EVENT_CODE.esc) {
-      cancel(event)
-    }
+    cancel(event)
   }
 }
 

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -100,8 +100,7 @@ const cancel = (e: MouseEvent | KeyboardEvent) => {
 }
 
 const onCloseRequested = (event: KeyboardEvent) => {
-  if (props.closeOnPressEscape) {
-    if (event.code === EVENT_CODE.esc) {
+  if (props.closeOnPressEscape && event.code === EVENT_CODE.esc) {
       cancel(event)
     }
   }

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -12,38 +12,40 @@
     :persistent="persistent"
   >
     <template #content>
-      <div :class="ns.b()">
-        <div :class="ns.e('main')">
-          <el-icon
-            v-if="!hideIcon && icon"
-            :class="ns.e('icon')"
-            :style="{ color: iconColor }"
-          >
-            <component :is="icon" />
-          </el-icon>
-          {{ title }}
-        </div>
-        <div :class="ns.e('action')">
-          <slot name="actions" :confirm="confirm" :cancel="cancel">
-            <el-button
-              size="small"
-              :type="cancelButtonType === 'text' ? '' : cancelButtonType"
-              :text="cancelButtonType === 'text'"
-              @click="cancel"
+      <el-focus-trap loop trapped @release-requested="onCloseRequested">
+        <div :class="ns.b()">
+          <div :class="ns.e('main')">
+            <el-icon
+              v-if="!hideIcon && icon"
+              :class="ns.e('icon')"
+              :style="{ color: iconColor }"
             >
-              {{ finalCancelButtonText }}
-            </el-button>
-            <el-button
-              size="small"
-              :type="confirmButtonType === 'text' ? '' : confirmButtonType"
-              :text="confirmButtonType === 'text'"
-              @click="confirm"
-            >
-              {{ finalConfirmButtonText }}
-            </el-button>
-          </slot>
+              <component :is="icon" />
+            </el-icon>
+            {{ title }}
+          </div>
+          <div :class="ns.e('action')">
+            <slot name="actions" :confirm="confirm" :cancel="cancel">
+              <el-button
+                size="small"
+                :type="cancelButtonType === 'text' ? '' : cancelButtonType"
+                :text="cancelButtonType === 'text'"
+                @click="cancel"
+              >
+                {{ finalCancelButtonText }}
+              </el-button>
+              <el-button
+                size="small"
+                :type="confirmButtonType === 'text' ? '' : confirmButtonType"
+                :text="confirmButtonType === 'text'"
+                @click="confirm"
+              >
+                {{ finalConfirmButtonText }}
+              </el-button>
+            </slot>
+          </div>
         </div>
-      </div>
+      </el-focus-trap>
     </template>
     <template v-if="$slots.reference">
       <slot name="reference" />
@@ -59,6 +61,8 @@ import ElTooltip from '@element-plus/components/tooltip'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { addUnit } from '@element-plus/utils'
 import { popconfirmEmits, popconfirmProps } from './popconfirm'
+import ElFocusTrap from '@element-plus/components/focus-trap'
+import { EVENT_CODE } from '@element-plus/constants'
 
 import type { TooltipInstance } from '@element-plus/components/tooltip'
 
@@ -90,9 +94,17 @@ const confirm = (e: MouseEvent) => {
   emit('confirm', e)
   hidePopper()
 }
-const cancel = (e: MouseEvent) => {
+const cancel = (e: MouseEvent | KeyboardEvent) => {
   emit('cancel', e)
   hidePopper()
+}
+
+const onCloseRequested = (event: KeyboardEvent) => {
+  if (props.closeOnPressEscape) {
+    if (event.code === EVENT_CODE.esc) {
+      cancel(event)
+    }
+  }
 }
 
 const finalConfirmButtonText = computed(

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -62,7 +62,6 @@ import { useLocale, useNamespace } from '@element-plus/hooks'
 import { addUnit } from '@element-plus/utils'
 import { popconfirmEmits, popconfirmProps } from './popconfirm'
 import ElFocusTrap from '@element-plus/components/focus-trap'
-import { EVENT_CODE } from '@element-plus/constants'
 
 import type { TooltipInstance } from '@element-plus/components/tooltip'
 


### PR DESCRIPTION
Like other popup layer components, it supports closing via Esc shortcut and better keyboard interaction.