### PR TITLE
feat(components): [affix] support append-to and teleported

### DIFF
--- a/docs/en-US/component/affix.md
+++ b/docs/en-US/component/affix.md
@@ -47,7 +47,7 @@ affix/fixed
 | position   | position of affix                                                                              | ^[enum]`'top' \| 'bottom'`      | top     |
 | target     | target container (CSS selector)                                                                | ^[string]                       | —       |
 | z-index    | `z-index` of affix                                                                             | ^[number]                       | 100     |
-| teleported | whether affix element is teleported, if `true` it will be teleported to where `append-to` sets | ^[boolean]                      | false   |
+| teleported ^(2.13.0) | whether affix element is teleported, if `true` it will be teleported to where `append-to` sets | ^[boolean]                      | false   |
 | append-to  | which element the affix element appends to                                                     | ^[CSSSelector] / ^[HTMLElement] | body    |
 
 ### Events

--- a/docs/en-US/component/affix.md
+++ b/docs/en-US/component/affix.md
@@ -41,13 +41,14 @@ affix/fixed
 
 ### Attributes
 
-| Name           | Description                     | Type                       | Default |
-| -------------- | ------------------------------- | -------------------------- | ------- |
-| offset         | offset distance                 | ^[number]                  | 0       |
-| position       | position of affix               | ^[enum]`'top' \| 'bottom'` | top     |
-| target         | target container (CSS selector) | ^[string]                  | —       |
-| z-index        | `z-index` of affix              | ^[number]                  | 100     |
-| append-to-body | append affix to body            | ^[boolean]                 | false   |
+| Name       | Description                                                                                    | Type                            | Default |
+| ---------- | ---------------------------------------------------------------------------------------------- | ------------------------------- | ------- |
+| offset     | offset distance                                                                                | ^[number]                       | 0       |
+| position   | position of affix                                                                              | ^[enum]`'top' \| 'bottom'`      | top     |
+| target     | target container (CSS selector)                                                                | ^[string]                       | —       |
+| z-index    | `z-index` of affix                                                                             | ^[number]                       | 100     |
+| teleported | whether affix element is teleported, if `true` it will be teleported to where `append-to` sets | ^[boolean]                      | false   |
+| append-to  | which element the affix element appends to                                                     | ^[CSSSelector] / ^[HTMLElement] | body    |
 
 ### Events
 

--- a/docs/en-US/component/affix.md
+++ b/docs/en-US/component/affix.md
@@ -41,14 +41,14 @@ affix/fixed
 
 ### Attributes
 
-| Name       | Description                                                                                    | Type                            | Default |
-| ---------- | ---------------------------------------------------------------------------------------------- | ------------------------------- | ------- |
-| offset     | offset distance                                                                                | ^[number]                       | 0       |
-| position   | position of affix                                                                              | ^[enum]`'top' \| 'bottom'`      | top     |
-| target     | target container (CSS selector)                                                                | ^[string]                       | —       |
-| z-index    | `z-index` of affix                                                                             | ^[number]                       | 100     |
+| Name                 | Description                                                                                    | Type                            | Default |
+| -------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------- | ------- |
+| offset               | offset distance                                                                                | ^[number]                       | 0       |
+| position             | position of affix                                                                              | ^[enum]`'top' \| 'bottom'`      | top     |
+| target               | target container (CSS selector)                                                                | ^[string]                       | —       |
+| z-index              | `z-index` of affix                                                                             | ^[number]                       | 100     |
 | teleported ^(2.13.0) | whether affix element is teleported, if `true` it will be teleported to where `append-to` sets | ^[boolean]                      | false   |
-| append-to ^(2.13.0) | which element the affix element appends to                                                     | ^[CSSSelector] / ^[HTMLElement] | body    |
+| append-to ^(2.13.0)  | which element the affix element appends to                                                     | ^[CSSSelector] / ^[HTMLElement] | body    |
 
 ### Events
 

