### PR TITLE
fix(components): [table] fix MutationObserver private field access

### DIFF
--- a/packages/components/table/src/table/key-render-helper.ts
+++ b/packages/components/table/src/table/key-render-helper.ts
@@ -1,4 +1,4 @@
-import { onMounted, onUnmounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref, toRaw } from 'vue'
 
 import type { Table } from './defaults'
 
@@ -14,7 +14,7 @@ export default function useKeyRender(table: Table<[]>) {
       updateOrderFns.forEach((fn: () => void) => fn())
     })
 
-    observer.value.observe(columnsWrapper!, config)
+    toRaw(observer.value).observe(columnsWrapper!, config)
   }
 
   onMounted(() => {
@@ -23,6 +23,6 @@ export default function useKeyRender(table: Table<[]>) {
   })
 
   onUnmounted(() => {
-    observer.value?.disconnect()
+    toRaw(observer.value)?.disconnect()
   })
 }


### PR DESCRIPTION
Use toRaw() to bypass Vue's reactive proxy when calling MutationObserver methods. In happy-dom environment, MutationObserver methods access private fields (e.g., #destroyed) which cannot be accessed when called through Vue's ref proxy due to incorrect 'this' context.

This fixes the issue where MutationObserver.observe() and disconnect() would fail with "Cannot read private member #destroyed" error in happy-dom test environment.

Please make sure these boxes are checked before submitting your PR, thank you!

- [X] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [X] Make sure you are merging your commits to `dev` branch.
- [X] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced table component stability by optimizing internal observer handling to prevent potential rendering issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->