### PR TITLE
Revert "fix(components): [select/select-v2] prevent dropdown closing on mixed input (#22869)"

### DIFF
--- a/packages/components/select-v2/src/option-item.vue
+++ b/packages/components/select-v2/src/option-item.vue
@@ -14,7 +14,6 @@
     ]"
     @mousemove="hoverItem"
     @click.stop="selectOptionClick"
-    @mousedown.prevent
   >
     <slot :item="item" :index="index" :disabled="disabled">
       <span>{{ getLabel(item) }}</span>

--- a/packages/components/select/src/option.vue
+++ b/packages/components/select/src/option.vue
@@ -8,7 +8,6 @@
     :aria-selected="itemSelected"
     @mousemove="hoverItem"
     @click.stop="selectOptionClick"
-    @mousedown.prevent
   >
     <slot>
       <span>{{ currentLabel }}</span>


### PR DESCRIPTION
This reverts commit 3ba25b97592a81023743769c678a9a9b48bedb94.

https://github.com/element-plus/element-plus/pull/22869#issuecomment-3691280067


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified mousedown event handling in select component options to allow default browser behavior to proceed, affecting focus management and selection interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->