### PR TITLE
fix(components): [select] shouldn't display the input box when disabled

### DIFF
--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -157,7 +157,7 @@
               :class="[
                 nsSelect.e('selected-item'),
                 nsSelect.e('input-wrapper'),
-                nsSelect.is('hidden', !filterable),
+                nsSelect.is('hidden', !filterable || selectDisabled),
               ]"
             >
               <input


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


When the select component has a selected option and the disabled attribute is set, the input component will occupy a certain amount of space, making it look unappealing.
The input component should be hidden when the "selected" option exists in the select component.


fix #22768