### PR TITLE
feat(components): [dropdown-item] add `icon` slot

### DIFF
--- a/docs/en-US/component/dropdown.md
+++ b/docs/en-US/component/dropdown.md
@@ -171,6 +171,7 @@ dropdown/virtual-trigger
 
 ### Dropdown-Item Slots
 
-| Name    | Description                |
-| ------- | -------------------------- |
-| default | customize of Dropdown Item |
+| Name    | Description                                 |
+| ------- | ------------------------------------------- |
+| default | customize of Dropdown Item                  |
+| icon    | custom icon, it will override the icon prop |

--- a/docs/en-US/component/dropdown.md
+++ b/docs/en-US/component/dropdown.md
@@ -171,7 +171,7 @@ dropdown/virtual-trigger
 
 ### Dropdown-Item Slots
 
-| Name    | Description                                 |
-| ------- | ------------------------------------------- |
-| default | customize of Dropdown Item                  |
+| Name           | Description                                 |
+| -------------- | ------------------------------------------- |
+| default        | customize of Dropdown Item                  |
 | icon ^(2.13.1) | custom icon, it will override the icon prop |

--- a/docs/en-US/component/dropdown.md
+++ b/docs/en-US/component/dropdown.md
@@ -174,4 +174,4 @@ dropdown/virtual-trigger
 | Name    | Description                                 |
 | ------- | ------------------------------------------- |
 | default | customize of Dropdown Item                  |
-| icon    | custom icon, it will override the icon prop |
+| icon ^(2.13.1) | custom icon, it will override the icon prop |

--- a/packages/components/dropdown/__tests__/dropdown.test.ts
+++ b/packages/components/dropdown/__tests__/dropdown.test.ts
@@ -1053,4 +1053,41 @@ describe('Dropdown', () => {
     expect(content.open).toBe(true)
     vi.useRealTimers()
   })
+
+  test('render icon slot content', async () => {
+    const wrapper = _mount(`
+      <el-dropdown trigger="hover">
+        <span class="el-dropdown-link">
+          Trigger
+        </span>
+        <template #dropdown>
+          <el-dropdown-menu>
+            <el-dropdown-item>
+              <template #icon>
+                <i class="test-icon">ICON</i>
+              </template>
+              Action
+            </el-dropdown-item>
+          </el-dropdown-menu>
+        </template>
+      </el-dropdown>
+    `)
+
+    await nextTick()
+
+    // Open dropdown
+    const triggerElm = wrapper.find('.el-dropdown-link')
+    await triggerElm.trigger(MOUSE_ENTER_EVENT)
+    await nextTick()
+
+    // Find icon element
+    const item = wrapper
+      .findComponent({ name: 'DropdownItemImpl' })
+      .find('.el-dropdown-menu__item')
+    const icon = item.find('.test-icon')
+
+    // The icon slot content should be rendered
+    expect(icon.exists()).toBe(true)
+    expect(icon.text()).toBe('ICON')
+  })
 })

--- a/packages/components/dropdown/__tests__/dropdown.test.ts
+++ b/packages/components/dropdown/__tests__/dropdown.test.ts
@@ -1080,14 +1080,47 @@ describe('Dropdown', () => {
     await triggerElm.trigger(MOUSE_ENTER_EVENT)
     await nextTick()
 
-    // Find icon element
-    const item = wrapper
+    // The el-icon should be rendered
+    const icon = wrapper
       .findComponent({ name: 'DropdownItemImpl' })
-      .find('.el-dropdown-menu__item')
-    const icon = item.find('.test-icon')
-
-    // The icon slot content should be rendered
+      .findComponent({ name: 'ElIcon' })
     expect(icon.exists()).toBe(true)
-    expect(icon.text()).toBe('ICON')
+
+    // The icon content should be rendered
+    const content = icon.find('.test-icon')
+    expect(content.exists()).toBe(true)
+    expect(content.text()).toBe('ICON')
+  })
+
+  test("no el-icon rendered if icon didn't passed in ", async () => {
+    const wrapper = _mount(`
+      <el-dropdown trigger="hover">
+        <span class="el-dropdown-link">
+          Trigger
+        </span>
+        <template #dropdown>
+          <el-dropdown-menu>
+            <el-dropdown-item>
+              Action
+            </el-dropdown-item>
+          </el-dropdown-menu>
+        </template>
+      </el-dropdown>
+    `)
+
+    await nextTick()
+
+    // Open dropdown
+    const triggerElm = wrapper.find('.el-dropdown-link')
+    await triggerElm.trigger(MOUSE_ENTER_EVENT)
+    await nextTick()
+
+    // Find icon element
+    const icon = wrapper
+      .findComponent({ name: 'DropdownItemImpl' })
+      .findComponent({ name: 'ElIcon' })
+
+    // The icon slot content shouldn't be rendered
+    expect(icon.exists()).toBe(false)
   })
 })

--- a/packages/components/dropdown/src/dropdown-item-impl.vue
+++ b/packages/components/dropdown/src/dropdown-item-impl.vue
@@ -18,8 +18,10 @@
     @pointermove="(e) => $emit('pointermove', e)"
     @pointerleave="(e) => $emit('pointerleave', e)"
   >
-    <el-icon v-if="icon">
-      <component :is="icon" />
+    <el-icon v-if="icon || $slots.icon">
+      <slot name="icon">
+        <component :is="icon" />
+      </slot>
     </el-icon>
     <slot />
   </li>

--- a/packages/components/dropdown/src/dropdown-item.vue
+++ b/packages/components/dropdown/src/dropdown-item.vue
@@ -6,6 +6,10 @@
       @pointermove="handlePointerMove"
       @clickimpl="handleClick"
     >
+      <template #icon>
+        <slot name="icon" />
+      </template>
+
       <slot />
     </el-dropdown-item-impl>
   </el-roving-focus-item>

--- a/packages/components/dropdown/src/dropdown-item.vue
+++ b/packages/components/dropdown/src/dropdown-item.vue
@@ -6,7 +6,7 @@
       @pointermove="handlePointerMove"
       @clickimpl="handleClick"
     >
-      <template #icon>
+      <template v-if="$slots.icon" #icon>
         <slot name="icon" />
       </template>
 


### PR DESCRIPTION
Previously, dropdown-item icons could only be set using the `icon` prop. Using other icon libraries required writing VNode functions within the prop，significantly reducing readability；alternatively, `<ElIcon>` had to be repeatedly written for a consistent layout.

Now, with the introduction of `icon` slot, elements are automatically passed to the **ElIcon**'s slot. This aligns with the **ElButton**'s icon design logic: both prop and slot can be used, but slot have higher priority.

close #22837

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a named "icon" slot on dropdown items; slot content is rendered when provided, with the existing icon prop used as a fallback for compatibility.
* **Tests**
  * Added tests verifying custom icon slot content renders and that no icon renders when none is provided.
* **Documentation**
  * Updated dropdown-item docs to describe the new icon slot, its precedence over the prop, and usage guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->