### PR TITLE
fix(components): fix empty slot incorrectly detected as ValidContent

### DIFF
--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -1,4 +1,4 @@
-import { nextTick, reactive, ref } from 'vue'
+import { Comment, h, nextTick, reactive, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, test } from 'vitest'
 import { ElForm, ElFormItem } from '@element-plus/components/form'
@@ -7,6 +7,8 @@ import CheckboxButton from '../src/checkbox-button.vue'
 import CheckboxGroup from '../src/checkbox-group.vue'
 
 import type { CheckboxValueType } from '../src/checkbox'
+
+const AXIOM = 'Rem is the best girl'
 
 describe('Checkbox', () => {
   test('create', async () => {
@@ -881,6 +883,41 @@ describe('check-button', () => {
       expect(checkboxGroup2.attributes('role')).toBe('group')
       expect(checkboxGroup2.attributes()['aria-label']).toBe('Bar')
       expect(checkboxGroup2.attributes()['aria-labelledby']).toBeFalsy()
+    })
+  })
+
+  describe('default slot', () => {
+    test.each([
+      {
+        name: 'with content',
+        slots: { default: () => AXIOM },
+        exists: true,
+        text: AXIOM,
+      },
+      {
+        name: 'empty',
+        slots: { default: () => null },
+        exists: false,
+      },
+      {
+        name: 'only comment nodes',
+        slots: { default: () => [h(Comment, 'some comment')] },
+        exists: false,
+      },
+      {
+        name: 'comment nodes followed by real node',
+        slots: { default: () => [h(Comment, 'some comment'), AXIOM] },
+        exists: true,
+        text: AXIOM,
+      },
+    ])('$name', ({ slots, exists, text }) => {
+      const wrapper = mount(() => <CheckboxButton v-slots={slots} />)
+      const inner = wrapper.find('.el-checkbox-button__inner')
+
+      expect(inner.exists()).toBe(exists)
+      if (exists) {
+        expect(inner.text()).toBe(text)
+      }
     })
   })
 })

--- a/packages/components/checkbox/src/checkbox-button.vue
+++ b/packages/components/checkbox/src/checkbox-button.vue
@@ -15,7 +15,7 @@
     />
 
     <span
-      v-if="$slots.default || label"
+      v-if="hasValidContent"
       :class="ns.be('button', 'inner')"
       :style="isChecked ? activeStyle : undefined"
     >
@@ -30,6 +30,7 @@ import { useNamespace } from '@element-plus/hooks'
 import { checkboxGroupContextKey } from './constants'
 import { useCheckbox } from './composables'
 import { checkboxEmits, checkboxProps } from './checkbox'
+import { flattedChildren, isComment } from '@element-plus/utils'
 
 import type { CSSProperties } from 'vue'
 
@@ -66,6 +67,15 @@ const inputBindings = computed(() => {
   return {
     value: actualValue.value,
   }
+})
+
+const hasValidContent = computed(() => {
+  if (props.label) return true
+  const slotContent = slots.default?.()
+  if (!slotContent) return false
+
+  const children = flattedChildren(slotContent)
+  return children.some((child) => child !== null && !isComment(child))
 })
 
 const checkboxGroup = inject(checkboxGroupContextKey, undefined)

--- a/packages/components/empty/__tests__/empty.test.tsx
+++ b/packages/components/empty/__tests__/empty.test.tsx
@@ -1,3 +1,4 @@
+import { Comment, h } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, test } from 'vitest'
 import Empty from '../src/empty.vue'
@@ -51,14 +52,38 @@ describe('Empty.vue', () => {
     expect(wrapper.find('.el-empty__description').text()).toEqual(AXIOM)
   })
 
-  test('should render default slots', async () => {
-    const wrapper = mount(() => (
-      <Empty
-        v-slots={{
-          default: () => AXIOM,
-        }}
-      />
-    ))
-    expect(wrapper.find('.el-empty__bottom').text()).toEqual(AXIOM)
+  describe('default slot', () => {
+    test.each([
+      {
+        name: 'with content',
+        slots: { default: () => AXIOM },
+        exists: true,
+        text: AXIOM,
+      },
+      {
+        name: 'empty',
+        slots: { default: () => null },
+        exists: false,
+      },
+      {
+        name: 'only comment nodes',
+        slots: { default: () => [h(Comment, 'some comment')] },
+        exists: false,
+      },
+      {
+        name: 'comment nodes followed by real node',
+        slots: { default: () => [h(Comment, 'some comment'), AXIOM] },
+        exists: true,
+        text: AXIOM,
+      },
+    ])('$name', ({ slots, exists, text }) => {
+      const wrapper = mount(() => <Empty v-slots={slots} />)
+      const bottom = wrapper.find('.el-empty__bottom')
+
+      expect(bottom.exists()).toBe(exists)
+      if (exists) {
+        expect(bottom.text()).toBe(text)
+      }
+    })
   })
 })

--- a/packages/components/empty/src/empty.vue
+++ b/packages/components/empty/src/empty.vue
@@ -10,16 +10,16 @@
       <slot v-if="$slots.description" name="description" />
       <p v-else>{{ emptyDescription }}</p>
     </div>
-    <div v-if="$slots.default" :class="ns.e('bottom')">
+    <div v-if="hasValidDefaultSlot" :class="ns.e('bottom')">
       <slot />
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, useSlots } from 'vue'
 import { useLocale, useNamespace } from '@element-plus/hooks'
-import { addUnit } from '@element-plus/utils'
+import { addUnit, flattedChildren, isComment } from '@element-plus/utils'
 import ImgEmpty from './img-empty.vue'
 import { emptyProps } from './empty'
 
@@ -30,7 +30,7 @@ defineOptions({
 })
 
 const props = defineProps(emptyProps)
-
+const slots = useSlots()
 const { t } = useLocale()
 const ns = useNamespace('empty')
 const emptyDescription = computed(
@@ -39,4 +39,12 @@ const emptyDescription = computed(
 const imageStyle = computed<CSSProperties>(() => ({
   width: addUnit(props.imageSize),
 }))
+
+const hasValidDefaultSlot = computed(() => {
+  const slotContent = slots.default?.()
+  if (!slotContent) return false
+
+  const children = flattedChildren(slotContent)
+  return children.some((child) => child !== null && !isComment(child))
+})
 </script>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Fix the same type of bug in **el-checkbox-button** and **el-empty** components as in PR #23312
Check if the default slot contains valid elements to avoid areas that should not be displayed becoming visible due to comment content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slot content validation in Checkbox, CheckboxButton, and Empty components to properly handle edge cases like comment-only slots and empty slots, ensuring more predictable rendering behavior.

* **Tests**
  * Expanded test coverage for slot rendering scenarios across multiple components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->