### PR TITLE
ci: `lock-issues` action add `inactive` labels

### DIFF
--- a/.github/workflows/issue-inactive.yml
+++ b/.github/workflows/issue-inactive.yml
@@ -37,6 +37,7 @@ jobs:
           actions: 'lock-issues'
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-state: closed
+          labels: 'inactive'
           inactive-day: 30
           body: |
             This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

https://github.com/actions-cool/issues-helper?tab=readme-ov-file#lock-issues

https://github.com/element-plus/element-plus/actions/runs/18947110416
`lock-issues` kept failing, and according to the error message, it seems to be a problem of too much data. Therefore, labels were added for filtering.