### PR TITLE
ci: fix lint-commit-message not working for PR from fork

### DIFF
--- a/.github/workflows/lint-commit-message-post.yml
+++ b/.github/workflows/lint-commit-message-post.yml
@@ -53,7 +53,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: successfully
+      - name: Successfully
         if: ${{ needs.result.outputs.succeeded == 'true' }}
         uses: actions-awesome/pr-helper@1.1.1
         with:
@@ -63,7 +63,7 @@ jobs:
           body-filter: '<!-- ELEMENT_PLUS_COMMIT_LINT -->'
           pr-number: ${{ needs.result.outputs.pr }}
 
-      - name: failed
+      - name: Failed
         if: ${{ needs.result.outputs.succeeded != 'true' }}
         uses: actions-awesome/pr-helper@1.1.1
         with:

--- a/.github/workflows/lint-commit-message-post.yml
+++ b/.github/workflows/lint-commit-message-post.yml
@@ -10,27 +10,27 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-        succeeded: ${{ steps.assert.outputs.succeeded }}
-        pr: ${{ steps.pr.outputs.pr }}
-        author: ${{ steps.author.outputs.author }}
+      succeeded: ${{ steps.assert.outputs.succeeded }}
+      pr: ${{ steps.pr.outputs.pr }}
+      author: ${{ steps.author.outputs.author }}
 
     steps:
       - name: Download result
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v9
         with:
           workflow: ${{ github.event.workflow.id }}
           run_id: ${{ github.event.workflow_run.id }}
           name: commit-lint-result
 
       - name: Derive PR number
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v9
         with:
           workflow: ${{ github.event.workflow.id }}
           run_id: ${{ github.event.workflow_run.id }}
           name: pr-number
 
       - name: Download PR author
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v9
         with:
           workflow: ${{ github.event.workflow.id }}
           run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/lint-commit-message-post.yml
