### PR TITLE
docs: remove padding-left

### DIFF
--- a/docs/.vitepress/vitepress/styles/base.scss
+++ b/docs/.vitepress/vitepress/styles/base.scss
@@ -187,11 +187,6 @@ img {
   max-width: 100%;
 }
 
-ul,
-ol {
-  padding-left: 1.25em;
-}
-
 li > ul,
 li > ol {
   margin: 0;


### PR DESCRIPTION
This style indirectly modify the default aspect of some components like `<el-timeline>`.
It may confuse the developer at real use case.
The update of `<ul>` style in the doc is insignificant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed default left padding from unordered and ordered lists, resulting in adjusted list spacing across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->