### PR TITLE
refactor(components): [image-viewer] use `useLockscreen` for scroll lock

### DIFF
--- a/packages/theme-chalk/src/image-viewer.scss
+++ b/packages/theme-chalk/src/image-viewer.scss
@@ -124,6 +124,12 @@
   }
 }
 
+@include b(image-viewer-parent) {
+  @include m(hidden) {
+    overflow: hidden;
+  }
+}
+
 .viewer-fade-enter-active {
   animation: viewer-fade-in getCssVar('transition-duration');
 }


### PR DESCRIPTION
I think the width provided by `useLockscreen` is necessary to prevent page shifting when the vertical scrollbar appears.

https://github.com/user-attachments/assets/623e1b65-7d9b-472e-8294-14e2b6104430