### PR TITLE
fix(components): [input-number] arrow key repeat and disabled-scientific not working

### DIFF
--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -659,19 +659,19 @@ describe('InputNumber.vue', () => {
     ))
     const input = wrapper.find('input')
     const preventDefault = vi.fn()
-    await input.trigger('keydown', {
+    await input.trigger('keyup', {
       key: 'e',
       preventDefault,
     })
     expect(preventDefault).toHaveBeenCalled()
     preventDefault.mockClear()
-    await input.trigger('keydown', {
+    await input.trigger('keyup', {
       key: 'E',
       preventDefault,
     })
     expect(preventDefault).toHaveBeenCalled()
     preventDefault.mockClear()
-    await input.trigger('keydown', {
+    await input.trigger('keyup', {
       key: '1',
       preventDefault,
     })

--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -659,19 +659,19 @@ describe('InputNumber.vue', () => {
     ))
     const input = wrapper.find('input')
     const preventDefault = vi.fn()
-    await input.trigger('keyup', {
+    await input.trigger('keydown', {
       key: 'e',
       preventDefault,
     })
     expect(preventDefault).toHaveBeenCalled()
     preventDefault.mockClear()
-    await input.trigger('keyup', {
+    await input.trigger('keydown', {
       key: 'E',
       preventDefault,
     })
     expect(preventDefault).toHaveBeenCalled()
     preventDefault.mockClear()
-    await input.trigger('keyup', {
+    await input.trigger('keydown', {
       key: '1',
       preventDefault,
     })

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -57,7 +57,6 @@
       :validate-event="false"
       :inputmode="inputmode"
       @keydown="handleKeydown"
-      @keyup="handleKeydown"
       @blur="handleBlur"
       @focus="handleFocus"
       @input="handleInput"

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -57,7 +57,6 @@
       :validate-event="false"
       :inputmode="inputmode"
       @keydown="handleKeydown"
-      @keyup="handleKeyup"
       @blur="handleBlur"
       @focus="handleFocus"
       @input="handleInput"
@@ -233,14 +232,6 @@ const handleKeydown = (event: KeyboardEvent | Event) => {
       decrease()
       break
     }
-  }
-}
-const handleKeyup = (event: KeyboardEvent | Event) => {
-  const key = getEventKey(event as KeyboardEvent)
-
-  if (props.disabledScientific && ['e', 'E'].includes(key)) {
-    event.preventDefault()
-    return
   }
 }
 const increase = () => {

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -56,7 +56,7 @@
       :aria-label="ariaLabel"
       :validate-event="false"
       :inputmode="inputmode"
-      @keyup="handleKeydown"
+      @keydown="handleKeydown"
       @blur="handleBlur"
       @focus="handleFocus"
       @input="handleInput"

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -57,6 +57,7 @@
       :validate-event="false"
       :inputmode="inputmode"
       @keydown="handleKeydown"
+      @keyup="handleKeyup"
       @blur="handleBlur"
       @focus="handleFocus"
       @input="handleInput"
@@ -221,19 +222,25 @@ const handleKeydown = (event: KeyboardEvent | Event) => {
     return
   }
 
-  if (event.type === 'keydown') {
-    switch (code) {
-      case EVENT_CODE.up: {
-        event.preventDefault()
-        increase()
-        break
-      }
-      case EVENT_CODE.down: {
-        event.preventDefault()
-        decrease()
-        break
-      }
+  switch (code) {
+    case EVENT_CODE.up: {
+      event.preventDefault()
+      increase()
+      break
     }
+    case EVENT_CODE.down: {
+      event.preventDefault()
+      decrease()
+      break
+    }
+  }
+}
+const handleKeyup = (event: KeyboardEvent | Event) => {
+  const key = getEventKey(event as KeyboardEvent)
+
+  if (props.disabledScientific && ['e', 'E'].includes(key)) {
+    event.preventDefault()
+    return
   }
 }
 const increase = () => {

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -57,6 +57,7 @@
       :validate-event="false"
       :inputmode="inputmode"
       @keydown="handleKeydown"
+      @keyup="handleKeydown"
       @blur="handleBlur"
       @focus="handleFocus"
       @input="handleInput"
@@ -221,16 +222,18 @@ const handleKeydown = (event: KeyboardEvent | Event) => {
     return
   }
 
-  switch (code) {
-    case EVENT_CODE.up: {
-      event.preventDefault()
-      increase()
-      break
-    }
-    case EVENT_CODE.down: {
-      event.preventDefault()
-      decrease()
-      break
+  if (event.type === 'keydown') {
+    switch (code) {
+      case EVENT_CODE.up: {
+        event.preventDefault()
+        increase()
+        break
+      }
+      case EVENT_CODE.down: {
+        event.preventDefault()
+        decrease()
+        break
+      }
     }
   }
 }


### PR DESCRIPTION
1. Arrow up/down keys trigger value changes twice
2. The `disabled-scientific` attribute not working

I’m not sure why the change was made from keydown to keyup, but for me, ensuring the feature works correctly on PC is more important.