### PR TITLE
fix(components): [cascader] clear search text on blur

### DIFF
--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -353,7 +353,9 @@ const { wrapperRef, isFocused, handleBlur } = useFocusController(inputRef, {
     )
   },
   afterBlur() {
-    popperVisible.value = false
+    nextTick(() => {
+      popperVisible.value = false
+    })
     if (props.validateEvent) {
       formItem?.validate?.('blur').catch((err) => debugWarn(err))
     }

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -353,9 +353,10 @@ const { wrapperRef, isFocused, handleBlur } = useFocusController(inputRef, {
     )
   },
   afterBlur() {
-    nextTick(() => {
-      popperVisible.value = false
-    })
+    popperVisible.value = false
+    if (props.filterable) {
+      syncPresentTextValue()
+    }
     if (props.validateEvent) {
       formItem?.validate?.('blur').catch((err) => debugWarn(err))
     }
@@ -443,8 +444,6 @@ const togglePopperVisible = (visible?: boolean) => {
     if (visible) {
       updatePopperPosition()
       nextTick(cascaderPanelRef.value?.scrollToExpandingNode)
-    } else if (props.filterable) {
-      syncPresentTextValue()
     }
 
     emit('visibleChange', visible)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

After version 2.11.0, `Cascader` with `filterable` does not clear the keyword after losing focus.

### Before

https://github.com/user-attachments/assets/32bd87b3-c1c6-4648-aaf2-efea082a2160

### After

https://github.com/user-attachments/assets/131713d5-1f6c-4ba0-9dda-c8f34e405210

