### PR TITLE
fix(components): [splitter] `resize-end` event `sizes` value is not the latest

### DIFF
--- a/packages/components/splitter/__tests__/splitter.test.tsx
+++ b/packages/components/splitter/__tests__/splitter.test.tsx
@@ -375,4 +375,40 @@ describe('Splitter', () => {
     await nextTick()
     expect(panels[0].attributes('style')).toContain('flex-basis: 100px;')
   })
+
+  it('should emit resizeEnd with latest sizes data in lazy mode', async () => {
+    const onResizeEnd = vi.fn()
+    const wrapper = mount(() => (
+      <div style={{ width: '400px', height: '400px' }}>
+        <ElSplitter lazy onResizeEnd={onResizeEnd}>
+          <ElSplitterPanel>Left Panel</ElSplitterPanel>
+          <ElSplitterPanel>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const splitBar = wrapper.find('.el-splitter-bar__dragger')
+
+    const mousedown = new MouseEvent('mousedown', { bubbles: true })
+    Object.defineProperty(mousedown, 'pageX', { value: 200 })
+    splitBar.element.dispatchEvent(mousedown)
+    await nextTick()
+
+    const mousemove = new MouseEvent('mousemove', { bubbles: true })
+    Object.defineProperty(mousemove, 'pageX', { value: 150 })
+    window.dispatchEvent(mousemove)
+    await nextTick()
+
+    const mouseup = new MouseEvent('mouseup', { bubbles: true })
+    Object.defineProperty(mouseup, 'pageX', { value: 150 })
+    window.dispatchEvent(mouseup)
+    await nextTick()
+
+    expect(onResizeEnd).toHaveBeenCalledWith(0, [150, 250])
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    expect(panels[0].attributes('style')).toContain('flex-basis: 150px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 250px;')
+  })
 })

--- a/packages/components/splitter/src/splitter.vue
+++ b/packages/components/splitter/src/splitter.vue
@@ -79,9 +79,7 @@ const onResize = (index: number, offset: number) => {
 
 const onResizeEnd = async (index: number) => {
   onMoveEnd()
-
   await nextTick()
-
   emits('resizeEnd', index, pxSizes.value)
 }
 

--- a/packages/components/splitter/src/splitter.vue
+++ b/packages/components/splitter/src/splitter.vue
@@ -2,6 +2,7 @@
 import {
   computed,
   getCurrentInstance,
+  nextTick,
   provide,
   reactive,
   toRef,
@@ -76,8 +77,13 @@ const onResize = (index: number, offset: number) => {
   }
 }
 
-const onResizeEnd = (index: number) => {
+const onResizeEnd = async (index: number) => {
   onMoveEnd()
+
+  if (lazy.value) {
+    await nextTick()
+  }
+
   emits('resizeEnd', index, pxSizes.value)
 }
 

--- a/packages/components/splitter/src/splitter.vue
+++ b/packages/components/splitter/src/splitter.vue
@@ -80,9 +80,7 @@ const onResize = (index: number, offset: number) => {
 const onResizeEnd = async (index: number) => {
   onMoveEnd()
 
-  if (lazy.value) {
-    await nextTick()
-  }
+  await nextTick()
 
   emits('resizeEnd', index, pxSizes.value)
 }

--- a/packages/components/splitter/src/type.ts
+++ b/packages/components/splitter/src/type.ts
@@ -25,7 +25,7 @@ export interface SplitterRootContext {
   registerPanel: (pane: PanelItemState) => void
   unregisterPanel: (pane: PanelItemState) => void
   onCollapse: (index: number, type: 'start' | 'end') => void
-  onMoveEnd: () => void
+  onMoveEnd: (index: number) => Promise<void>
   onMoveStart: (index: number) => void
   onMoving: (index: number, offset: number) => void
 }


### PR DESCRIPTION
### 问题描述
在Element Plus Splitter组件中，当开启 lazy 模式后， resizeEnd 事件回调中的 sizes 参数返回的是上一次的数据，而不是最新的尺寸数据。
### 问题分析
根本原因：
1. 在lazy模式下， onMoving 过程中不会立即更新panel的size，而是等到 onMoveEnd 时才调用 updatePanelSizes()
2. 在 splitter.vue 的 onResizeEnd 函数中，调用 onMoveEnd() 后立即触发 resizeEnd 事件
3. 此时 pxSizes.value 还是基于旧的panel size计算的，因为Vue的响应式更新是异步的

### 解决方案
文件： packages/components/splitter/src/splitter.vue

- 将 onResizeEnd 函数改为异步函数
- 在lazy模式下，使用 nextTick() 等待Vue响应式更新完成
- 确保 resizeEnd 事件传递最新的sizes数据