### PR TITLE
docs: improve slots type

### DIFF
--- a/docs/en-US/component/cascader.md
+++ b/docs/en-US/component/cascader.md
@@ -246,7 +246,7 @@ cascader/custom-header-footer
 
 ### Cascader Slots
 
-| Name                     | Description                                                                                    | Scope                                                     |
+| Name                     | Description                                                                                    | Type                                                      |
 | ------------------------ | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
 | default                  | the custom content of cascader node, which are current Node object and node data respectively. | ^[object]`{ node: any, data: any }`                       |
 | empty                    | content when there is no matched options.                                                      | —                                                         |
@@ -289,7 +289,7 @@ cascader/custom-header-footer
 
 ### CascaderPanel Slots
 
-| Name           | Description                                                                                    | Scope                               |
+| Name           | Description                                                                                    | Type                                |
 | -------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------- |
 | default        | the custom content of cascader node, which are current Node object and node data respectively. | ^[object]`{ node: any, data: any }` |
 | empty ^(2.8.3) | the content of the panel when there is no data.                                                | —                                   |

--- a/docs/en-US/component/config-provider.md
+++ b/docs/en-US/component/config-provider.md
@@ -153,6 +153,6 @@ In this section, you can learn how to use Config Provider to provide experimenta
 
 ### Config Provider Slots
 
-| Name    | Description               | Scope                                                   |
+| Name    | Description               | Type                                                    |
 | ------- | ------------------------- | ------------------------------------------------------- |
 | default | customize default content | config: provided global config (inherited from the top) |

--- a/docs/en-US/component/select-v2.md
+++ b/docs/en-US/component/select-v2.md
@@ -314,7 +314,7 @@ select-v2/custom-width
 
 ### Slots
 
-| Name             | Description                                                                                     | Subtags                                                                                                        |
+| Name             | Description                                                                                     | Type                                                                                                           |
 | ---------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | default          | Option renderer                                                                                 | —                                                                                                              |
 | header ^(2.5.2)  | content at the top of the dropdown                                                              | —                                                                                                              |

--- a/docs/en-US/component/skeleton.md
+++ b/docs/en-US/component/skeleton.md
@@ -133,7 +133,7 @@ skeleton/leading-trailing-without-bouncing
 
 ### Skeleton Slots
 
-| Name     | Description                            | Scope                      |
+| Name     | Description                            | Type                       |
 | -------- | -------------------------------------- | -------------------------- |
 | default  | real rendering DOM                     | ^[object]`$attrs`          |
 | template | content as rendering skeleton template | ^[object]`{ key: number }` |

--- a/docs/en-US/component/table-v2.md
+++ b/docs/en-US/component/table-v2.md
@@ -333,7 +333,7 @@ table-v2/manual-scroll
 
 ### TableV2 Slots
 
