### PR TITLE
fix(components): [date-picker] keyboard navigation on first of the month

### DIFF
--- a/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
+++ b/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
@@ -259,7 +259,7 @@ export const useBasicDateTable = (
 
   const isSelectedCell = (cell: DateCell) => {
     return (
-      (!unref(hasCurrent) && cell?.text === 1 && cell.type === 'normal') ||
+      (!unref(hasCurrent) && cell?.text === 1 && isNormalDay(cell.type)) ||
       cell.isCurrent
     )
   }

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1828,7 +1828,7 @@ describe('DatePicker keyboard events', () => {
 
   it('should be able to enter in date picker table through keyboard navigation', async () => {
     _mount('<el-date-picker v-model="value" type="date" />', () => ({
-      value: '2025-09-01',
+      value: '',
     }))
     await nextTick()
     const input = document.querySelector<HTMLInputElement>('input')


### PR DESCRIPTION
rel https://github.com/element-plus/element-plus/pull/22662

The first day of the month is a type "today" and not "normal".

Wanted to isolate this test case but it seems like [setSystemTime](https://v2.vitest.dev/api/vi.html#vi-setsystemtime) doesn't work as expected unfortunately.