### PR TITLE
fix(components): [select/select-v2] show empty slot when remote search empty

### DIFF
--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -2728,4 +2728,66 @@ describe('Select', () => {
     await input.trigger('blur')
     expect(handleVisibleChange).toHaveBeenCalledTimes(2)
   })
+
+  it('should show empty slot correctly in remote search scenarios', async () => {
+    vi.useFakeTimers()
+    const wrapper = _mount(
+      `
+      <el-select
+        v-model="value"
+        filterable
+        remote
+        :remote-method="remoteMethod"
+        :options="options"
+      >
+        <template #empty>
+          <div class="custom-empty">NO DATA</div>
+        </template>
+      </el-select>
+      `,
+      {
+        data() {
+          return {
+            value: '',
+            options: [],
+          }
+        },
+        methods: {
+          remoteMethod(query: string) {
+            if (!query || query === 'empty') {
+              this.options = []
+            } else {
+              this.options = [{ value: '1', label: 'Option 1' }]
+            }
+          },
+        },
+      }
+    )
+
+    const select = wrapper.findComponent({ name: 'ElSelectV2' })
+    const input = wrapper.find('input')
+    const vm = select.vm as any
+
+    await input.trigger('click')
+    expect(vm.options.length).toBe(0)
+    expect(vm.dropdownMenuVisible).toBe(true)
+    expect(document.querySelector('.custom-empty')).not.toBeNull()
+
+    await input.setValue('a')
+    vi.runAllTimers()
+    await nextTick()
+    expect(vm.options.length).toBe(1)
+    expect(vm.dropdownMenuVisible).toBe(true)
+    expect(document.querySelector('.custom-empty')).toBeNull()
+
+    await input.setValue('empty')
+    vi.runAllTimers()
+    await nextTick()
+
+    expect(vm.options.length).toBe(0)
+    expect(vm.dropdownMenuVisible).toBe(true)
+    expect(document.querySelector('.custom-empty')).not.toBeNull()
+
+    vi.useRealTimers()
+  })
 })

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -4,6 +4,7 @@ import {
   onMounted,
   reactive,
   ref,
+  useSlots,
   watch,
   watchEffect,
 } from 'vue'
@@ -52,6 +53,7 @@ import type { SelectDropdownInstance } from './select-dropdown'
 const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
   // inject
   const { t } = useLocale()
+  const slots = useSlots()
   const nsSelect = useNamespace('select')
   const nsInput = useNamespace('input')
   const { form: elForm, formItem: elFormItem } = useFormItem()
@@ -392,7 +394,9 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     get() {
       return (
         expanded.value &&
-        (props.loading || !isRemoteSearchEmpty.value) &&
+        (props.loading ||
+          !isRemoteSearchEmpty.value ||
+          (props.remote && !!slots.empty)) &&
         (!debouncing.value || !isEmpty(states.previousQuery))
       )
     },

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4239,4 +4239,55 @@ describe('Select', () => {
     await input.trigger('blur')
     expect(handleVisibleChange).toHaveBeenCalledTimes(2)
   })
+
+  test('should show empty slot when remote search returns empty', async () => {
+    const wrapper = mount({
+      components: {
+        'el-select': Select,
+        'el-option': Option,
+      },
+      template: `
+        <el-select
+          v-model="value"
+          filterable
+          remote
+          :remote-method="remoteMethod"
+        >
+          <el-option
+            v-for="item in options"
+            :key="item.value"
+            :label="item.label"
+            :value="item.value"
+          />
+          <template #empty>
+            <div class="custom-empty">NO DATA</div>
+          </template>
+        </el-select>
+      `,
+      setup() {
+        const value = ref('')
+        const options = ref<any[]>([])
+        const remoteMethod = vi.fn((query) => {
+          if (query.includes('empty')) {
+            options.value = []
+          } else {
+            options.value = [{ value: '1', label: 'Option 1' }]
+          }
+        })
+        return { value, options, remoteMethod }
+      },
+    })
+    const select = wrapper.findComponent(Select)
+    const input = wrapper.find('input')
+    await input.trigger('click')
+    await input.setValue('empty')
+    await nextTick()
+    await nextTick()
+    expect((select.vm as any).expanded).toBe(true)
+    const emptyText = document.querySelector('.custom-empty')
+    expect(emptyText).not.toBeNull()
+    expect(emptyText?.textContent).toBe('NO DATA')
+    const popper = document.querySelector('.el-select__popper') as HTMLElement
+    expect(popper.style.display).not.toBe('none')
+  })
 })

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4240,9 +4240,9 @@ describe('Select', () => {
     expect(handleVisibleChange).toHaveBeenCalledTimes(2)
   })
 
