### PR TITLE
Update launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,24 +4,28 @@
     {
       "name": "Launch Chrome",
       "request": "launch",
-      "type": "chrome",
+      "type": "pwa-chrome",      // Updated from "chrome" to "pwa-chrome" for modern VS Code debugging
       "url": "http://localhost:3000",
-      "webRoot": "${workspaceFolder}"
+      "webRoot": "${workspaceFolder}/src", // Usually the source folder
+      "breakOnLoad": true
     },
     {
       "name": "Launch Edge",
       "request": "launch",
-      "type": "msedge",
+      "type": "pwa-msedge",      // Updated from "msedge" to "pwa-msedge"
       "url": "http://localhost:3000",
-      "webRoot": "${workspaceFolder}"
+      "webRoot": "${workspaceFolder}/src",
+      "breakOnLoad": true
     },
     {
-      "name": "Run and debug",
+      "name": "Run and Debug Vite",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["dev"]
+      "runtimeArgs": ["dev"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }


### PR DESCRIPTION
This launch.json file defines debugging configurations for a Vue 3 + Vite project in Visual Studio Code. It allows you to:

Launch Chrome or Edge for client-side debugging:

Opens the development server at http://localhost:3000.

Uses modern VS Code debugging adapters (pwa-chrome and pwa-msedge).

Maps breakpoints in the src folder for front-end debugging.

Run and debug the Vite development server using pnpm dev:

Launches the Node process in the integrated terminal.

Keeps the console output visible in VS Code for easier troubleshooting.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
