### PR TITLE
docs(components): [dialog] add `modal-penetrable` to model example

### DIFF
--- a/docs/en-US/component/dialog.md
+++ b/docs/en-US/component/dialog.md
@@ -125,6 +125,8 @@ If `fullscreen` is true, `width` `top` `draggable` attributes don't work.
 
 Setting `modal` to `false` will hide modal (overlay) of dialog.
 
+Starting from version ^(2.10.5), `modal-penetrable` attribute is added, which can be penetrable.
+
 :::demo
 
 dialog/modal

--- a/docs/examples/dialog/modal.vue
+++ b/docs/examples/dialog/modal.vue
@@ -3,7 +3,7 @@
     Open the modal Dialog
   </el-button>
 
-  <el-dialog v-model="dialogVisible" :modal="false">
+  <el-dialog v-model="dialogVisible" :modal="false" modal-penetrable>
     <span>It's a modal Dialog</span>
     <template #footer>
       <div class="dialog-footer">


### PR DESCRIPTION
#### Rel:

- https://github.com/element-plus/element-plus/pull/21511

<img width="1182" height="715" alt="image" src="https://github.com/user-attachments/assets/46ab6693-26f7-45ac-8a76-0c2d40e2e8a4" />