### PR TITLE
fix(components): [checkbox-group/radio-group] avoid passing alias fields to component

### DIFF
--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -193,7 +193,7 @@ describe('Checkbox', () => {
       <CheckboxGroup
         v-model={modelValue.value}
         options={options}
-        props={{ value: 'name' }}
+        props={{ label: 'name' }}
       />
     ))
     await nextTick()

--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -186,6 +186,21 @@ describe('Checkbox', () => {
     expect(checkboxes[2].classes()).toContain('is-disabled')
   })
 
+  test('should avoid passing alias fields to el-checkbox', async () => {
+    const modelValue = ref(1)
+    const options = [{ value: '3', name: 'Option A' }]
+    const wrapper = mount(() => (
+      <CheckboxGroup
+        v-model={modelValue.value}
+        options={options}
+        props={{ value: 'name' }}
+      />
+    ))
+    await nextTick()
+    const checkbox = wrapper.find('.el-checkbox')
+    expect(checkbox.find('input').attributes('name')).not.toBe('Option A')
+  })
+
   test('checkbox group with dynamic modelValue', async () => {
     const form = reactive<{ checked: string }>({ checked: '' })
     const wrapper = mount({

--- a/packages/components/checkbox/src/checkbox-group.vue
+++ b/packages/components/checkbox/src/checkbox-group.vue
@@ -21,7 +21,7 @@
 
 <script lang="ts" setup>
 import { computed, nextTick, provide, toRefs, watch } from 'vue'
-import { isEqual, pick } from 'lodash-unified'
+import { isEqual, omit, pick } from 'lodash-unified'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { debugWarn } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
@@ -69,12 +69,13 @@ const aliasProps = computed(() => ({
   ...props.props,
 }))
 const getOptionProps = (option: Record<string, any>) => {
+  const { label, value, disabled } = aliasProps.value
   const base = {
-    label: option[aliasProps.value.label],
-    value: option[aliasProps.value.value],
-    disabled: option[aliasProps.value.disabled],
+    label: option[label],
+    value: option[value],
+    disabled: option[disabled],
   }
-  return { ...option, ...base }
+  return { ...omit(option, [label, value, disabled]), ...base }
 }
 
 provide(checkboxGroupContextKey, {

--- a/packages/components/radio/__tests__/radio.test.tsx
+++ b/packages/components/radio/__tests__/radio.test.tsx
@@ -264,6 +264,21 @@ describe('Radio group', () => {
     expect(radio.value).toEqual(6)
   })
 
+  it('should avoid passing alias fields to el-radio', async () => {
+    const modelValue = ref(1)
+    const options = [{ value: '3', name: 'Option A' }]
+    const wrapper = mount(() => (
+      <RadioGroup
+        v-model={modelValue.value}
+        options={options}
+        props={{ label: 'name' }}
+      />
+    ))
+    await nextTick()
+    const radio = wrapper.find('.el-radio')
+    expect(radio.find('input').attributes('name')).not.toBe('Option A')
+  })
+
   it('passes custom attributes from options to el-radio', () => {
     const options = [
       { value: 'a', label: 'A', 'data-test': 'custom-attr-1' },

--- a/packages/components/radio/src/radio-group.vue
+++ b/packages/components/radio/src/radio-group.vue
@@ -38,7 +38,7 @@ import {
   radioGroupProps,
 } from './radio-group'
 import { radioGroupKey } from './constants'
-import { isEqual } from 'lodash-unified'
+import { isEqual, omit } from 'lodash-unified'
 import ElRadio from './radio.vue'
 
 import type { RadioGroupProps } from './radio-group'
@@ -81,12 +81,13 @@ const aliasProps = computed(() => ({
   ...props.props,
 }))
 const getOptionProps = (option: Record<string, any>) => {
+  const { label, value, disabled } = aliasProps.value
   const base = {
-    label: option[aliasProps.value.label],
-    value: option[aliasProps.value.value],
-    disabled: option[aliasProps.value.disabled],
+    label: option[label],
+    value: option[value],
+    disabled: option[disabled],
   }
-  return { ...option, ...base }
+  return { ...omit(option, [label, value, disabled]), ...base }
 }
 
 provide(


### PR DESCRIPTION
I think **alias** properties should not be passed to the component. If an alias overlaps with an existing property name, it may cause unexpected behavior. 

For example, in the documentation, el-radio-group is supposed to have only one focusable element, but currently multiple focus points appear.
<img src="https://github.com/user-attachments/assets/b0cdd89f-bfa2-4743-853b-163955e59015" height="200" />


In extreme cases, this could even result in runtime errors. Here’s an example: [Playground](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8aDI+Q2xpY2sgXCJPcHRpb24gQlwiPC9oMj5cblxuICA8ZWwtcmFkaW8tZ3JvdXAgdi1tb2RlbD1cInJhZGlvXCIgOm9wdGlvbnM9XCJvcHRpb25zXCIgOnByb3BzPVwicHJvcHNcIiAvPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3QgcmFkaW8gPSByZWYoMylcbmNvbnN0IHByb3BzID0geyB2YWx1ZTogJ2lkJywgbGFiZWw6ICdvbkNoYW5nZScsIGRpc2FibGVkOiAndW5hYmxlJyB9XG5jb25zdCBvcHRpb25zID0gW1xuICB7XG4gICAgaWQ6IDMsXG4gICAgb25DaGFuZ2U6ICdPcHRpb24gQScsXG4gIH0sXG4gIHtcbiAgICBpZDogNixcbiAgICBvbkNoYW5nZTogJ09wdGlvbiBCJyxcbiAgfSxcbiAge1xuICAgIGlkOiA5LFxuICAgIG9uQ2hhbmdlOiAnT3B0aW9uIEMnLFxuICAgIHVuYWJsZTogdHJ1ZSxcbiAgfSxcbl1cbjwvc2NyaXB0PlxuIiwiZWxlbWVudC1wbHVzLmpzIjoiaW1wb3J0IEVsZW1lbnRQbHVzIGZyb20gJ2VsZW1lbnQtcGx1cydcbmltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcblxubGV0IGluc3RhbGxlZCA9IGZhbHNlXG5hd2FpdCBsb2FkU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gc2V0dXBFbGVtZW50UGx1cygpIHtcbiAgaWYgKGluc3RhbGxlZCkgcmV0dXJuXG4gIGNvbnN0IGluc3RhbmNlID0gZ2V0Q3VycmVudEluc3RhbmNlKClcbiAgaW5zdGFuY2UuYXBwQ29udGV4dC5hcHAudXNlKEVsZW1lbnRQbHVzKVxuICBpbnN0YWxsZWQgPSB0cnVlXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkU3R5bGUoKSB7XG4gIGNvbnN0IHN0eWxlcyA9IFsnaHR0cHM6Ly91bnBrZy5jb20vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmNzcycsICdodHRwczovL3VucGtnLmNvbS9lbGVtZW50LXBsdXNAbGF0ZXN0L3RoZW1lLWNoYWxrL2RhcmsvY3NzLXZhcnMuY3NzJ10ubWFwKChzdHlsZSkgPT4ge1xuICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgICAgbGluay5ocmVmID0gc3R5bGVcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgICB9KVxuICB9KVxuICByZXR1cm4gUHJvbWlzZS5hbGxTZXR0bGVkKHN0eWxlcylcbn1cbiIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3VucGtnLmNvbS9AdnVlL3J1bnRpbWUtZG9tQGxhdGVzdC9kaXN0L3J1bnRpbWUtZG9tLmVzbS1icm93c2VyLmpzXCIsXG4gICAgXCJAdnVlL3NoYXJlZFwiOiBcImh0dHBzOi8vdW5wa2cuY29tL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly91bnBrZy5jb20vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcImh0dHBzOi8vdW5wa2cuY29tL2VsZW1lbnQtcGx1c0BsYXRlc3QvXCIsXG4gICAgXCJAZWxlbWVudC1wbHVzL2ljb25zLXZ1ZVwiOiBcImh0dHBzOi8vdW5wa2cuY29tL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsIl9vIjp7fX0=)

<img src="https://github.com/user-attachments/assets/941ffb26-33ad-4a6c-b8ce-1665cadf0f69" height="200">
