### PR TITLE
docs(components): [tree-v2] improve demo style

### DIFF
--- a/docs/examples/tree-v2/custom-node-class.vue
+++ b/docs/examples/tree-v2/custom-node-class.vue
@@ -77,8 +77,9 @@ const data: Tree[] = [
 ]
 </script>
 
-<style>
-.is-penultimate > .el-tree-node__content {
+<style scoped>
+:deep(.is-penultimate .el-tree-node__label) {
   color: var(--el-color-primary);
+  font-weight: 600;
 }
 </style>

--- a/docs/examples/tree-v2/custom-node-class.vue
+++ b/docs/examples/tree-v2/custom-node-class.vue
@@ -79,7 +79,7 @@ const data: Tree[] = [
 
 <style scoped>
 :deep(.is-penultimate .el-tree-node__label) {
-  color: var(--el-color-primary);
+  color: #626aef;
   font-weight: 600;
 }
 </style>

--- a/docs/examples/tree/custom-node-class.vue
+++ b/docs/examples/tree/custom-node-class.vue
@@ -81,7 +81,7 @@ const data: Tree[] = [
 </script>
 
 <style>
-.is-penultimate > .el-tree-node__content {
+.is-penultimate > .el-tree-node__content .el-tree-node__label {
   color: #626aef;
 }
 .is-penultimate > .el-tree-node__children > div {


### PR DESCRIPTION
修正示例中的自定义类名样式未生效，节点颜色没变的问题。

### 1、变更前示例效果:
<img width="909" height="557" alt="image" src="https://github.com/user-attachments/assets/b4dbaf0f-593a-4538-9f54-c6c89f04cc47" />

### 2、变更后示例效果:
<img width="387" height="354" alt="image" src="https://github.com/user-attachments/assets/bc3a2e21-e4c1-4d38-aad5-03678e39e3af" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated tree component examples to use a scoped styling approach.

* **Style**
  * Refined CSS targeting so emphasis applies only to the node label.
  * Applied stronger label weight and a distinct accent color for penultimate nodes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->