### PR TITLE
fix(components): [popper] trigger memory leak issue

### DIFF
--- a/packages/components/popper/__tests__/trigger.test.tsx
+++ b/packages/components/popper/__tests__/trigger.test.tsx
@@ -73,12 +73,11 @@ describe('<ElPopperTrigger />', () => {
       await nextTick()
       expect(onClick).toHaveBeenCalled()
     })
-    it('should cleanup listeners when ref unmounts', async () => {
+    it('should cleanup listeners when triggerRef changes', async () => {
       const onClick = vi.fn()
-      const first = document.createElement('button')
-      const second = document.createElement('button')
+      const first = document.createElement('p')
       const removeSpy = vi.spyOn(first, 'removeEventListener')
-      const addSpy = vi.spyOn(second, 'addEventListener')
+      const addSpy = vi.spyOn(first, 'addEventListener')
 
       wrapper = mountTrigger({
         onClick,
@@ -88,16 +87,16 @@ describe('<ElPopperTrigger />', () => {
       await nextTick()
 
       await wrapper.setProps({
-        virtualRef: second,
+        virtualRef: {
+          getBoundingClientRect: () => {
+            return { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 }
+          },
+        },
       })
       await nextTick()
 
-      first.dispatchEvent(new MouseEvent('click'))
-      second.dispatchEvent(new MouseEvent('click'))
-
-      expect(onClick).toHaveBeenCalledTimes(1)
-      expect(removeSpy).toHaveBeenCalledWith('click', onClick, false)
       expect(addSpy).toHaveBeenCalledWith('click', onClick, false)
+      expect(removeSpy).toHaveBeenCalledWith('click', onClick, false)
     })
   })
 })

--- a/packages/components/popper/__tests__/trigger.test.tsx
+++ b/packages/components/popper/__tests__/trigger.test.tsx
@@ -73,5 +73,31 @@ describe('<ElPopperTrigger />', () => {
       await nextTick()
       expect(onClick).toHaveBeenCalled()
     })
+    it('should cleanup listeners when ref unmounts', async () => {
+      const onClick = vi.fn()
+      const first = document.createElement('button')
+      const second = document.createElement('button')
+      const removeSpy = vi.spyOn(first, 'removeEventListener')
+      const addSpy = vi.spyOn(second, 'addEventListener')
+
+      wrapper = mountTrigger({
+        onClick,
+        virtualTriggering: true,
+        virtualRef: first,
+      })
+      await nextTick()
+
+      await wrapper.setProps({
+        virtualRef: second,
+      })
+      await nextTick()
+
+      first.dispatchEvent(new MouseEvent('click'))
+      second.dispatchEvent(new MouseEvent('click'))
+
+      expect(onClick).toHaveBeenCalledTimes(1)
+      expect(removeSpy).toHaveBeenCalledWith('click', onClick, false)
+      expect(addSpy).toHaveBeenCalledWith('click', onClick, false)
+    })
   })
 })

--- a/packages/components/popper/src/trigger.vue
+++ b/packages/components/popper/src/trigger.vue
@@ -86,16 +86,24 @@ onMounted(() => {
     (el, prevEl) => {
       virtualTriggerAriaStopWatch?.()
       virtualTriggerAriaStopWatch = undefined
+
+      if (isElement(prevEl) && prevEl !== el) {
+        TRIGGER_ELE_EVENTS.forEach((eventName) => {
+          const handler = props[eventName]
+          if (handler) {
+            ;(prevEl as HTMLElement).removeEventListener(
+              eventName.slice(2).toLowerCase(),
+              handler,
+              ['onFocus', 'onBlur'].includes(eventName)
+            )
+          }
+        })
+      }
       if (isElement(el)) {
         TRIGGER_ELE_EVENTS.forEach((eventName) => {
           const handler = props[eventName]
           if (handler) {
             ;(el as HTMLElement).addEventListener(
-              eventName.slice(2).toLowerCase(),
-              handler,
-              ['onFocus', 'onBlur'].includes(eventName)
-            )
-            ;(prevEl as HTMLElement)?.removeEventListener?.(
               eventName.slice(2).toLowerCase(),
               handler,
               ['onFocus', 'onBlur'].includes(eventName)

--- a/packages/components/popper/src/trigger.vue
+++ b/packages/components/popper/src/trigger.vue
@@ -87,7 +87,7 @@ onMounted(() => {
       virtualTriggerAriaStopWatch?.()
       virtualTriggerAriaStopWatch = undefined
 
-      if (isElement(prevEl) && prevEl !== el) {
+      if (isElement(prevEl)) {
         TRIGGER_ELE_EVENTS.forEach((eventName) => {
           const handler = props[eventName]
           if (handler) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


fix(components): trigger memory leak issue

在 `tigger.vue` 文件中，当最后一个 `triggerRef` 结束时，由于 `el` 为空，而 `prevEl` 的清除方法 又位于 `if (isElement(el))` 条件语句内部，因此该清除方法不会被执行，从而导致泄露。

For reference:

In the `tigger.vue` file, when the last `triggerRef` cleared, `el` is null. Because the `removeEventListener` method for `prevEl` is located inside the `if (isElement(el))` conditional statement, the cleanup method will not be executed, which leads to a leak.
