### PR TITLE
docs(components): [dialog/drawer] comprehensive warnings

### DIFF
--- a/docs/en-US/component/dialog.md
+++ b/docs/en-US/component/dialog.md
@@ -215,7 +215,7 @@ dialog/events
 
 :::warning
 
-`title` has been **deprecated**, and **will be** removed in ^(2.4.0), please use `header`.
+`title` has been **deprecated**, and **will be** removed in ^(3.0.0), please use `header`.
 
 :::
 

--- a/docs/en-US/component/drawer.md
+++ b/docs/en-US/component/drawer.md
@@ -142,6 +142,12 @@ Drawer provides an API called `destroy-on-close`, which is a flag variable that 
 | footer              | Drawer footer Section                                                                          |
 | title ^(deprecated) | Works the same as the header slot. Use that instead.                                           |
 
+:::warning
+
+`title` has been **deprecated**, and **will be** removed in ^(3.0.0), please use `header`.
+
+:::
+
 ### Exposes
 
 | Name        | Description                                                     |


### PR DESCRIPTION
1. dialog have `useDeprecated` for version 3.0 but it has a warning in the doc for `2.4.0` and still use the slot title in the code.
2. Drawer didn't has the warning about the deprecation.