### PR TITLE
ci: add release version to commit message

### DIFF
--- a/.github/workflows/publish-docs-deploy-manual.yml
+++ b/.github/workflows/publish-docs-deploy-manual.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Install latest Element Plus
         run: cd docs && pnpm i element-plus@latest
 
+      - name: Get Latest Release Version
+        id: get_release
+        run: |
+          LATEST_VERSION=$(curl -s https://api.github.com/repos/element-plus/element-plus/releases/latest | jq -r '.tag_name')
+          echo "latest_version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+
       - name: Build Metadata
         run: cd internal/metadata && pnpm build
         env:
@@ -67,7 +73,7 @@ jobs:
           folder: docs/.vitepress/dist
           git-config-name: ElementPlusBot
           git-config-email: element-plus@outlook.com
-          commit-message: website deploy
+          commit-message: website deploy ${{ steps.get_release.outputs.latest_version }}
 
       - name: Deploy to Vercel
         uses: JamesIves/github-pages-deploy-action@v4.4.1

--- a/.github/workflows/publish-docs-deploy.yml
+++ b/.github/workflows/publish-docs-deploy.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Install latest Element Plus
         run: cd docs && pnpm i element-plus@latest
 
+      - name: Get Latest Release Version
+        id: get_release
+        run: |
+          LATEST_VERSION=$(curl -s https://api.github.com/repos/element-plus/element-plus/releases/latest | jq -r '.tag_name')
+          echo "latest_version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+
       - name: Build Metadata
         run: cd internal/metadata && pnpm build
         env:
@@ -74,7 +80,7 @@ jobs:
           folder: docs/.vitepress/dist
           git-config-name: ElementPlusBot
           git-config-email: element-plus@outlook.com
-          commit-message: website deploy
+          commit-message: website deploy ${{ steps.get_release.outputs.latest_version }}
 
       - name: Deploy to Vercel
         uses: JamesIves/github-pages-deploy-action@v4.4.1


### PR DESCRIPTION
After: website deploy 2.11.4

like https://github.com/element-plus/element-plus/blob/chore--update-commit/.github/workflows/publish-pr-commit-pkg.yml#L36-L40

Before: https://github.com/element-plus/element-plus/commits/gh-pages/

<img width="1547" height="892" alt="image" src="https://github.com/user-attachments/assets/d9d8ae6d-a44e-4814-8479-6e6aff1fe6bd" />