-  test('should show empty slot when remote search returns empty', async () => {
+  test('should show empty slot correctly in remote search scenarios', async () => {
     vi.useFakeTimers()
-    wrapper = mount({
+    const wrapper = mount({
       components: {
         'el-select': Select,
         'el-option': Option,
@@ -4268,35 +4268,40 @@ describe('Select', () => {
       setup() {
         const value = ref('')
         const options = ref<any[]>([])
-        const remoteMethod = vi.fn((query) => {
-          if (query.includes('empty')) {
+
+        const remoteMethod = (query: string) => {
+          if (!query || query === 'empty') {
             options.value = []
           } else {
             options.value = [{ value: '1', label: 'Option 1' }]
           }
-        })
+        }
         return { value, options, remoteMethod }
       },
     })
+
     const select = wrapper.findComponent(Select)
     const input = wrapper.find('input')
     const vm = select.vm as any
 
     await input.trigger('click')
-    vm.states.query = 'empty'
-    await vm.remoteMethod('empty')
+    expect(vm.states.options.size).toBe(0)
+    expect(vm.dropdownMenuVisible).toBe(true)
+    expect(document.querySelector('.custom-empty')).not.toBeNull()
+
+    await input.setValue('a')
     vi.runAllTimers()
     await nextTick()
+    expect(vm.states.options.size).toBe(1)
+    expect(vm.dropdownMenuVisible).toBe(true)
+    expect(document.querySelector('.custom-empty')).toBeNull()
+
+    await input.setValue('empty')
+    vi.runAllTimers()
     await nextTick()
     expect(vm.states.options.size).toBe(0)
-    expect(vm.states.query).toBe('empty')
     expect(vm.dropdownMenuVisible).toBe(true)
-    expect(vm.expanded).toBe(true)
-    const emptyText = document.querySelector('.custom-empty')
-    expect(emptyText).not.toBeNull()
-    expect(emptyText?.textContent).toBe('NO DATA')
-    const popper = document.querySelector('.el-select__popper') as HTMLElement
-    expect(popper.style.display).not.toBe('none')
+    expect(document.querySelector('.custom-empty')).not.toBeNull()
 
     vi.useRealTimers()
   })

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4241,7 +4241,8 @@ describe('Select', () => {
   })
 
   test('should show empty slot when remote search returns empty', async () => {
-    const wrapper = mount({
+    vi.useFakeTimers()
+    wrapper = mount({
       components: {
         'el-select': Select,
         'el-option': Option,
@@ -4279,15 +4280,24 @@ describe('Select', () => {
     })
     const select = wrapper.findComponent(Select)
     const input = wrapper.find('input')
+    const vm = select.vm as any
+
     await input.trigger('click')
-    await input.setValue('empty')
+    vm.states.query = 'empty'
+    await vm.remoteMethod('empty')
+    vi.runAllTimers()
     await nextTick()
     await nextTick()
-    expect((select.vm as any).expanded).toBe(true)
+    expect(vm.states.options.size).toBe(0)
+    expect(vm.states.query).toBe('empty')
+    expect(vm.dropdownMenuVisible).toBe(true)
+    expect(vm.expanded).toBe(true)
     const emptyText = document.querySelector('.custom-empty')
     expect(emptyText).not.toBeNull()
     expect(emptyText?.textContent).toBe('NO DATA')
     const popper = document.querySelector('.el-select__popper') as HTMLElement
     expect(popper.style.display).not.toBe('none')
+
+    vi.useRealTimers()
   })
 })

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -4,6 +4,7 @@ import {
   onMounted,
   reactive,
   ref,
+  useSlots,
   watch,
   watchEffect,
 } from 'vue'
@@ -59,6 +60,7 @@ import type {
 
 export const useSelect = (props: SelectProps, emit: SelectEmits) => {
   const { t } = useLocale()
+  const slots = useSlots()
   const contentId = useId()
   const nsSelect = useNamespace('select')
   const nsInput = useNamespace('input')
@@ -248,7 +250,9 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
     get() {
       return (
         expanded.value &&
-        (props.loading || !isRemoteSearchEmpty.value) &&
+        (props.loading ||
+          !isRemoteSearchEmpty.value ||
+          (props.remote && !!slots.empty)) &&
         (!debouncing.value || !isEmpty(states.previousQuery))
       )
     },


### PR DESCRIPTION
Fixes #23191

### What is this change?

Fixes the issue where the dropdown menu prevents the empty slot from showing when remote search returns empty.

### Why is this change needed?

When `remote` is enabled and search results are empty, the dropdown menu logic was incorrectly hiding the menu, making the `#empty` slot (e.g., "Add Option" button) invisible to users. This fix adds a condition to check for the empty slot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying select components (v1 and v2) display a custom empty-state template when remote searches return no results.

* **Bug Fixes**
  * Fixed dropdown visibility so custom empty-state templates are shown correctly during remote search flows when no options are found.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->