### PR TITLE
fix(components): [autocomplete] allow using Numpad Enter to select the option

### DIFF
--- a/packages/components/autocomplete/__tests__/autocomplete.test.tsx
+++ b/packages/components/autocomplete/__tests__/autocomplete.test.tsx
@@ -697,4 +697,42 @@ describe('Autocomplete.vue', () => {
       expect(footerEl!.textContent).toBe('Custom Footer')
     })
   })
+
+  describe('should select the option when using Enter or Numpad Enter', () => {
+    test('use Enter', async () => {
+      const wrapper = _mount()
+      await nextTick()
+
+      const target = wrapper.getComponent(Autocomplete).vm as InstanceType<
+        typeof Autocomplete
+      >
+      const input = wrapper.find('input')
+
+      await input.trigger('focus')
+      vi.runAllTimers()
+      await nextTick()
+
+      await input.trigger('keydown', { code: EVENT_CODE.down })
+      await input.trigger('keydown', { code: EVENT_CODE.enter })
+      expect(target.modelValue).toBe('Java')
+    })
+
+    test('use Numpad Enter', async () => {
+      const wrapper = _mount()
+      await nextTick()
+
+      const target = wrapper.getComponent(Autocomplete).vm as InstanceType<
+        typeof Autocomplete
+      >
+      const input = wrapper.find('input')
+
+      await input.trigger('focus')
+      vi.runAllTimers()
+      await nextTick()
+
+      await input.trigger('keydown', { code: EVENT_CODE.down })
+      await input.trigger('keydown', { code: EVENT_CODE.numpadEnter })
+      expect(target.modelValue).toBe('Java')
+    })
+  })
 })

--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -402,6 +402,7 @@ const handleKeydown = (e: KeyboardEvent | Event) => {
       highlight(highlightedIndex.value + 1)
       break
     case EVENT_CODE.enter:
+    case EVENT_CODE.numpadEnter:
       e.preventDefault()
       handleKeyEnter()
       break


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

relate #22714 and #22715
`Autocomplete` should also allow using `Numpad Enter` to select the option.