### PR TITLE
feat(components): [table] parent row checkbox support indeterminate and auto checked

### DIFF
--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -2156,6 +2156,62 @@ describe('Table.vue', () => {
       wrapper.findAll('.el-checkbox')[0].trigger('click')
       await doubleWait()
       expect(wrapper.vm.selected.length).toEqual(getTestData().length + 2)
+      wrapper.findAll('.el-checkbox')[0].trigger('click')
+      await doubleWait()
+
+      await (wrapper.vm.treeProps.checkStrictly = false)
+      wrapper.findAll('.el-checkbox')[3].trigger('click')
+      await doubleWait()
+      expect(
+        wrapper.findAll('.el-checkbox')[2].find('.el-checkbox__input').classes()
+      ).toContain('is-indeterminate')
+      wrapper.findAll('.el-checkbox')[4].trigger('click')
+      await doubleWait()
+      expect(wrapper.findAll('.el-checkbox')[4].classes()).toContain(
+        'is-checked'
+      )
+      expect(wrapper.findAll('.el-checkbox')[2].classes()).toContain(
+        'is-checked'
+      )
+      wrapper.findAll('.el-checkbox')[3].trigger('click')
+      await doubleWait()
+      expect(
+        wrapper.findAll('.el-checkbox')[2].find('.el-checkbox__input').classes()
+      ).toContain('is-indeterminate')
+      wrapper.findAll('.el-checkbox')[4].trigger('click')
+      await doubleWait()
+      expect(wrapper.findAll('.el-checkbox')[2].classes()).not.toContain(
+        'is-checked'
+      )
+      expect(
+        wrapper.findAll('.el-checkbox')[2].find('.el-checkbox__input').classes()
+      ).not.toContain('is-indeterminate')
+
+      await (wrapper.vm.treeProps.checkStrictly = true)
+      wrapper.findAll('.el-checkbox')[3].trigger('click')
+      await doubleWait()
+      expect(
+        wrapper.findAll('.el-checkbox')[2].find('.el-checkbox__input').classes()
+      ).not.toContain('is-indeterminate')
+      expect(wrapper.findAll('.el-checkbox')[2].classes()).not.toContain(
+        'is-checked'
+      )
+      wrapper.findAll('.el-checkbox')[4].trigger('click')
+      await doubleWait()
+      expect(
+        wrapper.findAll('.el-checkbox')[2].find('.el-checkbox__input').classes()
+      ).not.toContain('is-indeterminate')
+      expect(wrapper.findAll('.el-checkbox')[2].classes()).not.toContain(
+        'is-checked'
+      )
+      wrapper.findAll('.el-checkbox')[2].trigger('click')
+      await doubleWait()
+      expect(
+        wrapper.findAll('.el-checkbox')[2].find('.el-checkbox__input').classes()
+      ).not.toContain('is-indeterminate')
+      expect(wrapper.findAll('.el-checkbox')[2].classes()).toContain(
+        'is-checked'
+      )
     })
 
     it('a11y', async () => {

--- a/packages/components/table/src/config.ts
+++ b/packages/components/table/src/config.ts
@@ -82,6 +82,7 @@ export const cellForced = {
         onClick: (event: Event) => event.stopPropagation(),
         modelValue: store.isSelected(row),
         ariaLabel: store.t('el.table.selectRowLabel'),
+        indeterminate: store.isIndeterminate(row),
       })
     },
     sortable: false,

