### PR TITLE
feat(components): [upload] add `directory` prop

### DIFF
--- a/docs/en-US/component/upload.md
+++ b/docs/en-US/component/upload.md
@@ -81,6 +81,16 @@ upload/drag-and-drop
 
 :::
 
+## Upload Directory ^(2.13.1)
+
+Enable folder upload via the `directory` prop.
+
+:::demo
+
+upload/directory
+
+:::
+
 ## Manual Upload
 
 :::demo
@@ -121,6 +131,7 @@ upload/manual
 | http-request                  | override default xhr behavior, allowing you to implement your own upload-file's request.                                                                                              | ^[Function]`(options: UploadRequestOptions) => XMLHttpRequest \| Promise<unknown>`                                                         | ajaxUpload [see](https://github.com/element-plus/element-plus/blob/dev/packages/components/upload/src/ajax.ts#L55) |
 | disabled                      | whether to disable upload.                                                                                                                                                            | ^[boolean]                                                                                                                                 | false                                                                                                              |
 | limit                         | maximum number of uploads allowed.                                                                                                                                                    | ^[number]                                                                                                                                  | —                                                                                                                  |
+| directory ^(2.13.1)           | whether to support uploading directory.                                                                                                                                               | ^[boolean]                                                                                                                                 | false                                                                                                              |
 
 ### Slots
 

--- a/docs/en-US/component/upload.md
+++ b/docs/en-US/component/upload.md
@@ -85,7 +85,7 @@ upload/drag-and-drop
 
 Enable folder upload via the `directory` prop.
 
-:::demo
+:::demo After enabling it, only folders can be selected, and after selecting a folder, the files within the folder will be flattened.
 
 upload/directory
 
@@ -131,7 +131,7 @@ upload/manual
 | http-request                  | override default xhr behavior, allowing you to implement your own upload-file's request.                                                                                              | ^[Function]`(options: UploadRequestOptions) => XMLHttpRequest \| Promise<unknown>`                                                         | ajaxUpload [see](https://github.com/element-plus/element-plus/blob/dev/packages/components/upload/src/ajax.ts#L55) |
 | disabled                      | whether to disable upload.                                                                                                                                                            | ^[boolean]                                                                                                                                 | false                                                                                                              |
 | limit                         | maximum number of uploads allowed.                                                                                                                                                    | ^[number]                                                                                                                                  | —                                                                                                                  |
-| directory ^(2.13.1)           | whether to support uploading directory.                                                                                                                                               | ^[boolean]                                                                                                                                 | false                                                                                                              |
+| directory ^(2.13.1)           | whether to support uploading directory. After enabling it, only folders can be selected, and after selecting a folder, the files within the folder will be flattened.                 | ^[boolean]                                                                                                                                 | false                                                                                                              |
 
 ### Slots
 

--- a/docs/examples/upload/directory.vue
+++ b/docs/examples/upload/directory.vue
@@ -1,0 +1,25 @@
+<template>
+  <el-upload
+    class="upload-demo"
+    drag
+    action="https://run.mocky.io/v3/9d059bf9-4660-45f2-925d-ce80ad6c4d15"
+    directory
+    multiple
+    :on-change="handleChange"
+  >
+    <el-icon class="el-icon--upload"><upload-filled /></el-icon>
+    <div class="el-upload__text">
+      Drop directory here or <em>click to upload</em>
+    </div>
+  </el-upload>
+</template>
+
+<script setup lang="ts">
+import { UploadFilled } from '@element-plus/icons-vue'
+
+import type { UploadFile, UploadFiles } from 'element-plus'
+
+const handleChange = (uploadFile: UploadFile, uploadFiles: UploadFiles) => {
+  console.log(uploadFile, uploadFiles)
+}
+</script>

--- a/packages/components/upload/__tests__/upload-dragger.test.tsx
+++ b/packages/components/upload/__tests__/upload-dragger.test.tsx
@@ -1,9 +1,8 @@
 import { computed, provide } from 'vue'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vitest'
 import { uploadContextKey } from '@element-plus/components/upload'
 import UploadDragger from '../src/upload-dragger.vue'
-import { rAF } from '@element-plus/test-utils/tick'
 
 const AXIOM = 'Rem is the best girl'
 
@@ -101,7 +100,7 @@ describe('<upload-dragger />', () => {
         },
       })
 
-      await rAF()
+      await flushPromises()
       expect(dragger.emitted('file')).toHaveLength(1)
       const emittedFiles = dragger.emitted('file')![0][0] as File[]
       expect(emittedFiles).toHaveLength(1)

--- a/packages/components/upload/__tests__/upload-dragger.test.tsx
+++ b/packages/components/upload/__tests__/upload-dragger.test.tsx
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vitest'
 import { uploadContextKey } from '@element-plus/components/upload'
 import UploadDragger from '../src/upload-dragger.vue'
+import { rAF } from '@element-plus/test-utils/tick'
 
 const AXIOM = 'Rem is the best girl'
 
