### PR TITLE
chore: cancel `debugWarn` env check 

### DIFF
--- a/internal/build/src/tasks/modules.ts
+++ b/internal/build/src/tasks/modules.ts
@@ -44,6 +44,9 @@ const plugins: Plugin[] = [
     loaders: {
       '.vue': 'ts',
     },
+    define: {
+      'process.env.NODE_ENV': '"production"',
+    },
   }),
 ]
 

--- a/internal/build/src/tasks/modules.ts
+++ b/internal/build/src/tasks/modules.ts
@@ -44,9 +44,6 @@ const plugins: Plugin[] = [
     loaders: {
       '.vue': 'ts',
     },
-    define: {
-      'process.env.NODE_ENV': '"production"',
-    },
   }),
 ]
 

--- a/packages/utils/error.ts
+++ b/packages/utils/error.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { isString } from './types'
 
 class ElementPlusError extends Error {
@@ -15,14 +14,9 @@ export function throwError(scope: string, m: string): never {
 export function debugWarn(err: Error): void
 export function debugWarn(scope: string, message: string): void
 export function debugWarn(scope: string | Error, message?: string): void {
-  console.log(process.env.NODE_ENV)
-  console.log(typeof process.env.NODE_ENV)
-  console.log(String(process.env.NODE_ENV))
-
-  if (process.env.NODE_ENV !== 'production') {
-    const error: Error = isString(scope)
-      ? new ElementPlusError(`[${scope}] ${message}`)
-      : scope
-    console.warn(error)
-  }
+  const error: Error = isString(scope)
+    ? new ElementPlusError(`[${scope}] ${message}`)
+    : scope
+  // eslint-disable-next-line no-console
+  console.warn(error)
 }

--- a/packages/utils/error.ts
+++ b/packages/utils/error.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { isString } from './types'
 
 class ElementPlusError extends Error {
@@ -14,11 +15,14 @@ export function throwError(scope: string, m: string): never {
 export function debugWarn(err: Error): void
 export function debugWarn(scope: string, message: string): void
 export function debugWarn(scope: string | Error, message?: string): void {
+  console.log(process.env.NODE_ENV)
+  console.log(typeof process.env.NODE_ENV)
+  console.log(String(process.env.NODE_ENV))
+
   if (process.env.NODE_ENV !== 'production') {
     const error: Error = isString(scope)
       ? new ElementPlusError(`[${scope}] ${message}`)
       : scope
-    // eslint-disable-next-line no-console
     console.warn(error)
   }
 }


### PR DESCRIPTION
`debugWarn` fn stopped working after version 2.10.5.

### Rel:

- https://github.com/element-plus/element-plus/pull/21584  `development` -> `production`

I believe this is correct.   it's a bug in the original code.

 `< 2.10.5`   always `development`    `debugWarn` working.
 `> 2.10.5`  build -> `production`      `debugWarn` stopped working.
Now:  dev -> `development`    , build -> `production`  `debugWarn` working.

