### PR TITLE
feat(components): [color-picker-panel] sv-panel a11y

### DIFF
--- a/packages/components/color-picker-panel/src/__tests__/color-picker-panel.test.tsx
+++ b/packages/components/color-picker-panel/src/__tests__/color-picker-panel.test.tsx
@@ -564,4 +564,89 @@ describe('Color-picker-panel', () => {
     expect(input!.value).toEqual('#409cff')
     wrapper.unmount()
   })
+
+  it('control saturation and brightness changes through keyboard', async () => {
+    const color = ref('#409eff')
+    const wrapper = mount(() => <ColorPickerPanel v-model={color.value} />)
+
+    const cursor = wrapper.find('.el-color-svpanel__cursor')
+    await cursor.trigger('keydown', {
+      key: EVENT_CODE.down,
+      code: EVENT_CODE.down,
+    })
+    const input = wrapper.find<HTMLInputElement>('input').element
+    expect(input!.value).toEqual('#3f9cfc')
+
+    await cursor.trigger('keydown', {
+      key: EVENT_CODE.left,
+      code: EVENT_CODE.left,
+    })
+    expect(input!.value).toEqual('#429efc')
+
+    await cursor.trigger('keydown', {
+      key: EVENT_CODE.up,
+      code: EVENT_CODE.up,
+    })
+    expect(input!.value).toEqual('#429fff')
+
+    await cursor.trigger('keydown', {
+      key: EVENT_CODE.right,
+      code: EVENT_CODE.right,
+    })
+    expect(input!.value).toEqual('#409eff')
+
+    wrapper.unmount()
+  })
+
+  describe('a11y label', () => {
+    it('default', async () => {
+      const color = ref('#409eff')
+      const wrapper = mount(() => <ColorPickerPanel v-model={color.value} />)
+      const svPanel = wrapper.find('.el-color-svpanel__cursor')
+
+      expect(svPanel.attributes('tabindex')).toBe('0')
+      expect(svPanel.attributes('role')).toBe('slider')
+      expect(svPanel.attributes('aria-valuemin')).toBe('0,0')
+      expect(svPanel.attributes('aria-valuemax')).toBe('100,100')
+      expect(svPanel.attributes('aria-valuenow')).toBe('75,100')
+      expect(svPanel.attributes('aria-label')).toBe(
+        'pick saturation and brightness value'
+      )
+      expect(svPanel.attributes('aria-valuetext')).toBe(
+        'saturation 75, brightness 100, current color is #409eff'
+      )
+
+      const hueSlider = wrapper.find('.el-color-hue-slider__thumb')
+      expect(hueSlider.attributes('tabindex')).toBe('0')
+      expect(hueSlider.attributes('role')).toBe('slider')
+      expect(hueSlider.attributes('aria-valuemin')).toBe('0')
+      expect(hueSlider.attributes('aria-valuemax')).toBe('360')
+      expect(hueSlider.attributes('aria-valuenow')).toBe('210')
+      expect(hueSlider.attributes('aria-label')).toBe('pick hue value')
+      expect(hueSlider.attributes('aria-valuetext')).toBe(
+        'hue 210, current color is #409eff'
+      )
+
+      wrapper.unmount()
+    })
+
+    it('with show-alpha', async () => {
+      const color = ref('rgba(64, 158, 255, 0.5)')
+      const wrapper = mount(() => (
+        <ColorPickerPanel v-model={color.value} show-alpha />
+      ))
+      const alphaSlider = wrapper.find('.el-color-alpha-slider__thumb')
+      expect(alphaSlider.attributes('tabindex')).toBe('0')
+      expect(alphaSlider.attributes('role')).toBe('slider')
+      expect(alphaSlider.attributes('aria-valuemin')).toBe('0')
+      expect(alphaSlider.attributes('aria-valuemax')).toBe('100')
+      expect(alphaSlider.attributes('aria-valuenow')).toBe('50')
+      expect(alphaSlider.attributes('aria-label')).toBe('pick alpha value')
+      expect(alphaSlider.attributes('aria-valuetext')).toBe(
+        'alpha 50, current color is rgba(64, 158, 255, 0.5)'
+      )
+
+      wrapper.unmount()
+    })
+  })
 })

