### PR TITLE
chore: refine process.env judgment

### DIFF
--- a/internal/build/src/tasks/modules.ts
+++ b/internal/build/src/tasks/modules.ts
@@ -44,6 +44,9 @@ const plugins: Plugin[] = [
     loaders: {
       '.vue': 'ts',
     },
+    define: {
+      'process.env.NODE_ENV': '"production"',
+    },
   }),
 ]
 

--- a/internal/build/src/tasks/modules.ts
+++ b/internal/build/src/tasks/modules.ts
@@ -44,9 +44,6 @@ const plugins: Plugin[] = [
     loaders: {
       '.vue': 'ts',
     },
-    define: {
-      'process.env.NODE_ENV': '"production"',
-    },
   }),
 ]
 

--- a/packages/components/focus-trap/src/utils.ts
+++ b/packages/components/focus-trap/src/utils.ts
@@ -51,8 +51,7 @@ export const getVisibleElement = (
 }
 
 export const isHidden = (element: HTMLElement, container: HTMLElement) => {
-  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test')
-    return false
+  if (process.env.NODE_ENV === 'test') return false
   if (getComputedStyle(element).visibility === 'hidden') return true
 
   while (element) {

--- a/packages/components/tooltip/src/content.vue
+++ b/packages/components/tooltip/src/content.vue
@@ -93,11 +93,8 @@ const transitionClass = computed(() => {
 const persistentRef = computed(() => {
   // For testing, we would always want the content to be rendered
   // to the DOM, so we need to return true here.
-  if (typeof process !== 'undefined') {
-    if (
-      process.env.NODE_ENV === 'test' &&
-      !process.env.RUN_TEST_WITH_PERSISTENT
-    ) {
+  if (process.env.NODE_ENV === 'test') {
+    if (!process.env.RUN_TEST_WITH_PERSISTENT) {
       return true
     }
   }

--- a/packages/components/virtual-list/src/components/dynamic-size-grid.ts
+++ b/packages/components/virtual-list/src/components/dynamic-size-grid.ts
@@ -400,10 +400,7 @@ const DynamicSizeGrid = createGrid({
   clearCache: false,
 
   validateProps: ({ columnWidth, rowHeight }) => {
-    if (
-      typeof process !== 'undefined' &&
-      process.env.NODE_ENV !== 'production'
-    ) {
+    if (process.env.NODE_ENV !== 'production') {
       if (!isFunction(columnWidth)) {
         throwError(
           SCOPE,

--- a/packages/components/virtual-list/src/components/dynamic-size-list.ts
+++ b/packages/components/virtual-list/src/components/dynamic-size-list.ts
@@ -239,10 +239,7 @@ const DynamicSizeList = createList({
   clearCache: false,
 
   validateProps: ({ itemSize }) => {
-    if (
-      typeof process !== 'undefined' &&
-      process.env.NODE_ENV !== 'production'
-    ) {
+    if (process.env.NODE_ENV !== 'production') {
       if (typeof itemSize !== 'function') {
         throwError(
           SCOPE,

--- a/packages/components/virtual-list/src/components/fixed-size-grid.ts
+++ b/packages/components/virtual-list/src/components/fixed-size-grid.ts
@@ -205,10 +205,7 @@ const FixedSizeGrid = createGrid({
   clearCache: true,
 
   validateProps: ({ columnWidth, rowHeight }) => {
-    if (
-      typeof process !== 'undefined' &&
-      process.env.NODE_ENV !== 'production'
-    ) {
+    if (process.env.NODE_ENV !== 'production') {
       if (!isNumber(columnWidth)) {
         throwError(
           SCOPE,

--- a/packages/components/virtual-list/src/components/fixed-size-list.ts
+++ b/packages/components/virtual-list/src/components/fixed-size-list.ts
@@ -28,11 +28,7 @@ const FixedSizeList = buildList({
     scrollOffset
   ) => {
     const size = (isHorizontal(layout) ? width : height) as number
-    if (
-      typeof process !== 'undefined' &&
-      process.env.NODE_ENV !== 'production' &&
-      isString(size)
-    ) {
+    if (process.env.NODE_ENV !== 'production' && isString(size)) {
       throwError(
         '[ElVirtualList]',
         `

--- a/packages/directives/trap-focus/index.ts
+++ b/packages/directives/trap-focus/index.ts
@@ -42,7 +42,7 @@ const FOCUS_HANDLER = (e: KeyboardEvent) => {
 
     // the is critical since jsdom did not implement user actions, you can only mock it
     // DELETE ME: when testing env switches to puppeteer
-    if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
+    if (process.env.NODE_ENV === 'test') {
       const index = focusableElement.indexOf(e.target as HTMLElement)
       if (index !== -1) {
         focusableElement[goingBackward ? index - 1 : index + 1]?.focus()

--- a/packages/hooks/use-focus-controller/index.ts
+++ b/packages/hooks/use-focus-controller/index.ts
@@ -93,7 +93,7 @@ export function useFocusController<T extends { focus: () => void }>(
   useEventListener(wrapperRef, 'click', handleClick, true)
 
   // only for test
-  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
+  if (process.env.NODE_ENV === 'test') {
     onMounted(() => {
       const targetEl = isElement(target.value)
         ? target.value

--- a/packages/hooks/use-popper-container/index.ts
+++ b/packages/hooks/use-popper-container/index.ts
@@ -34,7 +34,7 @@ export const usePopperContainer = () => {
     // document.body.innerHTML = '' situation
     // for this we need to disable the caching since it's not really needed
     if (
-      (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') ||
+      process.env.NODE_ENV === 'test' ||
       !document.body.querySelector(selector.value)
     ) {
       createContainer(id.value)

--- a/packages/utils/dom/aria.ts
+++ b/packages/utils/dom/aria.ts
@@ -9,8 +9,7 @@ const isHTMLElement = (e: unknown): e is Element => {
  * Determine if the testing element is visible on screen no matter if its on the viewport or not
  */
 export const isVisible = (element: HTMLElement) => {
-  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test')
-    return true
+  if (process.env.NODE_ENV === 'test') return true
   const computed = getComputedStyle(element)
   // element.offsetParent won't work on fix positioned
   // WARNING: potential issue here, going to need some expert advices on this issue

--- a/packages/utils/error.ts
+++ b/packages/utils/error.ts
@@ -14,9 +14,11 @@ export function throwError(scope: string, m: string): never {
 export function debugWarn(err: Error): void
 export function debugWarn(scope: string, message: string): void
 export function debugWarn(scope: string | Error, message?: string): void {
-  const error: Error = isString(scope)
-    ? new ElementPlusError(`[${scope}] ${message}`)
-    : scope
-  // eslint-disable-next-line no-console
-  console.warn(error)
+  if (process.env.NODE_ENV !== 'production') {
+    const error: Error = isString(scope)
+      ? new ElementPlusError(`[${scope}] ${message}`)
+      : scope
+    // eslint-disable-next-line no-console
+    console.warn(error)
+  }
 }

--- a/packages/utils/error.ts
+++ b/packages/utils/error.ts
@@ -14,11 +14,9 @@ export function throwError(scope: string, m: string): never {
 export function debugWarn(err: Error): void
 export function debugWarn(scope: string, message: string): void
 export function debugWarn(scope: string | Error, message?: string): void {
-  if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
-    const error: Error = isString(scope)
-      ? new ElementPlusError(`[${scope}] ${message}`)
-      : scope
-    // eslint-disable-next-line no-console
-    console.warn(error)
-  }
+  const error: Error = isString(scope)
+    ? new ElementPlusError(`[${scope}] ${message}`)
+    : scope
+  // eslint-disable-next-line no-console
+  console.warn(error)
 }


### PR DESCRIPTION
Just noticed now that in dev mode we don't get warnings anymore:

In browser context the condition `typeof process !== 'undefined'` will be always false. Resulting with no warnings in dev mode along with potentials breaks that happens in some part where the condition is involved.

https://github.com/element-plus/element-plus/blob/0e1c46fe903ca31718e7e22c8a15811a54653ac5/packages/utils/error.ts#L17

After reverting the fixes, the issue https://github.com/element-plus/element-plus/issues/21560 should not to be related in our side. 

I checked in the vitest side and it looks like `process` should be mocked in browser mode, [solution](https://github.com/element-plus/element-plus/issues/21560).