### PR TITLE
feat(components): [upload] File list adds file name tooltip and file size display.

### DIFF
--- a/docs/en-US/component/upload.md
+++ b/docs/en-US/component/upload.md
@@ -71,6 +71,14 @@ upload/file-list
 
 :::
 
+## File List Tooltip&FileSize
+
+:::demo
+
+upload/file-list-tooltip-size
+
+:::
+
 ## Drag to Upload
 
 You can drag your file to a certain area to upload it.
@@ -121,6 +129,8 @@ upload/manual
 | http-request                  | override default xhr behavior, allowing you to implement your own upload-file's request.                                                                                              | ^[Function]`(options: UploadRequestOptions) => XMLHttpRequest \| Promise<unknown>`                                                         | ajaxUpload [see](https://github.com/element-plus/element-plus/blob/dev/packages/components/upload/src/ajax.ts#L55) |
 | disabled                      | whether to disable upload.                                                                                                                                                            | ^[boolean]                                                                                                                                 | false                                                                                                              |
 | limit                         | maximum number of uploads allowed.                                                                                                                                                    | ^[number]                                                                                                                                  | —                                                                                                                  |
+| show-file-list-size           | whether to show the size of uploaded file                                                                                                                                             | ^[boolean]                                                                                                                                 | false                                                                                                              |
+| show-file-list-tooltip        | whether to show the tooltip of uploaded file name                                                                                                                                     | ^[boolean]                                                                                                                                 | false                                                                                                              |
 
 ### Slots
 

--- a/docs/examples/upload/file-list-tooltip-size.vue
+++ b/docs/examples/upload/file-list-tooltip-size.vue
@@ -1,0 +1,28 @@
+<template>
+  <el-upload
+    v-model:file-list="fileList"
+    :on-change="handleChange"
+    :show-file-list-size="true"
+    :show-file-list-tooltip="true"
+    :auto-upload="false"
+  >
+    <el-button type="primary">Click to upload</el-button>
+    <template #tip>
+      <div class="el-upload__tip">
+        jpg/png files with a size less than 500kb
+      </div>
+    </template>
+  </el-upload>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import type { UploadProps, UploadUserFile } from 'element-plus'
+
+const fileList = ref<UploadUserFile[]>([])
+
+const handleChange: UploadProps['onChange'] = (uploadFile, uploadFiles) => {
+  fileList.value = fileList.value.slice(-3)
+}
+</script>

--- a/packages/components/upload/src/upload-list.ts
+++ b/packages/components/upload/src/upload-list.ts
@@ -26,6 +26,17 @@ export const uploadListProps = buildProps({
   crossorigin: {
     type: definePropType<'anonymous' | 'use-credentials' | ''>(String),
   },
+  /**
+   * @description whether to show the size of uploaded file
+   */
+  showFileSize: {
+    type: Boolean,
+    default: false,
+  },
+  showFileTooltip: {
+    type: Boolean,
+    default: false,
+  },
 } as const)
 
 export type UploadListProps = ExtractPropTypes<typeof uploadListProps>

--- a/packages/components/upload/src/upload-list.vue
+++ b/packages/components/upload/src/upload-list.vue
@@ -40,8 +40,21 @@
               :class="nsUpload.be('list', 'item-file-name')"
               :title="file.name"
             >
-              {{ file.name }}
+              <el-tooltip
+                :content="file.name"
+                placement="top"
+                :disabled="!showFileTooltip"
+              >
+                <span :class="nsUpload.be('list', 'item-file-name-text')">
+                  {{ file.name }}
+                </span>
+              </el-tooltip>
             </span>
+            <span
+              v-if="showFileSize"
+              :class="nsUpload.be('list', 'item-file-size')"
+              >{{ formatSize(file.size) }}</span
+            >
           </a>
           <el-progress
             v-if="file.status === 'uploading'"
@@ -118,6 +131,7 @@ import {
 } from '@element-plus/icons-vue'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import ElProgress from '@element-plus/components/progress'
+import ElTooltip from '@element-plus/components/tooltip'
 import { useFormDisabled } from '@element-plus/components/form'
 import { uploadListEmits, uploadListProps } from './upload-list'
 
@@ -146,5 +160,14 @@ const containerKls = computed(() => [
 
 const handleRemove = (file: UploadFile) => {
   emit('remove', file)
+}
+
+const formatSize = (size?: number) => {
+  if (!size && size !== 0) return ''
+  if (size < 1024) return `${size}B`
+  else if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)}KB`
+  else if (size < 1024 * 1024 * 1024)
+    return `${(size / 1024 / 1024).toFixed(1)}MB`
+  else return `${(size / 1024 / 1024 / 1024).toFixed(1)}GB`
 }
 </script>

--- a/packages/components/upload/src/upload.ts
+++ b/packages/components/upload/src/upload.ts
@@ -138,6 +138,20 @@ export const uploadBaseProps = buildProps({
     default: true,
   },
   /**
+   * @description whether to show the size of uploaded file
+   */
+  showFileListSize: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * @description whether to show the tooltip of uploaded file name
+   */
+  showFileListTooltip: {
+    type: Boolean,
+    default: false,
+  },
+  /**
    * @description accepted [file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-accept), will not work when `thumbnail-mode === true`
    */
   accept: {

--- a/packages/components/upload/src/upload.vue
+++ b/packages/components/upload/src/upload.vue
@@ -38,6 +38,8 @@
       :files="uploadFiles"
       :crossorigin="crossorigin"
       :handle-preview="onPreview"
+      :show-file-size="showFileListSize"
+      :show-file-tooltip="showFileListTooltip"
       @remove="handleRemove"
     >
       <template v-if="$slots.file" #default="{ file, index }">

--- a/packages/components/upload/src/upload.vue
+++ b/packages/components/upload/src/upload.vue
@@ -7,6 +7,8 @@
       :files="uploadFiles"
       :crossorigin="crossorigin"
       :handle-preview="onPreview"
+      :show-file-size="showFileListSize"
+      :show-file-tooltip="showFileListTooltip"
       @remove="handleRemove"
     >
       <template v-if="$slots.file" #default="{ file, index }">

--- a/packages/theme-chalk/src/upload.scss
+++ b/packages/theme-chalk/src/upload.scss
@@ -311,9 +311,19 @@
   }
 
   @include e(item-file-name) {
+    flex: 1;
+    width: 0;
+    margin-right: 5px;
+    text-align: left;
+  }
+
+  @include e(item-file-name-text) {
+    display: inline-block;
+    max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    cursor: pointer;
   }
 
   @include e(item-status-label) {

--- a/packages/theme-chalk/src/upload.scss
+++ b/packages/theme-chalk/src/upload.scss
@@ -324,6 +324,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     cursor: pointer;
+    vertical-align: top;
   }
 
   @include e(item-status-label) {


### PR DESCRIPTION
<img width="2560" height="1305" alt="image" src="https://github.com/user-attachments/assets/9d757bb3-7446-4158-83a3-e3baa9dca8df" />
File List Add Tips and Select File Size