### PR TITLE
ci: revert test-coverage trigger

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -4,6 +4,8 @@ name: 🧪 Test Coverage
 
 on:
   pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:
@@ -26,12 +28,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
 
-      - name: 'Run Test Coverage'
+      - name: "Run Test Coverage"
         run: pnpm run test:coverage
 
       - uses: davelosert/vitest-coverage-report-action@v2.2.0


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

#22656 The trigger timing was temporarily modified for testing purposes. I believe that the action generally doesn't need to run, so I've decided to revert it.