### PR TITLE
fix(components): [date-picker] should not pick a value when change view

### DIFF
--- a/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
+++ b/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
@@ -204,7 +204,13 @@ export const useBasicDateTable = (
     }
   )
 
-  const focus = async () => unref(currentCellRef)?.focus()
+  let suppressNextAutoFocus = false
+
+  const focus = async () => {
+    suppressNextAutoFocus = true
+    unref(currentCellRef)?.focus()
+    suppressNextAutoFocus = false
+  }
 
   const isCurrent = (cell: DateCell): boolean => {
     return (
@@ -268,12 +274,18 @@ export const useBasicDateTable = (
 
   const isSelectedCell = (cell: DateCell) => {
     return (
-      (!unref(hasCurrent) && cell?.text === 1 && isNormalDay(cell.type)) ||
-      cell.isCurrent
+      cell.isCurrent ||
+      (!unref(hasCurrent) &&
+        isNormalDay(cell.type) &&
+        cellMatchesDate(cell, props.date))
     )
   }
 
   const handleFocus = (event: FocusEvent) => {
+    if (suppressNextAutoFocus) {
+      suppressNextAutoFocus = false
+      return
+    }
     if (focusWithClick || unref(hasCurrent) || props.selectionMode !== 'date')
       return
     handlePickDate(event, true)

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-pick.vue
@@ -505,7 +505,8 @@ const handleYearPick = async (
     innerDate.value = getValidDateOfYear(data, lang.value, disabledDate)
     currentView.value = 'month'
     if (['month', 'year', 'date', 'week'].includes(selectionMode.value)) {
-      // TODO: fallback focus into basic month table
+      await nextTick()
+      handleFocusPicker()
     }
   }
   handlePanelChange('year')

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-pick.vue
@@ -484,9 +484,7 @@ const handleMonthPick = async (
     )
     currentView.value = 'date'
     if (['month', 'year', 'date', 'week'].includes(selectionMode.value)) {
-      emit(innerDate.value, true)
-      await nextTick()
-      handleFocusPicker()
+      // TODO: fallback focus into basic date table
     }
   }
   handlePanelChange('month')
@@ -507,9 +505,7 @@ const handleYearPick = async (
     innerDate.value = getValidDateOfYear(data, lang.value, disabledDate)
     currentView.value = 'month'
     if (['month', 'year', 'date', 'week'].includes(selectionMode.value)) {
-      emit(innerDate.value, true)
-      await nextTick()
-      handleFocusPicker()
+      // TODO: fallback focus into basic month table
     }
   }
   handlePanelChange('year')

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-pick.vue
@@ -484,7 +484,8 @@ const handleMonthPick = async (
     )
     currentView.value = 'date'
     if (['month', 'year', 'date', 'week'].includes(selectionMode.value)) {
-      // TODO: fallback focus into basic date table
+      await nextTick()
+      handleFocusPicker()
     }
   }
   handlePanelChange('month')

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -477,37 +477,36 @@ describe('DatePicker', () => {
     expect(input.element.value).toBe('2023-02-04')
   })
 
-  it('should not pick a value when changing picker view', async () => {
-    const wrapper = _mount(`<el-date-picker v-model="value" />`, () => ({
-      value: '',
-      disabledDate(time) {
-        const dayTime = new Date(2023, 1, 4).getTime()
-        return time.getTime() < dayTime
-      },
-    }))
+  it('should not emit during year > month > date view navigation', async () => {
+    const onUpdateModelValue = vi.fn()
+    const wrapper = _mount(
+      `<el-date-picker
+        v-model="value"
+        @update:modelValue="onUpdateModelValue"
+    />`,
+      () => ({ value: '2024-06-15', onUpdateModelValue })
+    )
     const input = wrapper.find('input')
     input.trigger('blur')
     input.trigger('focus')
     await nextTick()
-    const yearLabel: HTMLElement = document.querySelectorAll(
-      '.el-date-picker__header-label'
-    )[0]
-    yearLabel.click()
+    ;(
+      document.querySelectorAll(
+        '.el-date-picker__header-label'
+      )[0] as HTMLElement
+    ).click()
     await nextTick()
-    const yearCells = document.querySelectorAll('.el-date-table-cell__text')
-    const year2023 = [...yearCells].find((item) => item.innerHTML === '2023')
-    year2023.click()
+    ;[...document.querySelectorAll('.el-date-table-cell__text')]
+      .find((el) => el.innerHTML === '2025')!
+      .click()
     await nextTick()
-    const monthLabel: HTMLElement = document.querySelectorAll(
-      '.el-date-picker__header-label'
-    )[1]
-    monthLabel.click()
+    document.querySelectorAll('.el-date-table-cell__text')[2].click()
     await nextTick()
-    const monthCells = document.querySelectorAll('.el-date-table-cell__text')
-    const februaryCell = monthCells[1]
-    februaryCell.click()
+    expect(onUpdateModelValue).not.toHaveBeenCalled()
+
+    document.querySelector('td.available .el-date-table-cell__text')!.click()
     await nextTick()
-    expect(input.element.value).toBe('')
+    expect(onUpdateModelValue).toHaveBeenCalledTimes(1)
   })
 
   it('should work when using disabledDate prop and daterange type', async () => {
@@ -1852,7 +1851,8 @@ describe('DatePicker keyboard events', () => {
     await nextTick()
     triggerEvent(input, 'keydown', EVENT_CODE.down)
     await nextTick()
-    expect(document.querySelector('.current')?.textContent).toBe('1')
+    const focusedCell = document.querySelector('td[tabindex="0"]')
+    expect(focusedCell.classList.contains('available')).toBe(true)
   })
 })
 

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -443,36 +443,6 @@ describe('DatePicker', () => {
     expect(document.querySelector('.disabled')).not.toBeNull()
   })
 
-  it('select year picker when using disabledDate prop', async () => {
-    const wrapper = _mount(
-      `<el-date-picker
-        v-model="value"
-        :disabledDate="disabledDate"
-    />`,
-      () => ({
-        value: '2024-01-01',
-        disabledDate(time) {
-          const dayTime = new Date(2023, 1, 4).getTime()
-          return time.getTime() < dayTime
-        },
-      })
-    )
-    const input = wrapper.find('input')
-    input.trigger('blur')
-    input.trigger('focus')
-    await nextTick()
-    const yearLabel: HTMLElement = document.querySelectorAll(
-      '.el-date-picker__header-label'
-    )[0]
-    yearLabel.click()
-    await nextTick()
-    const yearCells = document.querySelectorAll('.el-date-table-cell__text')
-    const year2023 = [...yearCells].find((item) => item.innerHTML === '2023')
-    year2023.click()
-    await nextTick()
-    expect(input.element.value).toBe('2023-02-04')
-  })
-
   it('select month picker when using disabledDate prop', async () => {
     const wrapper = _mount(
       `<el-date-picker
@@ -499,6 +469,10 @@ describe('DatePicker', () => {
     const monthCells = document.querySelectorAll('.el-date-table-cell__text')
     const februaryCell = monthCells[1]
     februaryCell.click()
+    await nextTick()
+    document
+      .querySelector<HTMLElement>('td.available .el-date-table-cell__text')
+      .click()
     await nextTick()
     expect(input.element.value).toBe('2023-02-04')
   })

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -477,6 +477,39 @@ describe('DatePicker', () => {
     expect(input.element.value).toBe('2023-02-04')
   })
 
+  it('should not pick a value when changing picker view', async () => {
+    const wrapper = _mount(`<el-date-picker v-model="value" />`, () => ({
+      value: '',
+      disabledDate(time) {
+        const dayTime = new Date(2023, 1, 4).getTime()
+        return time.getTime() < dayTime
+      },
+    }))
+    const input = wrapper.find('input')
+    input.trigger('blur')
+    input.trigger('focus')
+    await nextTick()
+    const yearLabel: HTMLElement = document.querySelectorAll(
+      '.el-date-picker__header-label'
+    )[0]
+    yearLabel.click()
+    await nextTick()
+    const yearCells = document.querySelectorAll('.el-date-table-cell__text')
+    const year2023 = [...yearCells].find((item) => item.innerHTML === '2023')
+    year2023.click()
+    await nextTick()
+    const monthLabel: HTMLElement = document.querySelectorAll(
+      '.el-date-picker__header-label'
+    )[1]
+    monthLabel.click()
+    await nextTick()
+    const monthCells = document.querySelectorAll('.el-date-table-cell__text')
+    const februaryCell = monthCells[1]
+    februaryCell.click()
+    await nextTick()
+    expect(input.element.value).toBe('')
+  })
+
   it('should work when using disabledDate prop and daterange type', async () => {
     const wrapper = _mount(
       `<el-date-picker

--- a/packages/theme-chalk/src/date-picker/date-table.scss
+++ b/packages/theme-chalk/src/date-picker/date-table.scss
@@ -148,6 +148,14 @@
     &:focus {
       outline: none;
     }
+
+  }
+
+  &:not(.is-week-mode) td:focus-visible:not(.disabled) {
+    .#{$namespace}-date-table-cell__text {
+      outline: 2px solid getCssVar('datepicker-active-color');
+      outline-offset: 1px;
+    }
   }
 
   th {


### PR DESCRIPTION
fix https://github.com/element-plus/element-plus/issues/7842, fix https://github.com/element-plus/element-plus/discussions/21815

When switching the view in `type="date"`, the date-picker pick a value.
Before:
![Peek 2025-09-26 13-32](https://github.com/user-attachments/assets/d6ac3efe-bfc7-45a8-9ecf-f11ae514856b)

It is very annoying so i removed this behavior.

This is actually not the right way to fix the issue because now the focus leave the date-picker.
Other actions like "changing view with arrows" also don't support the fallback focus too and only keyboard users may notice the small difference so i think it's a fine trade off.

The right fix would involve a lot of refactor even if we think it is not. So i decided just removed this annoying behavior for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved unintended auto-focus behavior during date selection actions
  * Improved date and month selection logic in date picker views
  * Fixed view navigation flow between year, month, and date selections

* **Accessibility**
  * Enhanced focus indicators for date picker cells with improved keyboard navigation visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->