--- a/docs/en-US/component/affix.md
+++ b/docs/en-US/component/affix.md
@@ -48,7 +48,7 @@ affix/fixed
 | target     | target container (CSS selector)                                                                | ^[string]                       | —       |
 | z-index    | `z-index` of affix                                                                             | ^[number]                       | 100     |
 | teleported ^(2.13.0) | whether affix element is teleported, if `true` it will be teleported to where `append-to` sets | ^[boolean]                      | false   |
-| append-to  | which element the affix element appends to                                                     | ^[CSSSelector] / ^[HTMLElement] | body    |
+| append-to ^(2.13.0) | which element the affix element appends to                                                     | ^[CSSSelector] / ^[HTMLElement] | body    |
 
 ### Events
 

--- a/docs/en-US/component/affix.md
+++ b/docs/en-US/component/affix.md
@@ -41,12 +41,13 @@ affix/fixed
 
 ### Attributes
 
-| Name     | Description                     | Type                       | Default |
-| -------- | ------------------------------- | -------------------------- | ------- |
-| offset   | offset distance                 | ^[number]                  | 0       |
-| position | position of affix               | ^[enum]`'top' \| 'bottom'` | top     |
-| target   | target container (CSS selector) | ^[string]                  | —       |
-| z-index  | `z-index` of affix              | ^[number]                  | 100     |
+| Name           | Description                     | Type                       | Default |
+| -------------- | ------------------------------- | -------------------------- | ------- |
+| offset         | offset distance                 | ^[number]                  | 0       |
+| position       | position of affix               | ^[enum]`'top' \| 'bottom'` | top     |
+| target         | target container (CSS selector) | ^[string]                  | —       |
+| z-index        | `z-index` of affix              | ^[number]                  | 100     |
+| append-to-body | append affix to body            | ^[boolean]                 | false   |
 
 ### Events
 

--- a/packages/components/affix/__tests__/affix.test.tsx
+++ b/packages/components/affix/__tests__/affix.test.tsx
@@ -192,4 +192,39 @@ describe('Affix.vue', () => {
     mockAffixRect.mockRestore()
     mockDocumentRect.mockRestore()
   })
+
+  test('should render append-to props', async () => {
+    const wrapper = _mount(() => <Affix appendToBody>{AXIOM}</Affix>)
+    await nextTick()
+
+    expect(wrapper.text()).toEqual(AXIOM)
+    const mockAffixRect = vi
+      .spyOn(wrapper.find('.el-affix').element, 'getBoundingClientRect')
+      .mockReturnValue({
+        height: 40,
+        width: 1000,
+        top: -100,
+        bottom: -80,
+      } as DOMRect)
+    const mockDocumentRect = vi
+      .spyOn(document.documentElement, 'getBoundingClientRect')
+      .mockReturnValue({
+        height: 200,
+        width: 1000,
+        top: 0,
+        bottom: 200,
+      } as DOMRect)
+    expect(wrapper.find('.el-affix--fixed').exists()).toBe(false)
+    expect(wrapper.find('.el-affix').attributes('style')).toMatchInlineSnapshot(
+      `undefined`
+    )
+    await makeScroll(document.documentElement, 'scrollTop', 200)
+    expect(wrapper.find('.el-affix--fixed').exists()).toBe(false)
+    // if affix fixed, el-affix style should not be empty
+    expect(wrapper.find('.el-affix').attributes('style')).toMatchInlineSnapshot(
+      `"height: 40px; width: 1000px;"`
+    )
+    mockAffixRect.mockRestore()
+    mockDocumentRect.mockRestore()
+  })
 })

