### PR TITLE
fix(components): [table] fix header HMR and keep v-if fallback

### DIFF
--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -1,5 +1,6 @@
 import {
   Comment,
+  Fragment,
   computed,
   getCurrentInstance,
   h,
@@ -16,7 +17,7 @@ import {
   getDefaultClassName,
   treeCellPrefix,
 } from '../config'
-import { parseMinWidth, parseWidth } from '../util'
+import { ensureValidVNode, parseMinWidth, parseWidth } from '../util'
 
 import type { ComputedRef, RendererNode, Slots, VNode } from 'vue'
 import type { TableColumn, TableColumnCtx } from './defaults'
@@ -122,7 +123,17 @@ function useRender<T extends DefaultRow>(
       column.renderHeader = (scope) => {
         // help render
         instance.columnConfig.value['label']
-        return renderSlot(slots, 'header', scope, () => [column.label])
+
+        if (slots.header) {
+          const slotResult = slots.header(scope)
+          // Manual valid check to support v-if fallback
+          // and bypass renderSlot to support HMR
+          if (ensureValidVNode(slotResult)) {
+            return h(Fragment, slotResult)
+          }
+        }
+
+        return h('span', column.label)
       }
     }
 

--- a/packages/components/table/src/table-column/render-helper.ts
+++ b/packages/components/table/src/table-column/render-helper.ts
@@ -2,6 +2,7 @@ import {
   Comment,
   Fragment,
   computed,
+  createTextVNode,
   getCurrentInstance,
   h,
   ref,
@@ -133,7 +134,7 @@ function useRender<T extends DefaultRow>(
           }
         }
 
-        return h('span', column.label)
+        return createTextVNode(column.label)
       }
     }
 

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -1,4 +1,4 @@
-import { createVNode, isVNode, render } from 'vue'
+import { Comment, Fragment, createVNode, isVNode, render } from 'vue'
 import { flatMap, get, isNull, merge } from 'lodash-unified'
 import {
   ensureArray,
@@ -19,7 +19,7 @@ import ElTooltip, {
 
 import type { DefaultRow, Table, TreeProps } from './table/defaults'
 import type { TableColumnCtx } from './table-column/defaults'
-import type { CSSProperties, VNode } from 'vue'
+import type { CSSProperties, VNode, VNodeArrayChildren } from 'vue'
 
 export type TableOverflowTooltipOptions = Partial<
   Pick<
@@ -675,4 +675,22 @@ export const ensurePosition = (
   if (!Number.isNaN(style[key])) {
     style[key] = `${style[key]}px` as any
   }
+}
+
+export function ensureValidVNode(
+  vnodes: VNodeArrayChildren
+): VNodeArrayChildren | null {
+  return vnodes.some((child) => {
+    if (!isVNode(child)) return true
+    if (child.type === Comment) return false
+    if (
+      child.type === Fragment &&
+      !ensureValidVNode(child.children as VNodeArrayChildren)
+    ) {
+      return false
+    }
+    return true
+  })
+    ? vnodes
+    : null
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

1. The Issue Currently, the `header` slot of `ElTableColumn` does not trigger HMR updates. When developers modify the content of the header slot during development, the table header remains unchanged until a full reload.

2. Root Cause Analysis The issue stems from a conflict between Vue's renderSlot optimization and Element Plus's Table architecture.
- Architecture: `ElTableColumn` defines a `renderHeader` function (closure) and passes it to `ElTableHeader` via the Table Store.
- Vue Optimization: The `header` slot is often compiled as `STABLE` by Vue. When `renderSlot` is called inside `renderHeader`, it detects the `STABLE` flag and generates a VNode with `PatchFlags.STABLE_FRAGMENT`.
- The Conflict: Since `ElTableHeader` invokes `renderHeader` directly (not as a component slot), Vue's patch algorithm sees the `STABLE_FRAGMENT` flag and skips updating the children, causing HMR to fail.

3. Why not just bypass `renderSlot`? Simply replacing `renderSlot` with `h(Fragment, slots.header(scope))` solves the HMR issue but introduces a regression (reverting the fix from #15035). If a user writes `<template #header v-if="false">`, `slots.header` still exists but returns comment nodes. Without the validity check provided by `renderSlot`, the table would render empty comments instead of falling back to the `label` prop.

4. The Solution This PR implements a robust solution that supports both HMR and correct fallback behavior:

- Refactor: Extracted `ensureValidVNode` helper to `table/src/util.ts` (mirroring Vue's internal logic).
- Implementation: In `renderHeader`, we manually check the slot result using `ensureValidVNode`.

  - If valid: Render `h(Fragment, result)`. This creates a fresh Fragment without the `STABLE` flag, allowing Vue to patch updates correctly (HMR works).

  - If invalid (e.g., comments from `v-if="false"`): Fallback to rendering `column.label`.

Related Issue

- Fixes #21892
