### PR TITLE
fix: the KeyboardEvent.code is always empty string on Android

### DIFF
--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -33,6 +33,7 @@ import { cloneDeep, flattenDeep, isEqual } from 'lodash-unified'
 import {
   castArray,
   focusNode,
+  getEventCode,
   getSibling,
   isClient,
   isEmpty,
@@ -283,7 +284,7 @@ const scrollToExpandingNode = () => {
 
 const handleKeyDown = (e: KeyboardEvent) => {
   const target = e.target as HTMLElement
-  const { code } = e
+  const code = getEventCode(e)
 
   switch (code) {
     case EVENT_CODE.up:

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -216,6 +216,7 @@ import { useCssVar, useResizeObserver } from '@vueuse/core'
 import {
   debugWarn,
   focusNode,
+  getEventCode,
   getSibling,
   isClient,
   isPromise,
@@ -608,8 +609,9 @@ const handleExpandChange = (value: CascaderValue) => {
 
 const handleKeyDown = (e: KeyboardEvent) => {
   if (isComposing.value) return
+  const code = getEventCode(e)
 
-  switch (e.code) {
+  switch (code) {
     case EVENT_CODE.enter:
     case EVENT_CODE.numpadEnter:
       togglePopperVisible()

--- a/packages/components/color-picker-panel/src/composables/use-alpha-slider.ts
+++ b/packages/components/color-picker-panel/src/composables/use-alpha-slider.ts
@@ -6,7 +6,7 @@ import {
   shallowRef,
   watch,
 } from 'vue'
-import { addUnit, getClientXY } from '@element-plus/utils'
+import { addUnit, getClientXY, getEventCode } from '@element-plus/utils'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { EVENT_CODE } from '@element-plus/constants'
 import { draggable } from '../utils/draggable'
@@ -71,7 +71,8 @@ export const useAlphaSlider = (props: AlphaSliderProps) => {
 
   function handleKeydown(event: KeyboardEvent) {
     if (props.disabled) return
-    const { code, shiftKey } = event
+    const { shiftKey } = event
+    const code = getEventCode(event)
     const step = shiftKey ? 10 : 1
 
     switch (code) {

--- a/packages/components/color-picker/src/color-picker.vue
+++ b/packages/components/color-picker/src/color-picker.vue
@@ -118,7 +118,7 @@ import {
   EVENT_CODE,
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
-import { debugWarn } from '@element-plus/utils'
+import { debugWarn, getEventCode } from '@element-plus/utils'
 import { ArrowDown, Close } from '@element-plus/icons-vue'
 import { colorPickerEmits, colorPickerProps } from './color-picker'
 import {
@@ -294,7 +294,9 @@ function handleEsc(event: KeyboardEvent) {
 }
 
 function handleKeyDown(event: KeyboardEvent) {
-  switch (event.code) {
+  const code = getEventCode(event)
+
+  switch (code) {
     case EVENT_CODE.enter:
     case EVENT_CODE.numpadEnter:
     case EVENT_CODE.space:

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-pick.vue
@@ -236,7 +236,12 @@ import {
   extractTimeFormat,
 } from '@element-plus/components/time-picker'
 import { ElIcon } from '@element-plus/components/icon'
-import { extractFirst, isArray, isFunction } from '@element-plus/utils'
+import {
+  extractFirst,
+  getEventCode,
+  isArray,
+  isFunction,
+} from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import {
   ArrowLeft,
@@ -718,7 +723,8 @@ const _handleFocusPicker = () => {
 }
 
 const handleKeydownTable = (event: KeyboardEvent) => {
-  const { code } = event
+  const code = getEventCode(event)
+
   const validCode = [
     EVENT_CODE.up,
     EVENT_CODE.down,

--- a/packages/components/dropdown/src/dropdown-item-impl.vue
+++ b/packages/components/dropdown/src/dropdown-item-impl.vue
@@ -34,7 +34,11 @@ import {
 import { COLLECTION_ITEM_SIGN } from '@element-plus/components/collection'
 import { ElIcon } from '@element-plus/components/icon'
 import { useNamespace } from '@element-plus/hooks'
-import { composeEventHandlers, composeRefs } from '@element-plus/utils'
+import {
+  composeEventHandlers,
+  composeRefs,
+  getEventCode,
+} from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import {
   DROPDOWN_COLLECTION_ITEM_INJECTION_KEY,
@@ -88,9 +92,11 @@ export default defineComponent({
     })
 
     const handleKeydown = composeEventHandlers((e: KeyboardEvent) => {
+      const code = getEventCode(e)
+
       if (
         [EVENT_CODE.enter, EVENT_CODE.numpadEnter, EVENT_CODE.space].includes(
-          e.code
+          code
         )
       ) {
         e.preventDefault()

--- a/packages/components/dropdown/src/dropdown-menu.vue
+++ b/packages/components/dropdown/src/dropdown-menu.vue
@@ -17,7 +17,11 @@
 
 <script lang="ts">
 import { computed, defineComponent, inject, unref } from 'vue'
-import { composeEventHandlers, composeRefs } from '@element-plus/utils'
+import {
+  composeEventHandlers,
+  composeRefs,
+  getEventCode,
+} from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import { FOCUS_TRAP_INJECTION_KEY } from '@element-plus/components/focus-trap'
 import {
@@ -89,7 +93,9 @@ export default defineComponent({
         props.onKeydown?.(e)
       },
       (e) => {
-        const { currentTarget, code, target } = e
+        const { currentTarget, target } = e
+        const code = getEventCode(e)
+
         const isKeydownContained = (currentTarget as Node).contains(
           target as Node
         )

--- a/packages/components/focus-trap/src/focus-trap.vue
+++ b/packages/components/focus-trap/src/focus-trap.vue
@@ -16,7 +16,7 @@ import {
 import { isNil } from 'lodash-unified'
 import { EVENT_CODE } from '@element-plus/constants'
 import { useEscapeKeydown } from '@element-plus/hooks'
-import { isString } from '@element-plus/utils'
+import { getEventCode, isString } from '@element-plus/utils'
 import {
   createFocusOutPreventedEvent,
   focusFirstDescendant,
@@ -86,8 +86,9 @@ export default defineComponent({
       if (!props.loop && !props.trapped) return
       if (focusLayer.paused) return
 
-      const { code, altKey, ctrlKey, metaKey, currentTarget, shiftKey } = e
+      const { altKey, ctrlKey, metaKey, currentTarget, shiftKey } = e
       const { loop } = props
+      const code = getEventCode(e)
       const isTabbing =
         code === EVENT_CODE.tab && !altKey && !ctrlKey && !metaKey
 

--- a/packages/components/image-viewer/src/image-viewer.vue
+++ b/packages/components/image-viewer/src/image-viewer.vue
@@ -124,7 +124,7 @@ import { clamp, useEventListener } from '@vueuse/core'
 import { throttle } from 'lodash-unified'
 import { useLocale, useNamespace, useZIndex } from '@element-plus/hooks'
 import { EVENT_CODE } from '@element-plus/constants'
-import { keysOf } from '@element-plus/utils'
+import { getEventCode, keysOf } from '@element-plus/utils'
 import ElFocusTrap from '@element-plus/components/focus-trap'
 import ElTeleport from '@element-plus/components/teleport'
 import ElIcon from '@element-plus/components/icon'
@@ -248,7 +248,9 @@ function hide() {
 
 function registerEventListener() {
   const keydownHandler = throttle((e: KeyboardEvent) => {
-    switch (e.code) {
+    const code = getEventCode(e)
+
+    switch (code) {
       // ESC
       case EVENT_CODE.esc:
         props.closeOnPressEscape && hide()

--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -659,19 +659,19 @@ describe('InputNumber.vue', () => {
     ))
     const input = wrapper.find('input')
     const preventDefault = vi.fn()
-    await input.trigger('keydown', {
+    await input.trigger('keyup', {
       key: 'e',
       preventDefault,
     })
     expect(preventDefault).toHaveBeenCalled()
     preventDefault.mockClear()
-    await input.trigger('keydown', {
+    await input.trigger('keyup', {
       key: 'E',
       preventDefault,
     })
     expect(preventDefault).toHaveBeenCalled()
     preventDefault.mockClear()
-    await input.trigger('keydown', {
+    await input.trigger('keyup', {
       key: '1',
       preventDefault,
     })

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -56,7 +56,7 @@
       :aria-label="ariaLabel"
       :validate-event="false"
       :inputmode="inputmode"
-      @keydown="handleKeydown"
+      @keyup="handleKeydown"
       @blur="handleBlur"
       @focus="handleFocus"
       @input="handleInput"
@@ -86,6 +86,8 @@ import { vRepeatClick } from '@element-plus/directives'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import {
   debugWarn,
+  getEventCode,
+  getEventKey,
   isNumber,
   isString,
   isUndefined,
@@ -210,23 +212,27 @@ const ensurePrecision = (val: number, coefficient: 1 | -1 = 1) => {
   // Solve the accuracy problem of JS decimal calculation by converting the value to integer.
   return toPrecision(val + props.step * coefficient)
 }
-const handleKeydown = (event: Event) => {
-  const e = event as KeyboardEvent
-  if (props.disabledScientific && ['e', 'E'].includes(e.key)) {
-    e.preventDefault()
+const handleKeydown = (event: KeyboardEvent | Event) => {
+  const code = getEventCode(event as KeyboardEvent)
+  const key = getEventKey(event as KeyboardEvent)
+
+  if (props.disabledScientific && ['e', 'E'].includes(key)) {
+    event.preventDefault()
     return
   }
-  const keyHandlers = {
-    [EVENT_CODE.up]: () => {
-      e.preventDefault()
+
+  switch (code) {
+    case EVENT_CODE.up: {
+      event.preventDefault()
       increase()
-    },
-    [EVENT_CODE.down]: () => {
-      e.preventDefault()
+      break
+    }
+    case EVENT_CODE.down: {
+      event.preventDefault()
       decrease()
-    },
+      break
+    }
   }
-  keyHandlers[e.key]?.()
 }
 const increase = () => {
   if (props.readonly || inputNumberDisabled.value || maxDisabled.value) return

--- a/packages/components/input-tag/__tests__/input-tag.test.tsx
+++ b/packages/components/input-tag/__tests__/input-tag.test.tsx
@@ -30,20 +30,18 @@ describe('InputTag.vue', () => {
     const wrapper = mount(() => <InputTag v-model={inputValue.value} />)
 
     await wrapper.find('input').setValue(AXIOM)
-    await wrapper.find('input').trigger('keydown', { code: EVENT_CODE.enter })
+    await wrapper.find('input').trigger('keyup', { code: EVENT_CODE.enter })
     expect(wrapper.findAll('.el-tag').length).toBe(1)
     expect(wrapper.find('.el-tag').text()).toBe(AXIOM)
     expect(inputValue.value).toEqual([AXIOM])
 
     await wrapper.find('input').setValue('--')
-    await wrapper.find('input').trigger('keydown', { code: EVENT_CODE.enter })
+    await wrapper.find('input').trigger('keyup', { code: EVENT_CODE.enter })
     expect(wrapper.findAll('.el-tag').length).toBe(2)
     expect(wrapper.findAll('.el-tag')[1].text()).toBe('--')
     expect(inputValue.value).toEqual([AXIOM, '--'])
 
-    await wrapper
-      .find('input')
-      .trigger('keydown', { code: EVENT_CODE.backspace })
+    await wrapper.find('input').trigger('keyup', { code: EVENT_CODE.backspace })
     expect(wrapper.findAll('.el-tag').length).toBe(1)
     expect(wrapper.find('.el-tag').text()).toBe(AXIOM)
     expect(inputValue.value).toEqual([AXIOM])
@@ -59,10 +57,10 @@ describe('InputTag.vue', () => {
     ))
 
     await wrapper.find('input').setValue(AXIOM)
-    await wrapper.find('input').trigger('keydown', { code: EVENT_CODE.enter })
+    await wrapper.find('input').trigger('keyup', { code: EVENT_CODE.enter })
     expect(wrapper.findAll('.el-tag').length).toBe(0)
 
-    await wrapper.find('input').trigger('keydown', { code: EVENT_CODE.space })
+    await wrapper.find('input').trigger('keyup', { code: EVENT_CODE.space })
     expect(wrapper.findAll('.el-tag').length).toBe(1)
     expect(wrapper.find('.el-tag').text()).toBe(AXIOM)
   })
@@ -74,7 +72,7 @@ describe('InputTag.vue', () => {
     expect(wrapper.findAll('.el-tag').length).toBe(1)
 
     await wrapper.find('input').setValue(AXIOM)
-    await wrapper.find('input').trigger('keydown', { code: EVENT_CODE.enter })
+    await wrapper.find('input').trigger('keyup', { code: EVENT_CODE.enter })
     expect(wrapper.findAll('.el-tag').length).toBe(1)
   })
 
@@ -136,7 +134,7 @@ describe('InputTag.vue', () => {
     )
 
     await wrapper.find('input').setValue('Rem')
-    await wrapper.find('input').trigger('keydown', { code: EVENT_CODE.enter })
+    await wrapper.find('input').trigger('keyup', { code: EVENT_CODE.enter })
     expect(wrapper.find('input').element.placeholder).toMatchInlineSnapshot(
       `""`
     )
@@ -314,13 +312,13 @@ describe('InputTag.vue', () => {
       ))
 
       await wrapper.find('input').setValue(AXIOM)
-      await wrapper.find('input').trigger('keydown', { code: EVENT_CODE.enter })
+      await wrapper.find('input').trigger('keyup', { code: EVENT_CODE.enter })
       expect(handleModelValue).toHaveBeenCalledOnce()
       expect(handleModelValue).toHaveBeenCalledWith([AXIOM])
 
       await wrapper
         .find('input')
-        .trigger('keydown', { code: EVENT_CODE.backspace })
+        .trigger('keyup', { code: EVENT_CODE.backspace })
       expect(handleModelValue).toHaveBeenCalledTimes(2)
       expect(handleModelValue).toHaveBeenCalledWith([])
     })
@@ -333,13 +331,13 @@ describe('InputTag.vue', () => {
       ))
 
       await wrapper.find('input').setValue(AXIOM)
-      await wrapper.find('input').trigger('keydown', { code: EVENT_CODE.enter })
+      await wrapper.find('input').trigger('keyup', { code: EVENT_CODE.enter })
       expect(handleChange).toHaveBeenCalledOnce()
       expect(handleChange).toHaveBeenCalledWith([AXIOM])
 
       await wrapper
         .find('input')
-        .trigger('keydown', { code: EVENT_CODE.backspace })
+        .trigger('keyup', { code: EVENT_CODE.backspace })
       expect(handleChange).toHaveBeenCalledTimes(2)
       expect(handleChange).toHaveBeenCalledWith([])
     })
@@ -361,7 +359,7 @@ describe('InputTag.vue', () => {
       ))
 
       await wrapper.find('input').setValue(AXIOM)
-      await wrapper.find('input').trigger('keydown', { code: EVENT_CODE.enter })
+      await wrapper.find('input').trigger('keyup', { code: EVENT_CODE.enter })
       expect(handleTagAdd).toHaveBeenCalledOnce()
       expect(handleTagAdd).toHaveBeenCalledWith(AXIOM)
     })
@@ -380,14 +378,14 @@ describe('InputTag.vue', () => {
 
       await wrapper
         .find('input')
-        .trigger('keydown', { code: EVENT_CODE.backspace })
+        .trigger('keyup', { code: EVENT_CODE.backspace })
       expect(handleTagRemove).toHaveBeenCalledTimes(2)
       expect(handleTagRemove).toHaveBeenNthCalledWith(2, AXIOM, 0)
       expect(inputValue.value).toEqual([])
 
       await wrapper
         .find('input')
-        .trigger('keydown', { code: EVENT_CODE.backspace })
+        .trigger('keyup', { code: EVENT_CODE.backspace })
       expect(handleTagRemove).toHaveBeenCalledTimes(2)
     })
 

--- a/packages/components/input-tag/src/composables/use-input-tag.ts
+++ b/packages/components/input-tag/src/composables/use-input-tag.ts
@@ -5,7 +5,12 @@ import {
   INPUT_EVENT,
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
-import { debugWarn, ensureArray, isUndefined } from '@element-plus/utils'
+import {
+  debugWarn,
+  ensureArray,
+  getEventCode,
+  isUndefined,
+} from '@element-plus/utils'
 import { useComposition, useFocusController } from '@element-plus/hooks'
 import { useFormDisabled, useFormSize } from '@element-plus/components/form'
 
@@ -89,7 +94,9 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
 
   const handleKeydown = (event: KeyboardEvent) => {
     if (isComposing.value) return
-    switch (event.code) {
+    const code = getEventCode(event)
+
+    switch (code) {
       case props.trigger:
         event.preventDefault()
         event.stopPropagation()

--- a/packages/components/input-tag/src/input-tag.vue
+++ b/packages/components/input-tag/src/input-tag.vue
@@ -89,7 +89,7 @@
           @compositionupdate="handleCompositionUpdate"
           @compositionend="handleCompositionEnd"
           @input="handleInput"
-          @keydown="handleKeydown"
+          @keyup="handleKeydown"
         />
         <span
           ref="calculatorRef"

--- a/packages/components/mention/src/mention.vue
+++ b/packages/components/mention/src/mention.vue
@@ -67,7 +67,7 @@ import {
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
 import { useFormDisabled } from '@element-plus/components/form'
-import { isFunction } from '@element-plus/utils'
+import { getEventCode, isFunction } from '@element-plus/utils'
 import { mentionDefaultProps, mentionEmits, mentionProps } from './mention'
 import { getCursorPosition, getMentionCtx } from './helper'
 import ElMentionDropdown from './mention-dropdown.vue'
@@ -147,9 +147,10 @@ const handleInputChange = (value: string) => {
 }
 
 const handleInputKeyDown = (event: KeyboardEvent | Event) => {
-  if (!('code' in event) || elInputRef.value?.isComposing) return
+  if (elInputRef.value?.isComposing) return
+  const code = getEventCode(event as KeyboardEvent)
 
-  switch (event.code) {
+  switch (code) {
     case EVENT_CODE.left:
     case EVENT_CODE.right:
       syncAfterCursorMove()
@@ -159,7 +160,7 @@ const handleInputKeyDown = (event: KeyboardEvent | Event) => {
       if (!visible.value) return
       event.preventDefault()
       dropdownRef.value?.navigateOptions(
-        event.code === EVENT_CODE.up ? 'prev' : 'next'
+        code === EVENT_CODE.up ? 'prev' : 'next'
       )
       break
     case EVENT_CODE.enter:

--- a/packages/components/menu/src/utils/menu-item.ts
+++ b/packages/components/menu/src/utils/menu-item.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { triggerEvent } from '@element-plus/utils'
+import { getEventCode, triggerEvent } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import SubMenu from './submenu'
 
@@ -21,8 +21,10 @@ class MenuItem {
 
   addListeners(): void {
     this.domNode.addEventListener('keydown', (event: KeyboardEvent) => {
+      const code = getEventCode(event)
       let prevDef = false
-      switch (event.code) {
+
+      switch (code) {
         case EVENT_CODE.down: {
           triggerEvent(event.currentTarget as HTMLElement, 'mouseenter')
           this.submenu && this.submenu.gotoSubIndex(0)

--- a/packages/components/menu/src/utils/submenu.ts
+++ b/packages/components/menu/src/utils/submenu.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { triggerEvent } from '@element-plus/utils'
+import { getEventCode, triggerEvent } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 
 import type MenuItem from './menu-item'
@@ -31,8 +31,10 @@ class SubMenu {
     const parentNode = this.parent.domNode
     Array.prototype.forEach.call(this.subMenuItems, (el: Element) => {
       el.addEventListener('keydown', (event: KeyboardEvent) => {
+        const code = getEventCode(event)
         let prevDef = false
-        switch (event.code) {
+
+        switch (code) {
           case EVENT_CODE.down: {
             this.gotoSubIndex(this.subIndex + 1)
             prevDef = true

--- a/packages/components/message/src/message.vue
+++ b/packages/components/message/src/message.vue
@@ -49,7 +49,11 @@
 <script lang="ts" setup>
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useEventListener, useResizeObserver, useTimeoutFn } from '@vueuse/core'
-import { TypeComponents, TypeComponentsMap } from '@element-plus/utils'
+import {
+  TypeComponents,
+  TypeComponentsMap,
+  getEventCode,
+} from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import ElBadge from '@element-plus/components/badge'
 import { useGlobalComponentSettings } from '@element-plus/components/config-provider'
@@ -142,7 +146,8 @@ function close() {
   })
 }
 
-function keydown({ code }: KeyboardEvent) {
+function keydown(event: KeyboardEvent) {
+  const code = getEventCode(event)
   if (code === EVENT_CODE.esc) {
     // press esc to close the message
     close()

--- a/packages/components/notification/src/notification.vue
+++ b/packages/components/notification/src/notification.vue
@@ -41,7 +41,7 @@
 <script lang="ts" setup>
 import { computed, onMounted, ref } from 'vue'
 import { useEventListener, useTimeoutFn } from '@vueuse/core'
-import { TypeComponentsMap } from '@element-plus/utils'
+import { TypeComponentsMap, getEventCode } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import { ElIcon } from '@element-plus/components/icon'
 import { useGlobalComponentSettings } from '@element-plus/components/config-provider'
@@ -103,16 +103,23 @@ function close() {
   visible.value = false
 }
 
-function onKeydown({ code }: KeyboardEvent) {
-  if (code === EVENT_CODE.delete || code === EVENT_CODE.backspace) {
-    clearTimer() // press delete/backspace clear timer
-  } else if (code === EVENT_CODE.esc) {
-    // press esc to close the notification
-    if (visible.value) {
-      close()
-    }
-  } else {
-    startTimer() // resume timer
+function onKeydown(event: KeyboardEvent) {
+  const code = getEventCode(event)
+
+  switch (code) {
+    case EVENT_CODE.delete:
+    case EVENT_CODE.backspace:
+      clearTimer() // press delete/backspace clear timer
+      break
+    case EVENT_CODE.esc:
+      // press esc to close the notification
+      if (visible.value) {
+        close()
+      }
+      break
+    default: // resume timer
+      startTimer()
+      break
   }
 }
 

--- a/packages/components/rate/src/rate.vue
+++ b/packages/components/rate/src/rate.vue
@@ -72,7 +72,7 @@ import {
   EVENT_CODE,
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
-import { isArray, isObject, isString } from '@element-plus/utils'
+import { getEventCode, isArray, isObject, isString } from '@element-plus/utils'
 import {
   formContextKey,
   formItemContextKey,
@@ -253,15 +253,21 @@ function handleKey(e: KeyboardEvent) {
   if (rateDisabled.value) {
     return
   }
-  const code = e.code
+  const code = getEventCode(e)
   const step = props.allowHalf ? 0.5 : 1
   let _currentValue = currentValue.value
 
-  if (code === EVENT_CODE.up || code === EVENT_CODE.right) {
-    _currentValue += step
-  } else if (code === EVENT_CODE.left || code === EVENT_CODE.down) {
-    _currentValue -= step
+  switch (code) {
+    case EVENT_CODE.up:
+    case EVENT_CODE.right:
+      _currentValue += step
+      break
+    case EVENT_CODE.left:
+    case EVENT_CODE.down:
+      _currentValue -= step
+      break
   }
+
   _currentValue = clamp(_currentValue, 0, props.max)
 
   if (_currentValue === currentValue.value) {

--- a/packages/components/roving-focus-group/src/roving-focus-item.vue
+++ b/packages/components/roving-focus-group/src/roving-focus-item.vue
@@ -19,7 +19,7 @@ import {
   unref,
 } from 'vue'
 import { useId } from '@element-plus/hooks'
-import { composeEventHandlers } from '@element-plus/utils'
+import { composeEventHandlers, getEventCode } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import {
   ElCollectionItem as ElRovingFocusCollectionItem,
@@ -84,7 +84,9 @@ export default defineComponent({
         emit('keydown', e)
       },
       (e) => {
-        const { code, shiftKey, target, currentTarget } = e as KeyboardEvent
+        const { shiftKey, target, currentTarget } = e as KeyboardEvent
+        const code = getEventCode(e as KeyboardEvent)
+
         if (code === EVENT_CODE.tab && shiftKey) {
           onItemShiftTab()
           return

--- a/packages/components/roving-focus-group/src/utils.ts
+++ b/packages/components/roving-focus-group/src/utils.ts
@@ -1,4 +1,5 @@
 import { EVENT_CODE } from '@element-plus/constants'
+import { getEventCode } from '@element-plus/utils'
 
 import type { HTMLAttributes } from 'vue'
 
@@ -35,7 +36,8 @@ export const getFocusIntent = (
   orientation?: Orientation,
   dir?: Direction
 ) => {
-  const key = getDirectionAwareKey(event.code, dir)
+  const code = getEventCode(event)
+  const key = getDirectionAwareKey(code, dir)
   if (
     orientation === 'vertical' &&
     [EVENT_CODE.left, EVENT_CODE.right].includes(key)

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -18,6 +18,7 @@ import {
   ValidateComponentsMap,
   debugWarn,
   escapeStringRegexp,
+  getEventCode,
   isArray,
   isFunction,
   isNumber,
@@ -652,8 +653,9 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     )
 
   const handleDel = (e: KeyboardEvent) => {
+    const code = getEventCode(e)
     if (!props.multiple) return
-    if (e.code === EVENT_CODE.delete) return
+    if (code === EVENT_CODE.delete) return
     if (states.inputValue.length === 0) {
       e.preventDefault()
       const selected = (props.modelValue as Array<any>).slice()

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -18,6 +18,7 @@ import {
   ValidateComponentsMap,
   debugWarn,
   ensureArray,
+  getEventCode,
   isArray,
   isClient,
   isFunction,
@@ -512,8 +513,9 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
     })
 
   const deletePrevTag = (e: KeyboardEvent) => {
+    const code = getEventCode(e)
     if (!props.multiple) return
-    if (e.code === EVENT_CODE.delete) return
+    if (code === EVENT_CODE.delete) return
     if ((e.target as HTMLInputElement).value.length <= 0) {
       const value = ensureArray(props.modelValue).slice()
       const lastNotDisabledIndex = getLastNotDisabledIndex(value)

--- a/packages/components/slider/src/composables/use-slider-button.ts
+++ b/packages/components/slider/src/composables/use-slider-button.ts
@@ -2,6 +2,7 @@ import { computed, inject, nextTick, ref, watch } from 'vue'
 import { debounce } from 'lodash-unified'
 import { useEventListener } from '@vueuse/core'
 import { EVENT_CODE, UPDATE_MODEL_EVENT } from '@element-plus/constants'
+import { getEventCode } from '@element-plus/utils'
 import { sliderContextKey } from '../constants'
 
 import type { CSSProperties, ComputedRef, Ref, SetupContext } from 'vue'
@@ -149,9 +150,10 @@ export const useSliderButton = (
   }
 
   const onKeyDown = (event: KeyboardEvent) => {
+    const code = getEventCode(event)
     let isPreventDefault = true
 
-    switch (event.code) {
+    switch (code) {
       case EVENT_CODE.left:
       case EVENT_CODE.down:
         onLeftKeyDown()

--- a/packages/components/tabs/src/tab-nav.tsx
+++ b/packages/components/tabs/src/tab-nav.tsx
@@ -20,6 +20,7 @@ import {
   buildProps,
   capitalize,
   definePropType,
+  getEventCode,
   mutable,
   throwError,
 } from '@element-plus/utils'
@@ -248,9 +249,10 @@ const TabNav = defineComponent({
     }
 
     const changeTab = (event: KeyboardEvent) => {
+      const code = getEventCode(event)
       let step = 0
 
-      switch (event.code) {
+      switch (code) {
         case EVENT_CODE.left:
         case EVENT_CODE.up:
           step = -1

--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -13,6 +13,7 @@ import { omit } from 'lodash-unified'
 import {
   buildProps,
   definePropType,
+  getEventCode,
   isNumber,
   isString,
   isUndefined,
@@ -174,6 +175,12 @@ const Tabs = defineComponent({
       emit('tabAdd')
     }
 
+    const handleKeydown = (event: KeyboardEvent) => {
+      const code = getEventCode(event)
+      if ([EVENT_CODE.enter, EVENT_CODE.numpadEnter].includes(code))
+        handleTabAdd()
+    }
+
     const swapChildren = (
       vnode: VNode & {
         el: HTMLDivElement
@@ -226,10 +233,7 @@ const Tabs = defineComponent({
             ]}
             tabindex="0"
             onClick={handleTabAdd}
-            onKeydown={(ev: KeyboardEvent) => {
-              if ([EVENT_CODE.enter, EVENT_CODE.numpadEnter].includes(ev.code))
-                handleTabAdd()
-            }}
+            onKeydown={handleKeydown}
           >
             {addSlot ? (
               renderSlot(slots, 'add-icon')

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -189,7 +189,7 @@ import {
 import ElInput from '@element-plus/components/input'
 import ElIcon from '@element-plus/components/icon'
 import ElTooltip from '@element-plus/components/tooltip'
-import { NOOP, debugWarn, isArray } from '@element-plus/utils'
+import { NOOP, debugWarn, getEventCode, isArray } from '@element-plus/utils'
 import {
   CHANGE_EVENT,
   EVENT_CODE,
@@ -533,7 +533,7 @@ const isValidValue = (value: DayOrDays) => {
 const handleKeydownInput = async (event: Event | KeyboardEvent) => {
   if (props.readonly || pickerDisabled.value) return
 
-  const { code } = event as KeyboardEvent
+  const code = getEventCode(event as KeyboardEvent)
   emitKeydown(event as KeyboardEvent)
   if (code === EVENT_CODE.esc) {
     if (pickerVisible.value === true) {

--- a/packages/components/tour/src/step.vue
+++ b/packages/components/tour/src/step.vue
@@ -70,7 +70,7 @@ import { EVENT_CODE } from '@element-plus/constants'
 import { omit } from 'lodash-unified'
 import { ElButton } from '@element-plus/components/button'
 import { ElIcon } from '@element-plus/components/icon'
-import { CloseComponents } from '@element-plus/utils'
+import { CloseComponents, getEventCode } from '@element-plus/utils'
 import { useLocale } from '@element-plus/hooks'
 import { tourStepEmits, tourStepProps } from './step'
 import { tourKey } from './helper'
@@ -157,16 +157,17 @@ const onClose = () => {
 const handleKeydown = (e: KeyboardEvent) => {
   const target = e.target as HTMLElement | null
   if (target?.isContentEditable) return
+  const code = getEventCode(e)
 
-  const actions: Record<string, () => void> = {
-    [EVENT_CODE.left]: () => current.value > 0 && onPrev(),
-    [EVENT_CODE.right]: onNext,
-  }
-
-  const action = actions[e.code]
-  if (action) {
-    e.preventDefault()
-    action()
+  switch (code) {
+    case EVENT_CODE.left:
+      e.preventDefault()
+      current.value > 0 && onPrev()
+      break
+    case EVENT_CODE.right:
+      e.preventDefault()
+      onNext()
+      break
   }
 }
 

--- a/packages/components/tree/src/model/useKeydown.ts
+++ b/packages/components/tree/src/model/useKeydown.ts
@@ -2,6 +2,7 @@ import { onMounted, onUpdated } from 'vue'
 import { useEventListener } from '@vueuse/core'
 import { EVENT_CODE } from '@element-plus/constants'
 import { useNamespace } from '@element-plus/hooks'
+import { getEventCode } from '@element-plus/utils'
 
 import type TreeStore from './tree-store'
 import type { Ref } from 'vue'
@@ -38,7 +39,7 @@ export function useKeydown({ el$ }: UseKeydownOption, store: Ref<TreeStore>) {
   const handleKeydown = (ev: KeyboardEvent): void => {
     const currentItem = ev.target as HTMLDivElement
     if (!currentItem.className.includes(ns.b('node'))) return
-    const code = ev.code
+    const code = getEventCode(ev)
     const treeItems: HTMLElement[] = Array.from(
       el$.value!.querySelectorAll(`.${ns.is('focusable')}[role=treeitem]`)
     )

--- a/packages/directives/trap-focus/index.ts
+++ b/packages/directives/trap-focus/index.ts
@@ -1,5 +1,5 @@
 import { nextTick } from 'vue'
-import { obtainAllFocusableElements } from '@element-plus/utils'
+import { getEventCode, obtainAllFocusableElements } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 
 import type { ObjectDirective } from 'vue'
@@ -17,9 +17,10 @@ const FOCUS_STACK: TrapFocusElement[] = []
 const FOCUS_HANDLER = (e: KeyboardEvent) => {
   // Getting the top layer.
   if (FOCUS_STACK.length === 0) return
+  const code = getEventCode(e)
   const focusableElement =
     FOCUS_STACK[FOCUS_STACK.length - 1][FOCUSABLE_CHILDREN]
-  if (focusableElement.length > 0 && e.code === EVENT_CODE.tab) {
+  if (focusableElement.length > 0 && code === EVENT_CODE.tab) {
     if (focusableElement.length === 1) {
       e.preventDefault()
       if (document.activeElement !== focusableElement[0]) {

--- a/packages/hooks/use-escape-keydown/index.ts
+++ b/packages/hooks/use-escape-keydown/index.ts
@@ -1,11 +1,12 @@
 import { onBeforeUnmount, onMounted } from 'vue'
-import { isClient } from '@element-plus/utils'
+import { getEventCode, isClient } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 
 let registeredEscapeHandlers: ((e: KeyboardEvent) => void)[] = []
 
 const cachedHandler = (event: KeyboardEvent) => {
-  if (event.code === EVENT_CODE.esc) {
+  const code = getEventCode(event)
+  if (code === EVENT_CODE.esc) {
     registeredEscapeHandlers.forEach((registeredHandler) =>
       registeredHandler(event)
     )

--- a/packages/hooks/use-modal/index.ts
+++ b/packages/hooks/use-modal/index.ts
@@ -1,6 +1,7 @@
 import { watch } from 'vue'
 import { isClient, useEventListener } from '@vueuse/core'
 import { EVENT_CODE } from '@element-plus/constants'
+import { getEventCode } from '@element-plus/utils'
 
 import type { Ref } from 'vue'
 
@@ -12,7 +13,8 @@ const modalStack: ModalInstance[] = []
 
 const closeModal = (e: KeyboardEvent) => {
   if (modalStack.length === 0) return
-  if (e.code === EVENT_CODE.esc) {
+  const code = getEventCode(e)
+  if (code === EVENT_CODE.esc) {
     e.stopPropagation()
     const topModal = modalStack[modalStack.length - 1]
     topModal.handleClose()

--- a/packages/utils/browser.ts
+++ b/packages/utils/browser.ts
@@ -3,4 +3,7 @@ import { isClient, isIOS } from '@vueuse/core'
 export const isFirefox = (): boolean =>
   isClient && /firefox/i.test(window.navigator.userAgent)
 
+export const isAndroid = (): boolean =>
+  isClient && /android/i.test(window.navigator.userAgent)
+
 export { isClient, isIOS }

--- a/packages/utils/dom/event.ts
+++ b/packages/utils/dom/event.ts
@@ -1,3 +1,6 @@
+import { EVENT_CODE } from '@element-plus/constants'
+import { isAndroid } from '../browser'
+
 export const composeEventHandlers = <E>(
   theirsHandler?: (event: E) => boolean | void,
   oursHandler?: (event: E) => void,
@@ -17,4 +20,37 @@ type WhenMouseHandler = (e: PointerEvent) => any
 export const whenMouse = (handler: WhenMouseHandler): WhenMouseHandler => {
   return (e: PointerEvent) =>
     e.pointerType === 'mouse' ? handler(e) : undefined
+}
+
+export const getEventCode = (event: KeyboardEvent): string => {
+  if (event.code && event.code !== 'Unidentified') return event.code
+  // On android, event.code is always '' (see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code#browser_compatibility)
+  const key = getEventKey(event)
+
+  if (key) {
+    if (Object.values(EVENT_CODE).includes(key)) return key
+
+    switch (key) {
+      case ' ':
+        return EVENT_CODE.space
+      default:
+        return ''
+    }
+  }
+
+  return ''
+}
+
+export const getEventKey = (event: KeyboardEvent): string => {
+  let key = event.key && event.key !== 'Unidentified' ? event.key : ''
+
+  // On Android, event.key and event.code may not be useful when entering characters or space
+  // So here we directly get the last character of the input
+  // **only takes effect in the keyup event**
+  if (!key && event.type === 'keyup' && isAndroid()) {
+    const target = event.target as HTMLInputElement
+    key = target.value.charAt(target.selectionStart! - 1)
+  }
+
+  return key
 }


### PR DESCRIPTION
fix #20330, close #21013

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

replace event.code with getEventCode for consistent keyboard event handling

- Updated various components to utilize getEventCode for handling keyboard events instead of directly accessing event.code.
- This change improves compatibility across different browsers and devices, particularly addressing issues with Android.
