### PR TITLE
fix(components): [color-picker] the panel does not capture focus

### DIFF
--- a/packages/components/color-picker/__tests__/color-picker.test.tsx
+++ b/packages/components/color-picker/__tests__/color-picker.test.tsx
@@ -547,12 +547,12 @@ describe('Color-picker', () => {
   it('a11y', async () => {
     const color = ref('#20a0ff')
     const wrapper = mount(() => (
-      <ColorPicker v-model={color.value} tabindex={1} />
+      <ColorPicker v-model={color.value} tabindex={1} teleported={false} />
     ))
 
     await nextTick()
     const colorPickerButton = wrapper.find('.el-color-picker')
-    const colorPickerPanel = document.querySelector('.el-color-picker__panel')
+    const colorPickerPanel = wrapper.find('.el-color-picker__panel')
 
     expect(colorPickerButton.attributes('role')).toBe('button')
     expect(colorPickerButton.attributes('tabindex')).toBe('1')
@@ -563,17 +563,16 @@ describe('Color-picker', () => {
     expect(colorPickerButton.attributes('aria-disabled')).toBe('false')
     expect(colorPickerButton.attributes('aria-expanded')).toBe('false')
     expect(colorPickerButton.attributes('aria-haspopup')).toBe('dialog')
+    expect(colorPickerPanel?.attributes('aria-hidden')).toBe('true')
 
     await wrapper.find('.el-color-picker__trigger').trigger('click')
     await rAF()
-    expect(document.activeElement).toBe(
-      document.querySelector('.el-input__inner')
-    )
+    expect(wrapper.find('.el-input__wrapper.is-focus')).toBeTruthy()
     expect(colorPickerButton.attributes('aria-expanded')).toBe('true')
-    expect(colorPickerPanel?.getAttribute('role')).toBe('dialog')
-    expect(colorPickerPanel?.getAttribute('aria-hidden')).toBe('false')
-    expect(colorPickerPanel?.getAttribute('aria-modal')).toBe('false')
-    expect(colorPickerPanel?.getAttribute('id')).toBe(
+    expect(colorPickerPanel?.attributes('role')).toBe('dialog')
+    expect(colorPickerPanel?.attributes('aria-hidden')).toBe('false')
+    expect(colorPickerPanel?.attributes('aria-modal')).toBe('false')
+    expect(colorPickerPanel?.attributes('id')).toBe(
       colorPickerButton.attributes('aria-controls')
     )
 

--- a/packages/components/color-picker/__tests__/color-picker.test.tsx
+++ b/packages/components/color-picker/__tests__/color-picker.test.tsx
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { ElFormItem } from '@element-plus/components/form'
 import { EVENT_CODE } from '@element-plus/constants'
+import { rAF } from '@element-plus/test-utils/tick'
 import ColorPicker from '../src/color-picker.vue'
 import ColorPickerPanel from '@element-plus/components/color-picker-panel'
 
@@ -540,6 +541,42 @@ describe('Color-picker', () => {
 
     await wrapper.find('.el-color-picker').trigger('blur')
     expect(blurHandler).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('a11y', async () => {
+    const color = ref('#20a0ff')
+    const wrapper = mount(() => (
+      <ColorPicker v-model={color.value} tabindex={1} />
+    ))
+
+    await nextTick()
+    const colorPickerButton = wrapper.find('.el-color-picker')
+    const colorPickerPanel = document.querySelector('.el-color-picker__panel')
+
+    expect(colorPickerButton.attributes('role')).toBe('button')
+    expect(colorPickerButton.attributes('tabindex')).toBe('1')
+    expect(colorPickerButton.attributes('aria-label')).toBe('color picker')
+    expect(colorPickerButton.attributes('aria-description')).toBe(
+      'current color is #20a0ff. press enter to select a new color.'
+    )
+    expect(colorPickerButton.attributes('aria-disabled')).toBe('false')
+    expect(colorPickerButton.attributes('aria-expanded')).toBe('false')
+    expect(colorPickerButton.attributes('aria-haspopup')).toBe('dialog')
+
+    await wrapper.find('.el-color-picker__trigger').trigger('click')
+    await rAF()
+    expect(document.activeElement).toBe(
+      document.querySelector('.el-input__inner')
+    )
+    expect(colorPickerButton.attributes('aria-expanded')).toBe('true')
+    expect(colorPickerPanel?.getAttribute('role')).toBe('dialog')
+    expect(colorPickerPanel?.getAttribute('aria-hidden')).toBe('false')
+    expect(colorPickerPanel?.getAttribute('aria-modal')).toBe('false')
+    expect(colorPickerPanel?.getAttribute('id')).toBe(
+      colorPickerButton.attributes('aria-controls')
+    )
+
     wrapper.unmount()
   })
 })

--- a/packages/components/color-picker/src/color-picker.vue
+++ b/packages/components/color-picker/src/color-picker.vue
@@ -10,12 +10,15 @@
     :popper-style="popperStyle"
     :stop-popper-mouse-event="false"
     pure
+    loop
+    role="dialog"
     effect="light"
     trigger="click"
     :teleported="teleported"
     :transition="`${ns.namespace.value}-zoom-in-top`"
     :persistent="persistent"
     :append-to="appendTo"
+    @show="handleShowTooltip"
     @hide="setShowPicker(false)"
   >
     <template #content>
@@ -284,6 +287,10 @@ function clear() {
   resetColor()
 }
 
+function handleShowTooltip() {
+  pickerPanelRef?.value?.inputRef?.focus()
+}
+
 function handleClickOutside() {
   if (!showPicker.value) return
   hide()
@@ -307,7 +314,6 @@ function handleKeyDown(event: KeyboardEvent) {
       event.preventDefault()
       event.stopPropagation()
       show()
-      pickerPanelRef?.value?.inputRef?.focus()
       break
     case EVENT_CODE.esc:
       handleEsc(event)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

When the color-panel opens, the panel does not capture focus.