### PR TITLE
fix(components): [table] Fix the box-shadow of the table

### DIFF
--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -429,6 +429,13 @@
         box-shadow: getCssVar('table-fixed-right-column');
       }
     }
+    .#{$namespace}-table.is-scrolling-right {
+      .#{$namespace}-table-fixed-column--right.is-first-column {
+        &::before {
+          box-shadow: none;
+        }
+      }
+    }
 
     &.#{$namespace}-table--border {
       .#{$namespace}-table-fixed-column--left {
@@ -451,7 +458,13 @@
         box-shadow: getCssVar('table-fixed-left-column');
       }
     }
-
+    .#{$namespace}-table.is-scrolling-left {
+      .#{$namespace}-table-fixed-column--left.is-last-column {
+        &::before {
+          box-shadow: none;
+        }
+      }
+    }
     .#{$namespace}-table-fixed-column--left.is-last-column.#{$namespace}-table__cell {
       border-right: none;
     }
@@ -475,6 +488,21 @@
     .#{$namespace}-table-fixed-column--left.is-last-column {
       &::before {
         box-shadow: getCssVar('table-fixed-left-column');
+      }
+    }
+
+    .#{$namespace}-table.is-scrolling-right {
+      .#{$namespace}-table-fixed-column--right.is-first-column {
+        &::before {
+          box-shadow: none;
+        }
+      }
+    }
+    .#{$namespace}-table.is-scrolling-left {
+      .#{$namespace}-table-fixed-column--left.is-last-column {
+        &::before {
+          box-shadow: none;
+        }
       }
     }
   }


### PR DESCRIPTION
**The :before box-shadow of the fixed column cells within the nested table in the row will be affected by the parent table.** 

**Detailed description**: The impact can be categorized into three scenarios: 1) If the parent table is set as "is-scrolling-left" and the child table is set as "is-scrolling-right", then the fixed column on the left side of the child table will exhibit an undesired shadow. 2) If the parent table has the class "is-scrolling-right" and the child table has the class "is-scrolling-left", then the fixed column on the right side of the child table will display an undesired shadow. 3) If the parent table has the class "is-scrolling-none" and the child table has the class "is-scrolling-left", then the fixed column on the right side of the child table will display an undesired shadow. Similarly, if the child table has the class "is-scrolling-right", the fixed column on the left side of the child table will also show an undesired shadow.


Fixes #22497