### PR TITLE
fix(components): [color-picker] mouse drag fails after entering the iframe.

### DIFF
--- a/packages/components/color-picker-panel/src/utils/draggable.ts
+++ b/packages/components/color-picker-panel/src/utils/draggable.ts
@@ -3,19 +3,19 @@ import { isClient } from '@element-plus/utils'
 let isDragging = false
 
 export interface DraggableOptions {
-  drag?: (event: MouseEvent | TouchEvent) => void
-  start?: (event: MouseEvent | TouchEvent) => void
-  end?: (event: MouseEvent | TouchEvent) => void
+  drag?: (event: MouseEvent | TouchEvent | PointerEvent) => void
+  start?: (event: MouseEvent | TouchEvent | PointerEvent) => void
+  end?: (event: MouseEvent | TouchEvent | PointerEvent) => void
 }
 
 export function draggable(element: HTMLElement, options: DraggableOptions) {
   if (!isClient) return
 
-  const moveFn = function (event: MouseEvent | TouchEvent) {
+  const moveFn = function (event: MouseEvent | TouchEvent | PointerEvent) {
     options.drag?.(event)
   }
 
-  const upFn = function (event: MouseEvent | TouchEvent) {
+  const upFn = function (event: MouseEvent | TouchEvent | PointerEvent) {
     document.removeEventListener('mousemove', moveFn)
     document.removeEventListener('mouseup', upFn)
     document.removeEventListener('touchmove', moveFn)
@@ -28,8 +28,49 @@ export function draggable(element: HTMLElement, options: DraggableOptions) {
     options.end?.(event)
   }
 
+  const pointerMoveFn = function (event: PointerEvent) {
+    moveFn(event)
+  }
+
+  const pointerUpLikeFn = function (event: PointerEvent) {
+    try {
+      if (element.hasPointerCapture?.(event.pointerId)) {
+        element.releasePointerCapture(event.pointerId)
+      }
+    } catch { /* ignore */ }
+    element.removeEventListener('pointermove', pointerMoveFn)
+    element.removeEventListener('pointerup', pointerUpLikeFn)
+    element.removeEventListener('pointercancel', pointerUpLikeFn)
+    element.removeEventListener('lostpointercapture', pointerUpLikeFn)
+    upFn(event)
+  }
+
+  const pointerDownFn = function (event: PointerEvent) {
+    if (isDragging) return
+    if (event.button !== undefined && event.button !== 0) return
+
+    event.preventDefault()
+    document.onselectstart = () => false
+    document.ondragstart = () => false
+
+    try {
+      element.setPointerCapture(event.pointerId)
+    } catch { /* ignore */ }
+
+    element.addEventListener('pointermove', pointerMoveFn)
+    element.addEventListener('pointerup', pointerUpLikeFn)
+    element.addEventListener('pointercancel', pointerUpLikeFn)
+    element.addEventListener('lostpointercapture', pointerUpLikeFn)
+
+    isDragging = true
+    options.start?.(event)
+  }
+
   const downFn = function (event: MouseEvent | TouchEvent) {
     if (isDragging) return
+    if (event instanceof TouchEvent) {
+      event.preventDefault()
+    }
     document.onselectstart = () => false
     document.ondragstart = () => false
     document.addEventListener('mousemove', moveFn)
@@ -42,6 +83,10 @@ export function draggable(element: HTMLElement, options: DraggableOptions) {
     options.start?.(event)
   }
 
-  element.addEventListener('mousedown', downFn)
-  element.addEventListener('touchstart', downFn, { passive: false })
+  if ('PointerEvent' in window) {
+    element.addEventListener('pointerdown', pointerDownFn)
+  } else {
+    element.addEventListener('mousedown', downFn)
+    element.addEventListener('touchstart', downFn, { passive: false })
+  }
 }

--- a/packages/components/color-picker-panel/src/utils/draggable.ts
+++ b/packages/components/color-picker-panel/src/utils/draggable.ts
@@ -37,7 +37,9 @@ export function draggable(element: HTMLElement, options: DraggableOptions) {
       if (element.hasPointerCapture?.(event.pointerId)) {
         element.releasePointerCapture(event.pointerId)
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
     element.removeEventListener('pointermove', pointerMoveFn)
     element.removeEventListener('pointerup', pointerUpLikeFn)
     element.removeEventListener('pointercancel', pointerUpLikeFn)
@@ -55,7 +57,9 @@ export function draggable(element: HTMLElement, options: DraggableOptions) {
 
     try {
       element.setPointerCapture(event.pointerId)
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
 
     element.addEventListener('pointermove', pointerMoveFn)
     element.addEventListener('pointerup', pointerUpLikeFn)


### PR DESCRIPTION
When using this component to select a color by dragging, if the pointer enters an `<iframe>` after the mouse button is pressed, events like `mousemove/mouseup` will be taken over by the iframe’s own document, causing the drag logic on the parent page to stop working.

Here, we try using Pointer Events and capturing the pointer on drag start (`setPointerCapture`), so that even if the pointer enters the `<iframe>`, events continue to be dispatched to the captured element, resolving this issue.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
