### PR TITLE
docs(style):  fix class name repeat

### DIFF
--- a/docs/examples/autocomplete/custom-header-footer.vue
+++ b/docs/examples/autocomplete/custom-header-footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="demo">
+  <div class="autocomplete-custom-header-footer">
     <div>
       <p>Custom header content</p>
       <el-autocomplete
@@ -87,20 +87,20 @@ const handleClear = () => {
 }
 </script>
 
-<style>
-.demo {
+<style scoped>
+.autocomplete-custom-header-footer {
   display: flex;
 }
 
-.demo > div {
+.autocomplete-custom-header-footer > div {
   flex: 1;
   text-align: center;
 }
-.demo > div > .el-autocomplete {
+.autocomplete-custom-header-footer > div > .el-autocomplete {
   width: 50%;
 }
 
-.demo > div:not(:last-child) {
+.autocomplete-custom-header-footer > div:not(:last-child) {
   border-right: 1px solid var(--el-border-color);
 }
 </style>

--- a/docs/examples/autocomplete/custom-header-footer.vue
+++ b/docs/examples/autocomplete/custom-header-footer.vue
@@ -96,7 +96,7 @@ const handleClear = () => {
   flex: 1;
   text-align: center;
 }
-.autocomplete-custom-header-footer > div > .el-autocomplete {
+.autocomplete-custom-header-footer > div > :deep(.el-autocomplete) {
   width: 50%;
 }
 

--- a/docs/examples/cascader/custom-header-footer.vue
+++ b/docs/examples/cascader/custom-header-footer.vue
@@ -115,7 +115,7 @@ const handleClear = () => {
 }
 
 .cascader-custom-header {
-  .el-checkbox {
+  :deep(.el-checkbox) {
     display: flex;
     height: unset;
   }

--- a/docs/examples/cascader/custom-header-footer.vue
+++ b/docs/examples/cascader/custom-header-footer.vue
@@ -118,5 +118,4 @@ const handleClear = () => {
   display: flex;
   height: unset;
 }
-}
 </style>

--- a/docs/examples/cascader/custom-header-footer.vue
+++ b/docs/examples/cascader/custom-header-footer.vue
@@ -114,10 +114,9 @@ const handleClear = () => {
   border-right: 1px solid var(--el-border-color);
 }
 
-.cascader-custom-header {
-  :deep(.el-checkbox) {
-    display: flex;
-    height: unset;
-  }
+.cascader-custom-header .el-checkbox {
+  display: flex;
+  height: unset;
+}
 }
 </style>

--- a/docs/examples/cascader/custom-header-footer.vue
+++ b/docs/examples/cascader/custom-header-footer.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="demo">
+  <div class="cascader-custom-header-footer">
     <div>
       <p>Custom header content</p>
       <el-cascader
         v-model="value"
-        popper-class="custom-header"
+        popper-class="cascader-custom-header"
         :options="options"
         :props="props"
         clearable
@@ -100,21 +100,21 @@ const handleClear = () => {
 }
 </script>
 
-<style>
-.demo {
+<style scoped>
+.cascader-custom-header-footer {
   display: flex;
 }
 
-.demo > div {
+.cascader-custom-header-footer > div {
   flex: 1;
   text-align: center;
 }
 
-.demo > div:not(:last-child) {
+.cascader-custom-header-footer > div:not(:last-child) {
   border-right: 1px solid var(--el-border-color);
 }
 
-.custom-header {
+.cascader-custom-header {
   .el-checkbox {
     display: flex;
     height: unset;

--- a/docs/examples/watermark/custom.vue
+++ b/docs/examples/watermark/custom.vue
@@ -25,7 +25,7 @@ const config = reactive({
       :gap="config.gap"
       :offset="config.offset"
     >
-      <div class="watermarkContainer">
+      <div class="watermark-container">
         <h1>Element Plus</h1>
         <h2>A Vue 3 based component library for designers and developers</h2>
         <img src="/images/hamburger.png" alt="示例图片" />

--- a/docs/examples/watermark/custom.vue
+++ b/docs/examples/watermark/custom.vue
@@ -25,7 +25,7 @@ const config = reactive({
       :gap="config.gap"
       :offset="config.offset"
     >
-      <div class="demo">
+      <div class="watermarkContainer">
         <h1>Element Plus</h1>
         <h2>A Vue 3 based component library for designers and developers</h2>
         <img src="/images/hamburger.png" alt="示例图片" />
@@ -84,7 +84,7 @@ const config = reactive({
   display: flex;
   flex: auto;
 }
-.demo {
+.watermarkContainer {
   flex: auto;
 }
 .form {

--- a/docs/examples/watermark/custom.vue
+++ b/docs/examples/watermark/custom.vue
@@ -84,7 +84,7 @@ const config = reactive({
   display: flex;
   flex: auto;
 }
-.watermarkContainer {
+.watermark-container {
   flex: auto;
 }
 .form {


### PR DESCRIPTION
样式有冲突 [link](https://cn.element-plus.org/en-US/component/watermark#custom-configuration)
<img width="1439" height="796" alt="image" src="https://github.com/user-attachments/assets/28ff28a9-c5e2-46b7-bd35-3c7c130c1691" />

<img width="1486" height="795" alt="image" src="https://github.com/user-attachments/assets/ca88d347-40d3-41c6-aeba-23a4a0add92d" />

其他地方的类影响到这里了