### PR TITLE
fix(components): [table] prevent `showOverflowTooltip` overwrite

### DIFF
--- a/packages/components/table/src/table-column/watcher-helper.ts
+++ b/packages/components/table/src/table-column/watcher-helper.ts
@@ -1,5 +1,5 @@
 import { getCurrentInstance, watch } from 'vue'
-import { hasOwn } from '@element-plus/utils'
+import { hasOwn, isUndefined } from '@element-plus/utils'
 import { parseMinWidth, parseWidth } from '../util'
 
 import type { ComputedRef } from 'vue'
@@ -91,6 +91,8 @@ function useWatcher<T extends DefaultRow>(
         watch(
           () => owner.value.props[key],
           (newVal) => {
+            if (instance.columnConfig.value.type === 'selection') return
+            if (!isUndefined(props_[key])) return
             instance.columnConfig.value[key] = newVal as never
           }
         )


### PR DESCRIPTION
1. Prevent overwriting for 'selection' columns to avoid unwanted width changes.
2. Respect the column's own 'showOverflowTooltip' prop when explicitly defined.

When `el-table` uses `show-overflow-tooltip` as `object`, `el-table-column` will be overwritten if it already has a value. My use case is that a certain column needs to have its `show-overflow-tooltip` property disabled, and its own internally rendered `tooltip` should be used. This would ensure that it renders correctly regardless of whether the content overflows. However, in reality, when some columns overflow, both the default `tooltip` and the self-rendered `tooltip` are triggered simultaneously.`el-table-column`'s `showOverflowTooltip` is incorrectly overridden.

`el-table` 使用 `show-overflow-tooltip` 为 `object` 时，`el-table-column`如果存在值会被覆盖。我的使用场景是，某个列需要关闭 `show-overflow-tooltip` 属性，使用内部自己渲染 `tooltip`，这样可以保证是否内容溢出，都会正常渲染，但实际情况是，有的列溢出了，默认的 `tooltip` 和自己渲染的 `tooltip` 同时触发。`el-table-column`的 `showOverflowTooltip` 被错误覆盖。

# Issue

![1](https://github.com/user-attachments/assets/cd976b4f-e035-40f1-b52b-5f4a204fb07d)
![2](https://github.com/user-attachments/assets/0496124e-9926-442c-9ca5-78490d44b2d0)

