### PR TITLE
fix(components): [date-picker-panel] remove incorrect is-disabled class from range panel header

### DIFF
--- a/packages/components/date-picker-panel/__tests__/date-picker-panel.test.tsx
+++ b/packages/components/date-picker-panel/__tests__/date-picker-panel.test.tsx
@@ -985,21 +985,6 @@ describe('DatePickerPanel', () => {
         expect(leftHeader.text()).toBe('January')
         expect(rightHeader.text()).toBe('February')
       })
-
-      it('date picker panel header should not have is-disabled class when enabled', async () => {
-        const value = ref([new Date(2025, 11, 15), new Date(2025, 11, 20)])
-        const wrapper = mount(() => (
-          <DatePickerPanel v-model={value.value} type="datetimerange" />
-        ))
-        await nextTick()
-
-        const headers = wrapper.findAll('.el-date-range-picker__header')
-        expect(headers.length).toBeGreaterThan(0)
-
-        headers.forEach((header) => {
-          expect(header.classes()).not.toContain('is-disabled')
-        })
-      })
     })
   })
 })

--- a/packages/components/date-picker-panel/__tests__/date-picker-panel.test.tsx
+++ b/packages/components/date-picker-panel/__tests__/date-picker-panel.test.tsx
@@ -985,6 +985,21 @@ describe('DatePickerPanel', () => {
         expect(leftHeader.text()).toBe('January')
         expect(rightHeader.text()).toBe('February')
       })
+
+      it('date picker panel header should not have is-disabled class when enabled', async () => {
+        const value = ref([new Date(2025, 11, 15), new Date(2025, 11, 20)])
+        const wrapper = mount(() => (
+          <DatePickerPanel v-model={value.value} type="datetimerange" />
+        ))
+        await nextTick()
+
+        const headers = wrapper.findAll('.el-date-range-picker__header')
+        expect(headers.length).toBeGreaterThan(0)
+
+        headers.forEach((header) => {
+          expect(header.classes()).not.toContain('is-disabled')
+        })
+      })
     })
   })
 })

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
@@ -244,7 +244,7 @@
         </div>
         <div :class="[ppNs.e('content'), drpNs.e('content')]" class="is-right">
           <div
-            :class="[drpNs.e('header'), ppNs.is('disabled', dateRangeDisabled)]"
+            :class="drpNs.e('header')"
           >
             <button
               v-if="unlinkPanels"

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
@@ -244,10 +244,7 @@
         </div>
         <div :class="[ppNs.e('content'), drpNs.e('content')]" class="is-right">
           <div
-            :class="[
-              drpNs.e('header'),
-              ppNs.is('disabled', !enableYearArrow || dateRangeDisabled),
-            ]"
+            :class="[drpNs.e('header'), ppNs.is('disabled', dateRangeDisabled)]"
           >
             <button
               v-if="unlinkPanels"

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
@@ -243,9 +243,7 @@
           />
         </div>
         <div :class="[ppNs.e('content'), drpNs.e('content')]" class="is-right">
-          <div
-            :class="drpNs.e('header')"
-          >
+          <div :class="drpNs.e('header')">
             <button
               v-if="unlinkPanels"
               type="button"


### PR DESCRIPTION
closed #23102

This PR fixes some bad logic for determining when to apply the is-disabled class. The behavior prior to this PR included `!enableYearArrow`, however the purpose of `!enableYearArrow` seems to be to disable the "Previous/Next Year" button and not to disable the entire header.

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
