### PR TITLE
style(components): [splitter] use ew-ns cursor

### DIFF
--- a/packages/components/splitter/src/split-bar.vue
+++ b/packages/components/splitter/src/split-bar.vue
@@ -48,7 +48,7 @@ const draggerStyles = computed(() => {
   return {
     width: isHorizontal.value ? '16px' : '100%',
     height: isHorizontal.value ? '100%' : '16px',
-    cursor: isHorizontal.value ? 'col-resize' : 'row-resize',
+    cursor: isHorizontal.value ? 'ew-resize' : 'ns-resize',
     touchAction: 'none',
   }
 })

--- a/packages/theme-chalk/src/splitter.scss
+++ b/packages/theme-chalk/src/splitter.scss
@@ -18,10 +18,10 @@
     bottom: 0;
   }
   @include e(mask-horizontal) {
-    cursor: col-resize;
+    cursor: ew-resize;
   }
   @include e(mask-vertical) {
-    cursor: row-resize;
+    cursor: ns-resize;
   }
 
   @include e(horizontal) {


### PR DESCRIPTION
As @thinkasany said, it seems more reasonable to use ew-ns cursor.

- https://github.com/element-plus/element-plus/pull/21595#discussion_r2275672484



![screenshots](https://github.com/user-attachments/assets/09f03962-39c8-4a71-90eb-0963187ea96a)


#### [Before](https://element-plus.org/en-US/component/splitter.html#collapsible)


#### After

![screenshots](https://github.com/user-attachments/assets/83d8b708-5823-4882-964b-1bc3942ea58e)
