### PR TITLE
feat(utils): [dom] add support for ShadowDom

### DIFF
--- a/packages/utils/__tests__/dom/aria.test.ts
+++ b/packages/utils/__tests__/dom/aria.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
-import { focusElement, isFocusable, triggerEvent } from '../..'
+import { focusElement, isFocusable, isShadowRoot, triggerEvent } from '../..'
 
 const CE = (tag: string) => document.createElement(tag)
 
 describe('Aria Utils', () => {
+  describe('isShadowRoot', () => {
+    it('should return true when element is a shadow root', () => {
+      const $el = CE('div')
+      const shadowRoot = $el.attachShadow({ mode: 'open' })
+      expect(isShadowRoot(shadowRoot)).toBe(true)
+    })
+  })
+
   describe('Trigger Event', () => {
     it('Util trigger event to trigger event correctly', () => {
       const div = document.createElement('div')

--- a/packages/utils/dom/aria.ts
+++ b/packages/utils/dom/aria.ts
@@ -1,5 +1,10 @@
 const FOCUSABLE_ELEMENT_SELECTORS = `a[href],button:not([disabled]),button:not([hidden]),:not([tabindex="-1"]),input:not([disabled]),input:not([type="hidden"]),select:not([disabled]),textarea:not([disabled])`
 
+export const isShadowRoot = (e: unknown): e is ShadowRoot => {
+  if (typeof ShadowRoot === 'undefined') return false
+  return e instanceof ShadowRoot
+}
+
 const isHTMLElement = (e: unknown): e is Element => {
   if (typeof Element === 'undefined') return false
   return e instanceof Element

--- a/packages/utils/dom/scroll.ts
+++ b/packages/utils/dom/scroll.ts
@@ -3,6 +3,7 @@ import { easeInOutCubic } from '../easings'
 import { isFunction, isWindow } from '../types'
 import { cAF, rAF } from '../raf'
 import { getStyle } from './style'
+import { isShadowRoot } from './aria'
 
 export const isScroll = (el: HTMLElement, isVertical?: boolean): boolean => {
   if (!isClient) return false
@@ -31,7 +32,11 @@ export const getScrollContainer = (
 
     if (isScroll(parent, isVertical)) return parent
 
-    parent = parent.parentNode as HTMLElement
+    if (isShadowRoot(parent)) {
+      parent = parent.host as HTMLElement
+    } else {
+      parent = parent.parentNode as HTMLElement
+    }
   }
 
   return parent

--- a/packages/utils/dom/style.ts
+++ b/packages/utils/dom/style.ts
@@ -3,6 +3,7 @@ import { isClient } from '../browser'
 import { camelize } from '../strings'
 import { entriesOf, keysOf } from '../objects'
 import { debugWarn } from '../error'
+import { isShadowRoot } from './aria'
 
 import type { CSSProperties } from 'vue'
 
@@ -31,7 +32,7 @@ export const getStyle = (
   element: HTMLElement,
   styleName: keyof CSSProperties
 ): string => {
-  if (!isClient || !element || !styleName) return ''
+  if (!isClient || !element || !styleName || isShadowRoot(element)) return ''
 
   let key = camelize(styleName)
   if (key === 'float') key = 'cssFloat'


### PR DESCRIPTION
Add the isShadowRoot utility function to detect ShadowRoot handle ShadowRoot situations in getStyle and getScrollContainer add unit tests for isShadowRoot

BREAKING CHANGE: `getScrollContainer()` now returns shadowRoot

closed #23228

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shadow DOM detection utility for improved DOM traversal support.

* **Bug Fixes**
  * Improved scroll container handling within Shadow DOM boundaries.
  * Enhanced style access safety for Shadow DOM elements.

* **Tests**
  * Added test coverage for Shadow DOM detection functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->