### PR TITLE
fix(components): [table-v2] add missing `LEFT` member in Alignment

### DIFF
--- a/docs/en-US/component/table-v2.md
+++ b/docs/en-US/component/table-v2.md
@@ -560,6 +560,12 @@ enum SortOrder {
   DESC = 'desc',
 }
 
+enum Alignment {
+  LEFT = 'left',
+  CENTER = 'center',
+  RIGHT = 'right',
+}
+
 type SortBy = { key: KeyType; Order: SortOrder }
 type SortState = Record<KeyType, SortOrder>
 ```

--- a/packages/components/table-v2/src/constants.ts
+++ b/packages/components/table-v2/src/constants.ts
@@ -4,6 +4,7 @@ export enum SortOrder {
 }
 
 export enum Alignment {
+  LEFT = 'left',
   CENTER = 'center',
   RIGHT = 'right',
 }


### PR DESCRIPTION
closed #10113

sync with the doc declaration https://element-plus.org/en-US/component/table-v2.html#column-attribute
<br />
<img width="1187" height="131" alt="image" src="https://github.com/user-attachments/assets/39dbac45-dbbd-4f7f-9572-27f309f1ab5b" />