### PR TITLE
feat(components): [tabs] add tabs draggable option

### DIFF
--- a/packages/components/tabs/src/constants.ts
+++ b/packages/components/tabs/src/constants.ts
@@ -27,6 +27,7 @@ export type TabsPaneContext = UnwrapRef<{
 export interface TabsRootContext {
   props: TabsProps
   currentName: Ref<TabPaneName>
+  tabPanes: Ref<TabsPaneContext[]>
   registerPane: (pane: TabsPaneContext) => void
   unregisterPane: (pane: TabsPaneContext) => void
   nav$: Ref<TabNavInstance | undefined>

--- a/packages/components/tabs/src/tab-nav.tsx
+++ b/packages/components/tabs/src/tab-nav.tsx
@@ -318,9 +318,9 @@ const TabNav = defineComponent({
         draggedTargetIndex.value = null
         return
       }
-      const newOrder = [
-        ...rootTabs.tabPanes.value.map((pane) => pane.paneName),
-      ].filter((name): name is TabPaneName => name !== undefined)
+      const newOrder = rootTabs.tabPanes.value
+        .map((pane) => pane.paneName)
+        .filter((name): name is TabPaneName => name !== undefined)
       if (!newOrder) return
       const [draggedItem] = newOrder.splice(draggedIndex.value, 1)
       newOrder.splice(draggedTargetIndex.value, 0, draggedItem)

--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -77,6 +77,10 @@ export const tabsProps = buildProps({
    * @description whether width of tab automatically fits its container
    */
   stretch: Boolean,
+  /**
+   * @description whether the tabs are draggable.
+   */
+  draggable: Boolean,
 } as const)
 export type TabsProps = ExtractPropTypes<typeof tabsProps>
 export type TabsPropsPublic = __ExtractPublicPropTypes<typeof tabsProps>
@@ -92,6 +96,8 @@ export const tabsEmits = {
     ['remove', 'add'].includes(action),
   tabRemove: (name: TabPaneName) => isPaneName(name),
   tabAdd: () => true,
+  tabsOrderChange: (order: TabPaneName[]) =>
+    Array.isArray(order) && order.every(isPaneName),
 }
 export type TabsEmits = typeof tabsEmits
 
@@ -174,6 +180,10 @@ const Tabs = defineComponent({
       emit('tabAdd')
     }
 
+    const handleOrderChange = (order: TabPaneName[]) => {
+      emit('tabsOrderChange', order)
+    }
+
     const swapChildren = (
       vnode: VNode & {
         el: HTMLDivElement
@@ -203,6 +213,7 @@ const Tabs = defineComponent({
     provide(tabsRootContextKey, {
       props,
       currentName,
+      tabPanes: panes,
       registerPane,
       unregisterPane,
       nav$,
@@ -251,6 +262,7 @@ const Tabs = defineComponent({
           stretch={props.stretch}
           onTabClick={handleTabClick}
           onTabRemove={handleTabRemove}
+          onTabsOrderChange={handleOrderChange}
         />
       )
 


### PR DESCRIPTION
Simply add a draggable option for el-tabs.

This allow user to drag and drop freely to change the order of tabs when  the new **draggable** option in props is set to true

It will emit "**tabsOrdeChange**" to export the order of tabsnames

It **won't change anything** unless user change the order of el-tab-pane Element in the DOM

close #22007 
fix #19934 

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
