### PR TITLE
fix(components): [table] prevent incorrect drag when resizable is false

### DIFF
--- a/packages/components/table/src/table-header/event-helper.ts
+++ b/packages/components/table/src/table-header/event-helper.ts
@@ -49,7 +49,11 @@ function useEvent<T extends DefaultRow>(
     if (!isClient) return
     if (column.children && column.children.length > 0) return
     /* istanbul ignore if */
-    if (draggingColumn.value && props.border) {
+    if (
+      draggingColumn.value &&
+      props.border &&
+      draggingColumn.value.id === column.id
+    ) {
       dragging.value = true
 
       const table = parent


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #22325 

When the bug reproduces, `draggingColumn` and `column` in `handleMouseDown` are not the same column, so I added a check.