### PR TITLE
chore: Validator in buildProp/buildProps support passing props data

### DIFF
--- a/packages/utils/__tests__/vue/props.test.ts
+++ b/packages/utils/__tests__/vue/props.test.ts
@@ -14,6 +14,7 @@ import type {
   EpPropInputDefault,
   EpPropMergeType,
   IfNever,
+  PropsData,
   ResolvePropType,
   UnknownToNever,
   Writable,
@@ -86,7 +87,9 @@ describe('Types', () => {
     expectTypeOf<EpProp<'1', '2', false>>().toEqualTypeOf<{
       readonly type: PropType<'1'>
       readonly required: false
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       readonly default: '2'
       [epPropKey]: true
     }>()
@@ -94,7 +97,9 @@ describe('Types', () => {
     expectTypeOf<EpProp<'1', '2', true>>().toEqualTypeOf<{
       readonly type: PropType<'1'>
       readonly required: true
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       readonly default: '2'
       [epPropKey]: true
     }>()
@@ -110,7 +115,9 @@ describe('buildProp', () => {
     ).toEqualTypeOf<{
       readonly type: PropType<'a' | 'b'>
       readonly required: false
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -123,7 +130,9 @@ describe('buildProp', () => {
     ).toEqualTypeOf<{
       readonly type: PropType<1 | 2 | 3 | 4>
       readonly required: false
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -137,7 +146,9 @@ describe('buildProp', () => {
     ).toEqualTypeOf<{
       readonly type: PropType<1 | 2 | 3 | 4>
       readonly required: false
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -151,7 +162,9 @@ describe('buildProp', () => {
     ).toEqualTypeOf<{
       readonly type: PropType<number | 'a' | 'b' | 'c'>
       readonly required: false
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -165,7 +178,9 @@ describe('buildProp', () => {
     ).toEqualTypeOf<{
       readonly type: PropType<'a' | 'b' | 'c'>
       readonly required: true
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -181,7 +196,9 @@ describe('buildProp', () => {
       readonly type: PropType<'a' | 'b' | 'c'>
       readonly required: false
       readonly default: 'b'
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -196,7 +213,9 @@ describe('buildProp', () => {
       readonly type: PropType<string[]>
       readonly required: false
       readonly default: ['a', 'b']
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -215,7 +234,9 @@ describe('buildProp', () => {
       readonly type: PropType<Options>
       readonly required: false
       readonly default: { key: 'value' }
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -234,7 +255,9 @@ describe('buildProp', () => {
       readonly type: PropType<string | Options>
       readonly required: false
       readonly default: { key: string }
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -249,7 +272,9 @@ describe('buildProp', () => {
     ).toEqualTypeOf<{
       readonly type: PropType<number | 'a' | 'b' | 'c'>
       readonly required: true
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -262,7 +287,9 @@ describe('buildProp', () => {
     ).toEqualTypeOf<{
       readonly type: PropType<string>
       readonly required: false
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -271,7 +298,9 @@ describe('buildProp', () => {
     expectTypeOf(buildProp({ type: [String, Number, Boolean] })).toEqualTypeOf<{
       readonly type: PropType<string | number | boolean>
       readonly required: false
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -285,7 +314,9 @@ describe('buildProp', () => {
     ).toEqualTypeOf<{
       readonly type: PropType<'1' | '2' | '3'>
       readonly required: false
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -299,7 +330,9 @@ describe('buildProp', () => {
     ).toEqualTypeOf<{
       readonly type: PropType<string>
       readonly required: true
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -314,7 +347,9 @@ describe('buildProp', () => {
       readonly type: PropType<'a' | 'b'>
       readonly required: false
       readonly default: 'a'
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -329,7 +364,9 @@ describe('buildProp', () => {
       readonly type: PropType<{ key: 'a' | 'b' | 'c' } | undefined>
       readonly required: false
       readonly default: { key: 'a' }
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -344,7 +381,9 @@ describe('buildProp', () => {
       readonly type: PropType<string | number>
       readonly required: false
       readonly default: ''
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -359,7 +398,9 @@ describe('buildProp', () => {
       readonly type: PropType<Record<string, any>>
       readonly required: false
       readonly default: {}
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })
@@ -459,21 +500,27 @@ describe('buildProps', () => {
       readonly type: PropType<string>
       readonly required: false
       readonly default: 'hello'
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
 
     expectTypeOf(props.key1).toEqualTypeOf<{
       readonly type: PropType<'a' | 'b'>
       readonly required: false
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
 
     expectTypeOf(props.key2).toEqualTypeOf<{
       readonly type: PropType<1 | 2 | 3 | 4>
       readonly required: false
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
 
@@ -481,7 +528,9 @@ describe('buildProps', () => {
       readonly type: PropType<1 | 2 | 3 | 4>
       readonly required: false
       readonly default: 2
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
 
@@ -489,7 +538,9 @@ describe('buildProps', () => {
       readonly type: PropType<'a' | 'b'>
       readonly required: false
       readonly default: 'a'
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
 
@@ -504,7 +555,9 @@ describe('buildProps', () => {
     expectTypeOf(props.key12).toEqualTypeOf<{
       readonly type: PropType<string>
       readonly required: false
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
 
@@ -513,7 +566,9 @@ describe('buildProps', () => {
       readonly required: false
       // TODO
       readonly default: () => '123'
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
 
@@ -521,7 +576,9 @@ describe('buildProps', () => {
       readonly type: PropType<Function>
       readonly required: false
       readonly default: () => '123'
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
 
@@ -529,7 +586,9 @@ describe('buildProps', () => {
       readonly type: PropType<Function>
       readonly required: false
       readonly default: () => () => '123'
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
 
@@ -538,7 +597,9 @@ describe('buildProps', () => {
       readonly required: false
       // TODO
       readonly default: () => '123'
-      readonly validator: ((val: unknown) => boolean) | undefined
+      readonly validator:
+        | ((val: unknown, props: PropsData) => boolean)
+        | undefined
       [epPropKey]: true
     }>()
   })

--- a/packages/utils/vue/props/runtime.ts
+++ b/packages/utils/vue/props/runtime.ts
@@ -13,6 +13,7 @@ import type {
   IfEpProp,
   IfNativePropType,
   NativePropType,
+  PropsData,
 } from './types'
 
 export const epPropKey = '__epPropKey'
@@ -59,7 +60,7 @@ export const buildProp = <
 
   const _validator =
     values || validator
-      ? (val: unknown) => {
+      ? (val: unknown, props: PropsData) => {
           let valid = false
           let allowedValues: unknown[] = []
 
@@ -70,7 +71,7 @@ export const buildProp = <
             }
             valid ||= allowedValues.includes(val)
           }
-          if (validator) valid ||= validator(val)
+          if (validator) valid ||= validator(val, props)
 
           if (!valid && allowedValues.length > 0) {
             const allowValuesText = [...new Set(allowedValues)]

--- a/packages/utils/vue/props/types.ts
+++ b/packages/utils/vue/props/types.ts
@@ -77,6 +77,7 @@ export type NativePropType =
   | null
 export type IfNativePropType<T, Y, N> = [T] extends [NativePropType] ? Y : N
 
+export type PropsData = Record<string, unknown>
 /**
  * input prop `buildProp` or `buildProps` (constraints)
  *
@@ -89,7 +90,7 @@ export type IfNativePropType<T, Y, N> = [T] extends [NativePropType] ? Y : N
     type?: StringConstructor | undefined;
     required?: true | undefined;
     values?: readonly "a"[] | undefined;
-    validator?: ((val: any) => boolean) | ((val: any) => val is never) | undefined;
+    validator?: ((val: any, props: PropsData) => boolean) | ((val: any) => val is never) | undefined;
     default?: undefined;
   }
  */
@@ -103,7 +104,9 @@ export type EpPropInput<
   type?: Type
   required?: Required
   values?: readonly Value[]
-  validator?: ((val: any) => val is Validator) | ((val: any) => boolean)
+  validator?:
+    | ((val: any, props: PropsData) => val is Validator)
+    | ((val: any, props: PropsData) => boolean)
   default?: EpPropInputDefault<Required, Default>
 }
 
@@ -118,7 +121,7 @@ export type EpPropInput<
  * {
     readonly type: PropType<"a">;
     readonly required: true;
-    readonly validator: ((val: unknown) => boolean) | undefined;
+    readonly validator: ((val: unknown, props: PropsData) => boolean) | undefined;
     readonly default: "b";
     __epPropKey: true;
   }
@@ -126,7 +129,7 @@ export type EpPropInput<
 export type EpProp<Type, Default, Required> = {
   readonly type: PropType<Type>
   readonly required: [Required] extends [true] ? true : false
-  readonly validator: ((val: unknown) => boolean) | undefined
+  readonly validator: ((val: unknown, props: PropsData) => boolean) | undefined
   [epPropKey]: true
 } & IfNever<Default, unknown, { readonly default: Default }>
 


### PR DESCRIPTION
The validator callback function in buildProp and buildProps is compatible with Vue 3.4+ and passes the props argument.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Property validators can now receive the complete props object as a second parameter, enabling validation logic that depends on multiple prop values simultaneously for more sophisticated, context-aware validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->