### PR TITLE
chore: remove trailing slash from commitlint scope

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -2,7 +2,9 @@ import { execSync } from 'child_process'
 import { globSync } from 'tinyglobby'
 
 const getPackages = (packagePath) =>
-  globSync('*', { cwd: packagePath, onlyDirectories: true })
+  globSync('*', { cwd: packagePath, onlyDirectories: true }).map((dir) =>
+    dir.replace(/\/$/, '')
+  )
 
 const scopes = [
   ...getPackages('packages'),


### PR DESCRIPTION
<img width="485" height="173" alt="image" src="https://github.com/user-attachments/assets/deeb6e6f-e03b-4d75-ad62-2122d9fea57f" />