### PR TITLE
docs(components): [upload] modify the `abort` method description

### DIFF
--- a/docs/en-US/component/upload.md
+++ b/docs/en-US/component/upload.md
@@ -144,13 +144,13 @@ upload/manual
 
 ### Exposes
 
-| Name         | Description                                                                                            | Type                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
-| abort        | cancel upload request.                                                                                 | ^[Function]`(file?: UploadFile) => void`                                          |
-| submit       | upload the file list manually.                                                                         | ^[Function]`() => void`                                                           |
-| clearFiles   | clear the file list (this method is not supported in the `before-upload` hook).                        | ^[Function]`(status?: UploadStatus[]) => void`                                    |
-| handleStart  | select the file manually.                                                                              | ^[Function]`(rawFile: UploadRawFile) => void`                                     |
-| handleRemove | remove the file manually. `file` and `rawFile` has been merged. `rawFile` will be removed in `v2.2.0`. | ^[Function]`(file: UploadFile \| UploadRawFile, rawFile?: UploadRawFile) => void` |
+| Name         | Description                                                                                                                                      | Type                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| abort        | cancel upload request. When a `file` is specified, abort the corresponding pending upload; when no file is specified, abort all pending uploads. | ^[Function]`(file?: UploadFile) => void`                                          |
+| submit       | upload the file list manually.                                                                                                                   | ^[Function]`() => void`                                                           |
+| clearFiles   | clear the file list (this method is not supported in the `before-upload` hook).                                                                  | ^[Function]`(status?: UploadStatus[]) => void`                                    |
+| handleStart  | select the file manually.                                                                                                                        | ^[Function]`(rawFile: UploadRawFile) => void`                                     |
+| handleRemove | remove the file manually. `file` and `rawFile` has been merged. `rawFile` will be removed in `v2.2.0`.                                           | ^[Function]`(file: UploadFile \| UploadRawFile, rawFile?: UploadRawFile) => void` |
 
 ## Type Declarations
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### Instructions
- add abort method description  "When a `file` is specified, abort the corresponding pending upload; when no file is specified, abort all pending uploads."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Upload component documentation with clearer descriptions of the abort functionality, clarifying behavior when targeting specific files versus aborting all pending uploads. Improved formatting for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->