### PR TITLE
feat(components): [collapse] add collapsible attribute

### DIFF
--- a/docs/en-US/component/collapse.md
+++ b/docs/en-US/component/collapse.md
@@ -73,6 +73,15 @@ collapse/prevent-collapsing
 
 :::
 
+## Collapsible
+
+Specify the trigger area of collapsible by `collapsible`.
+:::demo
+
+collapse/collapsible
+
+:::
+
 ## Collapse API
 
 ### Collapse Attributes
@@ -107,12 +116,13 @@ collapse/prevent-collapsing
 
 ### Collapse Item Attributes
 
-| Name          | Description                        | Type                     | Default    |
-| ------------- | ---------------------------------- | ------------------------ | ---------- |
-| name          | unique identification of the panel | ^[string] / ^[number]    | —          |
-| title         | title of the panel                 | ^[string]                | ''         |
-| icon ^(2.8.3) | icon of the collapse item          | ^[string] / ^[Component] | ArrowRight |
-| disabled      | disable the collapse item          | ^[boolean]               | false      |
+| Name                  | Description                             | Type                                       | Default    |
+| --------------------- | --------------------------------------- | ------------------------------------------ | ---------- |
+| name                  | unique identification of the panel      | ^[string] / ^[number]                      | —          |
+| title                 | title of the panel                      | ^[string]                                  | ''         |
+| icon ^(2.8.3)         | icon of the collapse item               | ^[string] / ^[Component]                   | ArrowRight |
+| collapsible           | specify the trigger area of collapsible | ^[enum]`'icon' \| 'header' \| 'disabled' ` | -          |
+| disabled^(deprecated) | disable the collapse item               | ^[boolean]                                 | false      |
 
 ### Collapse Item Slot
 

--- a/docs/en-US/component/collapse.md
+++ b/docs/en-US/component/collapse.md
@@ -92,6 +92,7 @@ collapse/collapsible
 | accordion                      | whether to activate accordion mode                                                                                                                   | ^[boolean]                                     | false   |
 | expand-icon-position ^(2.9.10) | set expand icon position                                                                                                                             | ^[enum]`'left' \| 'right' `                    | right   |
 | before-collapse ^(2.9.11)      | before-collapse hook before the collapse state changes. If `false` is returned or a `Promise` is returned and then is rejected, will stop collapsing | ^[Function]`() => Promise<boolean> \| boolean` | —       |
+| collapsible                    | Specify how to trigger Collapse. Either by clicking icon or by clicking any area in header or disable collapse functionality itself                  | ^[enum]`'icon' \| 'header' \| 'disabled' `     | -       |
 
 ### Collapse Events
 
@@ -116,13 +117,13 @@ collapse/collapsible
 
 ### Collapse Item Attributes
 
-| Name                  | Description                             | Type                                       | Default    |
-| --------------------- | --------------------------------------- | ------------------------------------------ | ---------- |
-| name                  | unique identification of the panel      | ^[string] / ^[number]                      | —          |
-| title                 | title of the panel                      | ^[string]                                  | ''         |
-| icon ^(2.8.3)         | icon of the collapse item               | ^[string] / ^[Component]                   | ArrowRight |
-| collapsible           | specify the trigger area of collapsible | ^[enum]`'icon' \| 'header' \| 'disabled' ` | -          |
-| disabled^(deprecated) | disable the collapse item               | ^[boolean]                                 | false      |
+| Name                  | Description                                                                                                                           | Type                                       | Default    |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ---------- |
+| name                  | unique identification of the panel                                                                                                    | ^[string] / ^[number]                      | —          |
+| title                 | title of the panel                                                                                                                    | ^[string]                                  | ''         |
+| icon ^(2.8.3)         | icon of the collapse item                                                                                                             | ^[string] / ^[Component]                   | ArrowRight |
+| collapsible           | Specify whether the panel be collapsible or the trigger area of collapsible (Priority is higher than Collapse Attributes collapsible) | ^[enum]`'icon' \| 'header' \| 'disabled' ` | -          |
+| disabled^(deprecated) | disable the collapse item                                                                                                             | ^[boolean]                                 | false      |
 
 ### Collapse Item Slot
 

