### PR TITLE
chore: reorder recommended Prettier rules

### DIFF
--- a/internal/eslint-config/index.js
+++ b/internal/eslint-config/index.js
@@ -79,6 +79,7 @@ export default defineConfig([
   markdown.configs.processor,
 
   ...pluginVue.configs['flat/recommended'],
+  eslintPluginPrettierRecommended,
 
   {
     rules: {
@@ -552,5 +553,4 @@ export default defineConfig([
       '!.*',
     ],
   },
-  eslintPluginPrettierRecommended,
 ])

--- a/packages/components/cascader-panel/src/menu.vue
+++ b/packages/components/cascader-panel/src/menu.vue
@@ -25,12 +25,13 @@
     <div v-else-if="isEmpty" :class="ns.e('empty-text')">
       <slot name="empty">{{ t('el.cascader.noData') }}</slot>
     </div>
-    <!-- eslint-disable-next-line vue/html-self-closing -->
+    <!-- eslint-disable vue/html-self-closing -->
     <svg
       v-else-if="panel?.isHoverMenu"
       ref="hoverZone"
       :class="ns.e('hover-zone')"
     ></svg>
+    <!-- eslint-enable vue/html-self-closing -->
   </el-scrollbar>
 </template>
 


### PR DESCRIPTION
I think `eslint-plugin-prettier/recommended` should be placed before the project’s custom rules. 
Otherwise, when conflicts occur, it will override our custom rules—for example, `vue/html-self-closing`, causing those custom rules to lose their meaning.