### PR TITLE
docs: allow passing extra packages for ep-playground

### DIFF
--- a/docs/.vitepress/vitepress/composables/use-playground.ts
+++ b/docs/.vitepress/vitepress/composables/use-playground.ts
@@ -18,23 +18,27 @@ export const usePlayground = (source: string) => {
 
   const encoded = code ? utoa(JSON.stringify(originCode)) : ''
 
-  let link = `https://element-plus.run/`
+  const link = new URL('https://element-plus.run/')
 
   if (usePreview()) {
-    link = `${link}?pr=${usePreviewPR()}`
+    link.searchParams.append('pr', usePreviewPR())
   }
 
   if (isDark.value) {
-    link = `${link}${usePreview() ? '&' : '?'}theme=dark`
+    link.searchParams.append('theme', 'dark')
+  }
+
+  if (code.includes('@vueuse/core')) {
+    link.searchParams.append('extra_packages', '@vueuse/core')
   }
 
   if (code) {
-    link += `#${encoded}`
+    link.hash = encoded
   }
 
   return {
     encoded,
-    link,
+    link: link.toString(),
   }
 }
 


### PR DESCRIPTION
[ref](https://github.com/element-plus/element-plus/pull/22971)

tldr: In some examples, the playground crashes because it doesn't have vueuse as dependencies.

Workarounds seems a bit complicated to show for developers, perhaps it is more comfortable to make vueuse and other packages controlled in this repository.
We would assume the version would be the latest as @keeplearning66 pointed [here](https://github.com/element-plus/element-plus-playground/pull/334#issue-3600366042).