--- a/docs/examples/collapse/collapsible.vue
+++ b/docs/examples/collapse/collapsible.vue
@@ -1,0 +1,33 @@
+<template>
+  <el-collapse>
+    <el-collapse-item
+      title="This panel can be collapsed by clicking text or icon"
+      name="0"
+      collapsible="header"
+    >
+      <div>
+        Consistent with real life: in line with the process and logic of real
+        life, and comply with languages and habits that the users are used to;
+      </div>
+    </el-collapse-item>
+    <el-collapse-item
+      title="This panel can only be collapsed by clicking icon"
+      name="1"
+      collapsible="icon"
+    >
+      <div>
+        Operation feedback: enable the users to clearly perceive their
+        operations by style updates and interactive effects;
+      </div>
+    </el-collapse-item>
+    <el-collapse-item
+      title="This panel can't be collapsed"
+      name="2"
+      collapsible="disabled"
+    >
+      <div>
+        Simplify the process: keep operating process simple and intuitive;
+      </div>
+    </el-collapse-item>
+  </el-collapse>
+</template>

--- a/docs/examples/collapse/collapsible.vue
+++ b/docs/examples/collapse/collapsible.vue
@@ -1,9 +1,8 @@
 <template>
-  <el-collapse>
+  <el-collapse collapsible="header">
     <el-collapse-item
       title="This panel can be collapsed by clicking text or icon"
       name="0"
-      collapsible="header"
     >
       <div>
         Consistent with real life: in line with the process and logic of real
@@ -12,11 +11,10 @@
     </el-collapse-item>
   </el-collapse>
 
-  <el-collapse>
+  <el-collapse collapsible="icon">
     <el-collapse-item
       title="This panel can only be collapsed by clicking icon"
       name="1"
-      collapsible="icon"
     >
       <div>
         Operation feedback: enable the users to clearly perceive their
@@ -25,12 +23,8 @@
     </el-collapse-item>
   </el-collapse>
 
-  <el-collapse>
-    <el-collapse-item
-      title="This panel can't be collapsed"
-      name="2"
-      collapsible="disabled"
-    >
+  <el-collapse collapsible="disabled">
+    <el-collapse-item title="This panel can't be collapsed" name="2">
       <div>
         Simplify the process: keep operating process simple and intuitive;
       </div>

--- a/docs/examples/collapse/collapsible.vue
+++ b/docs/examples/collapse/collapsible.vue
@@ -10,6 +10,9 @@
         life, and comply with languages and habits that the users are used to;
       </div>
     </el-collapse-item>
+  </el-collapse>
+
+  <el-collapse>
     <el-collapse-item
       title="This panel can only be collapsed by clicking icon"
       name="1"
@@ -20,6 +23,9 @@
         operations by style updates and interactive effects;
       </div>
     </el-collapse-item>
+  </el-collapse>
+
+  <el-collapse>
     <el-collapse-item
       title="This panel can't be collapsed"
       name="2"

--- a/packages/components/collapse/__tests__/collapse.test.tsx
+++ b/packages/components/collapse/__tests__/collapse.test.tsx
@@ -401,13 +401,13 @@ describe('Collapse.vue', () => {
       const input = wrapper.find('[data-testid="test-input"]')
       const header = wrapper.find('.el-collapse-item__header')
 
-      await input.trigger('keydown.enter')
+      await input.trigger('keydown.Enter')
       await nextTick()
 
       const collapseItem = wrapper.findComponent(CollapseItem)
       expect(collapseItem.vm.isActive).toBe(true)
 
-      await header.trigger('keydown.enter')
+      await header.trigger('keydown.Enter')
       await nextTick()
       expect(collapseItem.vm.isActive).toBe(false)
     })
@@ -417,13 +417,13 @@ describe('Collapse.vue', () => {
       const input = wrapper.find('[data-testid="test-input"]')
       const header = wrapper.find('.el-collapse-item__header')
 
-      await input.trigger('keydown.space')
+      await input.trigger('keydown.Space')
       await nextTick()
 
       const collapseItem = wrapper.findComponent(CollapseItem)
       expect(collapseItem.vm.isActive).toBe(true)
 
-      await header.trigger('keydown.space')
+      await header.trigger('keydown.Space')
       await nextTick()
       expect(collapseItem.vm.isActive).toBe(false)
     })

--- a/packages/components/collapse/src/collapse-item.ts
+++ b/packages/components/collapse/src/collapse-item.ts
@@ -28,8 +28,15 @@ export const collapseItemProps = buildProps({
   },
   /**
    * @description disable the collapse item
+   * @deprecated This prop is deprecated and will be removed in the next major version. Use `collapsible="disabled"` instead.
    */
   disabled: Boolean,
+  /**
+   * @description Specify how to trigger Collapse. Either by clicking icon or by clicking any area in header or disable collapse functionality itself
+   */
+  collapsible: {
+    type: definePropType<'icon' | 'header' | 'disabled'>([String]),
+  },
 } as const)
 export type CollapseItemProps = ExtractPropTypes<typeof collapseItemProps>
 export type CollapseItemPropsPublic = __ExtractPublicPropTypes<

