### PR TITLE
feat(components): [tree-select] add `show-parent-tag` prop

### DIFF
--- a/docs/en-US/component/tree-select.md
+++ b/docs/en-US/component/tree-select.md
@@ -108,6 +108,8 @@ and please go to the original component to view the documentation.
 | ------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------ | ------- |
 | cacheData ^(2.2.26) | The cached data of the lazy node, the structure is the same as the data, used to get the label of the unloaded data | ^[object]`CacheOption[]` | []      |
 
+| show-parent-tag | In multiple selection mode with checkboxes, determines whether to display the parent tag itself instead of all its child tags when the parent node is selected. | boolean | false |
+
 ## Type Declarations
 
 <details>

--- a/packages/components/tree-select/src/tree-select.vue
+++ b/packages/components/tree-select/src/tree-select.vue
@@ -22,6 +22,10 @@ export default defineComponent({
       type: Array,
       default: () => [],
     },
+    showParentTag: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props, context) {
     const { slots, expose } = context

--- a/packages/components/tree-select/src/tree.ts
+++ b/packages/components/tree-select/src/tree.ts
@@ -114,9 +114,16 @@ export const useTree = (
   })
 
   const getChildCheckedKeys = () => {
-    return tree.value?.getCheckedKeys().filter((checkedKey) => {
-      const node = tree.value?.getNode(checkedKey) as Node
-      return !isNil(node) && isEmpty(node.childNodes)
+    const checkedKeys = tree.value?.getCheckedKeys()
+    const checkedSet = new Set(checkedKeys)
+    return checkedKeys.filter((checkedNode) => {
+      const node = tree.value?.getNode(checkedNode) as Node
+      if (isNil(node)) return false
+      if (props.showParentTag) {
+        return !checkedSet.has(node.parent?.key)
+      } else {
+        return isEmpty(node.childNodes)
+      }
     })
   }
 


### PR DESCRIPTION
In multiple selection mode with checkboxes, determines whether to display the parent tag itself instead of all its child tags when the parent node is selected.

BREAKING CHANGE :
docs/en-US/component/tree-select.md packages/components/tree-select/src/tree-select.vue  tree.ts

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
