### PR TITLE
fix(components): [date-picker] time list sync with input change

### DIFF
--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
@@ -792,6 +792,7 @@ const handleTimeInput = (value: string | null, type: ChangeType) => {
         .hour(parsedValueD.hour())
         .minute(parsedValueD.minute())
         .second(parsedValueD.second())
+      leftDate.value = minDate.value
     } else {
       maxTimePickerVisible.value = true
       maxDate.value = (maxDate.value || rightDate.value)

--- a/packages/components/date-picker/__tests__/date-time-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-time-picker.test.tsx
@@ -1198,4 +1198,25 @@ describe('Datetimerange', () => {
     await wrapper.find('.el-date-editor').trigger('click')
     expect(onUpdateModelValue).not.toHaveBeenCalled()
   })
+
+  it('should left list time be sync with input input change', async () => {
+    const modelValue = ['2025-09-01', '2025-09-07']
+    const wrapper = _mount(() => (
+      <DatePicker modelValue={modelValue} type="datetimerange" />
+    ))
+
+    const input = wrapper.find('input')
+    await input.trigger('blur')
+    await input.trigger('focus')
+    const leftTimeInput = document.querySelectorAll<HTMLInputElement>(
+      '.el-date-range-picker__time-picker-wrap input'
+    )[1]
+    leftTimeInput.value = 'AM 12:00:01'
+    triggerEvent(leftTimeInput, 'input')
+    await nextTick()
+    expect(
+      document.querySelectorAll('.el-time-spinner__list .is-active')[2]
+        .textContent
+    ).toBe('01')
+  })
 })


### PR DESCRIPTION
closed #22500 

the list input time was not sync with input change.
After:
![Peek 2025-10-26 15-00](https://github.com/user-attachments/assets/34612ec5-5926-4612-b1e2-79aab7d9ac98)