@@ -58,6 +59,53 @@ describe('<upload-dragger />', () => {
         },
       })
       expect(dragger.emitted('file')).toHaveLength(2)
+    })
+
+    test('ondrop works with directory prop', async () => {
+      const onDrop = vi.fn()
+      const wrapper = _mount({ onDrop, directory: true })
+      const dragger = wrapper.findComponent(UploadDragger)
+
+      const mockFileEntry = {
+        isFile: true,
+        isDirectory: false,
+        file: (callback: any) => callback(new File(['test'], 'test.txt')),
+      }
+
+      const mockDirectoryEntry = {
+        isFile: false,
+        isDirectory: true,
+        createReader: () => {
+          let read = false
+          return {
+            readEntries: (callback: any) => {
+              if (!read) {
+                read = true
+                callback([mockFileEntry])
+              } else {
+                callback([])
+              }
+            },
+          }
+        },
+      }
+
+      await dragger.trigger('drop', {
+        dataTransfer: {
+          files: [],
+          items: [
+            {
+              webkitGetAsEntry: () => mockDirectoryEntry,
+            },
+          ],
+        },
+      })
+
+      await rAF()
+      expect(dragger.emitted('file')).toHaveLength(1)
+      const emittedFiles = dragger.emitted('file')![0][0] as File[]
+      expect(emittedFiles).toHaveLength(1)
+      expect(emittedFiles[0].name).toBe('test.txt')
     })
   })
 })

--- a/packages/components/upload/src/upload-content.vue
+++ b/packages/components/upload/src/upload-content.vue
@@ -13,7 +13,11 @@
     @keydown.self.enter.space="handleKeydown"
   >
     <template v-if="drag">
-      <upload-dragger :disabled="disabled" @file="uploadFiles">
+      <upload-dragger
+        :disabled="disabled"
+        :directory="directory"
+        @file="uploadFiles"
+      >
         <slot />
       </upload-dragger>
     </template>
@@ -27,6 +31,7 @@
       :disabled="disabled"
       :multiple="multiple"
       :accept="accept"
+      :webkitdirectory="directory"
       type="file"
       @change="handleChange"
       @click.stop

--- a/packages/components/upload/src/upload-dragger.ts
+++ b/packages/components/upload/src/upload-dragger.ts
@@ -8,6 +8,7 @@ export const uploadDraggerProps = buildProps({
     type: Boolean,
     default: undefined,
   },
+  directory: Boolean,
 } as const)
 export type UploadDraggerProps = ExtractPropTypes<typeof uploadDraggerProps>
 export type UploadDraggerPropsPublic = ExtractPublicPropTypes<

--- a/packages/components/upload/src/upload-dragger.vue
+++ b/packages/components/upload/src/upload-dragger.vue
@@ -85,7 +85,7 @@ const onDrop = async (e: DragEvent) => {
 
   if (props.directory) {
     const entries = Array.from(items)
-      .map((item) => item.webkitGetAsEntry())
+      .map((item) => item?.webkitGetAsEntry?.())
       .filter((entry) => entry) as FileSystemEntry[]
 
     const allFiles = await Promise.all(entries.map(getAllFiles))

--- a/packages/components/upload/src/upload-dragger.vue
+++ b/packages/components/upload/src/upload-dragger.vue
@@ -64,7 +64,13 @@ const getAllFiles = async (
         )
       }
 
-      const entries = await getEntries()
+      const entries: FileSystemEntry[] = []
+      let readEntries = await getEntries()
+      while (readEntries.length > 0) {
+        entries.push(...readEntries)
+        readEntries = await getEntries()
+      }
+
       const filePromises = entries.map((entry) =>
         getAllFiles(entry).catch(() => [])
       )

--- a/packages/components/upload/src/upload-dragger.vue
+++ b/packages/components/upload/src/upload-dragger.vue
@@ -64,13 +64,7 @@ const getAllFiles = async (
         )
       }
 
-      const entries: FileSystemEntry[] = []
-      let readEntries = await getEntries()
-      while (readEntries.length > 0) {
-        entries.push(...readEntries)
-        readEntries = await getEntries()
-      }
-
+      const entries = await getEntries()
       const filePromises = entries.map((entry) =>
         getAllFiles(entry).catch(() => [])
       )

--- a/packages/components/upload/src/upload-dragger.vue
+++ b/packages/components/upload/src/upload-dragger.vue
@@ -14,6 +14,7 @@ import { inject, ref } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { useFormDisabled } from '@element-plus/components/form'
 import { throwError } from '@element-plus/utils/error'
+import { flatten } from 'lodash-unified'
 import { uploadContextKey } from './constants'
 import { uploadDraggerEmits, uploadDraggerProps } from './upload-dragger'
 
@@ -25,7 +26,7 @@ defineOptions({
   name: COMPONENT_NAME,
 })
 
-defineProps(uploadDraggerProps)
+const props = defineProps(uploadDraggerProps)
 const emit = defineEmits(uploadDraggerEmits)
 
 const uploaderContext = inject(uploadContextKey)