--- a/packages/components/affix/__tests__/affix.test.tsx
+++ b/packages/components/affix/__tests__/affix.test.tsx
@@ -195,10 +195,14 @@ describe('Affix.vue', () => {
 
   test('should render append-to props', async () => {
     const wrapper = _mount(() => (
-      <Affix teleported appendTo="body">
-        {AXIOM}
-      </Affix>
+      <>
+        <div class="teleport-target"></div>
+        <Affix teleported appendTo=".teleport-target">
+          {AXIOM}
+        </Affix>
+      </>
     ))
+    const teleportTarget = wrapper.find('.teleport-target')
     await nextTick()
 
     expect(wrapper.text()).toEqual(AXIOM)
@@ -219,15 +223,9 @@ describe('Affix.vue', () => {
         bottom: 200,
       } as DOMRect)
     expect(wrapper.find('.el-affix--fixed').exists()).toBe(false)
-    expect(wrapper.find('.el-affix').attributes('style')).toMatchInlineSnapshot(
-      `undefined`
-    )
+    expect(teleportTarget.find('.el-affix--fixed').exists()).toBe(false)
     await makeScroll(document.documentElement, 'scrollTop', 200)
-    expect(wrapper.find('.el-affix--fixed').exists()).toBe(false)
-    // if affix fixed, el-affix style should not be empty
-    expect(wrapper.find('.el-affix').attributes('style')).toMatchInlineSnapshot(
-      `"height: 40px; width: 1000px;"`
-    )
+    expect(teleportTarget.find('.el-affix--fixed').exists()).toBe(true)
     mockAffixRect.mockRestore()
     mockDocumentRect.mockRestore()
   })

--- a/packages/components/affix/__tests__/affix.test.tsx
+++ b/packages/components/affix/__tests__/affix.test.tsx
@@ -194,7 +194,11 @@ describe('Affix.vue', () => {
   })
 
   test('should render append-to props', async () => {
-    const wrapper = _mount(() => <Affix appendToBody>{AXIOM}</Affix>)
+    const wrapper = _mount(() => (
+      <Affix teleported appendTo="body">
+        {AXIOM}
+      </Affix>
+    ))
     await nextTick()
 
     expect(wrapper.text()).toEqual(AXIOM)

--- a/packages/components/affix/src/affix.ts
+++ b/packages/components/affix/src/affix.ts
@@ -5,6 +5,7 @@ import {
   isNumber,
 } from '@element-plus/utils'
 import { CHANGE_EVENT } from '@element-plus/constants'
+import { teleportProps } from '@element-plus/components/teleport'
 
 import type { ExtractPropTypes, __ExtractPublicPropTypes } from 'vue'
 import type { ZIndexProperty } from 'csstype'
@@ -41,11 +42,18 @@ export const affixProps = buildProps({
     default: 'top',
   },
   /**
-   * @description whether affix element is teleport to body
+   * @description whether affix element is teleported, if `true` it will be teleported to where `append-to` sets
    * */
-  appendToBody: {
+  teleported: {
     type: Boolean,
     default: false,
+  },
+  /**
+   * @description which element the affix element appends to
+   * */
+  appendTo: {
+    type: teleportProps.to.type,
+    default: 'body',
   },
 } as const)
 export type AffixProps = ExtractPropTypes<typeof affixProps>

--- a/packages/components/affix/src/affix.ts
+++ b/packages/components/affix/src/affix.ts
@@ -44,10 +44,7 @@ export const affixProps = buildProps({
   /**
    * @description whether affix element is teleported, if `true` it will be teleported to where `append-to` sets
    * */
-  teleported: {
-    type: Boolean,
-    default: false,
-  },
+  teleported: Boolean,
   /**
    * @description which element the affix element appends to
    * */

--- a/packages/components/affix/src/affix.ts
+++ b/packages/components/affix/src/affix.ts
@@ -40,6 +40,13 @@ export const affixProps = buildProps({
     values: ['top', 'bottom'],
     default: 'top',
   },
+  /**
+   * @description whether affix element is teleport to body
+   * */
+  appendToBody: {
+    type: Boolean,
+    default: false,
+  },
 } as const)
 export type AffixProps = ExtractPropTypes<typeof affixProps>
 export type AffixPropsPublic = __ExtractPublicPropTypes<typeof affixProps>

--- a/packages/components/affix/src/affix.vue
+++ b/packages/components/affix/src/affix.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="root" :class="ns.b()" :style="rootStyle">
-    <ElTeleport :disabled="teleportDisabled" :to="props.appendTo">
+    <el-teleport :disabled="teleportDisabled" :to="props.appendTo">
       <div :class="{ [ns.m('fixed')]: fixed }" :style="affixStyle">
         <slot />
       </div>

--- a/packages/components/affix/src/affix.vue
+++ b/packages/components/affix/src/affix.vue
@@ -4,7 +4,7 @@
       <div :class="{ [ns.m('fixed')]: fixed }" :style="affixStyle">
         <slot />
       </div>
-    </ElTeleport>
+    </el-teleport>
   </div>
 </template>
 

--- a/packages/components/affix/src/affix.vue
+++ b/packages/components/affix/src/affix.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="root" :class="ns.b()" :style="rootStyle">
-    <el-teleport :disabled="teleportDisabled" :to="props.appendTo">
+    <el-teleport :disabled="teleportDisabled" :to="appendTo">
       <div :class="{ [ns.m('fixed')]: fixed }" :style="affixStyle">
         <slot />
       </div>

--- a/packages/components/affix/src/affix.vue
+++ b/packages/components/affix/src/affix.vue
@@ -1,8 +1,10 @@
 <template>
   <div ref="root" :class="ns.b()" :style="rootStyle">
-    <div :class="{ [ns.m('fixed')]: fixed }" :style="affixStyle">
-      <slot />
-    </div>
+    <ElTeleport :disabled="teleportDisabled" to="body">
+      <div :class="{ [ns.m('fixed')]: fixed }" :style="affixStyle">
+        <slot />
+      </div>
+    </ElTeleport>
   </div>
 </template>
 
@@ -21,6 +23,7 @@ import {
   useEventListener,
   useWindowSize,
 } from '@vueuse/core'
+import ElTeleport from '@element-plus/components/teleport'
 import { addUnit, getScrollContainer, throwError } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { CHANGE_EVENT } from '@element-plus/constants'
@@ -46,6 +49,7 @@ const {
   width: rootWidth,
   top: rootTop,
   bottom: rootBottom,
+  left: rootLeft,
   update: updateRoot,
 } = useElementBounding(root, { windowScroll: false })
 const targetRect = useElementBounding(target)
@@ -53,6 +57,10 @@ const targetRect = useElementBounding(target)
 const fixed = ref(false)
 const scrollTop = ref(0)
 const transform = ref(0)
+
+const teleportDisabled = computed(() => {
+  return !props.appendToBody || !fixed.value
+})
 
 const rootStyle = computed<CSSProperties>(() => {
   return {
@@ -70,6 +78,7 @@ const affixStyle = computed<CSSProperties>(() => {
     width: `${rootWidth.value}px`,
     top: props.position === 'top' ? offset : '',
     bottom: props.position === 'bottom' ? offset : '',
+    left: props.appendToBody ? `${rootLeft.value}px` : '',
     transform: transform.value ? `translateY(${transform.value}px)` : '',
     zIndex: props.zIndex,
   }

--- a/packages/components/affix/src/affix.vue
+++ b/packages/components/affix/src/affix.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="root" :class="ns.b()" :style="rootStyle">
-    <ElTeleport :disabled="teleportDisabled" to="body">
+    <ElTeleport :disabled="teleportDisabled" :to="props.appendTo">
       <div :class="{ [ns.m('fixed')]: fixed }" :style="affixStyle">
         <slot />
       </div>
@@ -59,7 +59,7 @@ const scrollTop = ref(0)
 const transform = ref(0)
 
 const teleportDisabled = computed(() => {
-  return !props.appendToBody || !fixed.value
+  return !props.teleported || !fixed.value
 })
 
 const rootStyle = computed<CSSProperties>(() => {
@@ -78,7 +78,7 @@ const affixStyle = computed<CSSProperties>(() => {
     width: `${rootWidth.value}px`,
     top: props.position === 'top' ? offset : '',
     bottom: props.position === 'bottom' ? offset : '',
-    left: props.appendToBody ? `${rootLeft.value}px` : '',
+    left: props.teleported ? `${rootLeft.value}px` : '',
     transform: transform.value ? `translateY(${transform.value}px)` : '',
     zIndex: props.zIndex,
   }


### PR DESCRIPTION
Close #22301

### Problem

`position: fixed` breaks when a parent has `transform`, `filter`, `perspective`, etc. 

MDN Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position#fixed_positioning.

### Solution

Support `appendToBody` prop.



