### PR TITLE
fix(components): [watermark] use baselineOffset to get a complete canvas

### DIFF
--- a/packages/components/watermark/src/useClips.ts
+++ b/packages/components/watermark/src/useClips.ts
@@ -77,14 +77,14 @@ export default function useClips() {
       ctx.textAlign = textAlign
       ctx.textBaseline = textBaseline
       const contents = isArray(content) ? content : [content]
-
-      const argumentMetrics = ctx.measureText(contents[0])
-      ctx.textBaseline = 'top'
-      const topMetrics = ctx.measureText(contents[0])
-      baselineOffset =
-        argumentMetrics.actualBoundingBoxAscent -
-        topMetrics.actualBoundingBoxAscent
-
+      if (contents[0]) {
+        const argumentMetrics = ctx.measureText(contents[0])
+        ctx.textBaseline = 'top'
+        const topMetrics = ctx.measureText(contents[0])
+        baselineOffset =
+          argumentMetrics.actualBoundingBoxAscent -
+          topMetrics.actualBoundingBoxAscent
+      }
       contents?.forEach((item, index) => {
         const [alignRatio, spaceRatio] = TEXT_ALIGN_RATIO_MAP[textAlign]
         ctx.fillText(

--- a/packages/components/watermark/src/useClips.ts
+++ b/packages/components/watermark/src/useClips.ts
@@ -55,7 +55,7 @@ export default function useClips() {
       height,
       ratio
     )
-
+    let baselineOffset = 0
     if (content instanceof HTMLImageElement) {
       // Image
       ctx.drawImage(content, 0, 0, contentWidth, contentHeight)
@@ -77,6 +77,14 @@ export default function useClips() {
       ctx.textAlign = textAlign
       ctx.textBaseline = textBaseline
       const contents = isArray(content) ? content : [content]
+
+      const argumentMetrics = ctx.measureText(contents[0])
+      ctx.textBaseline = 'top'
+      const topMetrics = ctx.measureText(contents[0])
+      baselineOffset =
+        argumentMetrics.actualBoundingBoxAscent -
+        topMetrics.actualBoundingBoxAscent
+
       contents?.forEach((item, index) => {
         const [alignRatio, spaceRatio] = TEXT_ALIGN_RATIO_MAP[textAlign]
         ctx.fillText(
@@ -148,7 +156,7 @@ export default function useClips() {
         cutWidth,
         cutHeight,
         targetX,
-        targetY,
+        targetY + baselineOffset,
         cutWidth,
         cutHeight
       )


### PR DESCRIPTION
创建文字canvas时，textBaseline的偏移会导致文字显示不全，这个canvas导致后续旋转/平铺得到的所有canvas都是文字不完整的。 
When creating the text canvas, certain baseline values could cause the text to be partially clipped. An incomplete first canvas would result in all subsequent rotated and tiled canvases being clipped as well.

此次修改确保第一个canvas文字绘制完整，记录baselineOffset并应用到最后drawImage的targetY参数上模拟偏移距离。
This change ensures the text on the first canvas is fully rendered and records a baselineOffset, which is then applied to the targetY parameter in drawImage to maintain complete text visibility across rotations and repetitions.

fix https://github.com/element-plus/element-plus/issues/22478