### PR TITLE
refactor(components): [table] clear state on non-resizable columns

### DIFF
--- a/packages/components/table/src/table-header/event-helper.ts
+++ b/packages/components/table/src/table-header/event-helper.ts
@@ -136,7 +136,13 @@ function useEvent<T extends DefaultRow>(
     }
     const target = el?.closest('th')
 
-    if (!column || !column.resizable || !target) return
+    if (!column || !column.resizable || !target) {
+      if (!dragging.value) {
+        document.body.style.cursor = ''
+        draggingColumn.value = null
+      }
+      return
+    }
 
     if (!dragging.value && props.border) {
       const rect = target.getBoundingClientRect()

--- a/packages/components/table/src/table-header/event-helper.ts
+++ b/packages/components/table/src/table-header/event-helper.ts
@@ -137,10 +137,7 @@ function useEvent<T extends DefaultRow>(
     const target = el?.closest('th')
 
     if (!column || !column.resizable || !target) {
-      if (!dragging.value) {
-        document.body.style.cursor = ''
-        draggingColumn.value = null
-      }
+      draggingColumn.value = null
       return
     }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description
### Related Issue
Related to #22860
Refactor following discussion in https://github.com/element-plus/element-plus/pull/22860#issuecomment-3573691383
Complements #22327

### Motivation
Thanks @rzzf  for the feedback on #22860!
While #22327 fixed the dragging issue by validating `draggingColumn` and `column` consistency in `handleMouseDown`, this refactor addresses the root cause by proactively clearing the state when the cursor moves to a non-resizable column.
As suggested in https://github.com/element-plus/element-plus/pull/22860#issuecomment-3573691383:
<img width="965" height="280" alt="QQ_1764049592403" src="https://github.com/user-attachments/assets/21d61e02-c35d-4371-a4ef-1a1831690523" />

### Changes
File: `packages/components/table/src/table-header/event-helper.ts`

Before :
```
const handleMouseMove = (event: MouseEvent, column: TableColumnCtx<T>) => {
  // ... early checks
  const target = el?.closest('th')
  if (!column || !column.resizable || !target) return  // ❌ State not cleared
  if (!dragging.value && props.border) {
    // ... set or clear draggingColumn based on cursor position
  }
}
```
After :
```
const handleMouseMove = (event: MouseEvent, column: TableColumnCtx<T>) => {
  // ... early checks
  const target = el?.closest('th')
  if (!column || !column.resizable || !target) {
    if (!dragging.value) {
      document.body.style.cursor = ''      // ✅ Clear cursor
      draggingColumn.value = null          // ✅ Clear state
    }
    return
  }
  if (!dragging.value && props.border) {
    // ... set or clear draggingColumn based on cursor position
  }
}
```

### Key improvement
Proactively clear `draggingColumn` state when the cursor moves over a non-resizable column, ensuring the state always accurately represents the current draggable column under the cursor.

### Relationship with #22327
This refactor complements #22327 by providing defense in depth:
Aspect  | #22327 | This Refactor 
-- | -- | --
When | handleMouseDown | handleMouseMove
Type | Reactive validation | Proactive cleanup
Effect | Safety net | Root cause fix 

### Together they provide
- ✅ Accurate state at all times (this refactor)
- ✅ Validation safety net (#22327)
- ✅ Robust column dragging behavior

### Semantic correctness 

- `draggingColumn` should represent "the draggable column under cursor NOW"
- Clearing in handleMouseMove maintains this semantic contract

## Testing
### Local testing

1. Run local playground: pnpm run dev
2. Create a test table in `play/src/App.vue:`
```
<el-table :data="tableData" border>
  <el-table-column prop="name" label="Name" />
  <el-table-column prop="col1" label="Resizable" />
  <el-table-column prop="col2" label="Non-resizable" :resizable="false" />
</el-table>
```
3. Test scenario

- Hover over resizable column border → cursor changes to col-resize ✅
- Move to non-resizable column border → cursor returns to default ✅
- Try to drag non-resizable column → no dragging occurs ✅

### Expected behavior

- `draggingColumn` is `null` when cursor is over non-resizable column
- No dragging possible on non-resizable columns
- Cursor style correctly reflects draggability

