### PR TITLE
fix(components): [virtual-list] incorrect scroll boundary check

### DIFF
--- a/packages/components/virtual-list/src/hooks/use-wheel.ts
+++ b/packages/components/virtual-list/src/hooks/use-wheel.ts
@@ -38,7 +38,7 @@ const useWheel = (
 
     const newOffset = layout.value === HORIZONTAL ? deltaX : deltaY
 
-    if (hasReachedEdge(offset) && hasReachedEdge(offset + newOffset)) return
+    if (hasReachedEdge(newOffset)) return
 
     offset += newOffset
 


### PR DESCRIPTION
After rapidly scrolling upward with a mouse or trackpad, `offset` becomes negative. When scrolling downward slowly afterward, both `offset` and `offset + newOffset` remain negative, causing the boundary check to keep failing and preventing the list from scrolling down.

This issue doesn’t seem easy to reproduce in the playground. It may be better to verify it locally.

[play](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8cD5cbiAgICBBZnRlciBleHBhbmRpbmcgdG8gdGhlIHRoaXJkLWxldmVsIGNoaWxkIG5vZGVzLCB0cnkgc2Nyb2xsaW5nIGhvcml6b250YWxseS5cbiAgPC9wPlxuICA8ZWwtdHJlZS12MlxuICAgIGNsYXNzPVwidHJlZVwiXG4gICAgOmRhdGE9XCJkYXRhXCJcbiAgICA6cHJvcHM9XCJwcm9wc1wiXG4gICAgOmhlaWdodD1cIjIwMFwiXG4gICAgc2Nyb2xsYmFyLWFsd2F5cy1vblxuICAvPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmludGVyZmFjZSBUcmVlIHtcbiAgaWQ6IHN0cmluZ1xuICBsYWJlbDogc3RyaW5nXG4gIGNoaWxkcmVuPzogVHJlZVtdXG59XG5cbmNvbnN0IGdldEtleSA9IChwcmVmaXg6IHN0cmluZywgaWQ6IG51bWJlcikgPT4ge1xuICByZXR1cm4gYCR7cHJlZml4fS0ke2lkfWBcbn1cblxuY29uc3QgY3JlYXRlRGF0YSA9IChcbiAgbWF4RGVlcDogbnVtYmVyLFxuICBtYXhDaGlsZHJlbjogbnVtYmVyLFxuICBtaW5Ob2Rlc051bWJlcjogbnVtYmVyLFxuICBkZWVwID0gMSxcbiAga2V5ID0gJ25vZGUnXG4pOiBUcmVlW10gPT4ge1xuICBsZXQgaWQgPSAwXG4gIHJldHVybiBBcnJheS5mcm9tKHsgbGVuZ3RoOiBtaW5Ob2Rlc051bWJlciB9KVxuICAgIC5maWxsKGRlZXApXG4gICAgLm1hcCgoKSA9PiB7XG4gICAgICBjb25zdCBjaGlsZHJlbk51bWJlciA9XG4gICAgICAgIGRlZXAgPT09IG1heERlZXAgPyAwIDogTWF0aC5yb3VuZChNYXRoLnJhbmRvbSgpICogbWF4Q2hpbGRyZW4pXG4gICAgICBjb25zdCBub2RlS2V5ID0gZ2V0S2V5KGtleSwgKytpZClcbiAgICAgIHJldHVybiB7XG4gICAgICAgIGlkOiBub2RlS2V5LFxuICAgICAgICBsYWJlbDogbm9kZUtleSxcbiAgICAgICAgY2hpbGRyZW46IGNoaWxkcmVuTnVtYmVyXG4gICAgICAgICAgPyBjcmVhdGVEYXRhKG1heERlZXAsIG1heENoaWxkcmVuLCBjaGlsZHJlbk51bWJlciwgZGVlcCArIDEsIG5vZGVLZXkpXG4gICAgICAgICAgOiB1bmRlZmluZWQsXG4gICAgICB9XG4gICAgfSlcbn1cblxuY29uc3QgcHJvcHMgPSB7XG4gIHZhbHVlOiAnaWQnLFxuICBsYWJlbDogJ2xhYmVsJyxcbiAgY2hpbGRyZW46ICdjaGlsZHJlbicsXG59XG5jb25zdCBkYXRhID0gY3JlYXRlRGF0YSg0LCAzMCwgNDApXG48L3NjcmlwdD5cblxuPHN0eWxlPlxuLnRyZWUge1xuICB3aWR0aDogMTAwcHg7XG4gIGJvcmRlcjogMXB4IHNvbGlkO1xufVxuXG4uZWwtdHJlZS1ub2RlLFxuLmVsLXRyZWUtbm9kZV9fY29udGVudCB7XG4gIHdpZHRoOiBmaXQtY29udGVudCAhaW1wb3J0YW50O1xufVxuXG4uZWwtdmxfX3dpbmRvdyB7XG4gIG92ZXJmbG93LXk6IGhpZGRlbiAhaW1wb3J0YW50O1xuICBzY3JvbGxiYXItd2lkdGg6IHRoaW4gIWltcG9ydGFudDtcbn1cblxuLmVsLXZsX193aW5kb3c6Oi13ZWJraXQtc2Nyb2xsYmFyLXRyYWNrIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gIGJvcmRlci1yYWRpdXM6IDRweDtcbn1cblxuLmVsLXZsX193aW5kb3c6Oi13ZWJraXQtc2Nyb2xsYmFyLXRodW1iIHtcbiAgYmFja2dyb3VuZDogcmdiYSgxNDQsIDE0NywgMTUzLCAwLjMpO1xuICBib3JkZXItcmFkaXVzOiA0cHg7XG59XG5cbi5lbC12bF9fd2luZG93Ojotd2Via2l0LXNjcm9sbGJhci10aHVtYjpob3ZlciB7XG4gIGJhY2tncm91bmQ6IHJnYmEoMTQ0LCAxNDcsIDE1MywgMC41KTtcbn1cblxuLmVsLXZsX193aW5kb3c6Oi13ZWJraXQtc2Nyb2xsYmFyIHtcbiAgZGlzcGxheTogdW5zZXQ7XG4gIGhlaWdodDogNnB4O1xufVxuPC9zdHlsZT5cbiIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vcHJldmlldy0yMjk4OS1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2Rpc3QvaW5kZXguY3NzJywgJ2h0dHBzOi8vcHJldmlldy0yMjk4OS1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL3RoZW1lLWNoYWxrL2RhcmsvY3NzLXZhcnMuY3NzJ10ubWFwKChzdHlsZSkgPT4ge1xuICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgICAgbGluay5ocmVmID0gc3R5bGVcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgICB9KVxuICB9KVxuICByZXR1cm4gUHJvbWlzZS5hbGxTZXR0bGVkKHN0eWxlcylcbn1cbiIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AbGF0ZXN0L2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvc2hhcmVkXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vcHJldmlldy0yMjk4OS1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2Rpc3QvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwidW5zdXBwb3J0ZWRcIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AZWxlbWVudC1wbHVzL2ljb25zLXZ1ZUAyL2Rpc3QvaW5kZXgubWluLmpzXCJcbiAgfSxcbiAgXCJzY29wZXNcIjoge31cbn0iLCJfbyI6eyJzaG93SGlkZGVuIjp0cnVlLCJzdHlsZVNvdXJjZSI6Imh0dHBzOi8vcHJldmlldy0yMjk4OS1lbGVtZW50LXBsdXMuc3VyZ2Uuc2gvYnVuZGxlL2Rpc3QvaW5kZXguY3NzIn19)

<details>
<summary>video</summary>


https://github.com/user-attachments/assets/5477c813-8280-4f12-84ee-ae45dc0702e0


</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced virtual list scroll behavior to allow smoother movement in additional scenarios when approaching edge boundaries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->