### PR TITLE
fix(components): [table] prevent drag on non-resizable columns

### DIFF
--- a/packages/components/table/src/table-header/event-helper.ts
+++ b/packages/components/table/src/table-header/event-helper.ts
@@ -132,7 +132,17 @@ function useEvent<T extends DefaultRow>(
     }
     const target = el?.closest('th')
 
-    if (!column || !column.resizable || !target) return
+    if (!column || !target || !column.resizable) {
+      if (!dragging.value) {
+        const bodyStyle = document.body.style
+        bodyStyle.cursor = ''
+        if (target && hasClass(target, 'is-sortable')) {
+          ;(target as HTMLElement).style.cursor = 'pointer'
+        }
+      }
+      draggingColumn.value = null
+      return
+    }
 
     if (!dragging.value && props.border) {
       const rect = target.getBoundingClientRect()


### PR DESCRIPTION
关联问题:
- Fixes #22374

触发原因及背景:
-当在表头区域移动鼠标至不可拖拽的列（或无有效 th ）时， handleMouseMove 早退分支没有清理上一次的 draggingColumn 状态，这会导致用户在非可拖拽列上点击时进入错误的拖拽流程。

https://github.com/user-attachments/assets/37cb1145-8f03-4ea2-af7b-12644965f685

修复方案: 
在 handleMouseMove 的不满足拖拽条件的早退分支中，清空draggingColumn相关状态