+++ b/.github/workflows/lint-commit-message-post.yml
@@ -1,0 +1,78 @@
+name: 📮 Lint Commit Message Post
+
+on:
+  workflow_run:
+    workflows: ['Lint Commit Message']
+    types: [completed]
+
+jobs:
+  result:
+    runs-on: ubuntu-latest
+
+    outputs:
+        succeeded: ${{ steps.assert.outputs.succeeded }}
+        pr: ${{ steps.pr.outputs.pr }}
+        author: ${{ steps.author.outputs.author }}
+
+    steps:
+      - name: Download result
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: commit-lint-result
+
+      - name: Derive PR number
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: pr-number
+
+      - name: Download PR author
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: pr-author
+
+      - name: Assert result
+        id: assert
+        run: echo "succeeded=$(<lint-result.txt)" >> $GITHUB_OUTPUT
+      - name: Get PR number
+        id: pr
+        run: echo "pr=$(<pr.txt)" >> $GITHUB_OUTPUT
+      - name: Get PR author
+        id: author
+        run: echo "author=$(<author.txt)" >> $GITHUB_OUTPUT
+
+  on-success:
+    runs-on: ubuntu-latest
+    needs: result
+    name: Lint
+    permissions:
+      pull-requests: write
+    steps:
+      - name: successfully
+        if: ${{ needs.result.outputs.succeeded == 'true' }}
+        uses: actions-awesome/pr-helper@1.1.1
+        with:
+          actions: 'maintain-comment, add-labels, remove-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels-to-remove: 'CommitMessage::Unqualified'
+          body-filter: '<!-- ELEMENT_PLUS_COMMIT_LINT -->'
+          pr-number: ${{ needs.result.outputs.pr }}
+
+      - name: failed
+        if: ${{ needs.result.outputs.succeeded != 'true' }}
+        uses: actions-awesome/pr-helper@1.1.1
+        with:
+          actions: 'remove-labels, add-labels, maintain-comment'
+          labels-to-add: 'CommitMessage::Unqualified'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ needs.result.outputs.pr }}
+          comment-body: |
+            Hello, @${{ needs.result.outputs.author }}, your PR title does not meet the standards, please [refer to here](https://github.com/element-plus/element-plus/commits/dev/).
+            你好，@${{ needs.result.outputs.author }}，你的 PR 标题不符合规范，[请参考这里](https://github.com/element-plus/element-plus/commits/dev/)。
+            <!-- ELEMENT_PLUS_COMMIT_LINT -->
+          body-filter: '<!-- ELEMENT_PLUS_COMMIT_LINT -->'

--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -14,6 +14,7 @@ jobs:
       failed: ${{ steps.lint_commit.outputs.failed == 'true' }}
     env:
       PULL_REQUEST_NUMBER: ${{ github.event.number }}
+      PULL_REQUEST_AUTHOR: ${{ github.event.pull_request.user.login }}
 
     steps:
       - uses: actions/checkout@v4
@@ -36,24 +37,29 @@ jobs:
 
       - name: Set success result
         if: ${{ steps.lint_commit.outputs.failed != 'true' }}
-        uses: actions-awesome/pr-helper@1.1.1
-        with:
-          actions: 'maintain-comment, add-labels, remove-labels'
-          token: ${{ github.token }}
-          labels-to-remove: 'CommitMessage::Unqualified'
-          body-filter: '<!-- ELEMENT_PLUS_COMMIT_LINT -->'
-          pr-number: ${{ github.event.number }}
+        run: echo 'true' > ./lint-result.txt
 
       - name: Set failed result
         if: ${{ steps.lint_commit.outputs.failed == 'true' }}
-        uses: actions-awesome/pr-helper@1.1.1
+        run: echo 'false' > ./lint-result.txt
+
+      - name: Set PR number
+        run: echo $PULL_REQUEST_NUMBER > pr.txt
+
+      - name: Set PR author
+        run: echo $PULL_REQUEST_AUTHOR > ./author.txt
+
+      - uses: actions/upload-artifact@v4
         with:
-          actions: 'remove-labels, add-labels, maintain-comment'
-          labels-to-add: 'CommitMessage::Unqualified'
-          token: ${{ github.token }}
-          pr-number: ${{ github.event.number }}
-          comment-body: |
-            Hello, @${{ github.event.pull_request.user.login }}, your PR title does not meet the standards, please refer to [commit-history](https://github.com/element-plus/element-plus/commits/dev/) or [docs-examples](https://element-plus.org/en-US/guide/commit-examples.html) make changes.
-            你好，@${{ github.event.pull_request.user.login }}，你的 PR 标题不符合规范，请参考 [提交历史](https://github.com/element-plus/element-plus/commits/dev/) 或者 [文档示例](https://element-plus.org/en-US/guide/commit-examples.html) 进行修改。
-            <!-- ELEMENT_PLUS_COMMIT_LINT -->
-          body-filter: '<!-- ELEMENT_PLUS_COMMIT_LINT -->'
+          name: commit-lint-result
+          path: ./lint-result.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          path: ./pr.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-author
+          path: ./author.txt

--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -49,17 +49,17 @@ jobs:
       - name: Set PR author
         run: echo $PULL_REQUEST_AUTHOR > ./author.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: commit-lint-result
           path: ./lint-result.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: pr-number
           path: ./pr.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: pr-author
           path: ./author.txt

--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -44,10 +44,10 @@ jobs:
         run: echo 'false' > ./lint-result.txt
 
       - name: Set PR number
-        run: echo $PULL_REQUEST_NUMBER > pr.txt
+        run: echo "$PULL_REQUEST_NUMBER" > ./pr.txt
 
       - name: Set PR author
-        run: echo $PULL_REQUEST_AUTHOR > ./author.txt
+        run: echo "$PULL_REQUEST_AUTHOR" > ./author.txt
 
       - uses: actions/upload-artifact@v5
         with:


### PR DESCRIPTION
Rel #19947, #22761

The reason why `github.event.pull_request.user.login` cannot retrieve the username in a post workflow is that this workflow is triggered by a `workflow_run` event rather than directly by a `pull_request` event. 
The payload of `workflow_run` does not include the `pull_request` object, so `github.event.pull_request.user.login` is always empty. 
To obtain the PR author, you need to pass the information via **artifacts**, use the API, or carry it from the original workflow.

[workflow_run payloads](https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run)

Security Reference: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/#:~:text=Together%20with%20the,g.%20API%20tokens).

> Together with the pull_request_target, a new trigger workflow_run was introduced to enable scenarios that require building the untrusted code and also need write permissions to update the PR with e.g. code coverage results or other test results. To do this in a secure manner, the untrusted code must be handled via the pull_request trigger so that it is isolated in an unprivileged environment. The workflow processing the PR should then store any results like code coverage or failed/passed tests in artifacts and exit. The following workflow then starts on workflow_run where it is granted write permission to the target repository and access to repository secrets, so that it can download the artifacts and make any necessary modifications to the repository or interact with third party services that require repository secrets (e.g. API tokens).
