### PR TITLE
feat(components): add optional color warning for word count

### DIFF
--- a/packages/components/input/src/input.ts
+++ b/packages/components/input/src/input.ts
@@ -145,12 +145,11 @@ export const inputProps = buildProps({
    */
   showWordLimit: Boolean,
   /**
-   * @description word count position, valid when `show-word-limit` is true
+   * @description whether to show word count warning color when nearing limit
    */
-  wordLimitPosition: {
-    type: String,
-    values: ['inside', 'outside'],
-    default: 'inside',
+  showWordLimitWarning: {
+    type: Boolean,
+    default: false,
   },
   /**
    * @description suffix icon

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -213,6 +213,13 @@ const containerKls = computed(() => [
   nsInput.m(inputSize.value),
   nsInput.is('disabled', inputDisabled.value),
   nsInput.is('exceed', inputExceed.value),
+  nsInput.is(
+    'outside',
+    props.showWordLimit &&
+      props.type === 'textarea' &&
+      !props.autosize &&
+      (props.rows === 2 || !props.rows)
+  ),
   {
     [nsInput.b('group')]: slots.prepend || slots.append,
     [nsInput.m('prefix')]: slots.prefix || props.prefixIcon,

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -83,14 +83,8 @@
             >
               <component :is="passwordIcon" />
             </el-icon>
-            <span
-              v-if="isWordLimitVisible"
-              :class="[
-                nsInput.e('count'),
-                nsInput.is('outside', wordLimitPosition === 'outside'),
-              ]"
-            >
-              <span :class="nsInput.e('count-inner')">
+            <span v-if="isWordLimitVisible" :class="nsInput.e('count')">
+              <span :class="[nsInput.e('count-inner'), wordLimitClass]">
                 {{ textLength }} / {{ maxlength }}
               </span>
             </span>
@@ -146,10 +140,7 @@
       <span
         v-if="isWordLimitVisible"
         :style="countStyle"
-        :class="[
-          nsInput.e('count'),
-          nsInput.is('outside', wordLimitPosition === 'outside'),
-        ]"
+        :class="[nsInput.e('count'), wordLimitClass]"
       >
         {{ textLength }} / {{ maxlength }}
       </span>
@@ -311,6 +302,30 @@ const isWordLimitVisible = computed(
     !props.showPassword
 )
 const textLength = computed(() => nativeInputValue.value.length)
+const wordLimitPercentage = computed(() => {
+  const max = Number(props.maxlength)
+  if (!max || max <= 0) return 0
+  return Math.floor((textLength.value / max) * 100)
+})
+const wordLimitLevel = computed(() => {
+  if (!isWordLimitVisible.value || !props.showWordLimitWarning) return 0
+  if (inputExceed.value) return 2
+  const percentage = wordLimitPercentage.value
+  if (percentage >= 90) return 2
+  if (percentage >= 75) return 1
+  return 0
+})
+const wordLimitClass = computed(() => {
+  if (wordLimitLevel.value === 0) return ''
+  switch (wordLimitLevel.value) {
+    case 1:
+      return nsInput.is('warning')
+    case 2:
+      return nsInput.is('danger-level')
+    default:
+      return ''
+  }
+})
 const inputExceed = computed(
   () =>
     // show exceed style if length of initial value greater then maxlength

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -218,7 +218,7 @@ const containerKls = computed(() => [
     props.showWordLimit &&
       props.type === 'textarea' &&
       !props.autosize &&
-      (props.rows === 2 || !props.rows)
+      !props.autosize
   ),
   {
     [nsInput.b('group')]: slots.prepend || slots.append,

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -59,34 +59,22 @@
     width: 100%;
     font-size: inherit;
     font-family: inherit;
-    color: var(
-      #{getCssVarName('input-text-color')},
-      map.get($input, 'text-color')
-    );
-    background-color: var(
-      #{getCssVarName('input-bg-color')},
-      map.get($input, 'bg-color')
-    );
+    color: var(#{getCssVarName('input-text-color')},
+      map.get($input, 'text-color'));
+    background-color: var(#{getCssVarName('input-bg-color')},
+      map.get($input, 'bg-color'));
     background-image: none;
     -webkit-appearance: none;
-    @include inset-input-border(
-      var(
-        #{getCssVarName('input-border-color')},
-        map.get($input, 'border-color')
-      )
-    );
-    border-radius: getCssVarWithDefault(
-      'input-border-radius',
-      map.get($input, 'border-radius')
-    );
+    @include inset-input-border(var(#{getCssVarName('input-border-color')},
+        map.get($input, 'border-color')));
+    border-radius: getCssVarWithDefault('input-border-radius',
+        map.get($input, 'border-radius'));
     transition: getCssVar('transition-box-shadow');
     border: none;
 
     &::placeholder {
-      color: getCssVarWithDefault(
-        'input-placeholder-color',
-        map.get($input, 'placeholder-color')
-      );
+      color: getCssVarWithDefault('input-placeholder-color',
+          map.get($input, 'placeholder-color'));
     }
 
     &:hover {
@@ -129,6 +117,14 @@
         color: map.get($input-disabled, 'placeholder-color');
       }
     }
+  }
+
+  & .#{$namespace}-input__count.is-warning {
+    color: getCssVar('color-warning');
+  }
+
+  & .#{$namespace}-input__count.is-danger-level {
+    color: getCssVar('color-danger');
   }
 
   @include when(exceed) {
@@ -201,26 +197,17 @@
     flex-grow: 1;
     align-items: center;
     justify-content: center;
-    padding: $border-width
-      map.get($input-padding-horizontal, 'default')-$border-width;
-    background-color: var(
-      #{getCssVarName('input-bg-color')},
-      map.get($input, 'bg-color')
-    );
+    padding: $border-width map.get($input-padding-horizontal, 'default')-$border-width;
+    background-color: var(#{getCssVarName('input-bg-color')},
+      map.get($input, 'bg-color'));
     background-image: none;
-    border-radius: getCssVarWithDefault(
-      'input-border-radius',
-      map.get($input, 'border-radius')
-    );
+    border-radius: getCssVarWithDefault('input-border-radius',
+        map.get($input, 'border-radius'));
     cursor: text;
     transition: getCssVar('transition-box-shadow');
     transform: translate3d(0, 0, 0);
-    @include inset-input-border(
-      var(
-        #{getCssVarName('input-border-color')},
-        map.get($input, 'border-color')
-      )
-    );
+    @include inset-input-border(var(#{getCssVarName('input-border-color')},
+        map.get($input, 'border-color')));
 
     &:hover {
       @include inset-input-border(#{getCssVar('input', 'hover-border-color')});
@@ -233,26 +220,17 @@
 
   & {
     // use map.get as default value for date picker range
-    @include set-css-var-value(
-      'input-inner-height',
-      calc(
-        var(
-            #{getCssVarName('input-height')},
-            #{map.get($input-height, 'default')}
-          ) -
-          $border-width * 2
-      )
-    );
+    @include set-css-var-value('input-inner-height',
+      calc(var(#{getCssVarName('input-height')},
+          #{map.get($input-height, 'default')}) - $border-width * 2));
   }
 
   @include e(inner) {
     width: 100%;
     flex-grow: 1;
     -webkit-appearance: none;
-    color: var(
-      #{getCssVarName('input-text-color')},
-      map.get($input, 'text-color')
-    );
+    color: var(#{getCssVarName('input-text-color')},
+      map.get($input, 'text-color'));
     font-size: inherit;
     height: getCssVar('input-inner-height');
     line-height: getCssVar('input-inner-height');
@@ -267,10 +245,8 @@
     }
 
     &::placeholder {
-      color: getCssVarWithDefault(
-        'input-placeholder-color',
-        map.get($input, 'placeholder-color')
-      );
+      color: getCssVarWithDefault('input-placeholder-color',
+          map.get($input, 'placeholder-color'));
     }
 
     // override edge default style
@@ -292,10 +268,8 @@
       height: 100%;
       line-height: getCssVar('input-inner-height');
       text-align: center;
-      color: var(
-        #{getCssVarName('input-icon-color')},
-        map.get($input, 'icon-color')
-      );
+      color: var(#{getCssVarName('input-icon-color')},
+        map.get($input, 'icon-color'));
       transition: all getCssVar('transition-duration');
       pointer-events: none;
     }
@@ -306,18 +280,21 @@
       align-items: center;
       justify-content: center;
 
-      @if $slot == prefix {
+      @if $slot ==prefix {
         > :last-child {
           margin-right: 8px;
         }
 
         > :first-child {
+
           &,
           &.#{$namespace}-input__icon {
             margin-left: 0;
           }
         }
-      } @else {
+      }
+
+      @else {
         > :first-child {
           margin-left: 8px;
         }
@@ -341,12 +318,8 @@
 
   @include when(active) {
     .#{$namespace}-input__wrapper {
-      @include mixed-input-border(
-        var(
-          #{getCssVarName('input-focus-color')},
-          map.get($input, 'focus-color')
-        )
-      );
+      @include mixed-input-border(var(#{getCssVarName('input-focus-color')},
+          map.get($input, 'focus-color')));
     }
   }
 
@@ -379,6 +352,18 @@
     }
   }
 
+  & .#{$namespace}-input__suffix {
+    .#{$namespace}-input__count {
+      .#{$namespace}-input__count-inner.is-warning {
+        color: getCssVar('color-warning');
+      }
+
+      .#{$namespace}-input__count-inner.is-danger-level {
+        color: getCssVar('color-danger');
+      }
+    }
+  }
+
   @include when(exceed) {
     .#{$namespace}-input__wrapper {
       @include mixed-input-border(#{getCssVar('color-danger')});
@@ -398,20 +383,13 @@
       font-size: map.get($input-font-size, $size);
 
       @include e(wrapper) {
-        padding: $border-width
-          map.get($input-padding-horizontal, $size)-$border-width;
+        padding: $border-width map.get($input-padding-horizontal, $size)-$border-width;
       }
+
       & {
-        @include set-css-var-value(
-          'input-inner-height',
-          calc(
-            var(
-                #{getCssVarName('input-height')},
-                #{map.get($input-height, $size)}
-              ) -
-              $border-width * 2
-          )
-        );
+        @include set-css-var-value('input-inner-height',
+          calc(var(#{getCssVarName('input-height')},
+              #{map.get($input-height, $size)}) - $border-width * 2));
       }
     }
   }
@@ -475,7 +453,7 @@
   }
 
   @include m(prepend) {
-    > .#{$namespace}-input__wrapper {
+    >.#{$namespace}-input__wrapper {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
     }
@@ -492,7 +470,7 @@
   }
 
   @include m(append) {
-    > .#{$namespace}-input__wrapper {
+    >.#{$namespace}-input__wrapper {
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
     }


### PR DESCRIPTION
Enhance visual feedback for el-input word count when nearing maxlength. Since the browser's 'maxlength' prevents users from exceeding the limit, the danger state is rarely seen during normal use. 
This feature is optional and disabled by default to retain original component behavior unless explicitly enabled. 
Introduce new prop: showWordLimitWarning(default:false). 
When enabled, count display changes to orange (at 75%) or red(at 90%).

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
