### PR TITLE
feat(components): [timeline] add `reverse` prop

### DIFF
--- a/docs/en-US/component/timeline.md
+++ b/docs/en-US/component/timeline.md
@@ -47,7 +47,23 @@ timeline/center
 
 :::
 
+## Reverse ^(2.11.9)
+
+Use the reverse property to control the order of the nodes.
+
+:::demo
+
+timeline/reverse
+
+:::
+
 ## Timeline API
+
+### Timeline Attributes
+
+| Name              | Description           | Type       | Default |
+| ----------------- | --------------------- | ---------- | ------- |
+| reverse ^(2.11.9) | whether reverse order | ^[boolean] | false   |
 
 ### Timeline Slots
 

--- a/docs/examples/timeline/reverse.vue
+++ b/docs/examples/timeline/reverse.vue
@@ -1,0 +1,33 @@
+<template>
+  <el-switch v-model="reverse" active-text="reverse" />
+
+  <el-timeline class="mt-2" style="max-width: 600px" :reverse="reverse">
+    <el-timeline-item
+      v-for="(activity, index) in activities"
+      :key="index"
+      :timestamp="activity.timestamp"
+    >
+      {{ activity.content }}
+    </el-timeline-item>
+  </el-timeline>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+const reverse = ref(true)
+const activities = [
+  {
+    content: 'Event start',
+    timestamp: '2018-04-15',
+  },
+  {
+    content: 'Approved',
+    timestamp: '2018-04-13',
+  },
+  {
+    content: 'Success',
+    timestamp: '2018-04-11',
+  },
+]
+</script>

--- a/packages/components/timeline/__tests__/timeline.test.tsx
+++ b/packages/components/timeline/__tests__/timeline.test.tsx
@@ -1,4 +1,4 @@
-import { markRaw } from 'vue'
+import { markRaw, nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, test } from 'vitest'
 import { MoreFilled } from '@element-plus/icons-vue'
@@ -167,5 +167,45 @@ describe('TimeLine.vue', () => {
     const timestampWrappers = wrapper.findAll('.el-timeline-item')
 
     expect(timestampWrappers[1].classes()).toContain('el-timeline-item__center')
+  })
+
+  describe('reverse', () => {
+    test('v-for', async () => {
+      const reverse = ref(true)
+      const wrapper = mount(() => (
+        <TimeLine reverse={reverse.value}>
+          {activities.map((item, index) => (
+            <TimeLineItem key={index}>{item.content}</TimeLineItem>
+          ))}
+        </TimeLine>
+      ))
+
+      let firstTimelineItem = wrapper.find('.el-timeline-item__content')
+      expect(firstTimelineItem.text()).toMatchInlineSnapshot(`"Step 3: xxxxxx"`)
+
+      reverse.value = false
+      await nextTick()
+      firstTimelineItem = wrapper.find('.el-timeline-item__content')
+      expect(firstTimelineItem.text()).toMatchInlineSnapshot(`"Step 1: xxxxxx"`)
+    })
+
+    test('manual children', async () => {
+      const reverse = ref(true)
+      const wrapper = mount(() => (
+        <TimeLine reverse={reverse.value}>
+          <TimeLineItem>Step 1: xxxxxx</TimeLineItem>
+          <TimeLineItem>Step 2: xxxxxx</TimeLineItem>
+          <TimeLineItem>Step 3: xxxxxx</TimeLineItem>
+        </TimeLine>
+      ))
+
+      let firstTimelineItem = wrapper.find('.el-timeline-item__content')
+      expect(firstTimelineItem.text()).toMatchInlineSnapshot(`"Step 3: xxxxxx"`)
+
+      reverse.value = false
+      await nextTick()
+      firstTimelineItem = wrapper.find('.el-timeline-item__content')
+      expect(firstTimelineItem.text()).toMatchInlineSnapshot(`"Step 1: xxxxxx"`)
+    })
   })
 })

