### PR TITLE
fix(components): [date-picker-panel] add missing `is-disabled` class to disabled buttons when using `unlink-panels`

### DIFF
--- a/packages/components/date-picker-panel/__tests__/date-picker-panel.test.tsx
+++ b/packages/components/date-picker-panel/__tests__/date-picker-panel.test.tsx
@@ -1049,6 +1049,43 @@ describe('DatePickerPanel', () => {
         expect(rightHeader.text()).toBe('February')
         vi.useRealTimers()
       })
+
+      it('should render buttons with correct disabled status when unlinkPanels is true', async () => {
+        const value = ref<string[]>([])
+        const wrapper = mount(() => (
+          <DatePickerPanel
+            v-model={value.value}
+            type="datetimerange"
+            showFooter
+            unlinkPanels={true}
+          />
+        ))
+
+        await nextTick()
+        const pickers = wrapper.findAll('.el-date-range-picker__content')
+        const leftBtns = pickers[0].findAll(
+          '.el-date-range-picker__header .el-picker-panel__icon-btn'
+        )!
+        expect(leftBtns[0].classes()).not.toContain('is-disabled')
+        expect(leftBtns[0].attributes('disabled')).toBeUndefined()
+        expect(leftBtns[1].classes()).not.toContain('is-disabled')
+        expect(leftBtns[1].attributes('disabled')).toBeUndefined()
+        expect(leftBtns[2].classes()).toContain('is-disabled')
+        expect(leftBtns[2].attributes('disabled')).toBe('')
+        expect(leftBtns[3].classes()).toContain('is-disabled')
+        expect(leftBtns[3].attributes('disabled')).toBe('')
+        const rightBtns = pickers[1].findAll(
+          '.el-date-range-picker__header .el-picker-panel__icon-btn'
+        )!
+        expect(rightBtns[0].classes()).toContain('is-disabled')
+        expect(rightBtns[0].attributes('disabled')).toBe('')
+        expect(rightBtns[1].classes()).toContain('is-disabled')
+        expect(rightBtns[1].attributes('disabled')).toBe('')
+        expect(rightBtns[2].classes()).not.toContain('is-disabled')
+        expect(rightBtns[2].attributes('disabled')).toBeUndefined()
+        expect(rightBtns[3].classes()).not.toContain('is-disabled')
+        expect(rightBtns[3].attributes('disabled')).toBeUndefined()
+      })
     })
   })
 })

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
@@ -248,7 +248,10 @@
               v-if="unlinkPanels"
               type="button"
               :disabled="!enableYearArrow || dateRangeDisabled"
-              :class="ppNs.e('icon-btn')"
+              :class="[
+                ppNs.e('icon-btn'),
+                ppNs.is('disabled', !enableYearArrow || dateRangeDisabled),
+              ]"
               :aria-label="t(`el.datepicker.prevYear`)"
               class="d-arrow-left"
               @click="rightPrevYear"
@@ -263,7 +266,10 @@
               v-if="unlinkPanels && rightCurrentView === 'date'"
               type="button"
               :disabled="!enableMonthArrow || dateRangeDisabled"
-              :class="ppNs.e('icon-btn')"
+              :class="[
+                ppNs.e('icon-btn'),
+                ppNs.is('disabled', !enableMonthArrow || dateRangeDisabled),
+              ]"
               :aria-label="t(`el.datepicker.prevMonth`)"
               class="arrow-left"
               @click="rightPrevMonth"


### PR DESCRIPTION
fix: https://github.com/element-plus/element-plus/issues/23392

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved visual feedback in the date picker: year and month navigation buttons now show clearer disabled styling when panels are unlinked, making unavailable controls more visually distinct.
* **Tests**
  * Added a unit test verifying navigation buttons render with the correct enabled/disabled states when panels are unlinked.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->