### PR TITLE
fix(components): [alert] fix empty slot incorrectly detected as hasDesc

### DIFF
--- a/packages/components/alert/__tests__/alert.test.tsx
+++ b/packages/components/alert/__tests__/alert.test.tsx
@@ -1,3 +1,4 @@
+import { Comment, h } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, test } from 'vitest'
 import { TypeComponentsMap } from '@element-plus/utils'
@@ -68,5 +69,24 @@ describe('Alert.vue', () => {
       },
     })
     expect(wrapper.find('.el-alert__description').exists()).toBe(false)
+  })
+
+  test('default slot with only comment nodes should not show description', () => {
+    const wrapper = mount(Alert, {
+      slots: {
+        default: () => [h(Comment, 'some comment')],
+      },
+    })
+    expect(wrapper.find('.el-alert__description').exists()).toBe(false)
+  })
+
+  test('default slot with comment nodes followed by real node should show description', () => {
+    const wrapper = mount(Alert, {
+      slots: {
+        default: () => [h(Comment, 'some comment'), AXIOM],
+      },
+    })
+    expect(wrapper.find('.el-alert__description').exists()).toBe(true)
+    expect(wrapper.find('.el-alert__description').text()).toEqual(AXIOM)
   })
 })

--- a/packages/components/alert/__tests__/alert.test.tsx
+++ b/packages/components/alert/__tests__/alert.test.tsx
@@ -50,4 +50,23 @@ describe('Alert.vue', () => {
     await closeBtn.trigger('click')
     expect(wrapper.emitted()).toBeDefined()
   })
+
+  test('default slot with content should show description', () => {
+    const wrapper = mount(Alert, {
+      slots: {
+        default: AXIOM,
+      },
+    })
+    expect(wrapper.find('.el-alert__description').exists()).toBe(true)
+    expect(wrapper.find('.el-alert__description').text()).toEqual(AXIOM)
+  })
+
+  test('empty default slot should not show description', () => {
+    const wrapper = mount(Alert, {
+      slots: {
+        default: '',
+      },
+    })
+    expect(wrapper.find('.el-alert__description').exists()).toBe(false)
+  })
 })

--- a/packages/components/alert/__tests__/alert.test.tsx
+++ b/packages/components/alert/__tests__/alert.test.tsx
@@ -52,41 +52,38 @@ describe('Alert.vue', () => {
     expect(wrapper.emitted()).toBeDefined()
   })
 
-  test('default slot with content should show description', () => {
-    const wrapper = mount(Alert, {
-      slots: {
-        default: AXIOM,
+  describe('default slot', () => {
+    test.each([
+      {
+        name: 'with content',
+        slots: { default: AXIOM },
+        exists: true,
+        text: AXIOM,
       },
-    })
-    expect(wrapper.find('.el-alert__description').exists()).toBe(true)
-    expect(wrapper.find('.el-alert__description').text()).toEqual(AXIOM)
-  })
+      {
+        name: 'empty',
+        slots: { default: '' },
+        exists: false,
+      },
+      {
+        name: 'only comment nodes',
+        slots: { default: () => [h(Comment, 'some comment')] },
+        exists: false,
+      },
+      {
+        name: 'comment nodes followed by real node',
+        slots: { default: () => [h(Comment, 'some comment'), AXIOM] },
+        exists: true,
+        text: AXIOM,
+      },
+    ])('$name', ({ slots, exists, text }) => {
+      const wrapper = mount(Alert, { slots })
+      const description = wrapper.find('.el-alert__description')
 
-  test('empty default slot should not show description', () => {
-    const wrapper = mount(Alert, {
-      slots: {
-        default: '',
-      },
+      expect(description.exists()).toBe(exists)
+      if (exists) {
+        expect(description.text()).toBe(text)
+      }
     })
-    expect(wrapper.find('.el-alert__description').exists()).toBe(false)
-  })
-
-  test('default slot with only comment nodes should not show description', () => {
-    const wrapper = mount(Alert, {
-      slots: {
-        default: () => [h(Comment, 'some comment')],
-      },
-    })
-    expect(wrapper.find('.el-alert__description').exists()).toBe(false)
-  })
-
-  test('default slot with comment nodes followed by real node should show description', () => {
-    const wrapper = mount(Alert, {
-      slots: {
-        default: () => [h(Comment, 'some comment'), AXIOM],
-      },
-    })
-    expect(wrapper.find('.el-alert__description').exists()).toBe(true)
-    expect(wrapper.find('.el-alert__description').text()).toEqual(AXIOM)
   })
 })

--- a/packages/components/alert/src/alert.vue
+++ b/packages/components/alert/src/alert.vue
@@ -50,7 +50,8 @@ import {
   TypeComponents,
   TypeComponentsMap,
   debugWarn,
-  getFirstValidNode,
+  flattedChildren,
+  isComment,
 } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { alertEmits, alertProps } from './alert'
@@ -75,7 +76,9 @@ const hasDesc = computed(() => {
   if (props.description) return true
   const slotContent = slots.default?.()
   if (!slotContent) return false
-  return !!getFirstValidNode(slotContent)
+
+  const children = flattedChildren(slotContent)
+  return children.some((child) => child !== null && !isComment(child))
 })
 
 const close = (evt: MouseEvent) => {

--- a/packages/components/alert/src/alert.vue
+++ b/packages/components/alert/src/alert.vue
@@ -50,6 +50,7 @@ import {
   TypeComponents,
   TypeComponentsMap,
   debugWarn,
+  getFirstValidNode,
 } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { alertEmits, alertProps } from './alert'
@@ -70,7 +71,12 @@ const visible = ref(true)
 
 const iconComponent = computed(() => TypeComponentsMap[props.type])
 
-const hasDesc = computed(() => !!(props.description || slots.default))
+const hasDesc = computed(() => {
+  if (props.description) return true
+  const slotContent = slots.default?.()
+  if (!slotContent) return false
+  return !!getFirstValidNode(slotContent)
+})
 
 const close = (evt: MouseEvent) => {
   visible.value = false

--- a/packages/components/alert/src/alert.vue
+++ b/packages/components/alert/src/alert.vue
@@ -78,7 +78,7 @@ const hasDesc = computed(() => {
   if (!slotContent) return false
 
   const children = flattedChildren(slotContent)
-  return children.some((child) => child !== null && !isComment(child))
+  return children.some((child) => !isComment(child))
 })
 
 const close = (evt: MouseEvent) => {


### PR DESCRIPTION
Previously, `hasDesc` was computed by simply checking `slots.default` existence, which returns true even when the slot content is empty (e.g., comment nodes, empty fragments).

This caused the description area to render unnecessarily and the icon to display in large size when no actual content was provided.

Now using `flattedChildren`、`isComment` to properly validate whether the slot contains renderable content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Alert component detection of description/default slot content so descriptions render only for meaningful (non-comment) slot content, preventing false positives.

* **Tests**
  * Added tests confirming Alert shows description for non-empty slot content, omits it for empty or comment-only slots, and correctly handles mixed comment/real-node slot content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->