### PR TITLE
fix(components): [input] Fix the issue where autosize does not work

### DIFF
--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -160,7 +160,7 @@ import {
   useSlots,
   watch,
 } from 'vue'
-import { useResizeObserver } from '@vueuse/core'
+import { useElementSize, useResizeObserver } from '@vueuse/core'
 import { isNil } from 'lodash-unified'
 import { ElIcon } from '@element-plus/components/icon'
 import { Hide as IconHide, View as IconView } from '@element-plus/icons-vue'
@@ -484,8 +484,10 @@ watch(nativeInputValue, () => setNativeInputValue())
 // when change between <input> and <textarea>,
 // update DOM dependent value and styles
 // https://github.com/ElemeFE/element/issues/14857
+const { width: textareaWidth } = useElementSize(textarea)
+
 watch(
-  () => props.type,
+  () => [props.type, textareaWidth.value],
   async () => {
     await nextTick()
     setNativeInputValue()


### PR DESCRIPTION
fix #21982

When I set the input component to textarea mode and enabled autosize, the autosize did not take effect after dynamically changing the component width