### PR TITLE
ci: unable to add comment on PR from fork

### DIFF
--- a/.github/workflows/pr-conflict.yml
+++ b/.github/workflows/pr-conflict.yml
@@ -1,17 +1,27 @@
 name: Comment on PR with conflict Label
+# Note that this `pull_request_target` is vulnerable, it grants write access to a fork repo
+# DO NOT ADD ANY CHECKOUT/CACHING in this workflow
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, synchronize]
+
+permissions:
+  pull-requests: write
 
 jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
       - name: Check for specific label
-        if: contains(github.event.pull_request.labels.*.name, 'conflict pending')
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'conflict pending') &&
+          github.repository_owner == 'element-plus'
         uses: actions-cool/maintain-one-comment@v3.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             @${{ github.event.pull_request.user.login }} This PR has conflicts, please resolve them.
+            <!-- ELEMENT_PLUS_CONFLICT_COMMENT -->
+          body-include: '<!-- ELEMENT_PLUS_CONFLICT_COMMENT -->'
+          number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-conflict.yml
+++ b/.github/workflows/pr-conflict.yml
@@ -19,7 +19,6 @@ jobs:
           github.repository_owner == 'element-plus'
         uses: actions-cool/maintain-one-comment@v3.2.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             @${{ github.event.pull_request.user.login }} This PR has conflicts, please resolve them.
             <!-- ELEMENT_PLUS_CONFLICT_COMMENT -->


### PR DESCRIPTION
Use `pull_request_target` to trigger the workflow in the base repository context.

There should be no security issues in this workflow.
This workflow will not take effect in this PR because changing it to `pull_request_target` prevents it from running in a PR. Please see below for reference.

Rel https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. **This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.**
 
Reasons for failure:
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#using-the-permissions-key-for-forked-repositories
https://github.com/orgs/community/discussions/25358


Before:
Failed: https://github.com/element-plus/element-plus/actions/runs/19269312673/workflow?pr=22759

After:
https://github.com/rzzf/element-plus/pull/2#issuecomment-3517537046