@@ -40,7 +41,40 @@ const ns = useNamespace('upload')
 const dragover = ref(false)
 const disabled = useFormDisabled()
 
-const onDrop = (e: DragEvent) => {
+const getFile = (entry: FileSystemFileEntry): Promise<File> => {
+  return new Promise((resolve, reject) => entry.file(resolve, reject))
+}
+
+const getAllFiles = async (
+  entry: FileSystemEntry
+): Promise<UploadRawFile[]> => {
+  if (entry.isFile) {
+    const file = (await getFile(entry as FileSystemFileEntry)) as UploadRawFile
+    file.isDirectory = false
+    return [file]
+  }
+  if (entry.isDirectory) {
+    const dirReader = (entry as FileSystemDirectoryEntry).createReader()
+    const getEntries = (): Promise<FileSystemEntry[]> => {
+      return new Promise((resolve, reject) =>
+        dirReader.readEntries(resolve, reject)
+      )
+    }
+
+    const entries: FileSystemEntry[] = []
+    let readEntries = await getEntries()
+    while (readEntries.length > 0) {
+      entries.push(...readEntries)
+      readEntries = await getEntries()
+    }
+
+    const files = await Promise.all(entries.map(getAllFiles))
+    return flatten(files)
+  }
+  return []
+}
+
+const onDrop = async (e: DragEvent) => {
   if (disabled.value) return
   dragover.value = false
 
@@ -48,6 +82,17 @@ const onDrop = (e: DragEvent) => {
 
   const files = Array.from(e.dataTransfer!.files) as UploadRawFile[]
   const items = e.dataTransfer!.items || []
+
+  if (props.directory) {
+    const entries = Array.from(items)
+      .map((item) => item.webkitGetAsEntry())
+      .filter((entry) => entry) as FileSystemEntry[]
+
+    const allFiles = await Promise.all(entries.map(getAllFiles))
+    emit('file', flatten(allFiles))
+    return
+  }
+
   files.forEach((file, index) => {
     const item = items[index]
     const entry = item?.webkitGetAsEntry?.()

--- a/packages/components/upload/src/upload-dragger.vue
+++ b/packages/components/upload/src/upload-dragger.vue
@@ -48,28 +48,38 @@ const getFile = (entry: FileSystemFileEntry): Promise<File> => {
 const getAllFiles = async (
   entry: FileSystemEntry
 ): Promise<UploadRawFile[]> => {
-  if (entry.isFile) {
-    const file = (await getFile(entry as FileSystemFileEntry)) as UploadRawFile
-    file.isDirectory = false
-    return [file]
-  }
-  if (entry.isDirectory) {
-    const dirReader = (entry as FileSystemDirectoryEntry).createReader()
-    const getEntries = (): Promise<FileSystemEntry[]> => {
-      return new Promise((resolve, reject) =>
-        dirReader.readEntries(resolve, reject)
+  try {
+    if (entry.isFile) {
+      const file = (await getFile(
+        entry as FileSystemFileEntry
+      )) as UploadRawFile
+      file.isDirectory = false
+      return [file]
+    }
+    if (entry.isDirectory) {
+      const dirReader = (entry as FileSystemDirectoryEntry).createReader()
+      const getEntries = (): Promise<FileSystemEntry[]> => {
+        return new Promise((resolve, reject) =>
+          dirReader.readEntries(resolve, reject)
+        )
+      }
+
+      const entries: FileSystemEntry[] = []
+      let readEntries = await getEntries()
+      while (readEntries.length > 0) {
+        entries.push(...readEntries)
+        readEntries = await getEntries()
+      }
+
+      const filePromises = entries.map((entry) =>
+        getAllFiles(entry).catch(() => [])
       )
-    }
 
-    const entries: FileSystemEntry[] = []
-    let readEntries = await getEntries()
-    while (readEntries.length > 0) {
-      entries.push(...readEntries)
-      readEntries = await getEntries()
+      const files = await Promise.all(filePromises)
+      return flatten(files)
     }
-
-    const files = await Promise.all(entries.map(getAllFiles))
-    return flatten(files)
+  } catch {
+    return []
   }
   return []
 }

--- a/packages/components/upload/src/upload.ts
+++ b/packages/components/upload/src/upload.ts
@@ -184,6 +184,10 @@ export const uploadBaseProps = buildProps({
    * @description maximum number of uploads allowed
    */
   limit: Number,
+  /**
+   * @description whether to support uploading directory
+   */
+  directory: Boolean,
 } as const)
 
 export const uploadProps = buildProps({


### PR DESCRIPTION
resolves #23093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload now supports directory uploads via a new boolean prop (default: false), enabling folder selection, drag-and-drop of directories, and flattening contained files.

* **Documentation**
  * Added documentation and an interactive example demonstrating directory upload usage and API details.

* **Tests**
  * Added a test validating directory drop/upload behavior and the emitted file list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->