### PR TITLE
feat(components): [input-tag] add collapse-tag-click event and tests

### DIFF
--- a/docs/en-US/component/input-tag.md
+++ b/docs/en-US/component/input-tag.md
@@ -161,15 +161,16 @@ input-tag/prefix-suffix
 
 ### Events
 
-| Name       | Description                             | Type                                              |
-| ---------- | --------------------------------------- | ------------------------------------------------- |
-| change     | triggers when the modelValue change     | ^[Function]`(value: string[]) => void`            |
-| input      | triggers when the input value change    | ^[Function]`(value: string) => void`              |
-| add-tag    | triggers when a tag is added            | ^[Function]`(value: string \| string []) => void` |
-| remove-tag | triggers when a tag is removed          | ^[Function]`(value: string) => void`              |
-| focus      | triggers when InputTag focuses          | ^[Function]`(event: FocusEvent) => void`          |
-| blur       | triggers when InputTag blurs            | ^[Function]`(event: FocusEvent) => void`          |
-| clear      | triggers when the clear icon is clicked | ^[Function]`() => void`                           |
+| Name               | Description                                        | Type                                                                |
+| ------------------ | -------------------------------------------------- | ------------------------------------------------------------------- |
+| change             | triggers when the modelValue change                | ^[Function]`(value: string[]) => void`                              |
+| input              | triggers when the input value change               | ^[Function]`(value: string) => void`                                |
+| add-tag            | triggers when a tag is added                       | ^[Function]`(value: string \| string []) => void`                   |
+| remove-tag         | triggers when a tag is removed                     | ^[Function]`(value: string) => void`                                |
+| focus              | triggers when InputTag focuses                     | ^[Function]`(event: FocusEvent) => void`                            |
+| blur               | triggers when InputTag blurs                       | ^[Function]`(event: FocusEvent) => void`                            |
+| clear              | triggers when the clear icon is clicked            | ^[Function]`() => void`                                             |
+| collapse-tag-click | triggers when the collapsed tag (`+ N`) is clicked | ^[Function]`(event: MouseEvent, collapseTagList: string[]) => void` |
 
 ### Slots
 

--- a/packages/components/input-tag/__tests__/input-tag.test.tsx
+++ b/packages/components/input-tag/__tests__/input-tag.test.tsx
@@ -528,4 +528,27 @@ describe('InputTag.vue', () => {
       expect(tags[3].text()).toBe('+ 2')
     })
   })
+
+  test('collapse-tag-click', async () => {
+    const onCollapseClick = vi.fn()
+    const wrapper = mount(() => (
+      <InputTag
+        modelValue={['tag1', 'tag2', 'tag3', 'tag4']}
+        collapseTags
+        maxCollapseTags={2}
+        onCollapse-tag-click={onCollapseClick}
+      />
+    ))
+
+    const tags = wrapper.findAll('.el-tag')
+    const collapseTag = tags[2]
+    expect(collapseTag.text()).toBe('+ 2')
+
+    await collapseTag.trigger('click')
+
+    expect(onCollapseClick).toHaveBeenCalledOnce()
+    const [evt, list] = onCollapseClick.mock.calls[0]
+    expect(evt).toBeInstanceOf(MouseEvent)
+    expect(list).toEqual(['tag3', 'tag4'])
+  })
 })

--- a/packages/components/input-tag/src/input-tag.ts
+++ b/packages/components/input-tag/src/input-tag.ts
@@ -169,5 +169,11 @@ export const inputTagEmits = {
   focus: (evt: FocusEvent) => evt instanceof FocusEvent,
   blur: (evt: FocusEvent) => evt instanceof FocusEvent,
   clear: () => true,
+  'collapse-tag-click': (
+    evt: MouseEvent,
+    collapseTagList: string[] | undefined
+  ) =>
+    evt instanceof MouseEvent &&
+    (isArray(collapseTagList) || isUndefined(collapseTagList)),
 }
 export type InputTagEmits = typeof inputTagEmits

--- a/packages/components/input-tag/src/input-tag.vue
+++ b/packages/components/input-tag/src/input-tag.vue
@@ -44,6 +44,7 @@
             :type="tagType"
             :effect="tagEffect"
             disable-transitions
+            @click="$emit('collapse-tag-click', $event, collapseTagList)"
           >
             + {{ modelValue.length - maxCollapseTags }}
           </el-tag>


### PR DESCRIPTION
- Add collapse-tag-click event emitted when the collapsed tag (+ N) is clicked
- Pass MouseEvent and collapseTagList (string[]) as event parameters
- Update documentation Events table to include the new event
- Add unit tests to verify event emission and parameter values
