### PR TITLE
fix(components): [table-column] reactively update filterable state

### DIFF
--- a/packages/components/table/src/table-column/watcher-helper.ts
+++ b/packages/components/table/src/table-column/watcher-helper.ts
@@ -76,6 +76,12 @@ function useWatcher<T extends DefaultRow>(
           () => props_[columnKey],
           (newVal) => {
             instance.columnConfig.value[key as never] = newVal
+            if (key === 'filters' || key === 'filterMethod') {
+              instance.columnConfig.value['filterable'] = !!(
+                instance.columnConfig.value['filters'] ||
+                instance.columnConfig.value['filterMethod']
+              )
+            }
           }
         )
       }


### PR DESCRIPTION
This PR fixes an issue where the filter icon in ElTableColumn does not update dynamically when the filters or filter-method props are added or removed after the initial render.

Currently, the filterable property is only calculated during the component initialization. If a user dynamically toggles the filters prop (e.g., changing from null to an array), the watcher updates the filters value in columnConfig, but fails to re-evaluate the filterable flag. As a result, the filter icon remains hidden (or visible) incorrectly.

This change adds logic to the watcher in `watcher-helper.ts` to recalculate filterable whenever filters or filter-method changes, ensuring the UI stays in sync with the props.

Fixes #22877