### PR TITLE
fix(components): [table] Fix the box-shadow of the table

### DIFF
--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -429,6 +429,13 @@
         box-shadow: getCssVar('table-fixed-right-column');
       }
     }
+    .#{$namespace}-table.is-scrolling-right {
+      .#{$namespace}-table-fixed-column--right.is-first-column {
+        &::before {
+          box-shadow: none;
+        }
+      }
+    }
 
     &.#{$namespace}-table--border {
       .#{$namespace}-table-fixed-column--left {
@@ -452,6 +459,13 @@
       }
     }
 
+    .#{$namespace}-table.is-scrolling-left {
+      .#{$namespace}-table-fixed-column--left.is-last-column {
+        &::before {
+          box-shadow: none;
+        }
+      }
+    }
     .#{$namespace}-table-fixed-column--left.is-last-column.#{$namespace}-table__cell {
       border-right: none;
     }
@@ -477,6 +491,21 @@
         box-shadow: getCssVar('table-fixed-left-column');
       }
     }
+
+    .#{$namespace}-table.is-scrolling-right {
+      .#{$namespace}-table-fixed-column--right.is-first-column {
+        &::before {
+          box-shadow: none;
+        }
+      }
+    }
+    .#{$namespace}-table.is-scrolling-left {
+      .#{$namespace}-table-fixed-column--left.is-last-column {
+        &::before {
+          box-shadow: none;
+        }
+      }
+    }
   }
 
   @include when(scrolling-none) {
@@ -489,7 +518,34 @@
         }
       }
     }
+    .#{$namespace}-table.is-scrolling-right {
+      .#{$namespace}-table-fixed-column--left.is-last-column {
+        &::before {
+          box-shadow: getCssVar('table-fixed-left-column');
+        }
+      }
+    }
+    .#{$namespace}-table.is-scrolling-left {
+      .#{$namespace}-table-fixed-column--right.is-first-column {
+        &::before {
+          box-shadow: getCssVar('table-fixed-right-column');
+        }
+      }
+    }
 
+    .#{$namespace}-table.is-scrolling-middle {
+      .#{$namespace}-table-fixed-column--right.is-first-column {
+        &::before {
+          box-shadow: getCssVar('table-fixed-right-column');
+        }
+      }
+
+      .#{$namespace}-table-fixed-column--left.is-last-column {
+        &::before {
+          box-shadow: getCssVar('table-fixed-left-column');
+        }
+      }
+    }
     th.#{$namespace}-table-fixed-column--left,
     th.#{$namespace}-table-fixed-column--right {
       background-color: getCssVar('table-header-bg-color');


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


**The :before box-shadow of the fixed column cells within the nested table in the row will be affected by the parent table.**

**Detailed description**: The impact can be categorized into three scenarios: 1) If the parent table is set as "is-scrolling-left" and the child table is set as "is-scrolling-right", then the fixed column on the left side of the child table will exhibit an undesired shadow. 2) If the parent table has the class "is-scrolling-right" and the child table has the class "is-scrolling-left", then the fixed column on the right side of the child table will display an undesired shadow. 3) If the parent table has the class "is-scrolling-none" and the child table has the class "is-scrolling-left", then the fixed column on the right side of the child table will display an undesired shadow. Similarly, if the child table has the class "is-scrolling-right", the fixed column on the left side of the child table will also show an undesired shadow.

