### PR TITLE
fix(theme-chalk): [cascader] cursor style issue in filterable

### DIFF
--- a/packages/theme-chalk/src/cascader.scss
+++ b/packages/theme-chalk/src/cascader.scss
@@ -72,7 +72,9 @@
 
     .#{$namespace}-input__inner {
       text-overflow: ellipsis;
-      cursor: pointer;
+      &:read-only {
+        cursor: pointer;
+      }
     }
 
     .#{$namespace}-input__suffix-inner {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Summary
Fix the issue where the input showed a pointer cursor on hover in filterable Cascader; now it shows a text cursor when filterable

before:
<img width="345" height="423" alt="image" src="https://github.com/user-attachments/assets/ab87a206-92f8-4907-80c0-5316e3ec9294" />

after:
<img width="379" height="630" alt="image" src="https://github.com/user-attachments/assets/a8f80d5e-2f85-449c-8448-c88c47a922c1" />


Changes

Add &:read-only { cursor: pointer; } to .el-input__inner
No API or documentation updates
Impact

theme-chalk styles (packages/theme-chalk/src/cascader.scss)
No functional changes; non-breaking
Reproduction & Verification
[Playground](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZGl2IGNsYXNzPVwibS00XCI+XG4gICAgPHA+RmlsdGVyYWJsZSAoU2luZ2xlIHNlbGVjdGlvbik8L3A+XG4gICAgPGVsLWNhc2NhZGVyXG4gICAgICBwbGFjZWhvbGRlcj1cIlRyeSBzZWFyY2hpbmdMIEd1aWRlXCJcbiAgICAgIDpvcHRpb25zPVwib3B0aW9uc1wiXG4gICAgICBmaWx0ZXJhYmxlXG4gICAgLz5cbiAgPC9kaXY+XG48L3RlbXBsYXRlPlxuXG48c2NyaXB0IGxhbmc9XCJ0c1wiIHNldHVwPlxuXG5jb25zdCBvcHRpb25zID0gW1xuICB7XG4gICAgdmFsdWU6ICdndWlkZScsXG4gICAgbGFiZWw6ICdHdWlkZScsXG4gICAgY2hpbGRyZW46IFtcbiAgICAgIHtcbiAgICAgICAgdmFsdWU6ICdkaXNjaXBsaW5lcycsXG4gICAgICAgIGxhYmVsOiAnRGlzY2lwbGluZXMnLFxuICAgICAgICBjaGlsZHJlbjogW1xuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnY29uc2lzdGVuY3knLFxuICAgICAgICAgICAgbGFiZWw6ICdDb25zaXN0ZW5jeScsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2ZlZWRiYWNrJyxcbiAgICAgICAgICAgIGxhYmVsOiAnRmVlZGJhY2snLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdlZmZpY2llbmN5JyxcbiAgICAgICAgICAgIGxhYmVsOiAnRWZmaWNpZW5jeScsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2NvbnRyb2xsYWJpbGl0eScsXG4gICAgICAgICAgICBsYWJlbDogJ0NvbnRyb2xsYWJpbGl0eScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIHZhbHVlOiAnbmF2aWdhdGlvbicsXG4gICAgICAgIGxhYmVsOiAnTmF2aWdhdGlvbicsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdzaWRlIG5hdicsXG4gICAgICAgICAgICBsYWJlbDogJ1NpZGUgTmF2aWdhdGlvbicsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ3RvcCBuYXYnLFxuICAgICAgICAgICAgbGFiZWw6ICdUb3AgTmF2aWdhdGlvbicsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgXSxcbiAgfSxcbiAge1xuICAgIHZhbHVlOiAnY29tcG9uZW50JyxcbiAgICBsYWJlbDogJ0NvbXBvbmVudCcsXG4gICAgY2hpbGRyZW46IFtcbiAgICAgIHtcbiAgICAgICAgdmFsdWU6ICdiYXNpYycsXG4gICAgICAgIGxhYmVsOiAnQmFzaWMnLFxuICAgICAgICBjaGlsZHJlbjogW1xuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnbGF5b3V0JyxcbiAgICAgICAgICAgIGxhYmVsOiAnTGF5b3V0JyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnY29sb3InLFxuICAgICAgICAgICAgbGFiZWw6ICdDb2xvcicsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ3R5cG9ncmFwaHknLFxuICAgICAgICAgICAgbGFiZWw6ICdUeXBvZ3JhcGh5JyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnaWNvbicsXG4gICAgICAgICAgICBsYWJlbDogJ0ljb24nLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdidXR0b24nLFxuICAgICAgICAgICAgbGFiZWw6ICdCdXR0b24nLFxuICAgICAgICAgIH0sXG4gICAgICAgIF0sXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICB2YWx1ZTogJ2Zvcm0nLFxuICAgICAgICBsYWJlbDogJ0Zvcm0nLFxuICAgICAgICBjaGlsZHJlbjogW1xuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAncmFkaW8nLFxuICAgICAgICAgICAgbGFiZWw6ICdSYWRpbycsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2NoZWNrYm94JyxcbiAgICAgICAgICAgIGxhYmVsOiAnQ2hlY2tib3gnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdpbnB1dCcsXG4gICAgICAgICAgICBsYWJlbDogJ0lucHV0JyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnaW5wdXQtbnVtYmVyJyxcbiAgICAgICAgICAgIGxhYmVsOiAnSW5wdXROdW1iZXInLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdzZWxlY3QnLFxuICAgICAgICAgICAgbGFiZWw6ICdTZWxlY3QnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdjYXNjYWRlcicsXG4gICAgICAgICAgICBsYWJlbDogJ0Nhc2NhZGVyJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnc3dpdGNoJyxcbiAgICAgICAgICAgIGxhYmVsOiAnU3dpdGNoJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnc2xpZGVyJyxcbiAgICAgICAgICAgIGxhYmVsOiAnU2xpZGVyJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAndGltZS1waWNrZXInLFxuICAgICAgICAgICAgbGFiZWw6ICdUaW1lUGlja2VyJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnZGF0ZS1waWNrZXInLFxuICAgICAgICAgICAgbGFiZWw6ICdEYXRlUGlja2VyJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnZGF0ZXRpbWUtcGlja2VyJyxcbiAgICAgICAgICAgIGxhYmVsOiAnRGF0ZVRpbWVQaWNrZXInLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICd1cGxvYWQnLFxuICAgICAgICAgICAgbGFiZWw6ICdVcGxvYWQnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdyYXRlJyxcbiAgICAgICAgICAgIGxhYmVsOiAnUmF0ZScsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2Zvcm0nLFxuICAgICAgICAgICAgbGFiZWw6ICdGb3JtJyxcbiAgICAgICAgICB9LFxuICAgICAgICBdLFxuICAgICAgfSxcbiAgICAgIHtcbiAgICAgICAgdmFsdWU6ICdkYXRhJyxcbiAgICAgICAgbGFiZWw6ICdEYXRhJyxcbiAgICAgICAgY2hpbGRyZW46IFtcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ3RhYmxlJyxcbiAgICAgICAgICAgIGxhYmVsOiAnVGFibGUnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICd0YWcnLFxuICAgICAgICAgICAgbGFiZWw6ICdUYWcnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdwcm9ncmVzcycsXG4gICAgICAgICAgICBsYWJlbDogJ1Byb2dyZXNzJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAndHJlZScsXG4gICAgICAgICAgICBsYWJlbDogJ1RyZWUnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdwYWdpbmF0aW9uJyxcbiAgICAgICAgICAgIGxhYmVsOiAnUGFnaW5hdGlvbicsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2JhZGdlJyxcbiAgICAgICAgICAgIGxhYmVsOiAnQmFkZ2UnLFxuICAgICAgICAgIH0sXG4gICAgICAgIF0sXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICB2YWx1ZTogJ25vdGljZScsXG4gICAgICAgIGxhYmVsOiAnTm90aWNlJyxcbiAgICAgICAgY2hpbGRyZW46IFtcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2FsZXJ0JyxcbiAgICAgICAgICAgIGxhYmVsOiAnQWxlcnQnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdsb2FkaW5nJyxcbiAgICAgICAgICAgIGxhYmVsOiAnTG9hZGluZycsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ21lc3NhZ2UnLFxuICAgICAgICAgICAgbGFiZWw6ICdNZXNzYWdlJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnbWVzc2FnZS1ib3gnLFxuICAgICAgICAgICAgbGFiZWw6ICdNZXNzYWdlQm94JyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnbm90aWZpY2F0aW9uJyxcbiAgICAgICAgICAgIGxhYmVsOiAnTm90aWZpY2F0aW9uJyxcbiAgICAgICAgICB9LFxuICAgICAgICBdLFxuICAgICAgfSxcbiAgICAgIHtcbiAgICAgICAgdmFsdWU6ICduYXZpZ2F0aW9uJyxcbiAgICAgICAgbGFiZWw6ICdOYXZpZ2F0aW9uJyxcbiAgICAgICAgY2hpbGRyZW46IFtcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ21lbnUnLFxuICAgICAgICAgICAgbGFiZWw6ICdNZW51JyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAndGFicycsXG4gICAgICAgICAgICBsYWJlbDogJ1RhYnMnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdicmVhZGNydW1iJyxcbiAgICAgICAgICAgIGxhYmVsOiAnQnJlYWRjcnVtYicsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ2Ryb3Bkb3duJyxcbiAgICAgICAgICAgIGxhYmVsOiAnRHJvcGRvd24nLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdzdGVwcycsXG4gICAgICAgICAgICBsYWJlbDogJ1N0ZXBzJyxcbiAgICAgICAgICB9LFxuICAgICAgICBdLFxuICAgICAgfSxcbiAgICAgIHtcbiAgICAgICAgdmFsdWU6ICdvdGhlcnMnLFxuICAgICAgICBsYWJlbDogJ090aGVycycsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdkaWFsb2cnLFxuICAgICAgICAgICAgbGFiZWw6ICdEaWFsb2cnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICd0b29sdGlwJyxcbiAgICAgICAgICAgIGxhYmVsOiAnVG9vbHRpcCcsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICB2YWx1ZTogJ3BvcG92ZXInLFxuICAgICAgICAgICAgbGFiZWw6ICdQb3BvdmVyJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnY2FyZCcsXG4gICAgICAgICAgICBsYWJlbDogJ0NhcmQnLFxuICAgICAgICAgIH0sXG4gICAgICAgICAge1xuICAgICAgICAgICAgdmFsdWU6ICdjYXJvdXNlbCcsXG4gICAgICAgICAgICBsYWJlbDogJ0Nhcm91c2VsJyxcbiAgICAgICAgICB9LFxuICAgICAgICAgIHtcbiAgICAgICAgICAgIHZhbHVlOiAnY29sbGFwc2UnLFxuICAgICAgICAgICAgbGFiZWw6ICdDb2xsYXBzZScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgXSxcbiAgfSxcbiAge1xuICAgIHZhbHVlOiAncmVzb3VyY2UnLFxuICAgIGxhYmVsOiAnUmVzb3VyY2UnLFxuICAgIGNoaWxkcmVuOiBbXG4gICAgICB7XG4gICAgICAgIHZhbHVlOiAnYXh1cmUnLFxuICAgICAgICBsYWJlbDogJ0F4dXJlIENvbXBvbmVudHMnLFxuICAgICAgfSxcbiAgICAgIHtcbiAgICAgICAgdmFsdWU6ICdza2V0Y2gnLFxuICAgICAgICBsYWJlbDogJ1NrZXRjaCBUZW1wbGF0ZXMnLFxuICAgICAgfSxcbiAgICAgIHtcbiAgICAgICAgdmFsdWU6ICdkb2NzJyxcbiAgICAgICAgbGFiZWw6ICdEZXNpZ24gRG9jdW1lbnRhdGlvbicsXG4gICAgICB9LFxuICAgIF0sXG4gIH0sXG5dXG48L3NjcmlwdD5cbiIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmNzcycsICdodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvdGhlbWUtY2hhbGsvZGFyay9jc3MtdmFycy5jc3MnXS5tYXAoKHN0eWxlKSA9PiB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgICBsaW5rLmhyZWYgPSBzdHlsZVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICAgIH0pXG4gIH0pXG4gIHJldHVybiBQcm9taXNlLmFsbFNldHRsZWQoc3R5bGVzKVxufVxuIiwidHNjb25maWcuanNvbiI6IntcbiAgXCJjb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVSZXNvbHV0aW9uXCI6IFwiQnVuZGxlclwiLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdLFxuICAgIFwiYWxsb3dJbXBvcnRpbmdUc0V4dGVuc2lvbnNcIjogdHJ1ZSxcbiAgICBcImFsbG93SnNcIjogdHJ1ZSxcbiAgICBcImNoZWNrSnNcIjogdHJ1ZVxuICB9LFxuICBcInZ1ZUNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogMy4zXG4gIH1cbn1cbiIsIlBsYXlncm91bmRNYWluLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgQXBwIGZyb20gJy4vQXBwLnZ1ZSdcbmltcG9ydCB7IHNldHVwRWxlbWVudFBsdXMgfSBmcm9tICcuL2VsZW1lbnQtcGx1cy5qcydcbnNldHVwRWxlbWVudFBsdXMoKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPEFwcCAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9ydW50aW1lLWRvbUBsYXRlc3QvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L2Rpc3QvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L1wiLFxuICAgIFwiQGVsZW1lbnQtcGx1cy9pY29ucy12dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsIl9vIjp7fX0=)

Open the playground example with a filterable Cascader
Before: hovering over the input shows a pointer cursor
After: hovering shows a text cursor when editable; 