--- a/packages/components/timeline/__tests__/timeline.test.tsx
+++ b/packages/components/timeline/__tests__/timeline.test.tsx
@@ -170,20 +170,32 @@ describe('TimeLine.vue', () => {
   })
 
   describe('reverse', () => {
-    test('v-for', async () => {
-      const reverse = ref(true)
-      const wrapper = mount(() => (
-        <TimeLine reverse={reverse.value}>
-          {activities.map((item, index) => (
-            <TimeLineItem key={index}>{item.content}</TimeLineItem>
-          ))}
-        </TimeLine>
-      ))
+    test('v-for children', async () => {
+      const wrapper = mount({
+        template: `
+          <TimeLine :reverse="reverse">
+            <TimeLineItem
+              v-for="(item, index) in activities"
+              :key="index"
+            >
+              {{ item.content }}
+            </TimeLineItem>
+          </TimeLine>
+        `,
+        components: {
+          TimeLine,
+          TimeLineItem,
+        },
+        setup() {
+          const reverse = ref(true)
+          return { activities, reverse }
+        },
+      })
 
       let firstTimelineItem = wrapper.find('.el-timeline-item__content')
       expect(firstTimelineItem.text()).toMatchInlineSnapshot(`"Step 3: xxxxxx"`)
 
-      reverse.value = false
+      wrapper.vm.reverse = false
       await nextTick()
       firstTimelineItem = wrapper.find('.el-timeline-item__content')
       expect(firstTimelineItem.text()).toMatchInlineSnapshot(`"Step 1: xxxxxx"`)

--- a/packages/components/timeline/src/timeline.ts
+++ b/packages/components/timeline/src/timeline.ts
@@ -1,36 +1,28 @@
-import { defineComponent, h, provide, renderSlot } from 'vue'
+import { defineComponent, h, provide } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { TIMELINE_INJECTION_KEY } from './tokens'
+import { VNodeChildAtom, flattedChildren } from '@element-plus/utils'
 
 const Timeline = defineComponent({
   name: 'ElTimeline',
-  setup(_, { slots }) {
+  props: {
+    reverse: Boolean,
+  },
+  setup(props, { slots }) {
     const ns = useNamespace('timeline')
 
     provide(TIMELINE_INJECTION_KEY, slots)
 
-    /**
-     *  Maybe ,this component will not support prop 'reverse', why ?
-     *
-     *  Example 1:
-     *   <component-a>
-     *     <div>1</div>
-     *     <div>2</div>
-     *   </component-a>
-     *
-     *  Example 2:
-     *   <component-a>
-     *     <div v-for="i in 2" :key="i">{{ i }}</div>
-     *   </component-a>
-     *
-     *  'slots.default()' value in example 1 just like [Vnode, Vnode]
-     *  'slots.default()' value in example 2 just like [Vnode]
-     *
-     *   so i can't reverse the slots, when i use 'v-for' directive.
-     */
-
     return () => {
-      return h('ul', { class: [ns.b()] }, [renderSlot(slots, 'default')])
+      const children = flattedChildren(slots.default?.() ?? []).filter(
+        (node) => (node as any)?.type?.name === 'ElTimelineItem'
+      ) as VNodeChildAtom[]
+
+      return h(
+        'ul',
+        { class: [ns.b()] },
+        props.reverse ? children.reverse() : children
+      )
     }
   },
 })

--- a/packages/components/timeline/src/timeline.ts
+++ b/packages/components/timeline/src/timeline.ts
@@ -1,7 +1,9 @@
 import { defineComponent, h, provide } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { TIMELINE_INJECTION_KEY } from './tokens'
-import { VNodeChildAtom, flattedChildren } from '@element-plus/utils'
+import { flattedChildren } from '@element-plus/utils'
+
+import type { VNodeChildAtom } from '@element-plus/utils'
 
 const Timeline = defineComponent({
   name: 'ElTimeline',


### PR DESCRIPTION
Many component libraries support this property in their timeline components, so I think Element Plus could support it as well.

[antd](https://ant.design/components/timeline-cn#timeline)
[arco](https://arco.design/react/components/timeline#%E5%9F%BA%E7%A1%80%E7%94%A8%E6%B3%95)
[tdesign](https://tdesign.tencent.com/vue-next/components/timeline?tab=demo#%E6%8E%A7%E5%88%B6%E6%8E%92%E5%BA%8F%E7%9A%84%E6%97%B6%E9%97%B4%E8%BD%B4)
[nuxt ui](https://ui.nuxt.com/docs/components/timeline#reverse)