### PR TITLE
fix(components): [virtual-list] prevent scroll from exceeding its bounds

### DIFF
--- a/packages/components/select-v2/src/select-dropdown.tsx
+++ b/packages/components/select-v2/src/select-dropdown.tsx
@@ -282,6 +282,7 @@ export default defineComponent({
               innerElement="ul"
               innerProps={{
                 id: props.id,
+                style: { margin: 0, padding: 0 },
                 role: 'listbox',
                 'aria-label': props.ariaLabel,
                 'aria-orientation': 'vertical',

--- a/packages/components/select-v2/src/select-dropdown.tsx
+++ b/packages/components/select-v2/src/select-dropdown.tsx
@@ -282,7 +282,6 @@ export default defineComponent({
               innerElement="ul"
               innerProps={{
                 id: props.id,
-                style: { margin: 0, padding: 0 },
                 role: 'listbox',
                 'aria-label': props.ariaLabel,
                 'aria-orientation': 'vertical',

--- a/packages/components/virtual-list/__tests__/fixed-size-list.test.ts
+++ b/packages/components/virtual-list/__tests__/fixed-size-list.test.ts
@@ -76,7 +76,7 @@ describe('<fixed-size-list />', () => {
       wrapper
         .find(WINDOW_SELECTOR)
         .element.firstElementChild.getAttribute('style')
-    ).toBe('height: 2500px; width: 100%;')
+    ).toBe('height: 2500px; width: 100%; box-sizing: border-box;')
     expect(onItemRendered).toHaveBeenCalledTimes(1)
   })
 
@@ -163,7 +163,7 @@ describe('<fixed-size-list />', () => {
       wrapper
         .find(WINDOW_SELECTOR)
         .element.firstElementChild.getAttribute('style')
-    ).toBe('height: 100%; width: 2500px;')
+    ).toBe('height: 100%; width: 2500px; box-sizing: border-box;')
   })
 
   it('should handle horizontal scroll correctly', async () => {

--- a/packages/components/virtual-list/__tests__/fixed-size-list.test.ts
+++ b/packages/components/virtual-list/__tests__/fixed-size-list.test.ts
@@ -76,7 +76,7 @@ describe('<fixed-size-list />', () => {
       wrapper
         .find(WINDOW_SELECTOR)
         .element.firstElementChild.getAttribute('style')
-    ).toBe('height: 2500px; width: 100%; box-sizing: border-box;')
+    ).toBe('height: 2500px; width: 100%; margin: 0px; box-sizing: border-box;')
     expect(onItemRendered).toHaveBeenCalledTimes(1)
   })
 
@@ -163,7 +163,7 @@ describe('<fixed-size-list />', () => {
       wrapper
         .find(WINDOW_SELECTOR)
         .element.firstElementChild.getAttribute('style')
-    ).toBe('height: 100%; width: 2500px; box-sizing: border-box;')
+    ).toBe('height: 100%; width: 2500px; margin: 0px; box-sizing: border-box;')
   })
 
   it('should handle horizontal scroll correctly', async () => {

--- a/packages/components/virtual-list/src/builders/build-grid.ts
+++ b/packages/components/virtual-list/src/builders/build-grid.ts
@@ -212,6 +212,10 @@ const createGrid = ({
           height,
           pointerEvents: unref(states).isScrolling ? 'none' : undefined,
           width,
+
+          // fix scrolling issues in Firefox.
+          margin: 0,
+          boxSizing: 'border-box',
         }
       })
 

--- a/packages/components/virtual-list/src/builders/build-list.ts
+++ b/packages/components/virtual-list/src/builders/build-list.ts
@@ -143,6 +143,7 @@ const createList = ({
           height: horizontal ? '100%' : `${size}px`,
           pointerEvents: unref(states).isScrolling ? 'none' : undefined,
           width: horizontal ? `${size}px` : '100%',
+          boxSizing: 'border-box',
         }
       })
 

--- a/packages/components/virtual-list/src/builders/build-list.ts
+++ b/packages/components/virtual-list/src/builders/build-list.ts
@@ -143,6 +143,9 @@ const createList = ({
           height: horizontal ? '100%' : `${size}px`,
           pointerEvents: unref(states).isScrolling ? 'none' : undefined,
           width: horizontal ? `${size}px` : '100%',
+
+          // fix scrolling issues in Firefox.
+          margin: 0,
           boxSizing: 'border-box',
         }
       })


### PR DESCRIPTION
fix #22756

The default styles of the `<ul>` element cause its actual width to exceed the container, which results in scrolling beyond the allowed range when using a touchpad. I couldn’t reproduce the vertical scrolling issue mentioned in #22756, but it seems to be a related problem.

https://github.com/user-attachments/assets/cc397555-d552-4749-aef1-dc98129bffef