--- a/packages/components/color-picker-panel/src/composables/use-sv-panel.ts
+++ b/packages/components/color-picker-panel/src/composables/use-sv-panel.ts
@@ -1,0 +1,175 @@
+import { computed, getCurrentInstance, onMounted, ref, watch } from 'vue'
+import { EVENT_CODE } from '@element-plus/constants'
+import { useNamespace } from '@element-plus/hooks'
+import { addUnit, getClientXY, getEventCode } from '@element-plus/utils'
+import { draggable } from '../utils/draggable'
+
+import type { SvPanelProps } from '../props/sv-panel'
+
+export const useSvPanel = (props: SvPanelProps) => {
+  const instance = getCurrentInstance()!
+
+  const cursorRef = ref<HTMLElement>()
+  const cursorTop = ref(0)
+  const cursorLeft = ref(0)
+  const background = ref('hsl(0, 100%, 50%)')
+
+  const saturation = computed(() => props.color.get('saturation'))
+  const brightness = computed(() => props.color.get('value'))
+  const hue = computed(() => props.color.get('hue'))
+
+  function handleClick(event: MouseEvent | TouchEvent) {
+    if (props.disabled) return
+    const target = event.target
+
+    if (target !== cursorRef.value) {
+      handleDrag(event)
+    }
+    cursorRef.value?.focus({ preventScroll: true })
+  }
+
+  function handleDrag(event: MouseEvent | TouchEvent) {
+    if (props.disabled) return
+
+    const el = instance.vnode.el!
+    const rect = el.getBoundingClientRect()
+    const { clientX, clientY } = getClientXY(event)
+
+    let left = clientX - rect.left
+    let top = clientY - rect.top
+    left = Math.max(0, left)
+    left = Math.min(left, rect.width)
+
+    top = Math.max(0, top)
+    top = Math.min(top, rect.height)
+
+    cursorLeft.value = left
+    cursorTop.value = top
+    props.color.set({
+      saturation: (left / rect.width) * 100,
+      value: 100 - (top / rect.height) * 100,
+    })
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (props.disabled) return
+    const { shiftKey } = event
+    const code = getEventCode(event)
+    const step = shiftKey ? 10 : 1
+    let isPreventDefault = true
+
+    switch (code) {
+      case EVENT_CODE.left:
+        incrementSaturation(-step)
+        break
+      case EVENT_CODE.right:
+        incrementSaturation(step)
+        break
+      case EVENT_CODE.up:
+        incrementBrightness(step)
+        break
+      case EVENT_CODE.down:
+        incrementBrightness(-step)
+        break
+      default:
+        isPreventDefault = false
+        break
+    }
+
+    isPreventDefault && event.preventDefault()
+  }
+
+  function incrementSaturation(step: number) {
+    let next = saturation.value + step
+    next = next < 0 ? 0 : next > 100 ? 100 : next
+    props.color.set('saturation', next)
+  }
+
+  function incrementBrightness(step: number) {
+    let next = brightness.value + step
+    next = next < 0 ? 0 : next > 100 ? 100 : next
+    props.color.set('value', next)
+  }
+
+  return {
+    cursorRef,
+    cursorTop,
+    cursorLeft,
+    background,
+    saturation,
+    brightness,
+    hue,
+    handleClick,
+    handleDrag,
+    handleKeydown,
+  }
+}
+
+export const useSvPanelDOM = (
+  props: SvPanelProps,
+  {
+    cursorTop,
+    cursorLeft,
+    background,
+    handleDrag,
+  }: Pick<
+    ReturnType<typeof useSvPanel>,
+    'cursorTop' | 'cursorLeft' | 'background' | 'handleDrag'
+  >
+) => {
+  const instance = getCurrentInstance()!
+  const ns = useNamespace('color-svpanel')
+
+  function update() {
+    const saturation = props.color.get('saturation')
+    const brightness = props.color.get('value')
+
+    const el = instance.vnode.el!
+    const { clientWidth: width, clientHeight: height } = el
+
+    cursorLeft.value = (saturation * width) / 100
+    cursorTop.value = ((100 - brightness) * height) / 100
+
+    background.value = `hsl(${props.color.get('hue')}, 100%, 50%)`
+  }
+
+  onMounted(() => {
+    draggable(instance.vnode.el as HTMLElement, {
+      drag: (event) => {
+        handleDrag(event)
+      },
+      end: (event) => {
+        handleDrag(event)
+      },
+    })
+
+    update()
+  })
+
+  watch(
+    [
+      () => props.color.get('hue'),
+      () => props.color.get('value'),
+      () => props.color.value,
+    ],
+    () => update()
+  )
+
+  const rootKls = computed(() => [ns.b()])
+  const cursorKls = computed(() => ns.e('cursor'))
+  const rootStyle = computed(() => ({
+    backgroundColor: background.value,
+  }))
+  const cursorStyle = computed(() => ({
+    top: addUnit(cursorTop.value),
+    left: addUnit(cursorLeft.value),
+  }))
+
+  return {
+    rootKls,
+    cursorKls,
+    rootStyle,
+    cursorStyle,
+    update,
+  }
+}

