### PR TITLE
fix(components): [autocomplete] correct change event value type

### DIFF
--- a/packages/components/autocomplete/src/autocomplete.ts
+++ b/packages/components/autocomplete/src/autocomplete.ts
@@ -131,8 +131,7 @@ export const autocompleteEmits = {
   [UPDATE_MODEL_EVENT]: (value: string | number) =>
     isString(value) || isNumber(value),
   [INPUT_EVENT]: (value: string | number) => isString(value) || isNumber(value),
-  [CHANGE_EVENT]: (value: string | number) =>
-    isString(value) || isNumber(value),
+  [CHANGE_EVENT]: (value: string) => isString(value),
   focus: (evt: FocusEvent) => evt instanceof FocusEvent,
   blur: (evt: FocusEvent) => evt instanceof FocusEvent,
   clear: () => true,

--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -257,7 +257,7 @@ const handleMouseDown = (event: MouseEvent) => {
   }
 }
 
-const handleChange = (value: string | number) => {
+const handleChange = (value: string) => {
   emit(CHANGE_EVENT, value)
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

The `change` event in autocomplete component is only triggered by `handleChange`, which receives a string value from the underlying el-input component. The `number` type in the event definition was unreachable and misleading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Autocomplete component's change event now strictly accepts string values instead of mixed string or number types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->