### PR TITLE
improvement(components): [table] keep cursor style during drag

### DIFF
--- a/packages/components/table/src/table-header/event-helper.ts
+++ b/packages/components/table/src/table-header/event-helper.ts
@@ -129,34 +129,38 @@ function useEvent<T extends DefaultRow>(
   }
 
   const handleMouseMove = (event: MouseEvent, column: TableColumnCtx<T>) => {
-    if (column.children && column.children.length > 0) return
+    if (!props.border || (column.children && column.children.length > 0)) return
     const el = event.target as HTMLElement
-    if (!isElement(el)) {
+    const target = isElement(el) ? el.closest('th') : null
+    if (!target) {
       return
     }
-    const target = el?.closest('th')
 
-    if (!column || !column.resizable || !target) return
+    const isSortable = hasClass(target, 'is-sortable')
 
-    if (!dragging.value && props.border) {
-      const rect = target.getBoundingClientRect()
+    if (isSortable) {
+      const cursor = dragging.value ? 'col-resize' : ''
+      target.style.cursor = cursor
 
-      const bodyStyle = document.body.style
-      const isLastTh = target.parentNode?.lastElementChild === target
-      const allowDarg = props.allowDragLastColumn || !isLastTh
-      if (rect.width > 12 && rect.right - event.clientX < 8 && allowDarg) {
-        bodyStyle.cursor = 'col-resize'
-        if (hasClass(target, 'is-sortable')) {
-          target.style.cursor = 'col-resize'
-        }
-        draggingColumn.value = column as any
-      } else if (!dragging.value) {
-        bodyStyle.cursor = ''
-        if (hasClass(target, 'is-sortable')) {
-          target.style.cursor = 'pointer'
-        }
-        draggingColumn.value = null
+      const caret = target.querySelector<HTMLElement>('.caret-wrapper')
+      if (caret) {
+        caret.style.cursor = cursor
       }
+    }
+
+    if (!column?.resizable || dragging.value) return
+
+    const rect = target.getBoundingClientRect()
+    const isLastTh = target.parentNode?.lastElementChild === target
+    const allowDrag = props.allowDragLastColumn || !isLastTh
+    const isResizeHandleActive =
+      rect.width > 12 && rect.right - event.clientX < 8 && allowDrag
+    const cursor = isResizeHandleActive ? 'col-resize' : ''
+
+    document.body.style.cursor = cursor
+    draggingColumn.value = isResizeHandleActive ? (column as any) : null
+    if (isSortable) {
+      target.style.cursor = cursor
     }
   }
 

--- a/packages/components/table/src/table-header/event-helper.ts
+++ b/packages/components/table/src/table-header/event-helper.ts
@@ -148,7 +148,7 @@ function useEvent<T extends DefaultRow>(
       }
     }
 
-    if (!column?.resizable || dragging.value) {
+    if (!column.resizable || dragging.value) {
       draggingColumn.value = null
       return
     }

--- a/packages/components/table/src/table-header/event-helper.ts
+++ b/packages/components/table/src/table-header/event-helper.ts
@@ -161,7 +161,7 @@ function useEvent<T extends DefaultRow>(
   }
 
   const handleMouseOut = () => {
-    if (!isClient) return
+    if (!isClient || dragging.value) return
     document.body.style.cursor = ''
   }
   const toggleOrder = ({ order, sortOrders }: TableColumnCtx<T>) => {


### PR DESCRIPTION
[Before](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtdGFibGVcbiAgICA6ZGF0YT1cInRhYmxlRGF0YVwiXG4gICAgOmRlZmF1bHQtc29ydD1cInsgcHJvcDogJ25hbWUnLCBvcmRlcjogJ2Rlc2NlbmRpbmcnIH1cIlxuICAgIHN0eWxlPVwid2lkdGg6IDEwMCVcIlxuICAgIGJvcmRlclxuICA+XG4gICAgPGVsLXRhYmxlLWNvbHVtbiBwcm9wPVwiZGF0ZVwiIGxhYmVsPVwiRGF0ZVwiIHNvcnRhYmxlIHdpZHRoPVwiMTgwXCIgLz5cbiAgICA8ZWwtdGFibGUtY29sdW1uIHByb3A9XCJuYW1lXCIgbGFiZWw9XCJOYW1lXCIgc29ydGFibGUgd2lkdGg9XCIxODBcIiAvPlxuICAgIDxlbC10YWJsZS1jb2x1bW4gcHJvcD1cImFkZHJlc3NcIiBsYWJlbD1cIkFkZHJlc3NcIiA6Zm9ybWF0dGVyPVwiZm9ybWF0dGVyXCIgLz5cbiAgPC9lbC10YWJsZT5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgbGFuZz1cInRzXCIgc2V0dXA+XG5pbXBvcnQgdHlwZSB7IFRhYmxlQ29sdW1uQ3R4IH0gZnJvbSAnZWxlbWVudC1wbHVzJ1xuXG5pbnRlcmZhY2UgVXNlciB7XG4gIGRhdGU6IHN0cmluZ1xuICBuYW1lOiBzdHJpbmdcbiAgYWRkcmVzczogc3RyaW5nXG59XG5cbmNvbnN0IGZvcm1hdHRlciA9IChyb3c6IFVzZXIsIGNvbHVtbjogVGFibGVDb2x1bW5DdHg8VXNlcj4pID0+IHtcbiAgcmV0dXJuIHJvdy5hZGRyZXNzXG59XG5cbmNvbnN0IHRhYmxlRGF0YTogVXNlcltdID0gW1xuICB7XG4gICAgZGF0ZTogJzIwMTYtMDUtMDMnLFxuICAgIG5hbWU6ICdUb20nLFxuICAgIGFkZHJlc3M6ICdOby4gMTg5LCBHcm92ZSBTdCwgTG9zIEFuZ2VsZXMnLFxuICB9LFxuICB7XG4gICAgZGF0ZTogJzIwMTYtMDUtMDInLFxuICAgIG5hbWU6ICdUb20nLFxuICAgIGFkZHJlc3M6ICdOby4gMTg5LCBHcm92ZSBTdCwgTG9zIEFuZ2VsZXMnLFxuICB9LFxuICB7XG4gICAgZGF0ZTogJzIwMTYtMDUtMDQnLFxuICAgIG5hbWU6ICdUb20nLFxuICAgIGFkZHJlc3M6ICdOby4gMTg5LCBHcm92ZSBTdCwgTG9zIEFuZ2VsZXMnLFxuICB9LFxuICB7XG4gICAgZGF0ZTogJzIwMTYtMDUtMDEnLFxuICAgIG5hbWU6ICdUb20nLFxuICAgIGFkZHJlc3M6ICdOby4gMTg5LCBHcm92ZSBTdCwgTG9zIEFuZ2VsZXMnLFxuICB9LFxuXVxuPC9zY3JpcHQ+XG4iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgY29uc3Qgc3R5bGVzID0gWydodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvZGlzdC9pbmRleC5jc3MnLCAnaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L3RoZW1lLWNoYWxrL2RhcmsvY3NzLXZhcnMuY3NzJ10ubWFwKChzdHlsZSkgPT4ge1xuICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgICAgbGluay5ocmVmID0gc3R5bGVcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgICB9KVxuICB9KVxuICByZXR1cm4gUHJvbWlzZS5hbGxTZXR0bGVkKHN0eWxlcylcbn1cbiIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AbGF0ZXN0L2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvc2hhcmVkXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9cIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AZWxlbWVudC1wbHVzL2ljb25zLXZ1ZUAyL2Rpc3QvaW5kZXgubWluLmpzXCJcbiAgfSxcbiAgXCJzY29wZXNcIjoge31cbn0iLCJfbyI6e319)


https://github.com/user-attachments/assets/56d948e1-b3af-4a60-8604-dc98f8dbc7f1

After

https://github.com/user-attachments/assets/275bd123-ff32-44fe-855f-0d28272f4a77

