### PR TITLE
fix(components): [Dropdown] focus style is incorrect

### DIFF
--- a/packages/components/dropdown/src/dropdown.vue
+++ b/packages/components/dropdown/src/dropdown.vue
@@ -22,7 +22,6 @@
       :transition="`${ns.namespace.value}-zoom-in-top`"
       :teleported="teleported"
       pure
-      focus-on-target
       :persistent="persistent"
       @before-show="handleBeforeShowTooltip"
       @show="handleShowTooltip"


### PR DESCRIPTION
[Reproduce docs link](https://element-plus.org/zh-CN/component/dropdown)

Open the official document. Hover the mouse over any dropdown, Unexpected focus styles may appear.
<img width="201" height="283" alt="image" src="https://github.com/user-attachments/assets/5420f5ee-c252-4e59-88d0-04f0c7cd3b1a" />
<img width="255" height="220" alt="image" src="https://github.com/user-attachments/assets/3626adaf-90ed-47a4-bc8a-a9529e942c6f" />
