### PR TITLE
fix(components): [date-picker-panel] weekstart incorrect select offset

### DIFF
--- a/packages/components/date-picker-panel/__tests__/date-picker-panel.test.tsx
+++ b/packages/components/date-picker-panel/__tests__/date-picker-panel.test.tsx
@@ -1,6 +1,7 @@
 import { nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import dayjs from 'dayjs'
+import updateLocale from 'dayjs/plugin/updateLocale'
 import triggerEvent from '@element-plus/test-utils/trigger-event'
 import { describe, expect, it, vi } from 'vitest'
 import DatePickerPanel from '../src/date-picker-panel'
@@ -15,6 +16,14 @@ const makeRange = (start: number, end: number) => {
     result.push(i)
   }
   return result
+}
+
+const setDayjsWeekStart = (weekStart = 0) => {
+  dayjs.extend(updateLocale)
+  const dayjsLocale = dayjs.locale()
+  dayjs.updateLocale(dayjsLocale, {
+    weekStart,
+  })
 }
 
 describe('DatePickerPanel', () => {
@@ -101,6 +110,26 @@ describe('DatePickerPanel', () => {
         expect(onPanelChange).not.toHaveBeenCalled()
       }
     )
+  })
+
+  describe('should correctly select a date when weekStart change', () => {
+    const weekStarts = Array.from({ length: 7 }, (_, idx) => idx)
+
+    it.each(weekStarts)('dayjs "weekStart: %s" works', async (weekStart) => {
+      setDayjsWeekStart(weekStart)
+      const modelValue = ref<string>()
+      const wrapper = mount(() => (
+        <DatePickerPanel
+          v-model={modelValue.value}
+          defaultValue={new Date(2001, 0)}
+        />
+      ))
+      const cell = wrapper.find('.available')
+      await cell.trigger('mousemove')
+      await cell.trigger('click')
+
+      expect(wrapper.find('.available.current').text()).toBe(cell.text())
+    })
   })
 
   describe(':type="datetime" & :type="datetimerange"', () => {

--- a/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
+++ b/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
@@ -41,7 +41,7 @@ export const useBasicDateTable = (
 
   const offsetDay = computed(() => {
     // Sunday 7(0), cal the left and right offset days, 3217654, such as Monday is -1, the is to adjust the position of the first two rows of dates
-    return firstDayOfWeek > 3 ? 7 - firstDayOfWeek : -firstDayOfWeek
+    return firstDayOfWeek > 3 ? 7 - firstDayOfWeek : firstDayOfWeek
   })
 
   const startDate = computed(() => {

--- a/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
+++ b/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
@@ -40,7 +40,9 @@ export const useBasicDateTable = (
     .map((_) => _.toLowerCase())
 
   const offsetDay = computed(() => {
-    // Sunday 7(0), cal the left and right offset days, 3217654, such as Monday is -1, the is to adjust the position of the first two rows of dates
+    // Sunday 7(0), calculate the offset days to adjust the position of the first two rows of dates
+    // For weekStart <= 3: offset = weekStart (e.g., Monday = 1, Tuesday = 2, Wednesday = 3)
+    // For weekStart > 3: offset = 7 - weekStart (e.g., Thursday = 3, Friday = 2, Saturday = 1)
     return firstDayOfWeek > 3 ? 7 - firstDayOfWeek : firstDayOfWeek
   })
 


### PR DESCRIPTION
closed #23221

When the `dayjs.weekStart` is 2 and 3, depending where we at in the date picker the select offset will be wrong.
With this change, I don't know if it's the really the logic wanted but tested in many scenarios and it should be good.


Side effect change: For `dayjs.weekStart` 2 and 3 The number of days from previous/next month has changed and might be adapted(?).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date alignment and offset logic in the date picker so dates display and select correctly when the week-start day changes across locales.

* **Tests**
  * Added comprehensive tests verifying date selection behavior for all seven week-start values to ensure consistent behavior across locale configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->