### PR TITLE
fix(components): [tooltip] controlled mode `ESC` behavior error

### DIFF
--- a/packages/components/tooltip/__tests__/content.test.tsx
+++ b/packages/components/tooltip/__tests__/content.test.tsx
@@ -179,6 +179,50 @@ describe('<ElTooltipContent />', () => {
         expect(onClose).not.toHaveBeenCalled()
       })
 
+      it('should not close on ESC (focus-trap close) when controlled', async () => {
+        controlled.value = true
+        await nextTick()
+        const { vm } = wrapper
+
+        expect(onClose).not.toHaveBeenCalled()
+        vm.onContentClose()
+        await nextTick()
+        expect(onClose).not.toHaveBeenCalled()
+      })
+
+      it('should not close on blur when controlled', async () => {
+        controlled.value = true
+        await nextTick()
+        const { vm } = wrapper
+
+        expect(onClose).not.toHaveBeenCalled()
+        vm.onContentBlur()
+        await nextTick()
+        expect(onClose).not.toHaveBeenCalled()
+      })
+
+      it('should close on ESC (focus-trap close) when uncontrolled', async () => {
+        controlled.value = false
+        await nextTick()
+        const { vm } = wrapper
+
+        expect(onClose).not.toHaveBeenCalled()
+        vm.onContentClose()
+        await nextTick()
+        expect(onClose).toHaveBeenCalled()
+      })
+
+      it('should close on blur when uncontrolled and not virtual triggering', async () => {
+        controlled.value = false
+        await nextTick()
+        const { vm } = wrapper
+
+        expect(onClose).not.toHaveBeenCalled()
+        vm.onContentBlur()
+        await nextTick()
+        expect(onClose).toHaveBeenCalled()
+      })
+
       describe('onCloseOutside', () => {
         beforeEach(() => {
           // Have to mock this ref because we are not going to render the content in this component

--- a/packages/components/tooltip/src/content.vue
+++ b/packages/components/tooltip/src/content.vue
@@ -36,8 +36,8 @@
         :loop="loop"
         @mouseenter="onContentEnter"
         @mouseleave="onContentLeave"
-        @blur="onBlur"
-        @close="onClose"
+        @blur="onContentBlur"
+        @close="onContentClose"
       >
         <slot />
       </el-popper-content>
@@ -134,6 +134,11 @@ const stopWhenControlled = () => {
   if (unref(controlled)) return true
 }
 
+const onContentClose = () => {
+  if (stopWhenControlled()) return
+  onClose()
+}
+
 const onContentEnter = composeEventHandlers(stopWhenControlled, () => {
   if (props.enterable && isTriggerType(unref(trigger), 'hover')) {
     onOpen()
@@ -159,10 +164,9 @@ const onAfterShow = () => {
   onShow()
 }
 
-const onBlur = () => {
-  if (!props.virtualTriggering) {
-    onClose()
-  }
+const onContentBlur = () => {
+  if (stopWhenControlled()) return
+  if (!props.virtualTriggering) onClose()
 }
 
 const isFocusInsideContent = (event?: FocusEvent) => {


### PR DESCRIPTION
- Respect `controlled` mode in `ElTooltipContent`: ignore FocusTrap `close` (ESC) and `blur`-triggered close.

BREAKING CHANGE: Also affects Popover since it reuses Tooltip content behavior.

closed #22741

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
