### PR TITLE
fix(components): [table-v2] keep scrollToRow from changing horiz offset

### DIFF
--- a/packages/components/table-v2/__tests__/table-v2.test.tsx
+++ b/packages/components/table-v2/__tests__/table-v2.test.tsx
@@ -1,9 +1,10 @@
 import { h, nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, test } from 'vitest'
-import TableV2 from '../src/table-v2'
+import TableV2, { type TableV2Instance } from '../src/table-v2'
 import { TableV2SortOrder } from '../index'
 
+import type { ScrollPos } from '../src/composables/use-scrollbar'
 import type {
   TableV2HeaderRowCellRendererParams,
   TableV2RowCellRenderParam,
@@ -259,6 +260,38 @@ describe('TableV2.vue', () => {
     const cell = wrapper.find('.el-table-v2__row-cell')
     expect(cell.exists()).toBe(true)
     expect(cell.find('div [style^=margin-inline-star]').exists()).toBe(false)
+  })
+
+  test('scrollToRow keeps horizontal offset unchanged', async () => {
+    const columns = ref(generateColumns(10))
+    const data = ref(generateData(columns.value, 200))
+    const scrollLogs: ScrollPos[] = []
+    const wrapper = mount(() => (
+      <TableV2
+        fixed
+        columns={columns.value}
+        data={data.value}
+        width={400}
+        height={400}
+        onScroll={(pos: ScrollPos) => scrollLogs.push({ ...pos })}
+      />
+    ))
+
+    const tableVm = wrapper.findComponent(TableV2).vm.$
+      .exposed as TableV2Instance
+    tableVm.scrollToLeft(150)
+    await nextTick()
+    await nextTick()
+
+    const prevScrollLeft = scrollLogs[scrollLogs.length - 1]?.scrollLeft ?? 0
+    expect(prevScrollLeft).toBeGreaterThan(0)
+
+    tableVm.scrollToRow(50)
+    await nextTick()
+    await nextTick()
+
+    const lastScrollLeft = scrollLogs[scrollLogs.length - 1]?.scrollLeft ?? 0
+    expect(lastScrollLeft).toBe(prevScrollLeft)
   })
 
   describe('a11y', () => {

--- a/packages/components/table-v2/src/table-grid.tsx
+++ b/packages/components/table-v2/src/table-grid.tsx
@@ -114,7 +114,16 @@ const useTableGrid = (props: TableV2GridProps) => {
   }
 
   function scrollToRow(row: number, strategy: ScrollStrategy) {
-    unref(bodyRef)?.scrollToItem(row, 1, strategy)
+    const body = unref(bodyRef)
+    if (!body) return
+
+    const prevScrollLeft = scrollLeft.value
+
+    body.scrollToItem(row, 1, strategy)
+
+    scrollTo({
+      scrollLeft: prevScrollLeft,
+    })
   }
 
   function forceUpdate() {

--- a/packages/components/table-v2/src/table-grid.tsx
+++ b/packages/components/table-v2/src/table-grid.tsx
@@ -119,11 +119,13 @@ const useTableGrid = (props: TableV2GridProps) => {
 
     const prevScrollLeft = scrollLeft.value
 
-    body.scrollToItem(row, 1, strategy)
+    body.scrollToItem(row, 0, strategy)
 
-    scrollTo({
-      scrollLeft: prevScrollLeft,
-    })
+    if (prevScrollLeft) {
+      scrollTo({
+        scrollLeft: prevScrollLeft,
+      })
+    }
   }
 
   function forceUpdate() {


### PR DESCRIPTION
closed #22928

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves horizontal scroll position when jumping to a row and avoids errors if the grid body is unavailable.

* **Tests**
  * Added a test verifying horizontal scroll remains unchanged when mixing horizontal scrolling with row-based scrolling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->