### PR TITLE
style(theme-chalk): [form-item] reset top position label padding-right

### DIFF
--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -134,6 +134,7 @@ $form-item-label-top-margin-bottom: map.merge(
       text-align: left;
       margin-bottom: #{map.get($form-item-label-top-margin-bottom, 'default')};
       line-height: #{map.get($form-item-label-top-line-height, 'default')};
+      padding-right: 0;
     }
   }
 


### PR DESCRIPTION
Fixed the issue of the label and right margin of el-form-item when label-position is set to top

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
