### PR TITLE
chore: replace ns.is condition

### DIFF
--- a/packages/components/date-picker-panel/src/date-picker-com/panel-year-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-year-range.vue
@@ -196,7 +196,7 @@ const leftPanelKls = computed(() => {
     arrowLeftBtn: [ppNs.e('icon-btn'), 'd-arrow-left'],
     arrowRightBtn: [
       ppNs.e('icon-btn'),
-      { [ppNs.is('disabled')]: !enableYearArrow.value },
+      ppNs.is('disabled', !enableYearArrow.value),
       'd-arrow-right',
     ],
   }

--- a/packages/components/table-v2/src/table-v2.tsx
+++ b/packages/components/table-v2/src/table-v2.tsx
@@ -309,9 +309,7 @@ const TableV2 = defineComponent({
         props.class,
         ns.b(),
         ns.e('root'),
-        {
-          [ns.is('dynamic')]: unref(isDynamic),
-        },
+        ns.is('dynamic', unref(isDynamic)),
       ]
 
       const footerProps = {

--- a/packages/components/table/src/config.ts
+++ b/packages/components/table/src/config.ts
@@ -259,7 +259,7 @@ export function treeCellPrefix<T extends DefaultRow>(
             return [
               h(
                 ElIcon,
-                { class: { [ns.is('loading')]: treeNode.loading } },
+                { class: ns.is('loading', treeNode.loading) },
                 {
                   default: () => [h(icon)],
                 }

--- a/packages/components/table/src/table-header/index.ts
+++ b/packages/components/table/src/table-header/index.ts
@@ -192,7 +192,7 @@ export default defineComponent({
       'thead',
       {
         ref: 'theadRef',
-        class: { [ns.is('group')]: isGroup },
+        class: ns.is('group', isGroup),
       },
       columnRows.map((subColumns, rowIndex) =>
         h(

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,3 @@
+languageGlobs:
+  html: ['*.vue']
+  tsx: ['*.ts']

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,3 +1,0 @@
-languageGlobs:
-  html: ['*.vue']
-  tsx: ['*.ts']


### PR DESCRIPTION
Some of `ns.is` can be rewritten better as it accept directly the condition in the second parameter.

Thanks to [ast-grep](https://github.com/ast-grep/ast-grep):
Create file like https://github.com/element-plus/element-plus/commit/fa56c226738a25ca2022f261193f3209a65821c2 and:
```sh
sg --pattern '{ [$NS.is($CLASS)]: $$$CONDITION }'
```