-| Name        | Params                                      |
+| Name        | Type                                        |
 | ----------- | ------------------------------------------- |
 | cell        | `object`\<[CellSlotProps](#typings)\>       |
 | header      | `object`\<[HeaderSlotProps](#typings)\>     |

--- a/docs/en-US/component/tour.md
+++ b/docs/en-US/component/tour.md
@@ -95,10 +95,10 @@ tour-step component configuration with the same name has higher priority
 
 ### Tour slots
 
-| Name       | Description                                                   |
-| ---------- | ------------------------------------------------------------- |
-| default    | tourStep component list                                       |
-| indicators | custom indicator, The scope parameter is `{ current, total }` |
+| Name       | Description             | Type                                          |
+| ---------- | ----------------------- | --------------------------------------------- |
+| default    | tourStep component list | —                                             |
+| indicators | custom indicator        | ^[object]`{ current: number, total: number }` |
 
 ### Tour events
 
@@ -130,10 +130,10 @@ tour-step component configuration with the same name has higher priority
 
 ### TourStep slots
 
-| Name    | Description |
-| ------- | ----------- |
-| default | description |
-| header  | header      |
+| Name    | Description           |
+| ------- | --------------------- |
+| default | custom description    |
+| header  | custom header content |
 
 ### TourStep events
 

--- a/docs/en-US/component/transfer.md
+++ b/docs/en-US/component/transfer.md
@@ -86,7 +86,6 @@ transfer/prop-alias
 
 | Name                 | Description                                                          |
 | -------------------- | -------------------------------------------------------------------- |
-| default              | Custom content for data items. The scope parameter is `{ option }`   |
 | left-footer          | content of left list footer                                          |
 | right-footer         | content of right list footer                                         |
 | left-empty ^(2.9.0)  | content when left panel is empty or when no data matches the filter  |

--- a/docs/en-US/component/transfer.md
+++ b/docs/en-US/component/transfer.md
@@ -84,12 +84,13 @@ transfer/prop-alias
 
 ### Transfer Slots
 
-| Name                 | Description                                                          |
-| -------------------- | -------------------------------------------------------------------- |
-| left-footer          | content of left list footer                                          |
-| right-footer         | content of right list footer                                         |
-| left-empty ^(2.9.0)  | content when left panel is empty or when no data matches the filter  |
-| right-empty ^(2.9.0) | content when right panel is empty or when no data matches the filter |
+| Name                 | Description                                                          | Type                                    |
+| -------------------- | -------------------------------------------------------------------- | --------------------------------------- |
+| default              | Custom content for data items.                                       | ^[object]`{ option: TransferDataItem }` |
+| left-footer          | content of left list footer                                          | —                                       |
+| right-footer         | content of right list footer                                         | —                                       |
+| left-empty ^(2.9.0)  | content when left panel is empty or when no data matches the filter  | —                                       |
+| right-empty ^(2.9.0) | content when right panel is empty or when no data matches the filter | —                                       |
 
 ### Transfer Exposes
 

--- a/docs/en-US/component/tree-v2.md
+++ b/docs/en-US/component/tree-v2.md
@@ -169,7 +169,33 @@ tree-v2/filter
 
 ### TreeV2 Slots
 
-| Name           | Description                                                                                    |
-| -------------- | ---------------------------------------------------------------------------------------------- |
-| default        | Custom content for tree nodes. The scope parameter is `{ node: TreeNode, data: TreeNodeData }` |
-| empty ^(2.9.0) | empty you can customize content when data is empty.                                            |
+| Name           | Description                       | Type                                              |
+| -------------- | --------------------------------- | ------------------------------------------------- |
+| default        | custom content for tree nodes     | ^[object]`{ node: TreeNode, data: TreeNodeData }` |
+| empty ^(2.9.0) | custom content when data is empty | —                                                 |
+
+## Type Declarations
+
+<details>
+  <summary>Show declarations</summary>
+
+```ts
+type TreeNodeData = Record<string, any>
+type TreeKey = string | number
+type TreeData = TreeNodeData[]
+
+interface TreeNode {
+  key: TreeKey
+  level: number
+  parent?: TreeNode
+  children?: TreeNode[]
+  data: TreeNodeData
+  disabled?: boolean
+  label?: string
+  isLeaf?: boolean
+  expanded?: boolean
+  isEffectivelyChecked?: boolean
+}
+```
+
+</details>

--- a/docs/en-US/component/tree.md
+++ b/docs/en-US/component/tree.md
@@ -216,7 +216,57 @@ tree/draggable
 
 ### Slots
 
-| Name           | Description                                                            |
-| -------------- | ---------------------------------------------------------------------- |
-| default        | Custom content for tree nodes. The scope parameter is `{ node, data }` |
-| empty ^(2.3.4) | empty you can customize content when data is empty.                    |
+| Name           | Description                       | Type                                                                                |
+| -------------- | --------------------------------- | ----------------------------------------------------------------------------------- |
+| default        | custom content for tree nodes     | ^[object]`{ node: UnwrapRef<RootTreeType['root']>, data: Tree \| TreeOptionProps }` |
+| empty ^(2.3.4) | custom content when data is empty | —                                                                                   |
+
+## Type Declarations
+
+<details>
+  <summary>Show declarations</summary>
+
+```ts
+interface RootTreeType {
+  root: Ref<Node>
+  // ...
+}
+
+// UnwrapRef<RootTreeType['root']> => Node
+type Node = {
+  canFocus: boolean
+  checked: boolean
+  childNodes: Node[]
+  data: TreeNodeData
+  expanded: boolean
+  id: number
+  indeterminate: boolean
+  isCurrent: boolean
+  isEffectivelyChecked: boolean
+  isLeaf?: boolean
+  isLeafByUser?: boolean
+  level: number
+  loaded: boolean
+  loading: boolean
+  parent: Node | null
+  store: TreeStore
+  text: string | null
+  visible: boolean
+}
+
+// TreeNodeData => Tree / TreeOptionProps
+// Tree type is your prop type.
+// TreeOptionProps is default prop type
+interface TreeOptionProps {
+  children?: string
+  label?: string | ((data: TreeNodeData, node: Node) => string)
+  disabled?: string | ((data: TreeNodeData, node: Node) => boolean)
+  isLeaf?: string | ((data: TreeNodeData, node: Node) => boolean)
+  class?: (
+    data: TreeNodeData,
+    node: Node
+  ) => string | { [key: string]: boolean }
+}
+```
+
+</details>


### PR DESCRIPTION
The main focus is on improving the `tree` `tree-v2` slots type.

Because the `Node` type has the same name as the built-in **nodejs** type, `UnwrapRef<RootTreeType['root']>` was used.