### PR TITLE
style(theme-chalk): same height across pickers for range date pickers

### DIFF
--- a/packages/theme-chalk/src/date-picker/date-range-picker.scss
+++ b/packages/theme-chalk/src/date-picker/date-range-picker.scss
@@ -74,7 +74,7 @@
   }
 
   @include e(content) {
-    float: left;
+    display: table-cell;
     width: 50%;
     box-sizing: border-box;
     margin: 0;


### PR DESCRIPTION
| Before | After |
|--------|-------|
| <img width="654" height="422" alt="image" src="https://github.com/user-attachments/assets/f53de661-26cb-4ca9-b95b-d8c1d9d5fbc5" />| <img width="651" height="428" alt="image" src="https://github.com/user-attachments/assets/e0dce5ec-5074-426a-8da3-cf98dcb8e081" /> |

