### PR TITLE
fix(components): [transfer] prevent title width overflow

### DIFF
--- a/packages/components/transfer/__tests__/transfer.test.tsx
+++ b/packages/components/transfer/__tests__/transfer.test.tsx
@@ -97,7 +97,7 @@ describe('Transfer', () => {
     expect(
       wrapper.find('.el-transfer-panel__list .el-checkbox__label span').text()
     ).toBe('1 - 备选项 1')
-    expect(label.find('span').text()).toBe('no')
+    expect(label.find('.el-transfer-panel__header-count').text()).toBe('no')
   })
 
   it('check', () => {

--- a/packages/components/transfer/src/transfer-panel.vue
+++ b/packages/components/transfer/src/transfer-panel.vue
@@ -44,16 +44,16 @@
       </el-checkbox-group>
       <div
         v-show="hasNoMatch || isEmpty(data)"
-        :class="ns.be('panel', 'empty')"
+        :class="ns.be('panel', 'empty')"p
       >
         <slot name="empty">
           {{ hasNoMatch ? t('el.transfer.noMatch') : t('el.transfer.noData') }}
         </slot>
       </div>
     </div>
-    <div v-if="hasFooter" :class="ns.be('panel', 'footer')">
+    <p v-if="hasFooter" :class="ns.be('panel', 'footer')">
       <slot />
-    </div>
+    </p>
   </div>
 </template>
 

--- a/packages/components/transfer/src/transfer-panel.vue
+++ b/packages/components/transfer/src/transfer-panel.vue
@@ -44,7 +44,7 @@
       </el-checkbox-group>
       <div
         v-show="hasNoMatch || isEmpty(data)"
-        :class="ns.be('panel', 'empty')"p
+        :class="ns.be('panel', 'empty')"
       >
         <slot name="empty">
           {{ hasNoMatch ? t('el.transfer.noMatch') : t('el.transfer.noData') }}

--- a/packages/components/transfer/src/transfer-panel.vue
+++ b/packages/components/transfer/src/transfer-panel.vue
@@ -8,9 +8,9 @@
         @change="handleAllCheckedChange"
       >
         <span :class="ns.be('panel', 'header-title')">{{ title }}</span>
-        <span :class="ns.be('panel', 'header-count')">{{
-          checkedSummary
-        }}</span>
+        <span :class="ns.be('panel', 'header-count')">
+          {{ checkedSummary }}
+        </span>
       </el-checkbox>
     </p>
 

--- a/packages/components/transfer/src/transfer-panel.vue
+++ b/packages/components/transfer/src/transfer-panel.vue
@@ -7,8 +7,10 @@
         :validate-event="false"
         @change="handleAllCheckedChange"
       >
-        {{ title }}
-        <span>{{ checkedSummary }}</span>
+        <span :class="ns.be('panel', 'header-title')">{{ title }}</span>
+        <span :class="ns.be('panel', 'header-count')">{{
+          checkedSummary
+        }}</span>
       </el-checkbox>
     </p>
 
@@ -49,9 +51,9 @@
         </slot>
       </div>
     </div>
-    <p v-if="hasFooter" :class="ns.be('panel', 'footer')">
+    <div v-if="hasFooter" :class="ns.be('panel', 'footer')">
       <slot />
-    </p>
+    </div>
   </div>
 </template>
 

--- a/packages/theme-chalk/src/transfer.scss
+++ b/packages/theme-chalk/src/transfer.scss
@@ -151,7 +151,6 @@
         min-width: 0;
         font-size: 16px;
         color: getCssVar('text-color', 'primary');
-        line-height: getCssVar('transfer-panel-header-height');
         font-weight: normal;
       }
     }

--- a/packages/theme-chalk/src/transfer.scss
+++ b/packages/theme-chalk/src/transfer.scss
@@ -146,7 +146,7 @@
 
       .#{$namespace}-checkbox__label {
         display: flex;
-        flex-grow: 1;
+        flex: 1;
         align-items: center;
         min-width: 0;
         font-size: 16px;
@@ -158,7 +158,7 @@
 
   .#{$namespace}-transfer-panel__header-title {
     @include utils-ellipsis;
-    flex-grow: 1;
+    flex: 1;
     min-width: 0;
   }
 

--- a/packages/theme-chalk/src/transfer.scss
+++ b/packages/theme-chalk/src/transfer.scss
@@ -179,7 +179,6 @@
     border: 1px solid getCssVar('transfer-border-color');
     border-bottom-left-radius: getCssVar('transfer-border-radius');
     border-bottom-right-radius: getCssVar('transfer-border-radius');
-    white-space: nowrap;
     @include utils-vertical-center;
 
     .#{$namespace}-checkbox {

--- a/packages/theme-chalk/src/transfer.scss
+++ b/packages/theme-chalk/src/transfer.scss
@@ -145,24 +145,34 @@
       align-items: center;
 
       .#{$namespace}-checkbox__label {
