### PR TITLE
refactor(components): [splitter] disabled class and style

### DIFF
--- a/packages/components/splitter/src/split-bar.vue
+++ b/packages/components/splitter/src/split-bar.vue
@@ -143,7 +143,7 @@ const EndIcon = computed(() => (isHorizontal.value ? ArrowRight : ArrowDown))
       :class="[
         ns.e('dragger'),
         draggerPseudoClass,
-        resizable ? '' : ns.is('disabled'),
+       ns.is('disabled', !resizable),
         ns.is('lazy', resizable && lazy),
       ]"
       :style="draggerStyles"

--- a/packages/components/splitter/src/split-bar.vue
+++ b/packages/components/splitter/src/split-bar.vue
@@ -48,7 +48,11 @@ const draggerStyles = computed(() => {
   return {
     width: isHorizontal.value ? '16px' : '100%',
     height: isHorizontal.value ? '100%' : '16px',
-    cursor: isHorizontal.value ? 'ew-resize' : 'ns-resize',
+    cursor: !props.resizable
+      ? 'auto'
+      : isHorizontal.value
+      ? 'ew-resize'
+      : 'ns-resize',
     touchAction: 'none',
   }
 })
@@ -139,7 +143,7 @@ const EndIcon = computed(() => (isHorizontal.value ? ArrowRight : ArrowDown))
       :class="[
         ns.e('dragger'),
         draggerPseudoClass,
-        resizable ? '' : ns.e('disable'),
+        resizable ? '' : ns.is('disabled'),
         ns.is('lazy', resizable && lazy),
       ]"
       :style="draggerStyles"

--- a/packages/components/splitter/src/split-bar.vue
+++ b/packages/components/splitter/src/split-bar.vue
@@ -143,7 +143,7 @@ const EndIcon = computed(() => (isHorizontal.value ? ArrowRight : ArrowDown))
       :class="[
         ns.e('dragger'),
         draggerPseudoClass,
-       ns.is('disabled', !resizable),
+        ns.is('disabled', !resizable),
         ns.is('lazy', resizable && lazy),
       ]"
       :style="draggerStyles"

--- a/packages/theme-chalk/src/splitter.scss
+++ b/packages/theme-chalk/src/splitter.scss
@@ -37,12 +37,6 @@
   flex: none;
   position: relative;
   user-select: none;
-  .is-disabled {
-    cursor: auto;
-    &::before {
-      background-color: getCssVar('border-color-light');
-    }
-  }
 
   @include e(dragger) {
     z-index: 1;
@@ -70,7 +64,7 @@
     }
 
     &:hover {
-      &::before:not(.is-disabled) {
+      &:not(.is-disabled)::before {
         background-color: getCssVar('color-primary-light-5');
       }
     }

--- a/packages/theme-chalk/src/splitter.scss
+++ b/packages/theme-chalk/src/splitter.scss
@@ -37,12 +37,13 @@
   flex: none;
   position: relative;
   user-select: none;
-  @include e(disable) {
-    cursor: auto !important;
+  .is-disabled {
+    cursor: auto;
     &::before {
-      background-color: getCssVar('border-color-light') !important;
+      background-color: getCssVar('border-color-light');
     }
   }
+
   @include e(dragger) {
     z-index: 1;
     position: absolute;
@@ -69,7 +70,7 @@
     }
 
     &:hover {
-      &::before {
+      &::before:not(.is-disabled) {
         background-color: getCssVar('color-primary-light-5');
       }
     }


### PR DESCRIPTION
1. `!important` is not good for controlling styles

2. It seems that using `.is-disabled` is more intuitive and in line with project style.
<img width="418" height="1106" alt="image" src="https://github.com/user-attachments/assets/12f2209e-308c-4cab-80f3-a47d33a62229" />
