### PR TITLE
feat(components): [panel-time-picker] prop to highlight used shortcut

### DIFF
--- a/packages/components/date-picker-panel/src/composables/use-range-picker.ts
+++ b/packages/components/date-picker-panel/src/composables/use-range-picker.ts
@@ -41,10 +41,10 @@ export const useRangePicker = (
   const drpNs = useNamespace('date-range-picker')
   const { t, lang } = useLocale()
   const shourtcutIsClicked = ref<boolean>(false)
-  const shortcutSelected = ref<Shortcut | null>()
+  const selectedShortcut = ref<Shortcut | null>()
   const applyShortcut = useShortcut(lang)
   const handleShortcutClick = (shortcut: Shortcut) => {
-    shortcutSelected.value = shortcut
+    selectedShortcut.value = shortcut
     shourtcutIsClicked.value = true
     applyShortcut(shortcut)
   }
@@ -55,7 +55,7 @@ export const useRangePicker = (
     selecting: false,
   })
   const resetShortcutSelected = () => {
-    shortcutSelected.value = null
+    selectedShortcut.value = null
     shourtcutIsClicked.value = false
   }
 
@@ -174,7 +174,7 @@ export const useRangePicker = (
     lang,
     ppNs: pickerNs,
     drpNs,
-    selectedShortcut: shortcutSelected,
+    selectedShortcut,
 
     handleChangeRange,
     handleRangeConfirm,

--- a/packages/components/date-picker-panel/src/composables/use-range-picker.ts
+++ b/packages/components/date-picker-panel/src/composables/use-range-picker.ts
@@ -5,7 +5,7 @@ import { useLocale, useNamespace } from '@element-plus/hooks'
 import { isEqual } from 'lodash-unified'
 import { getDefaultValue, isValidRange } from '../utils'
 import { ROOT_PICKER_INJECTION_KEY } from '../constants'
-import { useShortcut } from './use-shortcut'
+import { Shortcut, useShortcut } from './use-shortcut'
 
 import type { Ref } from 'vue'
 import type { Dayjs } from 'dayjs'
@@ -40,13 +40,24 @@ export const useRangePicker = (
   const { pickerNs } = inject(ROOT_PICKER_INJECTION_KEY)!
   const drpNs = useNamespace('date-range-picker')
   const { t, lang } = useLocale()
-  const handleShortcutClick = useShortcut(lang)
+  const shourtcutIsClicked = ref<boolean>(false)
+  const shortcutSelected = ref<Shortcut | null>()
+  const applyShortcut = useShortcut(lang)
+  const handleShortcutClick = (shortcut: Shortcut) => {
+    shortcutSelected.value = shortcut
+    shourtcutIsClicked.value = true
+    applyShortcut(shortcut)
+  }
   const minDate = ref<Dayjs>()
   const maxDate = ref<Dayjs>()
   const rangeState = ref<RangeState>({
     endDate: null,
     selecting: false,
   })
+  const resetShortcutSelected = () => {
+    shortcutSelected.value = null
+    shourtcutIsClicked.value = false
+  }
 
   const handleChangeRange = (val: RangeState) => {
     rangeState.value = val
@@ -62,6 +73,7 @@ export const useRangePicker = (
   }
 
   const onSelect = (selecting: boolean) => {
+    resetShortcutSelected()
     rangeState.value.selecting = selecting
     if (!selecting) {
       rangeState.value.endDate = null
@@ -81,6 +93,7 @@ export const useRangePicker = (
   }
 
   const restoreDefault = () => {
+    resetShortcutSelected()
     let [start, end] = getDefaultValue(unref(defaultValue), {
       lang: unref(lang),
       step,
@@ -130,6 +143,12 @@ export const useRangePicker = (
         !(parsedValue as [Dayjs, Dayjs])?.length ||
         !isEqual(parsedValue, [minDate.value, maxDate.value])
       ) {
+        if (!shourtcutIsClicked.value) {
+          resetShortcutSelected()
+        }
+
+        shourtcutIsClicked.value = false
+
         parseValue(parsedValue)
       }
     },
@@ -155,6 +174,7 @@ export const useRangePicker = (
     lang,
     ppNs: pickerNs,
     drpNs,
+    selectedShortcut: shortcutSelected,
 
     handleChangeRange,
     handleRangeConfirm,

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
@@ -19,7 +19,12 @@
           :key="key"
           type="button"
           :disabled="disabled"
-          :class="ppNs.e('shortcut')"
+          :class="{
+            [ppNs.e('shortcut')]: true,
+            active:
+              highlightShortcutSelected &&
+              selectedShortcut?.text === shortcut.text,
+          }"
           @click="handleShortcutClick(shortcut)"
         >
           {{ shortcut.text }}
@@ -459,6 +464,10 @@ const isDefaultFormat = inject(
 const { disabledDate, cellClassName, defaultTime, clearable } = pickerBase.props
 const format: Ref<string | undefined> = toRef(pickerBase.props, 'format')
 const shortcuts = toRef(pickerBase.props, 'shortcuts')
+const highlightShortcutSelected = toRef(
+  pickerBase.props,
+  'highlightShortcutSelected'
+)
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 const { lang } = useLocale()
 const leftDate = ref<Dayjs>(dayjs().locale(lang.value))
@@ -470,6 +479,7 @@ const {
   rangeState,
   ppNs,
   drpNs,
+  selectedShortcut,
   handleChangeRange,
   handleRangeConfirm,
   handleShortcutClick,

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-month-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-month-range.vue
@@ -17,7 +17,12 @@
           v-for="(shortcut, key) in shortcuts"
           :key="key"
           type="button"
-          :class="ppNs.e('shortcut')"
+          :class="{
+            [ppNs.e('shortcut')]: true,
+            active:
+              highlightShortcutSelected &&
+              selectedShortcut?.text === shortcut.text,
+          }"
           :disabled="disabled"
           @click="handleShortcutClick(shortcut)"
         >
@@ -155,7 +160,8 @@ const isDefaultFormat = inject(
   ROOT_PICKER_IS_DEFAULT_FORMAT_INJECTION_KEY,
   undefined
 ) as any
-const { shortcuts, disabledDate, cellClassName } = pickerBase.props
+const { shortcuts, disabledDate, cellClassName, highlightShortcutSelected } =
+  pickerBase.props
 const format = toRef(pickerBase.props, 'format')
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 const leftDate = ref(dayjs().locale(lang.value))
@@ -167,6 +173,7 @@ const {
   rangeState,
   ppNs,
   drpNs,
+  selectedShortcut,
 
   handleChangeRange,
   handleRangeConfirm,

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-year-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-year-range.vue
@@ -7,7 +7,12 @@
           v-for="(shortcut, key) in shortcuts"
           :key="key"
           type="button"
-          :class="ppNs.e('shortcut')"
+          :class="{
+            [ppNs.e('shortcut')]: true,
+            active:
+              highlightShortcutSelected &&
+              selectedShortcut?.text === shortcut.text,
+          }"
           :disabled="disabled"
           @click="handleShortcutClick(shortcut)"
         >
@@ -138,7 +143,8 @@ const isDefaultFormat = inject(
   undefined
 ) as any
 const pickerBase = inject(PICKER_BASE_INJECTION_KEY) as any
-const { shortcuts, disabledDate, cellClassName } = pickerBase.props
+const { shortcuts, disabledDate, cellClassName, highlightShortcutSelected } =
+  pickerBase.props
 const format = toRef(pickerBase.props, 'format')
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 
@@ -148,6 +154,7 @@ const {
   rangeState,
   ppNs,
   drpNs,
+  selectedShortcut,
 
   handleChangeRange,
   handleRangeConfirm,

--- a/packages/components/date-picker-panel/src/props/date-picker-panel.ts
+++ b/packages/components/date-picker-panel/src/props/date-picker-panel.ts
@@ -68,6 +68,10 @@ export const datePickerPanelProps = buildProps({
     type: Array,
     default: () => [],
   },
+  highlightShortcutSelected: {
+    type: Boolean,
+    default: false,
+  },
   /**
    * @description whether to pick time using arrow buttons
    */

--- a/packages/components/time-picker/src/common/props.ts
+++ b/packages/components/time-picker/src/common/props.ts
@@ -196,6 +196,10 @@ export const timePickerDefaultProps = buildProps({
     type: Array,
     default: () => [],
   },
+  highlightShortcutSelected: {
+    type: Boolean,
+    default: false,
+  },
   /**
    * @description whether to pick time using arrow buttons
    */


### PR DESCRIPTION
# A Prop for panel-[date|month|year|]-range to highlight the used shortcut
Use of `highlightShortcutSelected` as prop to have the selected shortcut highlighted (css class `active`). 
The highlight is removed when the value is changed in ways other than selecting another shortcut.

From
<img width="791" height="377" alt="image" src="https://github.com/user-attachments/assets/a4a4477c-bcfe-4c1b-8fff-f09abeafb6db" />
<img width="828" height="326" alt="image" src="https://github.com/user-attachments/assets/06a399b0-403e-4bd2-962b-81b8f2a71345" />
<img width="830" height="373" alt="image" src="https://github.com/user-attachments/assets/87d4b3cf-f49c-4d32-8b52-f1ab935bb378" />

To
<img width="836" height="393" alt="image" src="https://github.com/user-attachments/assets/aeaaadcd-f7b1-4fb3-8581-4b87a22f9a92" />
<img width="810" height="355" alt="image" src="https://github.com/user-attachments/assets/720e52f1-35b0-4702-83a4-a2edd6e629f4" />
<img width="802" height="361" alt="image" src="https://github.com/user-attachments/assets/c264d950-f937-4b7d-91fe-54d7b16d922f" />



Please make sure these boxes are checked before submitting your PR, thank you!

- [ v] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [v] Make sure you are merging your commits to `dev` branch.
- [v] Add some descriptions and refer to relative issues for your PR.
