### PR TITLE
fix(components): [upload] make abort param optional

### DIFF
--- a/docs/en-US/component/upload.md
+++ b/docs/en-US/component/upload.md
@@ -146,7 +146,7 @@ upload/manual
 
 | Name         | Description                                                                                            | Type                                                                              |
 | ------------ | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
-| abort        | cancel upload request.                                                                                 | ^[Function]`(file: UploadFile) => void`                                           |
+| abort        | cancel upload request.                                                                                 | ^[Function]`(file?: UploadFile) => void`                                          |
 | submit       | upload the file list manually.                                                                         | ^[Function]`() => void`                                                           |
 | clearFiles   | clear the file list (this method is not supported in the `before-upload` hook).                        | ^[Function]`(status?: UploadStatus[]) => void`                                    |
 | handleStart  | select the file manually.                                                                              | ^[Function]`(rawFile: UploadRawFile) => void`                                     |

--- a/packages/components/upload/src/use-handlers.ts
+++ b/packages/components/upload/src/use-handlers.ts
@@ -39,7 +39,7 @@ export const useHandlers = (
   const getFile = (rawFile: UploadRawFile) =>
     uploadFiles.value.find((file) => file.uid === rawFile.uid)
 
-  function abort(file: UploadFile) {
+  function abort(file?: UploadFile) {
     uploadRef.value?.abort(file)
   }
 


### PR DESCRIPTION
- Change the parameter type definition of the abort function to optional

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### Instructions

- When calling the abort function in the [upload-content.vue](https://github.com/element-plus/element-plus/blob/8b7d8eacf59b2e03a581102b844ebbb8d2156f91/packages/components/upload/src/upload-content.vue#L223) file, the parameters are optional, but in [use-handlers.ts](https://github.com/element-plus/element-plus/blob/8b7d8eacf59b2e03a581102b844ebbb8d2156f91/packages/components/upload/src/use-handlers.ts#L42), the parameters of the abort function are defined as mandatory parameters, resulting in type mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload component's abort functionality is now more flexible, allowing calls without specifying a file.

* **Documentation**
  * Updated Upload component documentation to reflect API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->