### PR TITLE
fix: [table] useKeyRender fix MutationObserver private field access

### DIFF
--- a/packages/components/table/src/table/key-render-helper.ts
+++ b/packages/components/table/src/table/key-render-helper.ts
@@ -1,20 +1,20 @@
-import { onMounted, onUnmounted, ref } from 'vue'
+import { onMounted, onUnmounted } from 'vue'
 
 import type { Table } from './defaults'
 
 export default function useKeyRender(table: Table<[]>) {
-  const observer = ref<MutationObserver>()
+  let observer: MutationObserver
 
   const initWatchDom = () => {
     const el = table.vnode.el
     const columnsWrapper = (el as HTMLElement).querySelector('.hidden-columns')
     const config = { childList: true, subtree: true }
     const updateOrderFns = table.store.states.updateOrderFns
-    observer.value = new MutationObserver(() => {
+    observer = new MutationObserver(() => {
       updateOrderFns.forEach((fn: () => void) => fn())
     })
 
-    observer.value.observe(columnsWrapper!, config)
+    observer.observe(columnsWrapper!, config)
   }
 
   onMounted(() => {
@@ -23,6 +23,6 @@ export default function useKeyRender(table: Table<[]>) {
   })
 
   onUnmounted(() => {
-    observer.value?.disconnect()
+    observer?.disconnect()
   })
 }


### PR DESCRIPTION
Replace ref<MutationObserver> with plain variable to avoid Vue reactive proxy. In happy-dom environment, MutationObserver methods access private fields (e.g., #destroyed) which cannot be accessed when called through Vue's ref proxy due to incorrect 'this' context.

By using a plain variable instead of ref, we ensure the MutationObserver instance is called directly without proxy wrapper, allowing proper access to private fields.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update includes internal refactoring to improve code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->