### PR TITLE
fix(components): [avatar] watch srcSet changes to reset hasLoadError

### DIFF
--- a/packages/components/avatar/__tests__/avatar.test.tsx
+++ b/packages/components/avatar/__tests__/avatar.test.tsx
@@ -77,24 +77,28 @@ describe('Avatar.vue', () => {
     }
   })
 
-  test('src changed', async () => {
-    const wrapper = mount(
-      <Avatar
-        v-slots={{
-          default: () => 'fallback',
-        }}
-      />
-    )
+  describe('image source changed', () => {
+    test.each([
+      { name: 'src', prop: 'src' },
+      { name: 'srcSet', prop: 'srcSet' },
+    ])('$name', async ({ prop }) => {
+      const wrapper = mount(
+        <Avatar
+          v-slots={{
+            default: () => 'fallback',
+          }}
+        />
+      )
 
-    expect(wrapper.vm.hasLoadError).toBe(false)
-    await wrapper.setProps({ src: IMAGE_FAIL })
-    // wait error event trigger
-    await stableLoad(() => !wrapper.vm.hasLoadError)
-    expect(wrapper.vm.hasLoadError).toBe(true)
-    await wrapper.setProps({ src: IMAGE_SUCCESS })
-    await flushPromises()
-    expect(wrapper.vm.hasLoadError).toBe(false)
-    expect(wrapper.find('img').exists()).toBe(true)
+      expect(wrapper.vm.hasLoadError).toBe(false)
+      await wrapper.setProps({ [prop]: IMAGE_FAIL })
+      await stableLoad(() => !wrapper.vm.hasLoadError)
+      expect(wrapper.vm.hasLoadError).toBe(true)
+      await wrapper.setProps({ [prop]: IMAGE_SUCCESS })
+      await flushPromises()
+      expect(wrapper.vm.hasLoadError).toBe(false)
+      expect(wrapper.find('img').exists()).toBe(true)
+    })
   })
 })
 

--- a/packages/components/avatar/src/avatar.vue
+++ b/packages/components/avatar/src/avatar.vue
@@ -66,7 +66,7 @@ const fitStyle = computed<CSSProperties>(() => ({
 
 // need reset hasLoadError to false if src changed
 watch(
-  () => props.src,
+  () => [props.src, props.srcSet],
   () => (hasLoadError.value = false)
 )
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

When only using srcSet prop, the original watch only monitors src, which remains at default value ('') and never changes. This causes hasLoadError to not reset when srcSet changes after an initial load failure, preventing new images from displaying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage with parameterized tests for image source properties.

* **Bug Fixes**
  * Avatar component now properly handles image load errors when both standard and responsive image sources change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->