### PR TITLE
chore: fix typo and improve sentence in destroy-on-close example

### DIFF
--- a/docs/examples/dialog/destroy-on-close.vue
+++ b/docs/examples/dialog/destroy-on-close.vue
@@ -11,8 +11,8 @@
     center
   >
     <span>
-      Notice: before dialog gets opened for the first time this node and the one
-      bellow will not be rendered
+      Notice: before the dialog is opened for the first time, this node and the
+      one below will not be rendered.
     </span>
     <div>
       <strong>Extra content (Not rendered)</strong>


### PR DESCRIPTION
When I was reading the guide documentation, I found this sentence a bit confusing.
<img width="533" height="207" alt="Screenshot 2025-10-30 at 17 28 20" src="https://github.com/user-attachments/assets/eb453214-0d12-48b7-b785-8ef5354c6b85" />

It turned out that there was a small typo (“bellow” → “below”) and the phrasing wasn’t very natural.
So I tried to fix it for better readability.
Thanks to all the maintainers for your hard work!

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
