### PR TITLE
fix(tree-select): prevent selecting non-leaf node via Enter

### DIFF
--- a/packages/components/tree-select/__tests__/tree-select.test.tsx
+++ b/packages/components/tree-select/__tests__/tree-select.test.tsx
@@ -596,6 +596,39 @@ describe('TreeSelect.vue', () => {
     expect((document.activeElement as HTMLElement).dataset.key).toBe('111')
   })
 
+  test('should not select non-leaf node by pressing enter when hovering (check-strictly=false)', async () => {
+    const { wrapper, select, tree } = createComponent({
+      props: {
+        defaultExpandAll: true,
+        checkStrictly: false,
+      },
+    })
+
+    await nextTick()
+
+    const selectWrapper = wrapper.find('.el-select__wrapper')
+    await selectWrapper.trigger('click')
+    await selectWrapper.trigger('focus')
+    await nextTick()
+
+    const options = tree.findAll('.el-select-dropdown__item')
+    expect(options.length).toBeGreaterThan(0)
+
+    // Hover the first node (it is a parent node in defaultData).
+    await options[0].trigger('mouseenter')
+    await nextTick()
+
+    const input = selectWrapper.find('input')
+    await input.trigger('keydown', {
+      key: EVENT_CODE.enter,
+      code: EVENT_CODE.enter,
+    })
+    await nextTick()
+
+    // By default only leaf nodes are selectable; hovering a parent should not update modelValue.
+    expect(select.vm.modelValue).toBe(undefined)
+  })
+
   test('show correct label when child options are not rendered', async () => {
     const modelValue = ref<number>()
     const { select } = createComponent({

--- a/packages/components/tree-select/src/select.ts
+++ b/packages/components/tree-select/src/select.ts
@@ -61,6 +61,34 @@ export const useSelect = (
         const code = getEventCode(evt)
         const { dropdownMenuVisible } = select.value!
         if (
+          [EVENT_CODE.enter, EVENT_CODE.numpadEnter].includes(code) &&
+          dropdownMenuVisible
+        ) {
+          const hoveringIndex = select.value!.states.hoveringIndex
+          const hoveringOption = select.value!.optionsArray[hoveringIndex]
+          if (!hoveringOption || hoveringOption.isDisabled) return
+
+          const node = hoveringOption
+            ? tree.value?.getNode(hoveringOption.value)
+            : undefined
+
+          // Prevent selecting non-leaf nodes via keyboard Enter when `check-strictly` is false.
+          // In tree-select, only leaf nodes are selectable by default (same rule as mouse click).
+          if (
+            !props.showCheckbox &&
+            !props.checkStrictly &&
+            node &&
+            !node.isLeaf
+          ) {
+            evt.preventDefault()
+            evt.stopPropagation()
+
+            // Mimic click behavior: expand node if allowed, otherwise do nothing.
+            if (props.expandOnClickNode) node.expand()
+            return
+          }
+        }
+        if (
           [EVENT_CODE.down, EVENT_CODE.up].includes(code) &&
           dropdownMenuVisible
         ) {

--- a/packages/components/tree-select/src/select.ts
+++ b/packages/components/tree-select/src/select.ts
@@ -74,12 +74,7 @@ export const useSelect = (
 
           // Prevent selecting non-leaf nodes via keyboard Enter when `check-strictly` is false.
           // In tree-select, only leaf nodes are selectable by default (same rule as mouse click).
-          if (
-            !props.showCheckbox &&
-            !props.checkStrictly &&
-            node &&
-            !node.isLeaf
-          ) {
+          if (!props.checkStrictly && node && !node.isLeaf) {
             evt.preventDefault()
             evt.stopPropagation()
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Commit description
In TreeSelect, pressing Enter while a non-leaf (parent) node is focused could incorrectly trigger the select action, causing parent nodes to be selected via keyboard. This change prevents the Enter key from selecting non-leaf nodes, allowing selection via Enter only for leaf nodes, keeping keyboard behavior consistent with the component’s leaf-selection semantics and avoiding accidental value changes.
Fixes: #23096