### PR TITLE
fix(components): [rate] ensure the logic of mouseleave work

### DIFF
--- a/packages/components/rate/__tests__/rate.test.tsx
+++ b/packages/components/rate/__tests__/rate.test.tsx
@@ -152,15 +152,24 @@ describe('Rate.vue', () => {
     const value = ref(3.5)
     const wrapper = mount(() => <Rate v-model={value.value} allow-half />)
     expect(wrapper.find('.el-rate__decimal--box').exists()).toBe(true)
+    expect(
+      wrapper.findAll('.el-rate__decimal--box')[3].attributes('style')
+    ).toBe(undefined)
     value.value = 3.4
     await nextTick()
-    expect(wrapper.find('.el-rate__decimal--box').exists()).toBe(false)
+    expect(wrapper.find('.el-rate__decimal--box').exists()).toBe(true)
+    expect(
+      wrapper.findAll('.el-rate__decimal--box')[3].attributes('style')
+    ).contain('display: none;')
   })
 
   it('show background icon when disabled attribute is true', async () => {
     const value = ref(3.2)
     const wrapper = mount(() => <Rate v-model={value.value} disabled />)
     expect(wrapper.find('.el-rate__decimal--box').exists()).toBe(true)
+    expect(
+      wrapper.findAll('.el-rate__decimal--box')[3].attributes('style')
+    ).toBe(undefined)
   })
 
   describe('form item accessibility integration', () => {

--- a/packages/components/rate/src/rate.vue
+++ b/packages/components/rate/src/rate.vue
@@ -82,13 +82,9 @@ import {
 import { ElIcon } from '@element-plus/components/icon'
 import { useNamespace } from '@element-plus/hooks'
 import { rateEmits, rateProps } from './rate'
-import { useEventListener } from '@vueuse/core'
 
 import type { CSSProperties, Component } from 'vue'
 import type { IconInstance } from '@element-plus/components/icon'
-
-// ensure that currentValue is reset when the mouse moves out of the iframe.
-useEventListener(document, 'mouseleave', resetCurrentValue)
 
 function getValueFromMap<T>(
   value: number,

--- a/packages/components/rate/src/rate.vue
+++ b/packages/components/rate/src/rate.vue
@@ -82,9 +82,13 @@ import {
 import { ElIcon } from '@element-plus/components/icon'
 import { useNamespace } from '@element-plus/hooks'
 import { rateEmits, rateProps } from './rate'
+import { useEventListener } from '@vueuse/core'
 
 import type { CSSProperties, Component } from 'vue'
 import type { IconInstance } from '@element-plus/components/icon'
+
+// ensure that currentValue is reset when the mouse moves out of the iframe.
+useEventListener(document, 'mouseleave', resetCurrentValue)
 
 function getValueFromMap<T>(
   value: number,

--- a/packages/components/rate/src/rate.vue
+++ b/packages/components/rate/src/rate.vue
@@ -32,19 +32,26 @@
           ns.is('focus-visible', item === Math.ceil(currentValue || 1)),
         ]"
       >
-        <template v-if="!showDecimalIcon(item)">
-          <component :is="activeComponent" v-show="item <= currentValue" />
-          <component :is="voidComponent" v-show="item > currentValue" />
-        </template>
-        <template v-else>
-          <component :is="voidComponent" :class="[ns.em('decimal', 'box')]" />
-          <el-icon
-            :style="decimalStyle"
-            :class="[ns.e('icon'), ns.e('decimal')]"
-          >
-            <component :is="decimalIconComponent" />
-          </el-icon>
-        </template>
+        <component
+          :is="activeComponent"
+          v-show="!showDecimalIcon(item) && item <= currentValue"
+        />
+        <component
+          :is="voidComponent"
+          v-show="!showDecimalIcon(item) && item > currentValue"
+        />
+        <component
+          :is="voidComponent"
+          v-show="showDecimalIcon(item)"
+          :class="[ns.em('decimal', 'box')]"
+        />
+        <el-icon
+          v-show="showDecimalIcon(item)"
+          :style="decimalStyle"
+          :class="[ns.e('icon'), ns.e('decimal')]"
+        >
+          <component :is="decimalIconComponent" />
+        </el-icon>
       </el-icon>
     </span>
     <span


### PR DESCRIPTION
Fix #22004

### Issues
The display of rate not reset to respect  the value when the mouse moves quickly.

### Analysis
The mouseleave event rarely fails to trigger.

### Solution
Use the window mousemove event to determinate the mouse is within the rate.