### PR TITLE
fix(tag): disable transitions automatically when tag is inside table (#22437)

### DIFF
--- a/packages/components/tag/src/tag.vue
+++ b/packages/components/tag/src/tag.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    v-if="shouldDisable"
+    v-if="disableTransitions"
     :class="containerKls"
     :style="{ backgroundColor: color }"
     @click="handleClick"
@@ -16,7 +16,12 @@
     v-else
     :name="`${ns.namespace.value}-zoom-in-center`"
     appear
-    @vue:mounted="handleVNodeMounted"
+    @before-enter="onBeforeEnter"
+    @after-enter="onAfterEnter"
+    @before-leave="onBeforeLeave"
+    @after-leave="onAfterLeave"
+    @enter="onEnter"
+    @leave="onLeave"
   >
     <span
       :class="containerKls"
@@ -34,7 +39,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref, getCurrentInstance } from 'vue'
+import { computed } from 'vue'
 import ElIcon from '@element-plus/components/icon'
 import { Close } from '@element-plus/icons-vue'
 import { useNamespace } from '@element-plus/hooks'
@@ -81,20 +86,104 @@ const handleVNodeMounted = (vnode: VNode) => {
   }
 }
 
-const inTable = ref(false)
-onMounted(() => {
-  try {
-    const instance: any = getCurrentInstance()
-    const el = instance?.proxy?.$el
-    if (el && typeof el.closest === 'function') {
-      inTable.value = !!el.closest('.el-table')
-    }
-  } catch (e) {
-    // ignore
+function ensureParentRelative(parent: HTMLElement) {
+  const computed = getComputedStyle(parent)
+  if (computed.position === 'static') {
+    parent.setAttribute('data-el-tag-original-position', 'static')
+    parent.style.position = 'relative'
+  } else {
+    parent.setAttribute('data-el-tag-original-position', 'unchanged')
   }
-})
+}
 
-const shouldDisable = computed(() => {
-  return !!props.disableTransitions || inTable.value
-})
+function restoreParentPosition(parent: HTMLElement) {
+  const mark = parent.getAttribute('data-el-tag-original-position')
+  if (mark === 'static') {
+    parent.style.position = ''
+    parent.removeAttribute('data-el-tag-original-position')
+  } else if (mark === 'unchanged') {
+    parent.removeAttribute('data-el-tag-original-position')
+  }
+}
+
+function setAbsoluteForTransition(el: HTMLElement) {
+  const prev = {
+    position: el.style.position || '',
+    left: el.style.left || '',
+    top: el.style.top || '',
+    transform: el.style.transform || '',
+    width: el.style.width || '',
+    boxSizing: el.style.boxSizing || '',
+    zIndex: el.style.zIndex || '',
+  }
+  el.__elTagPrevStyle = prev as any
+
+  el.style.position = 'absolute'
+  el.style.left = '0'
+  el.style.top = '50%'
+  el.style.transform = 'translateY(-50%)'
+  el.style.width = '100%'
+  el.style.boxSizing = 'border-box'
+  el.style.zIndex = '1'
+}
+
+function restoreStyleAfterTransition(el: HTMLElement) {
+  const prev = (el as any).__elTagPrevStyle
+  if (prev) {
+    el.style.position = prev.position
+    el.style.left = prev.left
+    el.style.top = prev.top
+    el.style.transform = prev.transform
+    el.style.width = prev.width
+    el.style.boxSizing = prev.boxSizing
+    el.style.zIndex = prev.zIndex
+    delete (el as any).__elTagPrevStyle
+  }
+}
+
+function findHostParent(el: HTMLElement): HTMLElement | null {
+  return el.parentElement
+}
+
+function onBeforeEnter(el: Element) {
+  const e = el as HTMLElement
+  const host = findHostParent(e)
+  if (!host) return
+  ensureParentRelative(host)
+  setAbsoluteForTransition(e)
+}
+
+function onEnter(el: Element) {
+  // no-op
+}
+
+function onAfterEnter(el: Element) {
+  const e = el as HTMLElement
+  const host = findHostParent(e)
+  if (host) {
+    restoreStyleAfterTransition(e)
+    restoreParentPosition(host)
+  }
+}
+
+function onBeforeLeave(el: Element) {
+  const e = el as HTMLElement
+  const host = findHostParent(e)
+  if (!host) return
+  ensureParentRelative(host)
+  setAbsoluteForTransition(e)
+}
+
+function onLeave(el: Element) {
+  // no-op
+}
+
+function onAfterLeave(el: Element) {
+  const e = el as HTMLElement
+  const host = findHostParent(e)
+  if (host) {
+    restoreStyleAfterTransition(e)
+    restoreParentPosition(host)
+  }
+}
 </script>

--- a/packages/components/tag/src/tag.vue
+++ b/packages/components/tag/src/tag.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    v-if="disableTransitions"
+    v-if="shouldDisable"
     :class="containerKls"
     :style="{ backgroundColor: color }"
     @click="handleClick"
@@ -34,7 +34,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, onMounted, ref, getCurrentInstance } from 'vue'
 import ElIcon from '@element-plus/components/icon'
 import { Close } from '@element-plus/icons-vue'
 import { useNamespace } from '@element-plus/hooks'
@@ -80,4 +80,21 @@ const handleVNodeMounted = (vnode: VNode) => {
     vnode.component.subTree.component.bum = null
   }
 }
+
+const inTable = ref(false)
+onMounted(() => {
+  try {
+    const instance: any = getCurrentInstance()
+    const el = instance?.proxy?.$el
+    if (el && typeof el.closest === 'function') {
+      inTable.value = !!el.closest('.el-table')
+    }
+  } catch (e) {
+    // ignore
+  }
+})
+
+const shouldDisable = computed(() => {
+  return !!props.disableTransitions || inTable.value
+})
 </script>


### PR DESCRIPTION
当 el-tag 运行时检测到其 DOM 上有 .el-table 祖先时，自动禁用 el-tag 的过渡动画（transition），以避免分页切换时产生不必要的动画导致抖动。若用户显式传入 disableTransitions prop 则保持用户设定。
When el-tag detects a .el-table ancestor in its DOM at runtime, it automatically disables the transition animation of el-tag to prevent unnecessary animation-induced jitter during pagination. If the user explicitly passes the disableTransitions prop, the user's setting is retained.

Files changed：packages/components/tag/src/tag.vue

fix #22437