--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -206,6 +206,9 @@ function useStore<T extends DefaultRow>() {
     rowSelectedChanged(_states: StoreStates, row: T) {
       instance.store.toggleRowSelection(row)
       instance.store.updateAllSelected()
+      if (!instance?.store?.states?.checkStrictly.value) {
+        instance.store.updateParentSelected(row)
+      }
     },
 
     setHoverRow(states: StoreStates, row: T) {

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -109,6 +109,35 @@ function useWatcher<T extends DefaultRow>() {
     }
   )
 
+  const checkRowsCheckedStatus = (rows: T[]) => {
+    let rowIndex = 0
+    let selectedCount = 0
+
+    const checkSelectedStatus = (data: T[]) => {
+      for (const row of data) {
+        const isRowSelectable =
+          selectable.value && selectable.value.call(null, row, rowIndex)
+
+        if (!isSelected(row)) {
+          if (!selectable.value || isRowSelectable) {
+            return false
+          }
+        } else {
+          selectedCount++
+        }
+        rowIndex++
+        const children = instance.store.getChildren(row)
+        if (children?.length && !checkSelectedStatus(children)) {
+          return false
+        }
+      }
+      return true
+    }
+
+    const isAllSelected = checkSelectedStatus(rows || [])
+    return { selectedCount, isAllSelected }
+  }
+
   // 检查 rowKey 是否存在
   const assertRowKey = () => {
     if (!rowKey.value) throw new Error('[ElTable] prop row-key is required')
@@ -187,6 +216,34 @@ function useWatcher<T extends DefaultRow>() {
     }
   }
 
+  const getChildren = (row: T) => {
+    const childrenColumnName = instance?.store?.states?.childrenColumnName.value
+    const result: T[] | undefined = row[childrenColumnName]
+    return result
+  }
+
+  const getParentRow = (row: T, parentRow?: T) => {
+    let target: T | undefined
+    const children: T[] = parentRow
+      ? (getChildren(parentRow) ?? [])
+      : data.value
+    const result = children?.find(
+      (item) =>
+        getRowIdentity(row, rowKey.value) === getRowIdentity(item, rowKey.value)
+    )
+    if (result) {
+      target = parentRow
+    } else {
+      for (const _row of children) {
+        target = getParentRow(row, _row)
+        if (target) {
+          break
+        }
+      }
+    }
+    return target
+  }
+
   // 选择
   const isSelected = (row: T) => {
     if (selectedMap.value) {
@@ -194,6 +251,27 @@ function useWatcher<T extends DefaultRow>() {
     } else {
       return selection.value.includes(row)
     }
+  }
+
+  const isIndeterminate = (row: T) => {
+    const children = getChildren(row)
+    if (!children?.length) {
+      return false
+    }
+    const selected = isSelected(row)
+    if (selected) {
+      return false
+    }
+    if (instance?.store?.states?.checkStrictly.value) {
+      return false
+    }
+    let selectedCount = 0
+    for (const row of children) {
+      if (isSelected(row)) {
+        selectedCount++
+      }
+    }
+    return selectedCount > 0 && selectedCount < children.length
   }
 
   const clearSelection = () => {
@@ -236,7 +314,8 @@ function useWatcher<T extends DefaultRow>() {
     row: T,
     selected?: boolean,
     emitChange = true,
-    ignoreSelectable = false
+    ignoreSelectable = false,
+    ignoreChildren = false
   ) => {
     const treeProps = {
       children: instance?.store?.states?.childrenColumnName.value,
@@ -249,7 +328,8 @@ function useWatcher<T extends DefaultRow>() {
       treeProps,
       ignoreSelectable ? undefined : selectable.value,
       data.value.indexOf(row),
-      rowKey.value
+      rowKey.value,
+      ignoreChildren
     )
     if (changed) {
       const newSelection = (selection.value || []).slice()
@@ -312,36 +392,27 @@ function useWatcher<T extends DefaultRow>() {
       return
     }
 
-    const { childrenColumnName } = instance.store.states
-    let rowIndex = 0
-    let selectedCount = 0
+    const { selectedCount, isAllSelected: _isAllSelected } =
+      checkRowsCheckedStatus(data.value)
+    isAllSelected.value = selectedCount === 0 ? false : _isAllSelected
+  }
 
-    const checkSelectedStatus = (data: T[]) => {
-      for (const row of data) {
-        const isRowSelectable =
-          selectable.value && selectable.value.call(null, row, rowIndex)
+  const updateParentSelected = (row: T) => {
+    const parentRow = getParentRow(row)
 
-        if (!isSelected(row)) {
-          if (!selectable.value || isRowSelectable) {
-            return false
-          }
-        } else {
-          selectedCount++
-        }
-        rowIndex++
-
-        if (
-          row[childrenColumnName.value]?.length &&
-          !checkSelectedStatus(row[childrenColumnName.value])
-        ) {
-          return false
-        }
-      }
-      return true
+    if (parentRow === undefined) {
+      return
     }
-
-    const isAllSelected_ = checkSelectedStatus(data.value || [])
-    isAllSelected.value = selectedCount === 0 ? false : isAllSelected_
+    const children = instance.store.getChildren(parentRow) ?? []
+    const { selectedCount, isAllSelected: _isAllSelected } =
+      checkRowsCheckedStatus(children)
+    toggleRowSelection(
+      parentRow,
+      selectedCount === 0 ? false : _isAllSelected,
+      true,
+      false,
+      true
+    )
   }
 
   const getChildrenCount = (rowKey: string) => {
@@ -529,6 +600,7 @@ function useWatcher<T extends DefaultRow>() {
     updateColumns,
     scheduleLayout,
     isSelected,
+    isIndeterminate,
     clearSelection,
     cleanSelection,
     getSelectionRows,
@@ -536,6 +608,7 @@ function useWatcher<T extends DefaultRow>() {
     _toggleAllSelection,
     toggleAllSelection: null as (() => void) | null,
     updateAllSelected,
+    updateParentSelected,
     updateFilters,
     updateCurrentRow,
     updateSort,
@@ -554,6 +627,7 @@ function useWatcher<T extends DefaultRow>() {
     loadOrToggle,
     updateTreeData,
     updateKeyChildren,
+    getChildren,
     states: {
       tableSize,
       rowKey,

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -304,7 +304,8 @@ export function toggleRowStatus<T extends DefaultRow>(
   tableTreeProps?: TreeProps,
   selectable?: ((row: T, index: number) => boolean) | null,
   rowIndex?: number,
-  rowKey?: string | null
+  rowKey?: string | null,
+  ignoreChildren: boolean = false
 ): boolean {
   let _rowIndex = rowIndex ?? 0
   let changed = false
@@ -357,6 +358,7 @@ export function toggleRowStatus<T extends DefaultRow>(
   }
 
   if (
+    !ignoreChildren &&
     !tableTreeProps?.checkStrictly &&
     tableTreeProps?.children &&
     isArray(row[tableTreeProps.children])


### PR DESCRIPTION
Close #21397 Close #18177

### Issues
When checked child row, the parent row is neither checked nor indeterminate.

### Analysis
1. The checkbox in table not use indeterminate prop.
2. The logic of updating the parent when child checked is missing

### Solutions
Implement the missing code.

### Others
I've referred some UI libs. it has been implemented. Maybe it's time to add this feature.
