### PR TITLE
fix(components): [date-picker] duplicate panels after confirm time

### DIFF
--- a/packages/components/date-picker-panel/__tests__/date-picker-panel.test.tsx
+++ b/packages/components/date-picker-panel/__tests__/date-picker-panel.test.tsx
@@ -985,6 +985,65 @@ describe('DatePickerPanel', () => {
         expect(leftHeader.text()).toBe('January')
         expect(rightHeader.text()).toBe('February')
       })
+
+      it('should not duplicate panels after confirm left time input', async () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date(2000, 0))
+        const modelValue = ref([])
+        const wrapper = mount(() => (
+          <DatePickerPanel v-model={modelValue.value} type="datetimerange" />
+        ))
+        const input = wrapper.find('input')
+        await input.trigger('blur')
+        await input.trigger('focus')
+        const pickerss = wrapper.findAll('.el-picker-panel__content')
+        const cells = pickerss[1].findAll('.available .el-date-table-cell')
+        await cells[0].trigger('click')
+        await cells[1].trigger('click')
+        const leftTimeInput = wrapper.findAll<HTMLInputElement>(
+          '.el-date-range-picker__time-picker-wrap input'
+        )[1]
+        await leftTimeInput.trigger('focus')
+        await wrapper.find('.el-time-panel__btn.confirm').trigger('click')
+        const leftHeader = pickerss[0].findAll(
+          '.el-date-range-picker__header-label'
+        )[1]
+        const rightHeader = pickerss[1].findAll(
+          '.el-date-range-picker__header-label'
+        )[1]
+
+        expect(leftHeader.text()).toBe('January')
+        expect(rightHeader.text()).toBe('February')
+        vi.useRealTimers()
+      })
+
+      it('should not duplicate panels after confirm right time input', async () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date(2000, 0))
+        const modelValue = ref([])
+        const wrapper = mount(() => (
+          <DatePickerPanel v-model={modelValue.value} type="datetimerange" />
+        ))
+        const cells = wrapper.findAll('.available .el-date-table-cell')
+        await cells[0].trigger('click')
+        await cells[1].trigger('click')
+        const pickerss = wrapper.findAll('.el-date-range-picker__header')
+        const rightTimeInput = wrapper.findAll<HTMLInputElement>(
+          '.el-date-range-picker__time-picker-wrap input'
+        )[3]
+        await rightTimeInput.trigger('focus')
+        await wrapper.find('.el-time-panel__btn.confirm').trigger('click')
+        const leftHeader = pickerss[0].findAll(
+          '.el-date-range-picker__header-label'
+        )[1]
+        const rightHeader = pickerss[1].findAll(
+          '.el-date-range-picker__header-label'
+        )[1]
+
+        expect(leftHeader.text()).toBe('January')
+        expect(rightHeader.text()).toBe('February')
+        vi.useRealTimers()
+      })
     })
   })
 })

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
@@ -830,7 +830,6 @@ const handleTimeChange = (_value: string | null, type: ChangeType) => {
 const handleMinTimePick = (value: Dayjs, visible: boolean, first: boolean) => {
   if (timeUserInput.value.min) return
   if (value) {
-    leftDate.value = value
     minDate.value = (minDate.value || leftDate.value)
       .hour(value.hour())
       .minute(value.minute())
@@ -858,7 +857,6 @@ const handleMaxTimePick = (
 ) => {
   if (timeUserInput.value.max) return
   if (value) {
-    rightDate.value = value
     maxDate.value = (maxDate.value || rightDate.value)
       .hour(value.hour())
       .minute(value.minute())
@@ -901,7 +899,6 @@ const parseUserInput = (value: Dayjs | Dayjs[]) => {
     isDefaultFormat
   )
 }
-
 function sortDates(minDate: Dayjs | undefined, maxDate: Dayjs | undefined) {
   if (props.unlinkPanels && maxDate) {
     const minDateYear = minDate?.year() || 0

--- a/packages/components/date-picker/__tests__/date-time-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-time-picker.test.tsx
@@ -1232,6 +1232,70 @@ describe('Datetimerange', () => {
     ).toBe('01')
   })
 
+  it('should not duplicate panels after confirm left time input', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2000, 0))
+    const modelValue = ref([])
+    const wrapper = _mount(() => (
+      <DatePicker v-model={modelValue.value} type="datetimerange" />
+    ))
+    const input = wrapper.find('input')
+    await input.trigger('blur')
+    await input.trigger('focus')
+    const rangePicker = wrapper.findComponent(DatePickerRange)
+    const pickerss = rangePicker.findAll('.el-picker-panel__content')
+    const cells = pickerss[1].findAll('.available .el-date-table-cell')
+    await cells[0].trigger('click')
+    await cells[1].trigger('click')
+    const leftTimeInput = rangePicker.findAll<HTMLInputElement>(
+      '.el-date-range-picker__time-picker-wrap input'
+    )[1]
+    await leftTimeInput.trigger('focus')
+    await rangePicker.find('.el-time-panel__btn.confirm').trigger('click')
+    const leftHeader = pickerss[0].findAll(
+      '.el-date-range-picker__header-label'
+    )[1]
+    const rightHeader = pickerss[1].findAll(
+      '.el-date-range-picker__header-label'
+    )[1]
+
+    expect(leftHeader.text()).toBe('January')
+    expect(rightHeader.text()).toBe('February')
+    vi.useRealTimers()
+  })
+
+  it('should not duplicate panels after confirm right time input', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2000, 0))
+    const modelValue = ref([])
+    const wrapper = _mount(() => (
+      <DatePicker v-model={modelValue.value} type="datetimerange" />
+    ))
+    const input = wrapper.find('input')
+    await input.trigger('blur')
+    await input.trigger('focus')
+    const rangePicker = wrapper.findComponent(DatePickerRange)
+    const cells = rangePicker.findAll('.available .el-date-table-cell')
+    await cells[0].trigger('click')
+    await cells[1].trigger('click')
+    const pickerss = rangePicker.findAll('.el-date-range-picker__header')
+    const rightTimeInput = rangePicker.findAll<HTMLInputElement>(
+      '.el-date-range-picker__time-picker-wrap input'
+    )[3]
+    await rightTimeInput.trigger('focus')
+    await rangePicker.find('.el-time-panel__btn.confirm').trigger('click')
+    const leftHeader = pickerss[0].findAll(
+      '.el-date-range-picker__header-label'
+    )[1]
+    const rightHeader = pickerss[1].findAll(
+      '.el-date-range-picker__header-label'
+    )[1]
+
+    expect(leftHeader.text()).toBe('January')
+    expect(rightHeader.text()).toBe('February')
+    vi.useRealTimers()
+  })
+
   it('should work with editable prop', async () => {
     const modelValue = ['2025-09-01', '2025-09-07']
     _mount(() => (


### PR DESCRIPTION
regression of https://github.com/element-plus/element-plus/pull/20713

bug reproduction:
1. select two dates in the same panel
2. in the opposite panel, select the time and confirm.
![Peek 2025-12-18 22-48](https://github.com/user-attachments/assets/b7319f26-63b7-4073-b89c-e8925be180c6)
