### PR TITLE
docs(docs): correct description in internationalization guide

### DIFF
--- a/docs/en-US/guide/i18n.md
+++ b/docs/en-US/guide/i18n.md
@@ -5,12 +5,12 @@ lang: en-US
 
 # Internationalization
 
-Element Plus components are using English **by default**, if you wish you use other
-languages, you can get you answer by keep reading.
+Element Plus components use English **by default**. If you want to use other
+languages, read on to find out how.
 
 ## Global configuration
 
-Element Plus provides global configurations
+Element Plus provides global configuration options.
 
 ```ts [main.ts]
 import ElementPlus from 'element-plus'
@@ -41,7 +41,7 @@ import zhCn from 'element-plus/es/locale/lang/zh-cn'
 
 ## Date and time localization
 
-We use [Day.js](https://day.js.org/docs/en/i18n/i18n) library to manage date and time in components like `DatePicker`. It is important to set a proper locale in Day.js to make the internationalization fully works. You have to import Day.js's locale config separately.
+We use [Day.js](https://day.js.org/docs/en/i18n/i18n) library to manage date and time in components like `DatePicker`. It is important to set a proper locale in Day.js to make internationalization work properly. You have to import Day.js's locale config separately.
 
 ```ts
 import 'dayjs/locale/zh-cn'
@@ -49,8 +49,8 @@ import 'dayjs/locale/zh-cn'
 
 ## CDN Usage
 
-If you are using Element Plus via CDN, then you need to do this, let's again take
-unpkg as an example
+If you are using Element Plus via CDN, you need to do the following. Let's take
+unpkg as an example:
 
 ```html
 <script src="//unpkg.com/element-plus/dist/locale/zh-cn"></script>
@@ -61,7 +61,7 @@ unpkg as an example
 </script>
 ```
 
-Full documentation refer to: [ConfigProvider](/en-US/component/config-provider)
+For full documentation, refer to: [ConfigProvider](/en-US/component/config-provider)
 
 [Supported Language List](https://github.com/element-plus/element-plus/tree/dev/packages/locale/lang)
 
@@ -136,8 +136,7 @@ Full documentation refer to: [ConfigProvider](/en-US/component/config-provider)
 </ul>
 
 If you need any other languages, [PR](https://github.com/element-plus/element-plus/pulls)
-is always welcomed, you only need to add a language file at
-[here](https://github.com/element-plus/element-plus/tree/dev/packages/locale/lang).
+is always welcome, you only need to add a language file [here](https://github.com/element-plus/element-plus/tree/dev/packages/locale/lang).
 
 <style>
   .language-list {

--- a/docs/examples/message-box/customized-icon.vue
+++ b/docs/examples/message-box/customized-icon.vue
@@ -12,9 +12,23 @@ const open = () => {
     'It will permanently delete the file. Continue?',
     'Warning',
     {
+      confirmButtonText: 'OK',
+      cancelButtonText: 'Cancel',
       type: 'warning',
       icon: markRaw(Delete),
     }
   )
+    .then(() => {
+      ElMessage({
+        type: 'success',
+        message: 'Delete completed',
+      })
+    })
+    .catch(() => {
+      ElMessage({
+        type: 'info',
+        message: 'Delete canceled',
+      })
+    })
 }
 </script>


### PR DESCRIPTION
Fix minor grammar and consistency issues in i18n.md documentation.

No functional changes.

closed #22609

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
