### PR TITLE
fix(components): [table] correct oldCurrentRow in setCurrentRowByKey for current-change event

### DIFF
--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -194,7 +194,7 @@ describe('Table.vue', () => {
     })
 
     it('updates height and maxHeight sequentially without recursive error', async () => {
-      const errorSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const errorSpy = vi.spyOn(console, 'warn').mockImplementation(() => { })
       const wrapper = createTable(':height="height" :max-height="maxHeight"', {
         data() {
           return {
@@ -385,6 +385,62 @@ describe('Table.vue', () => {
       expect(rows[1].classes()).toContain('current-row')
       wrapper.unmount()
     })
+
+    it('current-change event should pass correct oldCurrentRow when using current-row-key', async () => {
+      const currentChangeHandler = vi.fn()
+      const wrapper = mount({
+        components: {
+          ElTable,
+          ElTableColumn,
+        },
+        template: `
+        <el-table
+          :data="testData"
+          row-key="id"
+          highlight-current-row
+          :current-row-key="currentRowKey"
+          @current-change="handleCurrentChange"
+        >
+          <el-table-column prop="name" label="片名" />
+          <el-table-column prop="release" label="发行日期" />
+          <el-table-column prop="director" label="导演" />
+          <el-table-column prop="runtime" label="时长（分）" />
+        </el-table>
+      `,
+        created() {
+          this.testData = getTestData()
+        },
+        data() {
+          return { currentRowKey: null }
+        },
+        methods: {
+          handleCurrentChange(newRow, oldRow) {
+            currentChangeHandler(newRow, oldRow)
+          },
+        },
+      })
+      await doubleWait()
+
+      // 第一次设置 current-row-key，oldRow 应该是 null
+      wrapper.vm.currentRowKey = 1
+      await doubleWait()
+      expect(currentChangeHandler).toHaveBeenCalledTimes(1)
+      expect(currentChangeHandler).toHaveBeenLastCalledWith(
+        expect.objectContaining({ id: 1 }),
+        null
+      )
+
+      // 切换到另一个 current-row-key，oldRow 应该是之前的行数据
+      wrapper.vm.currentRowKey = 2
+      await doubleWait()
+      expect(currentChangeHandler).toHaveBeenCalledTimes(2)
+      expect(currentChangeHandler).toHaveBeenLastCalledWith(
+        expect.objectContaining({ id: 2 }),
+        expect.objectContaining({ id: 1 })
+      )
+
+      wrapper.unmount()
+    })
   })
   describe('filter', () => {
     let wrapper: VueWrapper<ComponentPublicInstance>
@@ -465,7 +521,7 @@ describe('Table.vue', () => {
       await doubleWait()
       expect(
         (wrapper.vm as ComponentPublicInstance & { filters: any }).filters[
-          'director'
+        'director'
         ]
       ).toEqual(['John Lasseter'])
       expect(
@@ -519,7 +575,7 @@ describe('Table.vue', () => {
       await doubleWait()
       expect(
         (wrapper.vm as ComponentPublicInstance & { filters: any }).filters[
-          'director'
+        'director'
         ]
       ).toEqual([])
       expect([
@@ -2027,7 +2083,7 @@ describe('Table.vue', () => {
       expandIcon.trigger('click')
       await doubleWait()
       expect(expandIcon.classes()).toContain('el-table__expand-icon--expanded')
-      ;(wrapper.vm as any).closeExpandRow()
+        ; (wrapper.vm as any).closeExpandRow()
       await doubleWait()
       expect(expandIcon.classes()).not.toContain(
         'el-table__expand-icon--expanded'

--- a/packages/components/table/src/store/current.ts
+++ b/packages/components/table/src/store/current.ts
@@ -23,6 +23,7 @@ function useCurrent<T extends DefaultRow>(watcherData: WatcherPropsData<T>) {
 
   const setCurrentRowByKey = (key: string) => {
     const { data, rowKey } = watcherData
+    const oldCurrentRow = currentRow.value
     let _currentRow: T | null = null
     if (rowKey.value) {
       _currentRow =
@@ -31,7 +32,7 @@ function useCurrent<T extends DefaultRow>(watcherData: WatcherPropsData<T>) {
         ) ?? null
     }
     currentRow.value = _currentRow ?? null
-    instance.emit('current-change', currentRow.value, null)
+    instance.emit('current-change', currentRow.value, oldCurrentRow)
   }
 
   const updateCurrentRow = (_currentRow: T) => {

--- a/packages/components/table/src/store/current.ts
+++ b/packages/components/table/src/store/current.ts
@@ -1,5 +1,4 @@
 import { getCurrentInstance, ref, unref } from 'vue'
-import { isNull } from 'lodash-unified'
 import { getRowIdentity } from '../util'
 
 import type { Ref } from 'vue'
@@ -58,10 +57,9 @@ function useCurrent<T extends DefaultRow>(watcherData: WatcherPropsData<T>) {
       if (rowKey) {
         const currentRowKey = getRowIdentity(oldCurrentRow, rowKey)
         setCurrentRowByKey(currentRowKey)
+        // setCurrentRowByKey 已经触发了 current-change 事件，不需要再次触发
       } else {
         currentRow.value = null
-      }
-      if (isNull(currentRow.value)) {
         instance.emit('current-change', null, oldCurrentRow)
       }
     } else if (_currentRowKey.value) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [√] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [√] Make sure you are merging your commits to `dev` branch.
- [√] Add some descriptions and refer to relative issues for your PR.

---

## 修复内容

修复了 `setCurrentRowByKey` 函数中 `current-change` 事件的 `oldCurrentRow` 参数问题。

## 问题描述

在通过 `current-row-key` prop 切换当前行时，`current-change` 事件的第二个参数（oldCurrentRow）始终为 `null`，而不是之前的行数据。这导致无法正确获取切换前的行数据。

## 修复方案

在 `setCurrentRowByKey` 函数中，在更新 `currentRow.value` 之前保存 `oldCurrentRow`，然后在触发事件时传递正确的 `oldCurrentRow` 值。

### 修改文件

- `packages/components/table/src/store/current.ts`

### 关键改动

**修复前**


```js
instance.emit('current-change', currentRow.value, null)
```

**修复后**

```js
const oldCurrentRow = currentRow.value
instance.emit('current-change', currentRow.value, oldCurrentRow)
```

**修复后完整代码**

```js
  const setCurrentRowByKey = (key: string) => {
    const { data, rowKey } = watcherData
    const oldCurrentRow = currentRow.value
    let _currentRow: T | null = null
    if (rowKey.value) {
      _currentRow =
        (unref(data) || []).find(
          (item) => getRowIdentity(item, rowKey.value) === key
        ) ?? null
    }
    currentRow.value = _currentRow ?? null
    instance.emit('current-change', currentRow.value, oldCurrentRow)
  }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The table's current-change event now correctly includes the previous row when changing selection by row key.

* **Tests**
  * Added test verifying current-change emits correct previous-row info across sequential current-row updates using row-key selection.

* **Style**
  * Minor formatting and string-style tweaks that don't affect behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->