### PR TITLE
fix(components): [autocomplete] fix incorrect aria-controls value

### DIFF
--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -443,7 +443,7 @@ onMounted(() => {
   ;[
     { key: 'role', value: 'textbox' },
     { key: 'aria-autocomplete', value: 'list' },
-    { key: 'aria-controls', value: 'id' },
+    { key: 'aria-controls', value: listboxId.value },
     {
       key: 'aria-activedescendant',
       value: `${listboxId.value}-item-${highlightedIndex.value}`,


### PR DESCRIPTION
The aria-controls attribute was incorrectly set to the literal string 'id' instead of the actual listbox ID, breaking screen reader association.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed autocomplete component's accessibility by ensuring the input field correctly references the listbox dropdown, improving screen reader compatibility and keyboard navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->