### PR TITLE
refactor(components): [affix] use type-based definitions

### DIFF
--- a/packages/components/affix/src/affix.ts
+++ b/packages/components/affix/src/affix.ts
@@ -7,13 +7,39 @@ import {
 import { CHANGE_EVENT } from '@element-plus/constants'
 import { teleportProps } from '@element-plus/components/teleport'
 
-import type {
-  CSSProperties,
-  ExtractPropTypes,
-  ExtractPublicPropTypes,
-} from 'vue'
+import type { CSSProperties, ExtractPublicPropTypes } from 'vue'
 import type Affix from './affix.vue'
 
+export interface AffixProps {
+  /**
+   * @description affix element zIndex value
+   * */
+  zIndex?: CSSProperties['z-index']
+  /**
+   * @description target container. (CSS selector)
+   */
+  target?: string
+  /**
+   * @description offset distance
+   * */
+  offset?: number
+  /**
+   * @description position of affix
+   * */
+  position?: 'top' | 'bottom'
+  /**
+   * @description whether affix element is teleported, if `true` it will be teleported to where `append-to` sets
+   * */
+  teleported?: boolean
+  /**
+   * @description which element the affix element appends to
+   * */
+  appendTo?: string | HTMLElement
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `AffixProps` instead.
+ */
 export const affixProps = buildProps({
   /**
    * @description affix element zIndex value
@@ -56,7 +82,10 @@ export const affixProps = buildProps({
     default: 'body',
   },
 } as const)
-export type AffixProps = ExtractPropTypes<typeof affixProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `AffixProps` instead.
+ */
 export type AffixPropsPublic = ExtractPublicPropTypes<typeof affixProps>
 
 export const affixEmits = {

--- a/packages/components/affix/src/affix.vue
+++ b/packages/components/affix/src/affix.vue
@@ -27,15 +27,22 @@ import ElTeleport from '@element-plus/components/teleport'
 import { addUnit, getScrollContainer, throwError } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { CHANGE_EVENT } from '@element-plus/constants'
-import { affixEmits, affixProps } from './affix'
+import { affixEmits } from './affix'
 
 import type { CSSProperties } from 'vue'
+import type { AffixProps } from './affix'
 
 const COMPONENT_NAME = 'ElAffix'
 defineOptions({
   name: COMPONENT_NAME,
 })
-const props = defineProps(affixProps)
+const props = withDefaults(defineProps<AffixProps>(), {
+  zIndex: 100,
+  target: '',
+  offset: 0,
+  position: 'top',
+  appendTo: 'body',
+})
 const emit = defineEmits(affixEmits)
 
 const ns = useNamespace('affix')


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

rel #23399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the Affix component's type definitions for better type safety and developer experience.
  * Explicit default values have been established for component properties (zIndex, offset, position, target, appendTo).
  * Updated type exports; the previous public type alias is now marked as deprecated in favor of the new interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->