### PR TITLE
fix(components): [select] after the last select unmounts memory leak issue

### DIFF
--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -3915,4 +3915,83 @@ describe('Select', () => {
     await input.trigger('keydown', { code: EVENT_CODE.numpadEnter })
     expect(vm.value).toBe(1)
   })
+
+  test('should restore warn handler after the last select unmounts', async () => {
+    const warnHandler = vi.fn()
+    const Parent = defineComponent({
+      components: {
+        'el-select': Select,
+        'el-option': Option,
+      },
+      setup() {
+        const showFirst = ref(true)
+        const showSecond = ref(true)
+        const value = ref('')
+        const options = [
+          { label: 'label-1', value: 1 },
+          { label: 'label-2', value: 2 },
+        ]
+        const hideFirst = () => {
+          showFirst.value = false
+        }
+        const hideSecond = () => {
+          showSecond.value = false
+        }
+        return {
+          showFirst,
+          showSecond,
+          value,
+          options,
+          hideFirst,
+          hideSecond,
+        }
+      },
+      template: `
+        <div>
+          <el-select v-if="showFirst" v-model="value">
+            <el-option
+              v-for="item in options"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value"
+            />
+          </el-select>
+          <el-select v-if="showSecond" v-model="value">
+            <el-option
+              v-for="item in options"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value"
+            />
+          </el-select>
+        </div>
+      `,
+    })
+
+    const wrapper = mount(Parent, {
+      attachTo: 'body',
+      global: {
+        config: {
+          warnHandler,
+        },
+        provide: {
+          namespace: 'el',
+        },
+      },
+    })
+
+    const appContext = (wrapper.vm.$ as any).appContext
+
+    expect(appContext.config.warnHandler).not.toBe(warnHandler)
+
+    wrapper.vm.hideFirst()
+    await nextTick()
+    expect(appContext.config.warnHandler).not.toBe(warnHandler)
+
+    wrapper.vm.hideSecond()
+    await nextTick()
+    expect(appContext.config.warnHandler).toBe(warnHandler)
+
+    wrapper.unmount()
+  })
 })

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -372,7 +372,10 @@ const createSelectWarnHandler = (appContext: AppContext): WarnHandler => {
     const message = args[0]
     if (
       !message ||
-      message.includes('Slot "default" invoked outside of the render function')
+      (message.includes(
+        'Slot "default" invoked outside of the render function'
+      ) &&
+        args[2]?.includes('ElTreeSelect'))
     )
       return
     const original = warnHandlerMap.get(appContext)?.originalWarnHandler

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -350,10 +350,53 @@ import ElOptions from './options'
 import { selectProps } from './select'
 import ElOptionGroup from './option-group.vue'
 
-import type { VNode } from 'vue'
+import type { AppConfig, AppContext, VNode } from 'vue'
 import type { SelectContext } from './type'
 
 const COMPONENT_NAME = 'ElSelect'
+
+type WarnHandler = AppConfig['warnHandler']
+
+interface WarnHandlerRecord {
+  originalWarnHandler: WarnHandler
+  handler: WarnHandler
+  count: number
+}
+
+const warnHandlerMap = new WeakMap<AppContext, WarnHandlerRecord>()
+
+const createSelectWarnHandler = (appContext: AppContext): WarnHandler => {
+  return (...args) => {
+    // Overrides warnings about slots not being executable outside of a render function.
+    // We call slot below just to simulate data when persist is false, this warning message should be ignored
+    const message = args[0]
+    if (
+      !message ||
+      message.includes('Slot "default" invoked outside of the render function')
+    )
+      return
+    const original = warnHandlerMap.get(appContext)?.originalWarnHandler
+    if (original) {
+      original(...args)
+      return
+    }
+    // eslint-disable-next-line no-console
+    console.warn(...args)
+  }
+}
+
+const getWarnHandlerRecord = (appContext: AppContext): WarnHandlerRecord => {
+  let record = warnHandlerMap.get(appContext)
+  if (!record) {
+    record = {
+      originalWarnHandler: appContext.config.warnHandler,
+      handler: createSelectWarnHandler(appContext),
+      count: 0,
+    }
+    warnHandlerMap.set(appContext, record)
+  }
+  return record
+}
 export default defineComponent({
   name: COMPONENT_NAME,
   componentName: COMPONENT_NAME,
@@ -382,21 +425,9 @@ export default defineComponent({
 
   setup(props, { emit, slots }) {
     const instance = getCurrentInstance()!
-    const originalWarnHandler = instance.appContext.config.warnHandler
-    instance.appContext.config.warnHandler = (...args) => {
-      // Overrides warnings about slots not being executable outside of a render function.
-      // We call slot below just to simulate data when persist is false, this warning message should be ignored
-      if (
-        !args[0] ||
-        args[0].includes(
-          'Slot "default" invoked outside of the render function'
-        )
-      ) {
-        return
-      }
-      // eslint-disable-next-line no-console
-      console.warn(...args)
-    }
+    const warnRecord = getWarnHandlerRecord(instance.appContext)
+    warnRecord.count += 1
+    instance.appContext.config.warnHandler = warnRecord.handler
     const modelValue = computed(() => {
       const { modelValue: rawModelValue, multiple } = props
       const fallback = multiple ? [] : undefined
@@ -504,7 +535,13 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       // https://github.com/element-plus/element-plus/issues/21279
-      instance.appContext.config.warnHandler = originalWarnHandler
+      const record = warnHandlerMap.get(instance.appContext)
+      if (!record) return
+      record.count -= 1
+      if (record.count <= 0) {
+        instance.appContext.config.warnHandler = record.originalWarnHandler
+        warnHandlerMap.delete(instance.appContext)
+      }
     })
 
     return {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.



select 实例各自封装 `warnHandler` 时，形成了一个链，
每个新实例的 handler 都引用前一个实例的 handler。
这些闭包间接持有了已销毁组件的实例和响应式，导致泄露。

For reference:

When each select instance wraps the `warnHandler`, a chain is formed where every new instance's handler references the previous instance's handler. These closures indirectly hold the instances and reactive state of destroyed components, leading to a leak.

- #21279