--- a/packages/components/color-picker-panel/src/composables/use-sv-panel.ts
+++ b/packages/components/color-picker-panel/src/composables/use-sv-panel.ts
@@ -155,7 +155,7 @@ export const useSvPanelDOM = (
     () => update()
   )
 
-  const rootKls = computed(() => [ns.b()])
+  const rootKls = computed(() => ns.b())
   const cursorKls = computed(() => ns.e('cursor'))
   const rootStyle = computed(() => ({
     backgroundColor: background.value,

--- a/packages/components/color-picker-panel/src/props/sv-panel.ts
+++ b/packages/components/color-picker-panel/src/props/sv-panel.ts
@@ -1,0 +1,15 @@
+import { buildProps, definePropType } from '@element-plus/utils'
+
+import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
+import type Color from '../utils/color'
+
+export const svPanelProps = buildProps({
+  color: {
+    type: definePropType<Color>(Object),
+    required: true,
+  },
+  disabled: Boolean,
+} as const)
+
+export type SvPanelProps = ExtractPropTypes<typeof svPanelProps>
+export type SvPanelPropsPublic = __ExtractPublicPropTypes<typeof svPanelProps>

--- a/packages/locale/lang/af.ts
+++ b/packages/locale/lang/af.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Nou',

--- a/packages/locale/lang/ar-eg.ts
+++ b/packages/locale/lang/ar-eg.ts
@@ -13,6 +13,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'الآن',

--- a/packages/locale/lang/ar.ts
+++ b/packages/locale/lang/ar.ts
@@ -13,6 +13,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'الآن',

--- a/packages/locale/lang/az.ts
+++ b/packages/locale/lang/az.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'İndi',

--- a/packages/locale/lang/bg.ts
+++ b/packages/locale/lang/bg.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Сега',

--- a/packages/locale/lang/bn.ts
+++ b/packages/locale/lang/bn.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'এখন',

--- a/packages/locale/lang/ca.ts
+++ b/packages/locale/lang/ca.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Ara',

--- a/packages/locale/lang/ckb.ts
+++ b/packages/locale/lang/ckb.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'ئێستا',

--- a/packages/locale/lang/cs.ts
+++ b/packages/locale/lang/cs.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Teď',

--- a/packages/locale/lang/da.ts
+++ b/packages/locale/lang/da.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Nu',

--- a/packages/locale/lang/de.ts
+++ b/packages/locale/lang/de.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Jetzt',

--- a/packages/locale/lang/el.ts
+++ b/packages/locale/lang/el.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Τώρα',

--- a/packages/locale/lang/en.ts
+++ b/packages/locale/lang/en.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}',
       hueLabel: 'pick hue value',
       hueDescription: 'hue {hue}, current color is {color}',
+      svLabel: 'pick saturation and brightness value',
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}',
     },
     datepicker: {
       now: 'Now',

--- a/packages/locale/lang/eo.ts
+++ b/packages/locale/lang/eo.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Nun',

--- a/packages/locale/lang/es.ts
+++ b/packages/locale/lang/es.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Ahora',

--- a/packages/locale/lang/et.ts
+++ b/packages/locale/lang/et.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Praegu',

--- a/packages/locale/lang/eu.ts
+++ b/packages/locale/lang/eu.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Orain',

--- a/packages/locale/lang/fa.ts
+++ b/packages/locale/lang/fa.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'اکنون',

--- a/packages/locale/lang/fi.ts
+++ b/packages/locale/lang/fi.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Nyt',

--- a/packages/locale/lang/fr.ts
+++ b/packages/locale/lang/fr.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Maintenant',

--- a/packages/locale/lang/he.ts
+++ b/packages/locale/lang/he.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'כעת',

--- a/packages/locale/lang/hi.ts
+++ b/packages/locale/lang/hi.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'अभी',

--- a/packages/locale/lang/hr.ts
+++ b/packages/locale/lang/hr.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Sada',

--- a/packages/locale/lang/hu.ts
+++ b/packages/locale/lang/hu.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Most',

--- a/packages/locale/lang/hy-am.ts
+++ b/packages/locale/lang/hy-am.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Հիմա',

--- a/packages/locale/lang/id.ts
+++ b/packages/locale/lang/id.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Sekarang',

--- a/packages/locale/lang/it.ts
+++ b/packages/locale/lang/it.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Ora',

--- a/packages/locale/lang/ja.ts
+++ b/packages/locale/lang/ja.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: '現在',

--- a/packages/locale/lang/kk.ts
+++ b/packages/locale/lang/kk.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Қазір',

--- a/packages/locale/lang/km.ts
+++ b/packages/locale/lang/km.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'ឥឡូវនេះ',

--- a/packages/locale/lang/ko.ts
+++ b/packages/locale/lang/ko.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: '지금',

--- a/packages/locale/lang/ku.ts
+++ b/packages/locale/lang/ku.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Niha',

--- a/packages/locale/lang/ky.ts
+++ b/packages/locale/lang/ky.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'азыр',

--- a/packages/locale/lang/lo.ts
+++ b/packages/locale/lang/lo.ts
@@ -13,6 +13,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'ຕອນນີ້',

--- a/packages/locale/lang/lt.ts
+++ b/packages/locale/lang/lt.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Dabar',

--- a/packages/locale/lang/lv.ts
+++ b/packages/locale/lang/lv.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Tagad',

--- a/packages/locale/lang/mg.ts
+++ b/packages/locale/lang/mg.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Zao',

--- a/packages/locale/lang/mn.ts
+++ b/packages/locale/lang/mn.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Одоо',

--- a/packages/locale/lang/ms.ts
+++ b/packages/locale/lang/ms.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Sekarang',

--- a/packages/locale/lang/my.ts
+++ b/packages/locale/lang/my.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'ယခု',

--- a/packages/locale/lang/nb-no.ts
+++ b/packages/locale/lang/nb-no.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Nå',

--- a/packages/locale/lang/nl.ts
+++ b/packages/locale/lang/nl.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Nu',

--- a/packages/locale/lang/no.ts
+++ b/packages/locale/lang/no.ts
@@ -13,6 +13,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Nå',

--- a/packages/locale/lang/pa.ts
+++ b/packages/locale/lang/pa.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'اوس',

--- a/packages/locale/lang/pl.ts
+++ b/packages/locale/lang/pl.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Teraz',

--- a/packages/locale/lang/pt-br.ts
+++ b/packages/locale/lang/pt-br.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Agora',

--- a/packages/locale/lang/pt.ts
+++ b/packages/locale/lang/pt.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Agora',

--- a/packages/locale/lang/ro.ts
+++ b/packages/locale/lang/ro.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Acum',

--- a/packages/locale/lang/ru.ts
+++ b/packages/locale/lang/ru.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Сейчас',

--- a/packages/locale/lang/sk.ts
+++ b/packages/locale/lang/sk.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Teraz',

--- a/packages/locale/lang/sl.ts
+++ b/packages/locale/lang/sl.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Zdaj',

--- a/packages/locale/lang/sr.ts
+++ b/packages/locale/lang/sr.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Сада',

--- a/packages/locale/lang/sv.ts
+++ b/packages/locale/lang/sv.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Nu',

--- a/packages/locale/lang/sw.ts
+++ b/packages/locale/lang/sw.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'sasa',

--- a/packages/locale/lang/ta.ts
+++ b/packages/locale/lang/ta.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'தற்போது',

--- a/packages/locale/lang/te.ts
+++ b/packages/locale/lang/te.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'ఇప్పుడు',

--- a/packages/locale/lang/th.ts
+++ b/packages/locale/lang/th.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'ตอนนี้',

--- a/packages/locale/lang/tk.ts
+++ b/packages/locale/lang/tk.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Şuwagt',

--- a/packages/locale/lang/tr.ts
+++ b/packages/locale/lang/tr.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Şimdi',

--- a/packages/locale/lang/ug-cn.ts
+++ b/packages/locale/lang/ug-cn.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'ھازىرقى ۋاقىت',

--- a/packages/locale/lang/uk.ts
+++ b/packages/locale/lang/uk.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Зараз',

--- a/packages/locale/lang/uz-uz.ts
+++ b/packages/locale/lang/uz-uz.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Hozir',

--- a/packages/locale/lang/vi.ts
+++ b/packages/locale/lang/vi.ts
@@ -14,6 +14,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: 'Hiện tại',

--- a/packages/locale/lang/zh-cn.ts
+++ b/packages/locale/lang/zh-cn.ts
@@ -13,6 +13,8 @@ export default {
       alphaDescription: '透明度 {alpha}, 当前颜色 {color}',
       hueLabel: '选择色相值',
       hueDescription: '色相 {hue}, 当前颜色 {color}',
+      svLabel: '选择饱和度与明度的值',
+      svDescription: '饱和度 {saturation}, 明度 {brightness}, 当前颜色 {color}',
     },
     datepicker: {
       now: '此刻',

--- a/packages/locale/lang/zh-hk.ts
+++ b/packages/locale/lang/zh-hk.ts
@@ -13,6 +13,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: '現在',

--- a/packages/locale/lang/zh-mo.ts
+++ b/packages/locale/lang/zh-mo.ts
@@ -13,6 +13,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: '現在',

--- a/packages/locale/lang/zh-tw.ts
+++ b/packages/locale/lang/zh-tw.ts
@@ -13,6 +13,9 @@ export default {
       alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
       hueLabel: 'pick hue value', // to be translated
       hueDescription: 'hue {hue}, current color is {color}', // to be translated
+      svLabel: 'pick saturation and brightness value', // to be translated
+      svDescription:
+        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
     },
     datepicker: {
       now: '現在',

--- a/packages/theme-chalk/src/color-picker-panel.scss
+++ b/packages/theme-chalk/src/color-picker-panel.scss
@@ -194,36 +194,25 @@
   position: relative;
   width: 280px;
   height: 180px;
-
-  @include e(('white', 'black')) {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-  }
-
-  @include e('white') {
-    background: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
-  }
-
-  @include e('black') {
-    background: linear-gradient(to top, #000, rgba(0, 0, 0, 0));
-  }
+  background-image:
+    linear-gradient(to top, #000, rgba(0, 0, 0, 0)),
+    linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
 
   @include e(cursor) {
     position: absolute;
+    cursor: pointer;
+    width: 4px;
+    height: 4px;
+    box-shadow:
+      0 0 0 1.5px #fff,
+      inset 0 0 1px 1px rgba(0, 0, 0, 0.3),
+      0 0 1px 2px rgba(0, 0, 0, 0.4);
+    border-radius: 50%;
+    transform: translate(-2px, -2px);
 
-    > div {
-      cursor: head;
-      width: 4px;
-      height: 4px;
-      box-shadow:
-        0 0 0 1.5px #fff,
-        inset 0 0 1px 1px rgba(0, 0, 0, 0.3),
-        0 0 1px 2px rgba(0, 0, 0, 0.4);
-      border-radius: 50%;
-      transform: translate(-2px, -2px);
+    &:focus-visible {
+      outline: 2px solid getCssVar('color-primary');
+      outline-offset: 2px;
     }
   }
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

1. Refactoring the sv-panel component and improving accessibility features
2. Support controlling saturation and brightness through keyboard
3. Add a prompt for the current color when using the [screen reader](https://developer.mozilla.org/en-US/docs/Glossary/Screen_reader)

[after](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8cD5DbGljayBtZSwgcHJlc3MgdGhlIFRhYiBrZXkgdHdpY2UsIHRoZW4geW91IGNhbiB1c2UgdGhlIGFycm93IGtleXMgdG8gbW9kaWZ5IHRoZSBjb2xvciB2YWx1ZTwvcD5cbiAgPGVsLWNvbG9yLXBpY2tlci1wYW5lbCB2LW1vZGVsPVwiY29sb3JcIiAvPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3QgY29sb3IgPSByZWYoJyM0MDlFRkYnKVxuPC9zY3JpcHQ+XG4iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgY29uc3Qgc3R5bGVzID0gWydodHRwczovL3ByZXZpZXctMjI0NzAtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmNzcycsICdodHRwczovL3ByZXZpZXctMjI0NzAtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS90aGVtZS1jaGFsay9kYXJrL2Nzcy12YXJzLmNzcyddLm1hcCgoc3R5bGUpID0+IHtcbiAgICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICAgIGxpbmsuaHJlZiA9IHN0eWxlXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2xvYWQnLCByZXNvbHZlKVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdlcnJvcicsIHJlamVjdClcbiAgICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gICAgfSlcbiAgfSlcbiAgcmV0dXJuIFByb21pc2UuYWxsU2V0dGxlZChzdHlsZXMpXG59XG4iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcbiAgICBcImpzeFwiOiBcInByZXNlcnZlXCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJ0eXBlc1wiOiBbXCJlbGVtZW50LXBsdXMvZ2xvYmFsLmQudHNcIl0sXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwiUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly91bnBrZy5jb20vQHZ1ZS9ydW50aW1lLWRvbUBsYXRlc3QvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL3VucGtnLmNvbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vcHJldmlldy0yMjQ3MC1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2Rpc3QvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly91bnBrZy5jb20vQGVsZW1lbnQtcGx1cy9pY29ucy12dWVAMi9kaXN0L2luZGV4Lm1pbi5qc1wiXG4gIH0sXG4gIFwic2NvcGVzXCI6IHt9XG59IiwiX28iOnsic2hvd0hpZGRlbiI6dHJ1ZSwic3R5bGVTb3VyY2UiOiJodHRwczovL3ByZXZpZXctMjI0NzAtZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmNzcyJ9fQ==)
