### PR TITLE
docs: Updates default zIndex value in documentation

### DIFF
--- a/docs/en-US/guide/quickstart.md
+++ b/docs/en-US/guide/quickstart.md
@@ -182,7 +182,7 @@ For Laravel users we have a [Laravel Template](https://github.com/element-plus/e
 
 When registering Element Plus, you can pass a global config object with `size` and
 `zIndex` to set the default `size` for form components, and `zIndex` for
-popup components, the default value for `zIndex` is `2000`.
+popup components, the default value for `zIndex` is `3000`.
 
 Full import:
 


### PR DESCRIPTION
Clarifies that the default zIndex for popup components is 3000, improving accuracy of usage instructions for global config options.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
