### PR TITLE
ci: remove unnecessary comment

### DIFF
--- a/.github/workflows/issue-inactive.yml
+++ b/.github/workflows/issue-inactive.yml
@@ -39,10 +39,6 @@ jobs:
           issue-state: closed
           labels: 'inactive'
           inactive-day: 30
-          body: |
-            This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
-
-            此 issue 已被自动锁定，因为关闭后没有任何近期活动。如果有相关 bug，请重新创建一个新 issue。
 
   check-inactive:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I’ve subscribed to the issues in this repository and receive notification emails almost every day. 
This can be somewhat distracting for both the issue author and other subscribed developers. When the same problem comes up again, people will naturally open a new issue or leave a comment on the fix PR. Therefore, I think the downsides of this comment outweigh its benefits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the automatic notification message from the issue-locking workflow, simplifying the issue management process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->