### PR TITLE
fix(components): [anchor] prevent scroll stutter on rapid clicks

### DIFF
--- a/packages/components/anchor/src/anchor.vue
+++ b/packages/components/anchor/src/anchor.vue
@@ -84,12 +84,19 @@ const setCurrentAnchor = (href: string) => {
 }
 
 let clearAnimate: (() => void) | null = null
+let currentTargetHref = ''
 
 const scrollToAnchor = (href: string) => {
   if (!containerEl.value) return
   const target = getElement(href)
   if (!target) return
-  if (clearAnimate) clearAnimate()
+
+  if (clearAnimate) {
+    if (currentTargetHref === href) return
+    clearAnimate()
+  }
+
+  currentTargetHref = href
   isScrolling = true
   const scrollEle = getScrollElement(target, containerEl.value)
   const distance = getOffsetTopDistance(target, scrollEle)
@@ -104,6 +111,7 @@ const scrollToAnchor = (href: string) => {
       // make sure it is executed after throttleByRaf's handleScroll
       setTimeout(() => {
         isScrolling = false
+        currentTargetHref = ''
       }, 20)
     }
   )


### PR DESCRIPTION
- Add currentTargetHref to track active scroll target
- Ignore duplicate clicks on same anchor during animation
- Prevent unnecessary animation restarts causing visual stutter

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### Related Issues
Closes #22963

### Problem
When users rapidly click the same anchor link multiple times, the scroll animation would be canceled and restarted repeatedly, causing visual stuttering and poor user experience.

**Root Cause:** The current implementation calls `clearAnimate()` to cancel the previous animation but immediately creates a new animation regardless of whether the target is the same. This causes unnecessary animation restarts when clicking the same link.

### Solution
Introduced a `currentTargetHref` variable to track the target of the currently active scroll animation:

- If a click targets the same anchor as the active animation → Ignore the click
- If a click targets a different anchor → Cancel old animation and start new one
- When animation completes → Reset `currentTargetHref` to empty string
