### PR TITLE
feat(components): [message-box] add `iconPlacement` prop

### DIFF
--- a/docs/en-US/component/message-box.md
+++ b/docs/en-US/component/message-box.md
@@ -101,7 +101,7 @@ message-box/centered-content
 
 ## Customized Icon
 
-The icon can be customized to any Vue component or [render function (JSX)](https://vuejs.org/guide/extras/render-function.html).
+The icon can be customized to any Vue component or [render function (JSX)](https://vuejs.org/guide/extras/render-function.html). Set `iconPlacement` ^(2.11.10) to customize the placement of the icon.
 
 :::demo
 
@@ -166,6 +166,7 @@ The corresponding methods are: `ElMessageBox`, `ElMessageBox.alert`, `ElMessageB
 | dangerouslyUseHTMLString          | whether `message` is treated as HTML string                                                                                              | ^[boolean]                                                                                          | false                                            |
 | type                              | message type, used for icon display                                                                                                      | ^[enum]`'primary' (2.9.11) \| 'success' \| 'info' \| 'warning' \| 'error'`                          | ''                                               |
 | icon                              | custom icon component, overrides `type`                                                                                                  | ^[string] / ^[Component]                                                                            | ''                                               |
+| iconPlacement ^(2.11.10)          | custom icon component placement                                                                                                          | ^[enum]`'' \| 'title' \| 'message'`                                                                 | ''                                               |
 | closeIcon ^(2.9.5)                | custom close icon component, default is Close                                                                                            | ^[string] / ^[Component]                                                                            | ''                                               |
 | customClass                       | custom class name for MessageBox                                                                                                         | ^[string]                                                                                           | ''                                               |
 | customStyle                       | custom inline style for MessageBox                                                                                                       | ^[CSSProperties]                                                                                    | {}                                               |

--- a/docs/examples/message-box/customized-icon.vue
+++ b/docs/examples/message-box/customized-icon.vue
@@ -1,11 +1,23 @@
 <template>
-  <el-button plain @click="open">Click to open Message Box</el-button>
+  <div>
+    <el-radio-group v-model="iconPlacement" style="margin-bottom: 20px">
+      <el-radio-button value="">default</el-radio-button>
+      <el-radio-button value="title">title</el-radio-button>
+      <el-radio-button value="message">message</el-radio-button>
+    </el-radio-group>
+
+    <div>
+      <el-button plain @click="open">Click to open Message Box</el-button>
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import { markRaw } from 'vue'
+import { markRaw, ref } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Delete } from '@element-plus/icons-vue'
+
+const iconPlacement = ref('')
 
 const open = () => {
   ElMessageBox.confirm(
@@ -16,6 +28,7 @@ const open = () => {
       cancelButtonText: 'Cancel',
       type: 'warning',
       icon: markRaw(Delete),
+      iconPlacement: iconPlacement.value,
     }
   )
     .then(() => {

--- a/packages/components/message-box/__tests__/message-box.test.ts
+++ b/packages/components/message-box/__tests__/message-box.test.ts
@@ -86,6 +86,20 @@ describe('MessageBox', () => {
     expect(icon.querySelector('svg').innerHTML).toBe(svg.innerHTML)
   })
 
+  test('custom icon placement', async () => {
+    MessageBox({
+      type: 'warning',
+      title: 'This is title',
+      message: 'This is message',
+      iconPlacement: 'title',
+    })
+    await rAF()
+    const title = document.querySelector('.el-message-box__title')
+    const titleIcon = title.querySelector('.el-message-box__status')
+
+    expect(titleIcon).toBeTruthy()
+  })
+
   test('html string', async () => {
     MessageBox({
       title: 'html string',

--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -43,7 +43,7 @@
             >
               <div :class="ns.e('title')">
                 <el-icon
-                  v-if="iconComponent && center"
+                  v-if="iconComponent && (center || iconPlacementIsInTitle)"
                   :class="[ns.e('status'), typeClass]"
                 >
                   <component :is="iconComponent" />
@@ -70,7 +70,12 @@
             <div :id="contentId" :class="ns.e('content')">
               <div :class="ns.e('container')">
                 <el-icon
-                  v-if="iconComponent && !center && hasMessage"
+                  v-if="
+                    iconComponent &&
+                    !center &&
+                    hasMessage &&
+                    !iconPlacementIsInTitle
+                  "
                   :class="[ns.e('status'), typeClass]"
                 >
                   <component :is="iconComponent" />
@@ -191,6 +196,7 @@ import type { ComponentPublicInstance, PropType } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
 import type {
   Action,
+  MessageBoxIconPlacement,
   MessageBoxState,
   MessageBoxType,
 } from './message-box.type'
@@ -248,6 +254,10 @@ export default defineComponent({
     },
     boxType: {
       type: String as PropType<MessageBoxType>,
+      default: '',
+    },
+    iconPlacement: {
+      type: String as PropType<MessageBoxIconPlacement>,
       default: '',
     },
   },
@@ -325,6 +335,9 @@ export default defineComponent({
     const iconComponent = computed(() => {
       const type = state.type
       return state.icon || (type && TypeComponentsMap[type]) || ''
+    })
+    const iconPlacementIsInTitle = computed(() => {
+      return props.iconPlacement === 'title'
     })
     const hasMessage = computed(() => !!state.message)
     const rootRef = ref<HTMLElement>()
@@ -498,6 +511,7 @@ export default defineComponent({
       inputId,
       btnSize,
       iconComponent,
+      iconPlacementIsInTitle,
       confirmButtonClasses,
       rootRef,
       focusStartRef,

--- a/packages/components/message-box/src/message-box.type.ts
+++ b/packages/components/message-box/src/message-box.type.ts
@@ -15,6 +15,8 @@ export interface MessageBoxInputData {
   action: Action
 }
 
+export type MessageBoxIconPlacement = '' | 'title' | 'message'
+
 export type MessageBoxInputValidator =
   | ((value: string) => boolean | string)
   | undefined
@@ -146,6 +148,9 @@ export interface ElMessageBoxOptions {
 
   /** Custom icon component */
   icon?: string | Component
+
+  /** Custom icon placement */
+  iconPlacement?: MessageBoxIconPlacement
 
   /** Custom close icon component */
   closeIcon?: string | Component

--- a/packages/theme-chalk/src/message-box.scss
+++ b/packages/theme-chalk/src/message-box.scss
@@ -74,6 +74,8 @@
   }
 
   @include e(title) {
+    display: flex;
+    gap: 6px;
     font-size: getCssVar('messagebox-font-size');
     line-height: getCssVar('messagebox-font-line-height');
     color: getCssVar('messagebox-title-color');


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Enables the `iconPlacement` prop in Message, allowing you to set the icon's position before the title text or the message text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message boxes now offer customizable icon placement, allowing you to position status icons in three ways: default positioning, within the title area, or within the message content area.

* **Documentation**
  * Updated guides and examples demonstrating how to customize icon placement in message boxes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->