### PR TITLE
fix(components): [input] correct event type for v-model.number

### DIFF
--- a/packages/components/input/src/input.ts
+++ b/packages/components/input/src/input.ts
@@ -2,24 +2,23 @@ import {
   buildProps,
   definePropType,
   iconPropType,
-  isString,
   mutable,
 } from '@element-plus/utils'
-import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { useAriaProps, useSizeProp } from '@element-plus/hooks'
 import { CircleClose } from '@element-plus/icons-vue'
+import { ComponentSize } from '@element-plus/constants'
 
 import type {
-  ExtractPropTypes,
+  Component,
   ExtractPublicPropTypes,
   HTMLAttributes,
   StyleValue,
 } from 'vue'
 
 export type InputModelModifiers = {
-  lazy?: boolean
-  number?: boolean
-  trim?: boolean
+  lazy?: true
+  number?: true
+  trim?: true
 }
 export type InputAutoSize = { minRows?: number; maxRows?: number } | boolean
 // Some commonly used values for input type
@@ -227,24 +226,59 @@ export const inputProps = buildProps({
    */
   name: String,
 } as const)
-export type InputProps = ExtractPropTypes<typeof inputProps>
+
+export interface InputProps<T extends InputModelModifiers> {
+  id?: string
+  size?: ComponentSize
+  disabled?: boolean
+  modelValue?: string | number | null | undefined
+  modelModifiers?: T
+  maxlength?: string
+  minlength?: string
+  type?: InputType
+  resize?: 'none' | 'both' | 'horizontal' | 'vertical'
+  autosize?: InputAutoSize
+  autocomplete?: string
+  formatter?: (value: string | number) => string
+  parser?: (value: string) => string
+  placeholder?: string
+  form?: string
+  readonly?: boolean | 'true' | 'false'
+  clearable?: boolean
+  clearIcon?: string | Component
+  showPassword?: boolean
+  showWordLimit?: boolean
+  wordLimitPosition?: 'inside' | 'outside'
+  suffixIcon?: string | Component
+  prefixIcon?: string | Component
+  containerRole?: string
+  tabindex?: string | number
+  validateEvent?: boolean
+  inputStyle?: StyleValue
+  autofocus?: boolean
+  rows?: number
+  ariaLabel?: string
+  inputmode?: HTMLAttributes['inputmode']
+  name?: string
+}
 export type InputPropsPublic = ExtractPublicPropTypes<typeof inputProps>
 
-export const inputEmits = {
-  [UPDATE_MODEL_EVENT]: (value: string) => isString(value),
-  input: (value: string) => isString(value),
-  change: (value: string, evt?: Event) =>
-    isString(value) && (evt instanceof Event || evt === undefined),
-  focus: (evt: FocusEvent) => evt instanceof FocusEvent,
-  blur: (evt: FocusEvent) => evt instanceof FocusEvent,
-  clear: () => true,
-  mouseleave: (evt: MouseEvent) => evt instanceof MouseEvent,
-  mouseenter: (evt: MouseEvent) => evt instanceof MouseEvent,
+export type InputEmits<T> = {
+  'update:modelValue': [value: string | number]
+  input: [value: T extends { number: true } ? string | number : string]
+  change: [
+    value: T extends { number: true } ? string | number : string,
+    evt?: Event,
+  ]
+  focus: [evt: FocusEvent]
+  blur: [evt: FocusEvent]
+  clear: []
+  mouseleave: [evt: MouseEvent]
+  mouseenter: [evt: MouseEvent]
   // NOTE: when autofill by browser, the keydown event is instanceof Event, not KeyboardEvent
   // relative bug report https://github.com/element-plus/element-plus/issues/6665
-  keydown: (evt: KeyboardEvent | Event) => evt instanceof Event,
-  compositionstart: (evt: CompositionEvent) => evt instanceof CompositionEvent,
-  compositionupdate: (evt: CompositionEvent) => evt instanceof CompositionEvent,
-  compositionend: (evt: CompositionEvent) => evt instanceof CompositionEvent,
+  keydown: [evt: KeyboardEvent | Event]
+  compositionstart: [evt: CompositionEvent]
+  compositionupdate: [evt: CompositionEvent]
+  compositionend: [evt: CompositionEvent]
 }
-export type InputEmits = typeof inputEmits

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -160,7 +160,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script lang="ts" setup generic="T extends InputModelModifiers">
 import {
   computed,
   nextTick,
@@ -175,7 +175,11 @@ import {
 import { useResizeObserver } from '@vueuse/core'
 import { isNil } from 'lodash-unified'
 import { ElIcon } from '@element-plus/components/icon'
-import { Hide as IconHide, View as IconView } from '@element-plus/icons-vue'
+import {
+  CircleClose as IconCircleClose,
+  Hide as IconHide,
+  View as IconView,
+} from '@element-plus/icons-vue'
 import {
   useFormDisabled,
   useFormItem,
@@ -202,7 +206,11 @@ import {
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
 import { calcTextareaHeight, looseToNumber } from './utils'
-import { inputEmits, inputProps } from './input'
+import {
+  type InputEmits,
+  type InputModelModifiers,
+  type InputProps,
+} from './input'
 
 import type { StyleValue } from 'vue'
 
@@ -213,8 +221,21 @@ defineOptions({
   name: COMPONENT_NAME,
   inheritAttrs: false,
 })
-const props = defineProps(inputProps)
-const emit = defineEmits(inputEmits)
+
+const props = withDefaults(defineProps<InputProps<T>>(), {
+  modelValue: '',
+  modelModifiers: () => ({}) as T,
+  type: 'text',
+  autosize: false,
+  autocomplete: 'off',
+  clearIcon: () => IconCircleClose,
+  wordLimitPosition: 'inside',
+  tabindex: 0,
+  validateEvent: true,
+  inputStyle: () => ({}),
+  rows: 2,
+})
+const emit = defineEmits<InputEmits<T>>()
 
 const rawAttrs = useRawAttrs()
 const attrs = useAttrs()
@@ -409,7 +430,7 @@ const formatValue = (value: string) => {
     value = value.trim()
   }
   if (number) {
-    value = `${looseToNumber(value)}`
+    value = looseToNumber(value)
   }
   if (props.formatter && props.parser) {
     value = props.parser(value)

--- a/packages/components/input/src/instance.ts
+++ b/packages/components/input/src/instance.ts
@@ -1,3 +1,7 @@
 import type Input from './input.vue'
+import type { ComponentExposed } from 'vue-component-type-helpers'
+import type { ComponentPublicInstance } from 'vue'
 
-export type InputInstance = InstanceType<typeof Input> & unknown
+export type InputInstance = ComponentPublicInstance<typeof Input> &
+  ComponentExposed<typeof Input> &
+  unknown


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

**BugDesc**
- When we use v-model.number on the ElInput component, the value inside the input and change event handlers is of type string. We expect it to be of type number. The official documentation also mentions this point: in the function signatures of the input and change events, the value parameter should be of type number or string.

https://github.com/user-attachments/assets/ff8c7723-aee8-417d-a259-c71912471dcf


**Fix**
- fixed correct event type for v-model.number
- modified the function signature. Due to the change in the function signature, other components or tests need to be updated to be compatible with the TypeScript types.


https://github.com/user-attachments/assets/a0130a84-3ecf-4d14-8e27-dbebadcf2a28

