### PR TITLE
fix(components): [tree] optimize tree-select empty detection

### DIFF
--- a/packages/components/tree-select/__tests__/tree-select.test.tsx
+++ b/packages/components/tree-select/__tests__/tree-select.test.tsx
@@ -972,6 +972,7 @@ describe('TreeSelect.vue', () => {
   test('render slot `empty`', async () => {
     const { wrapper, tree } = createComponent({
       props: {
+        modelValue: '',
         data: [],
       },
       slots: {

--- a/packages/components/tree-select/__tests__/tree-select.test.tsx
+++ b/packages/components/tree-select/__tests__/tree-select.test.tsx
@@ -968,4 +968,23 @@ describe('TreeSelect.vue', () => {
     await input.trigger('focus')
     expect(wrapper.findComponent(CircleClose).exists()).toBe(true)
   })
+
+  test('render slot `empty`', async () => {
+    const { wrapper, tree } = createComponent({
+      props: {
+        data: [],
+      },
+      slots: {
+        empty: () => <div class="empty-slot">EmptySlot</div>,
+      },
+    })
+    const input = wrapper.find('input')
+    await input.trigger('blur')
+    await input.trigger('focus')
+    expect(
+      document.querySelector<HTMLElement>('.empty-slot')?.textContent
+    ).toBe('EmptySlot')
+    expect(tree.find('.el-tree').exists()).toBe(true)
+    expect(tree.find('.el-tree__empty-block').exists()).toBe(false)
+  })
 })

--- a/packages/components/tree/__tests__/tree.test.ts
+++ b/packages/components/tree/__tests__/tree.test.ts
@@ -2043,4 +2043,21 @@ describe('Tree.vue', () => {
     expect(nodeLabelWrapper1.text()).toEqual('customize: Level one 1')
     expect(nodeLabelWrapper2.text()).toEqual('Level one 2')
   })
+
+  test('render slot `empty`', async () => {
+    const wrapper = mount({
+      template: `
+        <el-tree :data="[]">
+          <template #empty>
+            EmptySlot
+          </template>
+        </el-tree>
+      `,
+      components: {
+        'el-tree': Tree,
+      },
+    })
+    await nextTick()
+    expect(wrapper.find('.el-tree__empty-block').text()).toBe('EmptySlot')
+  })
 })

--- a/packages/components/tree/src/tree.vue
+++ b/packages/components/tree/src/tree.vue
@@ -41,7 +41,6 @@ import {
   computed,
   defineComponent,
   getCurrentInstance,
-  inject,
   provide,
   ref,
   watch,
@@ -49,7 +48,6 @@ import {
 import { definePropType, iconPropType } from '@element-plus/utils'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { formItemContextKey } from '@element-plus/components/form'
-import { selectKey } from '@element-plus/components/select/src/token'
 import TreeStore from './model/tree-store'
 import { getNodeKey as getNodeKeyUtil, handleCurrentChange } from './model/util'
 import ElTreeNode from './tree-node.vue'
@@ -164,7 +162,6 @@ export default defineComponent({
   setup(props, ctx) {
     const { t } = useLocale()
     const ns = useNamespace('tree')
-    const selectInfo = inject(selectKey, null)
 
     const store = ref<TreeStore>(
       new TreeStore({
@@ -203,16 +200,26 @@ export default defineComponent({
 
     useKeydown({ el$ }, store)
 
+    const instance = getCurrentInstance()
+
+    const isSelectTree = computed(() => {
+      let parent = instance?.parent
+      while (parent) {
+        if (parent.type.name === 'ElTreeSelect') {
+          return true
+        }
+        parent = parent.parent
+      }
+      return false
+    })
+
     const isEmpty = computed(() => {
       const { childNodes } = root.value
-      const hasFilteredOptions = selectInfo
-        ? (selectInfo as any).hasFilteredOptions !== 0
-        : false
       return (
         (!childNodes ||
           childNodes.length === 0 ||
           childNodes.every(({ visible }) => !visible)) &&
-        !hasFilteredOptions
+        !isSelectTree.value
       )
     })
 
@@ -399,7 +406,7 @@ export default defineComponent({
       store,
       root,
       currentNode,
-      instance: getCurrentInstance(),
+      instance,
     })
 
     provide(formItemContextKey, undefined)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
fixed #21264

**Description**
The empty-check logic of `ElTreeSelect` uses `ElSelect`.

[playground](https://element-plus.run/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxlbC1zZWxlY3Q+XG4gICAgPGVsLW9wdGlvbiBoaWRkZW4gdmFsdWU9XCJcIj48L2VsLW9wdGlvbj5cbiAgICA8ZWwtdHJlZSA6ZGF0YT1cIltdXCI+XG4gICAgICA8dGVtcGxhdGUgI2VtcHR5PlxuICAgICAgICAxMjNcbiAgICAgIDwvdGVtcGxhdGU+XG4gICAgPC9lbC10cmVlPlxuICA8L2VsLXNlbGVjdD5cbjwvdGVtcGxhdGU+XG4iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgY29uc3Qgc3R5bGVzID0gWydodHRwczovL3ByZXZpZXctMjIzMDItZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmNzcycsICdodHRwczovL3ByZXZpZXctMjIzMDItZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS90aGVtZS1jaGFsay9kYXJrL2Nzcy12YXJzLmNzcyddLm1hcCgoc3R5bGUpID0+IHtcbiAgICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICAgIGxpbmsuaHJlZiA9IHN0eWxlXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2xvYWQnLCByZXNvbHZlKVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdlcnJvcicsIHJlamVjdClcbiAgICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gICAgfSlcbiAgfSlcbiAgcmV0dXJuIFByb21pc2UuYWxsU2V0dGxlZChzdHlsZXMpXG59XG4iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcbiAgICBcImpzeFwiOiBcInByZXNlcnZlXCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJ0eXBlc1wiOiBbXCJlbGVtZW50LXBsdXMvZ2xvYmFsLmQudHNcIl0sXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwiUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3J1bnRpbWUtZG9tQGxhdGVzdC9kaXN0L3J1bnRpbWUtZG9tLmVzbS1icm93c2VyLmpzXCIsXG4gICAgXCJAdnVlL3NoYXJlZFwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9zaGFyZWRAbGF0ZXN0L2Rpc3Qvc2hhcmVkLmVzbS1idW5kbGVyLmpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL3ByZXZpZXctMjIzMDItZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcInVuc3VwcG9ydGVkXCIsXG4gICAgXCJAZWxlbWVudC1wbHVzL2ljb25zLXZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQGVsZW1lbnQtcGx1cy9pY29ucy12dWVAMi9kaXN0L2luZGV4Lm1pbi5qc1wiXG4gIH0sXG4gIFwic2NvcGVzXCI6IHt9XG59IiwiX28iOnsic2hvd0hpZGRlbiI6dHJ1ZSwic3R5bGVTb3VyY2UiOiJodHRwczovL3ByZXZpZXctMjIzMDItZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmNzcyJ9fQ==)