### PR TITLE
fix(components): [table-v2] correct the indentation of sub-row

### DIFF
--- a/packages/components/table-v2/__tests__/table-v2.test.tsx
+++ b/packages/components/table-v2/__tests__/table-v2.test.tsx
@@ -336,12 +336,12 @@ describe('TableV2.vue', () => {
           {
             id: 'row-0-sub-0',
             parentId: 'row-0',
-            ['column-0']: 'Sub 0',
+            'column-0': 'Sub 0',
             children: [
               {
                 id: 'row-0-sub-0-sub-0',
                 parentId: 'row-0-sub-0',
-                ['column-0']: 'Sub-Sub 0',
+                'column-0': 'Sub-Sub 0',
               },
             ],
           },

--- a/packages/components/table-v2/__tests__/table-v2.test.tsx
+++ b/packages/components/table-v2/__tests__/table-v2.test.tsx
@@ -319,12 +319,12 @@ describe('TableV2.vue', () => {
     })
   })
 
-  test('expand button should not apply margin style of icon', async () => {
+  test('expand button of sub-row should not apply margin style of icon', async () => {
     const columns = [
       {
         key: 'column-0',
         dataKey: 'column-0',
-        title: `Column 0`,
+        title: 'Column 0',
         width: 150,
       },
     ]
@@ -334,14 +334,14 @@ describe('TableV2.vue', () => {
         'column-0': 'Row 0 - Col 0',
         children: [
           {
-            id: `row-0-sub-0`,
+            id: 'row-0-sub-0',
             parentId: 'row-0',
-            ['column-0']: `Sub 0`,
+            ['column-0']: 'Sub 0',
             children: [
               {
-                id: `row-0-sub-0-sub-0`,
-                parentId: `row-0-sub-0`,
-                ['column-0']: `Sub-Sub 0`,
+                id: 'row-0-sub-0-sub-0',
+                parentId: 'row-0-sub-0',
+                ['column-0']: 'Sub-Sub 0',
               },
             ],
           },

--- a/packages/components/table-v2/__tests__/table-v2.test.tsx
+++ b/packages/components/table-v2/__tests__/table-v2.test.tsx
@@ -318,4 +318,52 @@ describe('TableV2.vue', () => {
       expect(header.attributes('role')).toBe('columnheader')
     })
   })
+
+  test('expand button should not apply margin style of icon', async () => {
+    const columns = [
+      {
+        key: 'column-0',
+        dataKey: 'column-0',
+        title: `Column 0`,
+        width: 150,
+      },
+    ]
+    const data = [
+      {
+        id: 'row-0',
+        'column-0': 'Row 0 - Col 0',
+        children: [
+          {
+            id: `row-0-sub-0`,
+            parentId: 'row-0',
+            ['column-0']: `Sub 0`,
+            children: [
+              {
+                id: `row-0-sub-0-sub-0`,
+                parentId: `row-0-sub-0`,
+                ['column-0']: `Sub-Sub 0`,
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const wrapper = mount(() => (
+      <TableV2
+        columns={columns}
+        data={data}
+        width={300}
+        height={200}
+        expand-column-key="column-0"
+      />
+    ))
+
+    const expandButton = wrapper.find('.el-table-v2__expand-icon')
+    await expandButton.trigger('click')
+    await nextTick()
+
+    const subExpandButton = wrapper.findAll('.el-table-v2__expand-icon')[1]
+    expect(subExpandButton.attributes('style')).toBeFalsy()
+  })
 })

--- a/packages/components/table-v2/src/components/expand-icon.tsx
+++ b/packages/components/table-v2/src/components/expand-icon.tsx
@@ -32,6 +32,8 @@ const ExpandIcon = (
   )
 }
 
+ExpandIcon.inheritAttrs = false
+
 export default ExpandIcon
 
 export type ExpandIconInstance = ReturnType<typeof ExpandIcon>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #23305

### Before

<img width="1425" height="305" alt="309A0045-43AC-4553-9639-FA7925EB37A0" src="https://github.com/user-attachments/assets/90baca2d-7e1b-4ed6-813b-db8823b4ab3e" />

### After

<img width="1448" height="309" alt="E5B2FE1B-8F95-4eab-BE35-8FF967BFE41E" src="https://github.com/user-attachments/assets/92ce0a5a-b8ac-49fd-b7a4-2fca0511d71d" />



This issue seems to be caused by the fact that `button` also applies the `margin` of `icon`.

<img width="1352" height="244" alt="15A597CB-BD39-4a96-A854-AA9EA2E51625" src="https://github.com/user-attachments/assets/050334ae-5858-4107-beb6-fd4b41c5781d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended native attribute inheritance on the table expand icon, removing stray attributes from rendered elements and ensuring consistent markup for nested rows.

* **Tests**
  * Added a test verifying nested expand icons do not receive unintended inline margin styles when rows are expanded, preventing regressions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->