### PR TITLE
fix(components): [message] missing content wrapper in VNode message

### DIFF
--- a/packages/components/message/__tests__/message.test.ts
+++ b/packages/components/message/__tests__/message.test.ts
@@ -51,6 +51,18 @@ describe('Message.vue', () => {
       expect(wrapper.find('.text-node').exists()).toBe(true)
     })
 
+    test('VNode should be wrapped in .el-message__content', () => {
+      const wrapper = _mount({
+        slots: {
+          default: h('span', AXIOM),
+        },
+      })
+
+      const content = wrapper.find('.el-message__content')
+      expect(content.exists()).toBe(true)
+      expect(content.text()).toEqual(AXIOM)
+    })
+
     test('should be able to render raw HTML with dangerouslyUseHTMLString prop', () => {
       const tagClass = 'test-class'
       const wrapper = _mount({

--- a/packages/components/message/src/message.vue
+++ b/packages/components/message/src/message.vue
@@ -32,13 +32,16 @@
       <el-icon v-if="iconComponent" :class="[ns.e('icon'), typeClass]">
         <component :is="iconComponent" />
       </el-icon>
-      <slot>
-        <p v-if="!dangerouslyUseHTMLString" :class="ns.e('content')">
+      <p
+        v-if="!dangerouslyUseHTMLString || $slots.default"
+        :class="ns.e('content')"
+      >
+        <slot>
           {{ message }}
-        </p>
-        <!-- Caution here, message could've been compromised, never use user's input as message -->
-        <p v-else :class="ns.e('content')" v-html="message" />
-      </slot>
+        </slot>
+      </p>
+      <!-- Caution here, message could've been compromised, never use user's input as message -->
+      <p v-else :class="ns.e('content')" v-html="message" />
       <el-icon v-if="showClose" :class="ns.e('closeBtn')" @click.stop="close">
         <Close />
       </el-icon>


### PR DESCRIPTION
fixes #23351

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test verifying message content passed via the default slot is wrapped with the correct message-content styling and preserves text.

* **Bug Fixes**
  * Message rendering now properly uses custom slot content when provided and retains correct fallback behavior for plain text or HTML when no slot is present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->