### PR TITLE
fix(components): [loading] accept type VNode for text property

### DIFF
--- a/packages/components/loading/__tests__/loading.test.tsx
+++ b/packages/components/loading/__tests__/loading.test.tsx
@@ -1,4 +1,4 @@
-import { nextTick, ref } from 'vue'
+import { createVNode, nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import Loading from '../src/service'
@@ -7,6 +7,8 @@ import ElInput from '../../input'
 
 import type { VNode } from 'vue'
 import type { LoadingInstance } from '../src/loading'
+
+const AXIOM = 'Rem is the best girl'
 
 function destroyLoadingInstance(loadingInstance: LoadingInstance) {
   if (!loadingInstance) return
@@ -144,6 +146,15 @@ describe('Loading', () => {
   test('create service', async () => {
     loadingInstance = Loading()
     expect(document.querySelector('.el-loading-mask')).toBeTruthy()
+  })
+
+  test('accept VNode as text', async () => {
+    loadingInstance = Loading({
+      text: createVNode('div', { 'data-testid': 'my-loading' }, AXIOM),
+    })
+    const loadingText = document.querySelector('[data-testid="my-loading"]')
+    expect(loadingText).not.toBeNull()
+    expect(loadingText?.textContent).toBe(AXIOM)
   })
 
   test('close service', async () => {

--- a/packages/components/loading/src/types.ts
+++ b/packages/components/loading/src/types.ts
@@ -1,3 +1,4 @@
+import type { VNode } from 'vue'
 import type { MaybeRef } from '@vueuse/core'
 
 export type LoadingOptionsResolved = {
@@ -15,7 +16,7 @@ export type LoadingOptionsResolved = {
   /**
    * @description loading text that displays under the spinner
    */
-  text: MaybeRef<string>
+  text: MaybeRef<string | VNode | VNode[]>
   /**
    * @description same as the `fullscreen` modifier of `v-loading`
    */


### PR DESCRIPTION
closed #12927

Along with type `string`, accept writing:
```ts
ElLoading.service({
    text: h('div', null, 'Loading'),
    text: [h('div', null, 'Loading')],
})
```

It's already accepting it just a typescript issue so the test case is not really relevant.