### PR TITLE
feat(components): [date-picker] sibling values panel position

### DIFF
--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
@@ -898,23 +898,38 @@ const parseUserInput = (value: Dayjs | Dayjs[]) => {
 }
 
 function sortDates(minDate: Dayjs | undefined, maxDate: Dayjs | undefined) {
-  if (props.unlinkPanels && maxDate) {
-    const minDateYear = minDate?.year() || 0
-    const minDateMonth = minDate?.month() || 0
-    const maxDateYear = maxDate.year()
-    const maxDateMonth = maxDate.month()
-    rightDate.value =
-      minDateYear === maxDateYear && minDateMonth === maxDateMonth
-        ? maxDate.add(1, unit)
-        : maxDate
-  } else {
-    rightDate.value = leftDate.value.add(1, unit)
-    if (maxDate) {
-      rightDate.value = rightDate.value
-        .hour(maxDate.hour())
-        .minute(maxDate.minute())
-        .second(maxDate.second())
+  if (maxDate) {
+    if (props.samePanelInRangePosition === 'right') {
+      const minDateYear = minDate?.year() || 0
+      const minDateMonth = minDate?.month() || 0
+      const maxDateYear = maxDate.year()
+      const maxDateMonth = maxDate.month()
+      if (minDateYear === maxDateYear && minDateMonth === maxDateMonth) {
+        leftDate.value = maxDate.subtract(1, unit)
+        rightDate.value = maxDate
+
+        return
+      }
+    } else if (props.unlinkPanels) {
+      const minDateYear = minDate?.year() || 0
+      const minDateMonth = minDate?.month() || 0
+      const maxDateYear = maxDate.year()
+      const maxDateMonth = maxDate.month()
+      rightDate.value =
+        minDateYear === maxDateYear && minDateMonth === maxDateMonth
+          ? maxDate.add(1, unit)
+          : maxDate
+
+      return
     }
+  }
+
+  rightDate.value = leftDate.value.add(1, unit)
+  if (maxDate) {
+    rightDate.value = rightDate.value
+      .hour(maxDate.hour())
+      .minute(maxDate.minute())
+      .second(maxDate.second())
   }
 }
 

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-month-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-month-range.vue
@@ -249,14 +249,27 @@ const parseUserInput = (value: Dayjs | Dayjs[]) => {
 }
 
 function sortDates(minDate: Dayjs | undefined, maxDate: Dayjs | undefined) {
-  if (props.unlinkPanels && maxDate) {
-    const minDateYear = minDate?.year() || 0
-    const maxDateYear = maxDate.year()
-    rightDate.value =
-      minDateYear === maxDateYear ? maxDate.add(1, unit) : maxDate
-  } else {
-    rightDate.value = leftDate.value.add(1, unit)
+  if (maxDate) {
+    if (props.samePanelInRangePosition === 'right') {
+      const minDateYear = minDate?.year() || 0
+      const maxDateYear = maxDate.year()
+      if (minDateYear === maxDateYear) {
+        leftDate.value = maxDate.subtract(1, unit)
+        rightDate.value = maxDate
+
+        return
+      }
+    } else if (props.unlinkPanels) {
+      const minDateYear = minDate?.year() || 0
+      const maxDateYear = maxDate.year()
+      rightDate.value =
+        minDateYear === maxDateYear ? maxDate.add(1, unit) : maxDate
+
+      return
+    }
   }
+
+  rightDate.value = leftDate.value.add(1, unit)
 }
 
 watch(

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-year-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-year-range.vue
@@ -271,15 +271,29 @@ const handleClear = () => {
 }
 
 function sortDates(minDate: Dayjs | undefined, maxDate: Dayjs | undefined) {
-  if (props.unlinkPanels && maxDate) {
-    const minDateYear = minDate?.year() || 0
-    const maxDateYear = maxDate.year()
+  if (maxDate) {
+    if (props.samePanelInRangePosition === 'right') {
+      const minDateYear = minDate?.year() || 0
+      const maxDateYear = maxDate.year()
 
-    rightDate.value =
-      minDateYear + step > maxDateYear ? maxDate.add(step, unit) : maxDate
-  } else {
-    rightDate.value = leftDate.value.add(step, unit)
+      if (minDateYear + step > maxDateYear) {
+        leftDate.value = maxDate.subtract(step, unit)
+        rightDate.value = maxDate
+
+        return
+      }
+    } else if (props.unlinkPanels) {
+      const minDateYear = minDate?.year() || 0
+      const maxDateYear = maxDate.year()
+
+      rightDate.value =
+        minDateYear + step > maxDateYear ? maxDate.add(step, unit) : maxDate
+
+      return
+    }
   }
+
+  rightDate.value = leftDate.value.add(step, unit)
 }
 
 watch(

--- a/packages/components/date-picker-panel/src/props/shared.ts
+++ b/packages/components/date-picker-panel/src/props/shared.ts
@@ -93,6 +93,10 @@ export const panelRangeSharedProps = buildProps({
   parsedValue: {
     type: definePropType<DayOrDays>(Array),
   },
+  samePanelInRangePosition: {
+    type: definePropType<'left' | 'right'>(String),
+    default: 'left',
+  },
 } as const)
 
 export const selectionModeWithDefault = (


### PR DESCRIPTION
# In DatePicker ranges, a prop to have siblings values in the right hand side panel 
`samePanelInRangePosition` prop in the DatePicker component for ranges allows to set in which of the two panels show the values if they are sibling.
Therefore it applies to:
* Full dates (also with times) in the same month
* Months in the same year
* Years in the same step (i.e. decade)

From
<img width="698" height="596" alt="image" src="https://github.com/user-attachments/assets/2141c87c-840e-4729-9a0f-8c006b4e2400" />
<img width="691" height="302" alt="image" src="https://github.com/user-attachments/assets/7f54cddd-015b-491c-b113-337f75ef34e8" />
<img width="701" height="459" alt="image" src="https://github.com/user-attachments/assets/292e9446-b306-4469-9b7c-8d14078fa5c4" />

To
<img width="705" height="535" alt="image" src="https://github.com/user-attachments/assets/e1e5afec-f909-4a4a-b1fb-6762aa102f6f" />
<img width="728" height="440" alt="image" src="https://github.com/user-attachments/assets/3ac3cab3-455c-45ae-b8a2-05f9514f65cd" />

<img width="691" height="315" alt="image" src="https://github.com/user-attachments/assets/b462127b-8392-4546-9804-d4c5356bed3f" />


## Please make sure these boxes are checked before submitting your PR, thank you!

- [v] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [v] Make sure you are merging your commits to `dev` branch.
- [v] Add some descriptions and refer to relative issues for your PR.