+        display: flex;
+        flex: 1;
+        min-width: 0;
         font-size: 16px;
         color: getCssVar('text-color', 'primary');
+        line-height: getCssVar('transfer-panel-header-height');
         font-weight: normal;
-
-        span {
-          position: absolute;
-          right: 15px;
-          top: 50%;
-          transform: translate3d(0, -50%, 0);
-          color: getCssVar('text-color', 'secondary');
-          font-size: 12px;
-          font-weight: normal;
-        }
       }
     }
   }
 
+  .#{$namespace}-transfer-panel__header-title {
+    @include utils-ellipsis;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .#{$namespace}-transfer-panel__header-count {
+    flex-shrink: 0;
+    margin-left: 8px;
+    margin-right: 15px;
+    color: getCssVar('text-color', 'secondary');
+    font-size: 12px;
+  }
+
   .#{$namespace}-transfer-panel__footer {
+    display: flex;
+    align-items: center;
     height: getCssVar('transfer-panel-footer-height');
     background: getCssVar('bg-color', 'overlay');
     margin: 0;
@@ -170,10 +180,8 @@
     border: 1px solid getCssVar('transfer-border-color');
     border-bottom-left-radius: getCssVar('transfer-border-radius');
     border-bottom-right-radius: getCssVar('transfer-border-radius');
-    @include utils-vertical-center;
 
     .#{$namespace}-checkbox {
-      padding-left: 20px;
       color: getCssVar('text-color', 'regular');
     }
   }

--- a/packages/theme-chalk/src/transfer.scss
+++ b/packages/theme-chalk/src/transfer.scss
@@ -171,10 +171,6 @@
   }
 
   .#{$namespace}-transfer-panel__footer {
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-    align-items: flex-start;
     height: getCssVar('transfer-panel-footer-height');
     background: getCssVar('bg-color', 'overlay');
     margin: 0;
@@ -182,6 +178,8 @@
     border: 1px solid getCssVar('transfer-border-color');
     border-bottom-left-radius: getCssVar('transfer-border-radius');
     border-bottom-right-radius: getCssVar('transfer-border-radius');
+    white-space: nowrap;
+    @include utils-vertical-center;
 
     .#{$namespace}-checkbox {
       color: getCssVar('text-color', 'regular');

--- a/packages/theme-chalk/src/transfer.scss
+++ b/packages/theme-chalk/src/transfer.scss
@@ -172,7 +172,8 @@
 
   .#{$namespace}-transfer-panel__footer {
     display: flex;
-    align-items: center;
+    justify-content: center;
+    flex-direction: column;
     height: getCssVar('transfer-panel-footer-height');
     background: getCssVar('bg-color', 'overlay');
     margin: 0;

--- a/packages/theme-chalk/src/transfer.scss
+++ b/packages/theme-chalk/src/transfer.scss
@@ -174,6 +174,7 @@
     display: flex;
     justify-content: center;
     flex-direction: column;
+    align-items: flex-start;
     height: getCssVar('transfer-panel-footer-height');
     background: getCssVar('bg-color', 'overlay');
     margin: 0;

--- a/packages/theme-chalk/src/transfer.scss
+++ b/packages/theme-chalk/src/transfer.scss
@@ -146,7 +146,8 @@
 
       .#{$namespace}-checkbox__label {
         display: flex;
-        flex: 1;
+        flex-grow: 1;
+        align-items: center;
         min-width: 0;
         font-size: 16px;
         color: getCssVar('text-color', 'primary');
@@ -158,7 +159,7 @@
 
   .#{$namespace}-transfer-panel__header-title {
     @include utils-ellipsis;
-    flex: 1;
+    flex-grow: 1;
     min-width: 0;
   }
 

--- a/packages/theme-chalk/src/transfer.scss
+++ b/packages/theme-chalk/src/transfer.scss
@@ -182,6 +182,7 @@
     @include utils-vertical-center;
 
     .#{$namespace}-checkbox {
+      padding-left: 20px;
       color: getCssVar('text-color', 'regular');
     }
   }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

As you can see, when the title content is too long, it covers the elements on the right, and when the footer content is too long, it also fails to stay centered.

<img width="892" height="416" alt="demo" src="https://github.com/user-attachments/assets/b038e132-628f-485f-969f-d37cc1b426a2" />

Expected behavior:
<img width="874" height="416" alt="demo2" src="https://github.com/user-attachments/assets/03e73fbf-9c97-4ba2-bca0-b22dad415003" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved Transfer header and footer layout, spacing, and text truncation for better alignment and visual consistency.
* **Tests**
  * Updated Transfer test to more reliably target the header count, improving test stability.
* **Chores**
  * Adjusted header markup to wrap title and count into semantic elements for clearer structure and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->