### PR TITLE
chore: fix build

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,9 +11,9 @@ catalog:
   '@popperjs/core': npm:@sxzz/popperjs-es@^2.11.7
   '@vitejs/plugin-vue': ^5.1.4
   '@vitejs/plugin-vue-jsx': ^4.0.1
-  '@vue/server-renderer': ^3.5.2
-  '@vue/shared': ~3.2.37
-  '@vue/test-utils': ^2.0.0
+  '@vue/server-renderer': ^3.5.22
+  '@vue/shared': ^3.5.22
+  '@vue/test-utils': ^2.4.6
   '@vueuse/core': ^10.11.0
   lodash-unified: ^1.0.3
   normalize-wheel-es: ^1.2.0


### PR DESCRIPTION
The dependencies in pnpm workspace was different from 3.5 causing the pnpm build failed.