### PR TITLE
feat(components): [select-v2] add `option-extra-width` prop

### DIFF
--- a/docs/en-US/component/select-v2.md
+++ b/docs/en-US/component/select-v2.md
@@ -231,6 +231,16 @@ select-v2/custom-width
 
 :::
 
+## Slot Width Compensation
+
+When you're using the default slot to render extra content (icons, tags, etc.) before the label, the automatically calculated dropdown width might still only consider the text. Use `option-extra-width` to hint how many extra pixels should be reserved so the dropdown can fully display the slot content.
+
+::::demo
+
+select-v2/slot-extra-width
+
+::::
+
 ## API
 
 ### Attributes
@@ -270,6 +280,7 @@ select-v2/custom-width
 | popper-options                      | [popper.js](https://popper.js.org/docs/v2/) parameters                                                                                   | ^[object]refer to [popper.js](https://popper.js.org/docs/v2/) doc                                                                                                           | {}                                             |
 | automatic-dropdown                  | for non-filterable Select, this prop decides if the option menu pops up when the input is focused                                        | ^[boolean]                                                                                                                                                                  | false                                          |
 | fit-input-width ^(2.9.2)            | whether the width of the dropdown is the same as the input, if the value is `number`, then the width is fixed                            | ^[boolean] / ^[number]                                                                                                                                                      | true                                           |
+| option-extra-width                  | extra width (in px) added to each option when auto-calculating dropdown width; can also be a function returning the additional width     | ^[number] / ^[Function]`(option: Option) => number`                                                                                                                         | 0                                              |
 | suffix-icon ^(2.9.8)                | custom suffix icon component                                                                                                             | ^[string] / ^[object]`Component`                                                                                                                                            | ArrowDown                                      |
 | height                              | The height of the dropdown panel, 34px for each item                                                                                     | ^[number]                                                                                                                                                                   | 274                                            |
 | item-height                         | The height of the dropdown item                                                                                                          | ^[number]                                                                                                                                                                   | 34                                             |

--- a/docs/examples/select-v2/slot-extra-width.vue
+++ b/docs/examples/select-v2/slot-extra-width.vue
@@ -1,0 +1,40 @@
+<template>
+  <el-select-v2
+    v-model="value"
+    :options="options"
+    placeholder="Select with icon"
+    style="width: 100px"
+    :fit-input-width="false"
+    :option-extra-width="24"
+  >
+    <template #default="{ item }">
+      <div class="flex items-center gap-2">
+        <el-icon :size="16">
+          <component :is="item.icon" />
+        </el-icon>
+        <span>{{ item.label }}</span>
+      </div>
+    </template>
+  </el-select-v2>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+import {
+  Apple,
+  Coffee,
+  IceCream,
+  Orange,
+  Pear,
+  Watermelon,
+} from '@element-plus/icons-vue'
+
+const iconPool = [Apple, Coffee, IceCream, Orange, Pear, Watermelon]
+
+const value = ref('')
+const options = iconPool.map((icon, index) => ({
+  value: `Option ${index + 1}`,
+  label: `Option ${index + 1}`,
+  icon,
+}))
+</script>

--- a/packages/components/select-v2/src/defaults.ts
+++ b/packages/components/select-v2/src/defaults.ts
@@ -319,6 +319,16 @@ export const selectV2Props = buildProps({
       return isBoolean(val) || isNumber(val)
     },
   },
+  /**
+   * @description extra width that will be added to each option when calculating dropdown width
+   */
+  optionExtraWidth: {
+    type: definePropType<number | ((option: OptionType) => number)>([
+      Number,
+      Function,
+    ]),
+    default: 0,
+  },
   suffixIcon: {
     type: iconPropType,
     default: ArrowDown,

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -294,6 +294,13 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     }
   }
 
+  const getOptionExtraWidth = (option: OptionType) => {
+    const extra = isFunction(props.optionExtraWidth)
+      ? props.optionExtraWidth(option)
+      : props.optionExtraWidth
+    return isNumber(extra) && extra > 0 ? extra : 0
+  }
+
   // TODO Caching implementation
   // 1. There is no need to calculate options that have already been calculated
   // 2. Repeatedly expand and close when persistent is set to false, no need for repeated calculations
@@ -314,7 +321,8 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     )}`
     const maxWidth = filteredOptions.value.reduce((max, option) => {
       const metrics = ctx.measureText(getLabel(option))
-      return Math.max(metrics.width, max)
+      const optionWidth = metrics.width + getOptionExtraWidth(option)
+      return Math.max(optionWidth, max)
     }, 0)
     return maxWidth + padding
   }
@@ -884,6 +892,15 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     () => props.fitInputWidth,
     () => {
       calculatePopperSize()
+    }
+  )
+
+  watch(
+    () => props.optionExtraWidth,
+    () => {
+      if (!props.fitInputWidth) {
+        calculatePopperSize()
+      }
     }
   )
 


### PR DESCRIPTION

**Summary**  
- Add `optionExtraWidth` prop (number or `(option) => number`) so SelectV2 can account for slot-rendered adornments when auto-calculating dropdown width.  
- Extend `calculateLabelMaxWidth` to include the declared extra width per option, and react to prop changes when `fit-input-width` is false.  
- Document the workflow with a “Slot Width Compensation” section, API entry, and demo (`select-v2/slot-extra-width`) showing icons inside option slots.

**Testing**  
- [ ] `pnpm test select-v2` (or relevant unit suite)  
- [ ] `pnpm docs:build` (docs compile)  
- [ ] Manually verified the new demo and SelectV2 behavior in dev server

**Notes**  
- Default value is `0`, so existing users are unaffected.  
- Demo illustrates why `fit-input-width="false"` + `option-extra-width="24"` keeps icon + label fully visible.