### PR TITLE
test(components): [input-number] avoid reusing Event instance in test

### DIFF
--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -711,17 +711,16 @@ describe('InputNumber.vue', () => {
     ))
 
     const input = wrapper.find('input')
-    const event = new Event('input')
 
     expect(input.element.value).toBe('1')
 
     input.element.value = '100'
-    input.element.dispatchEvent(event)
+    input.element.dispatchEvent(new Event('input'))
     await input.trigger('keydown', { key: EVENT_CODE.down })
     expect(input.element.value).toBe('10')
 
     input.element.value = '110'
-    input.element.dispatchEvent(event)
+    input.element.dispatchEvent(new Event('input'))
     await input.trigger('keydown', { key: EVENT_CODE.down })
     expect(input.element.value).toBe('10')
   })


### PR DESCRIPTION
Intermittent failures occur in both local and CI environments. This might be related to reusing the same Event instance, but I’m not entirely sure yet.

<img width="578" height="275" alt="image" src="https://github.com/user-attachments/assets/6104fd28-fc74-4c2a-aef1-b3b91c967fc3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored input number test to improve code clarity and maintainability through inline variable optimization, with no changes to test coverage or assertions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->