--- a/packages/components/collapse/src/collapse-item.ts
+++ b/packages/components/collapse/src/collapse-item.ts
@@ -32,7 +32,7 @@ export const collapseItemProps = buildProps({
    */
   disabled: Boolean,
   /**
-   * @description Specify how to trigger Collapse. Either by clicking icon or by clicking any area in header or disable collapse functionality itself
+   * @description Specify whether the panel be collapsible or the trigger area of collapsible
    */
   collapsible: {
     type: definePropType<'icon' | 'header' | 'disabled'>([String]),

--- a/packages/components/collapse/src/collapse-item.vue
+++ b/packages/components/collapse/src/collapse-item.vue
@@ -6,22 +6,20 @@
       :aria-expanded="isActive"
       :aria-controls="scopedContentId"
       :aria-describedby="scopedContentId"
-      :tabindex="disabled ? undefined : 0"
-      :aria-disabled="disabled"
+      :aria-disabled="!headerTrigger"
       role="button"
-      @click="handleHeaderClick"
-      @keydown.space.enter.stop="handleEnterClick"
-      @focus="handleFocus"
-      @blur="focusing = false"
+      v-bind="headerProps"
     >
-      <span :class="itemTitleKls">
+      <span :class="itemTitleKls" v-bind="titleProps">
         <slot name="title" :is-active="isActive">{{ title }}</slot>
       </span>
-      <slot name="icon" :is-active="isActive">
-        <el-icon :class="arrowKls">
-          <component :is="icon" />
-        </el-icon>
-      </slot>
+      <div :class="warpArrowKls" v-bind="iconProps">
+        <slot name="icon" :is-active="isActive">
+          <el-icon :class="arrowKls">
+            <component :is="icon" />
+          </el-icon>
+        </slot>
+      </div>
     </div>
 
     <el-collapse-transition>
@@ -42,23 +40,35 @@
 </template>
 
 <script lang="ts" setup>
+import { debugWarn } from '@element-plus/utils'
 import ElCollapseTransition from '@element-plus/components/collapse-transition'
 import ElIcon from '@element-plus/components/icon'
 import { collapseItemProps } from './collapse-item'
 import { useCollapseItem, useCollapseItemDOM } from './use-collapse-item'
 
+const COMPONENT_NAME = 'ElCollapseItem'
 defineOptions({
-  name: 'ElCollapseItem',
+  name: COMPONENT_NAME,
 })
 
 const props = defineProps(collapseItemProps)
+
+props.disabled &&
+  debugWarn(
+    COMPONENT_NAME,
+    'disabled prop is deprecated and will be removed in the next major version. Use collapsible="disabled" instead.'
+  )
+
 const {
-  focusing,
   id,
   isActive,
-  handleFocus,
-  handleHeaderClick,
-  handleEnterClick,
+  disabled,
+  headerTrigger,
+  iconTrigger,
+  titleTrigger,
+  headerProps,
+  titleProps,
+  iconProps,
 } = useCollapseItem(props)
 
 const {
@@ -70,7 +80,15 @@ const {
   itemContentKls,
   scopedContentId,
   scopedHeadId,
-} = useCollapseItemDOM(props, { focusing, isActive, id })
+  warpArrowKls,
+} = useCollapseItemDOM(props, {
+  isActive,
+  id,
+  disabled,
+  headerTrigger,
+  iconTrigger,
+  titleTrigger,
+})
 
 defineExpose({
   /** @description current collapse-item whether active */

--- a/packages/components/collapse/src/collapse.ts
+++ b/packages/components/collapse/src/collapse.ts
@@ -15,6 +15,7 @@ export type CollapseActiveName = string | number
 export type CollapseModelValue = Arrayable<CollapseActiveName>
 
 export type CollapseIconPositionType = 'left' | 'right'
+export type CollapseCollapsibleType = 'icon' | 'header' | 'disabled'
 
 export const emitChangeFn = (value: CollapseModelValue) =>
   isNumber(value) || isString(value) || isArray(value)
@@ -45,6 +46,12 @@ export const collapseProps = buildProps({
     type: definePropType<(name: CollapseActiveName) => Awaitable<boolean>>(
       Function
     ),
+  },
+  /**
+   * @description Specify how to trigger Collapse. Either by clicking icon or by clicking any area in header or disable collapse functionality itself
+   */
+  collapsible: {
+    type: definePropType<CollapseCollapsibleType>([String]),
   },
 } as const)
 export type CollapseProps = ExtractPropTypes<typeof collapseProps>

--- a/packages/components/collapse/src/constants.ts
+++ b/packages/components/collapse/src/constants.ts
@@ -1,8 +1,9 @@
 import type { InjectionKey, Ref } from 'vue'
-import type { CollapseActiveName } from './collapse'
+import type { CollapseActiveName, CollapseCollapsibleType } from './collapse'
 
 export interface CollapseContext {
   activeNames: Ref<CollapseActiveName[]>
+  collapsible: CollapseCollapsibleType | undefined
   handleItemClick: (name: CollapseActiveName) => void
 }
 

--- a/packages/components/collapse/src/use-collapse-item.ts
+++ b/packages/components/collapse/src/use-collapse-item.ts
@@ -23,7 +23,9 @@ export const useCollapseItem = (props: CollapseItemProps) => {
     collapse?.activeNames.value.includes(unref(name))
   )
 
-  const collapsible = computed(() => props.collapsible ?? '')
+  const collapsible = computed(
+    () => props.collapsible || collapse?.collapsible || ''
+  )
   const disabled = computed(
     () => props.disabled || collapsible.value === 'disabled'
   )

--- a/packages/components/collapse/src/use-collapse-item.ts
+++ b/packages/components/collapse/src/use-collapse-item.ts
@@ -1,15 +1,16 @@
-import { computed, inject, ref, unref } from 'vue'
+import { computed, inject, unref } from 'vue'
 import { useIdInjection, useNamespace } from '@element-plus/hooks'
+import { EVENT_CODE } from '@element-plus/constants'
+import { getEventCode } from '@element-plus/utils'
 import { collapseContextKey } from './constants'
 
+import type { ComputedRef } from 'vue'
 import type { CollapseItemProps } from './collapse-item'
 
 export const useCollapseItem = (props: CollapseItemProps) => {
   const collapse = inject(collapseContextKey)
   const { namespace } = useNamespace('collapse')
 
-  const focusing = ref(false)
-  const isClick = ref(false)
   const idInjection = useIdInjection()
   const id = computed(() => idInjection.current++)
   const name = computed(() => {
@@ -22,63 +23,103 @@ export const useCollapseItem = (props: CollapseItemProps) => {
     collapse?.activeNames.value.includes(unref(name))
   )
 
-  const handleFocus = () => {
-    setTimeout(() => {
-      if (!isClick.value) {
-        focusing.value = true
-      } else {
-        isClick.value = false
-      }
-    }, 50)
-  }
+  const collapsible = computed(() => props.collapsible ?? '')
+  const disabled = computed(
+    () => props.disabled || collapsible.value === 'disabled'
+  )
+  const headerTrigger = computed(
+    () =>
+      !props.disabled &&
+      !['disabled', 'icon', 'header'].includes(collapsible.value)
+  )
+  const iconTrigger = computed(
+    () => !props.disabled && ['icon', 'header'].includes(collapsible.value)
+  )
+  const titleTrigger = computed(
+    () => !props.disabled && collapsible.value === 'header'
+  )
 
-  const handleHeaderClick = (e: MouseEvent) => {
-    if (props.disabled) return
-    const target = e.target as HTMLElement
-    if (target?.closest('input, textarea, select')) return
-    collapse?.handleItemClick(unref(name))
-    focusing.value = false
-    isClick.value = true
-  }
-
-  const handleEnterClick = (e: KeyboardEvent) => {
+  const handleInteraction = (
+    trigger: ComputedRef<boolean>,
+    e: MouseEvent | KeyboardEvent
+  ) => {
+    if (!unref(trigger)) return
     const target = e.target as HTMLElement
     if (target?.closest('input, textarea, select')) return
     e.preventDefault()
     collapse?.handleItemClick(unref(name))
   }
 
+  const handleKeydown = (trigger: ComputedRef<boolean>, e: KeyboardEvent) => {
+    const code = getEventCode(e)
+    if ([EVENT_CODE.space, EVENT_CODE.enter].includes(code)) {
+      handleInteraction(trigger, e)
+    }
+  }
+
+  const createInteractionProps = (trigger: ComputedRef<boolean>) =>
+    computed(() =>
+      trigger.value
+        ? {
+            tabindex: 0,
+            onClick: (e: MouseEvent) => handleInteraction(trigger, e),
+            onKeydown: (e: KeyboardEvent) => handleKeydown(trigger, e),
+          }
+        : {}
+    )
+
+  const headerProps = createInteractionProps(headerTrigger)
+  const titleProps = createInteractionProps(titleTrigger)
+  const iconProps = createInteractionProps(iconTrigger)
+
   return {
-    focusing,
     id,
     isActive,
-    handleFocus,
-    handleHeaderClick,
-    handleEnterClick,
+    disabled,
+    headerTrigger,
+    iconTrigger,
+    titleTrigger,
+    headerProps,
+    titleProps,
+    iconProps,
+    handleInteraction,
   }
 }
 
 export const useCollapseItemDOM = (
   props: CollapseItemProps,
-  { focusing, isActive, id }: Partial<ReturnType<typeof useCollapseItem>>
+  {
+    isActive,
+    id,
+    disabled,
+    headerTrigger,
+    iconTrigger,
+    titleTrigger,
+  }: Partial<ReturnType<typeof useCollapseItem>>
 ) => {
   const ns = useNamespace('collapse')
 
   const rootKls = computed(() => [
     ns.b('item'),
     ns.is('active', unref(isActive)),
-    ns.is('disabled', props.disabled),
+    ns.is('disabled', unref(disabled)),
   ])
   const headKls = computed(() => [
     ns.be('item', 'header'),
     ns.is('active', unref(isActive)),
-    { focusing: unref(focusing) && !props.disabled },
+    ns.is('collapsible', unref(headerTrigger)),
   ])
   const arrowKls = computed(() => [
     ns.be('item', 'arrow'),
     ns.is('active', unref(isActive)),
   ])
-  const itemTitleKls = computed(() => [ns.be('item', 'title')])
+  const warpArrowKls = computed(() => [
+    ns.is('collapsible', unref(iconTrigger)),
+  ])
+  const itemTitleKls = computed(() => [
+    ns.be('item', 'title'),
+    ns.is('collapsible', unref(titleTrigger)),
+  ])
   const itemWrapperKls = computed(() => ns.be('item', 'wrap'))
   const itemContentKls = computed(() => ns.be('item', 'content'))
   const scopedContentId = computed(() => ns.b(`content-${unref(id)}`))
@@ -88,6 +129,7 @@ export const useCollapseItemDOM = (
     itemTitleKls,
     arrowKls,
     headKls,
+    warpArrowKls,
     rootKls,
     itemWrapperKls,
     itemContentKls,

--- a/packages/components/collapse/src/use-collapse.ts
+++ b/packages/components/collapse/src/use-collapse.ts
@@ -89,6 +89,7 @@ export const useCollapse = (
 
   provide(collapseContextKey, {
     activeNames,
+    collapsible: props.collapsible,
     handleItemClick,
   })
   return {

--- a/packages/theme-chalk/src/collapse.scss
+++ b/packages/theme-chalk/src/collapse.scss
@@ -27,7 +27,6 @@
     line-height: getCssVar('collapse-header-height');
     background-color: getCssVar('collapse-header-bg-color');
     color: getCssVar('collapse-header-text-color');
-    cursor: pointer;
     border-bottom: 1px solid getCssVar('collapse-border-color');
     font-size: getCssVar('collapse-header-font-size');
     font-weight: 500;
@@ -42,15 +41,21 @@
     }
 
     @include e(title) {
-      text-align: left;
-      flex: auto;
+      margin-right: auto;
     }
 
-    &.focusing:focus:not(:hover) {
+    &:focus-visible:not(:hover) {
       color: getCssVar('color-primary');
     }
     @include when(active) {
       border-bottom-color: transparent;
+    }
+
+    @include when(collapsible) {
+      cursor: pointer;
+    }
+    & > .is-collapsible {
+      cursor: pointer;
     }
   }
 


### PR DESCRIPTION
close #20992

有三处 `breaking change`.

1. https://github.com/element-plus/element-plus/blob/f62501cf402f3dad82fe953259dcc613183c964e/packages/components/collapse/src/collapse-item.vue#L20
为了图标区域可点击,给这里外层包裹了`div`.

2. https://github.com/element-plus/element-plus/blob/f62501cf402f3dad82fe953259dcc613183c964e/packages/components/collapse/src/use-collapse-item.ts#L25
使用 `css` 的 `focus-visible` 替换原有用 `js` 实现的 `focus` 逻辑. 以前使用了定时器,有50毫秒延迟.更改之后没有了.


3. https://github.com/element-plus/element-plus/blob/f62501cf402f3dad82fe953259dcc613183c964e/packages/components/collapse/src/collapse-item.ts#L30
将 `collapse-item`的 `disabled` 属性集成到新属性`collapsible`里面,同时将它弃用.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `collapsible` attribute enabling fine-grained control over collapse trigger areas (header text, icon, or entire item)

* **Documentation**
  * Added documentation section and interactive examples demonstrating collapsible attribute usage

* **Deprecations**
  * Deprecated `disabled` prop; use `collapsible="disabled"` for equivalent functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->