### PR TITLE
docs(components): [tooltip] add events

### DIFF
--- a/docs/en-US/component/tooltip.md
+++ b/docs/en-US/component/tooltip.md
@@ -192,13 +192,12 @@ tooltip/append-to
 
 ### Events
 
-| Name   | Description                                                                                                       | Type                                               |
-| ------ | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| before-show | Triggers before tooltip is shown. Passes trigger reason as argument. | ^[Function]`(event?: Event) => void` |
-| show | Triggers when tooltip is shown. Passes trigger reason as argument. | ^[Function]`(event?: Event) => void` |
+| Name        | Description                                                           | Type                                 |
+| ----------- | --------------------------------------------------------------------- | ------------------------------------ |
+| before-show | Triggers before tooltip is shown. Passes trigger reason as argument.  | ^[Function]`(event?: Event) => void` |
+| show        | Triggers when tooltip is shown. Passes trigger reason as argument.    | ^[Function]`(event?: Event) => void` |
 | before-hide | Triggers before tooltip is hidden. Passes trigger reason as argument. | ^[Function]`(event?: Event) => void` |
-| hide | Triggers when tooltip is hidden. Passes trigger reason as argument. | ^[Function]`(event?: Event) => void` |
-
+| hide        | Triggers when tooltip is hidden. Passes trigger reason as argument.   | ^[Function]`(event?: Event) => void` |
 
 ### Slots
 

--- a/docs/en-US/component/tooltip.md
+++ b/docs/en-US/component/tooltip.md
@@ -190,6 +190,16 @@ tooltip/append-to
 | aria-label ^(a11y)        | same as `aria-label`                                                                                                                                                                  | ^[string]                                                                                                                                                                   | —                 |
 | focus-on-target ^(2.11.2) | when triggering tooltips through hover, whether to focus the trigger element, which improves accessibility                                                                            | ^[boolean]                                                                                                                                                                  | false             |
 
+### Events
+
+| Name   | Description                                                                                                       | Type                                               |
+| ------ | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| before-show | Triggers before tooltip is shown. Passes trigger reason as argument. | ^[Function]`(value: boolean) => void` |
+| show | Triggers when tooltip is shown. Passes trigger reason as argument. | ^[Function]`(value: boolean) => void` |
+| before-hide | Triggers before tooltip is hidden. Passes trigger reason as argument. | ^[Function]`(value: boolean) => void` |
+| hide | Triggers when tooltip is hidden. Passes trigger reason as argument. | ^[Function]`(value: boolean) => void` |
+
+
 ### Slots
 
 | Name    | Description                                                                    |

--- a/docs/en-US/component/tooltip.md
+++ b/docs/en-US/component/tooltip.md
@@ -194,10 +194,10 @@ tooltip/append-to
 
 | Name   | Description                                                                                                       | Type                                               |
 | ------ | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| before-show | Triggers before tooltip is shown. Passes trigger reason as argument. | ^[Function]`(value: boolean) => void` |
-| show | Triggers when tooltip is shown. Passes trigger reason as argument. | ^[Function]`(value: boolean) => void` |
-| before-hide | Triggers before tooltip is hidden. Passes trigger reason as argument. | ^[Function]`(value: boolean) => void` |
-| hide | Triggers when tooltip is hidden. Passes trigger reason as argument. | ^[Function]`(value: boolean) => void` |
+| before-show | Triggers before tooltip is shown. Passes trigger reason as argument. | ^[Function]`(event?: Event) => void` |
+| show | Triggers when tooltip is shown. Passes trigger reason as argument. | ^[Function]`(event?: Event) => void` |
+| before-hide | Triggers before tooltip is hidden. Passes trigger reason as argument. | ^[Function]`(event?: Event) => void` |
+| hide | Triggers when tooltip is hidden. Passes trigger reason as argument. | ^[Function]`(event?: Event) => void` |
 
 
 ### Slots


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


No related issue, just found some piece of functionality missing from docs. Tooltip components do emit events, but nowhere in docs is reflected: https://github.com/element-plus/element-plus/blob/2.11.5/packages/components/tooltip/src/tooltip.vue#L139