### PR TITLE
docs(components): [anchor] use vp-raw to fix demo scroll

### DIFF
--- a/docs/examples/anchor/scroll.vue
+++ b/docs/examples/anchor/scroll.vue
@@ -49,17 +49,19 @@
         </div>
       </el-col>
       <el-col :span="6">
-        <el-anchor
-          :container="containerRef"
-          direction="vertical"
-          type="default"
-          :offset="30"
-          @click="handleClick"
-        >
-          <el-anchor-link href="#part1" title="part1" />
-          <el-anchor-link href="#part2" title="part2" />
-          <el-anchor-link href="#part3" title="part3" />
-        </el-anchor>
+        <div class="vp-raw">
+          <el-anchor
+            :container="containerRef"
+            direction="vertical"
+            type="default"
+            :offset="30"
+            @click="handleClick"
+          >
+            <el-anchor-link href="#part1" title="part1" />
+            <el-anchor-link href="#part2" title="part2" />
+            <el-anchor-link href="#part3" title="part3" />
+          </el-anchor>
+        </div>
       </el-col>
     </el-row>
   </div>


### PR DESCRIPTION
Linked Issue
- Fixes #22543

Root Cause & Principle
- VitePress intercepts internal <a> clicks during the capture phase and, for same‑page hashes, performs history.pushState and a page‑level scrollTo . The demo’s `<a href="#id">` links are intercepted, leading to window scroll and hash updates. Wrapping the demo with .vp-raw prevents VitePress from intercepting links in that area, so only the component’s container‑scrolling logic runs.
