### PR TITLE
refactor(components): [anchor] use type-based definitions

### DIFF
--- a/packages/components/anchor/src/anchor-link.ts
+++ b/packages/components/anchor/src/anchor-link.ts
@@ -1,7 +1,21 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 
+export interface AnchorLinkProps {
+  /**
+   * @description the text content of the anchor link
+   */
+  title?: string
+  /**
+   * @description The address of the anchor link
+   */
+  href?: string
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `AnchorLinkProps` instead.
+ */
 export const anchorLinkProps = buildProps({
   /**
    * @description the text content of the anchor link
@@ -13,7 +27,9 @@ export const anchorLinkProps = buildProps({
   href: String,
 })
 
-export type AnchorLinkProps = ExtractPropTypes<typeof anchorLinkProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `AnchorLinkProps` instead.
+ */
 export type AnchorLinkPropsPublic = ExtractPublicPropTypes<
   typeof anchorLinkProps
 >

--- a/packages/components/anchor/src/anchor-link.vue
+++ b/packages/components/anchor/src/anchor-link.vue
@@ -30,7 +30,9 @@ defineOptions({
   name: 'ElAnchorLink',
 })
 
-const props = defineProps<AnchorLinkProps>()
+const props = withDefaults(defineProps<AnchorLinkProps>(), {
+  href: undefined,
+})
 
 const linkRef = ref<HTMLElement | null>(null)
 

--- a/packages/components/anchor/src/anchor-link.vue
+++ b/packages/components/anchor/src/anchor-link.vue
@@ -22,14 +22,15 @@ import {
   ref,
   watch,
 } from 'vue'
-import { anchorLinkProps } from './anchor-link'
 import { anchorKey } from './constants'
+
+import type { AnchorLinkProps } from './anchor-link'
 
 defineOptions({
   name: 'ElAnchorLink',
 })
 
-const props = defineProps(anchorLinkProps)
+const props = defineProps<AnchorLinkProps>()
 
 const linkRef = ref<HTMLElement | null>(null)
 

--- a/packages/components/anchor/src/anchor.ts
+++ b/packages/components/anchor/src/anchor.ts
@@ -5,9 +5,47 @@ import {
   isUndefined,
 } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 import type Anchor from './anchor.vue'
 
+export interface AnchorProps {
+  /**
+   * @description scroll container
+   */
+  container?: string | HTMLElement | Window | null
+  /**
+   * @description Set the offset of the anchor scroll
+   */
+  offset?: number
+  /**
+   * @description The offset of the element starting to trigger the anchor
+   */
+  bound?: number
+  /**
+   * @description Set the scroll duration of the container when the anchor is clicked, in milliseconds
+   */
+  duration?: number
+  /**
+   * @description Whether to show the marker
+   */
+  marker?: boolean
+  /**
+   * @description Set Anchor type
+   */
+  type?: 'default' | 'underline'
+  /**
+   * @description Set Anchor direction
+   */
+  direction?: 'vertical' | 'horizontal'
+  /**
+   * @description Scroll whether link is selected at the top
+   */
+  selectScrollTop?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `AnchorProps` instead.
+ */
 export const anchorProps = buildProps({
   /**
    * @description scroll container
@@ -66,7 +104,9 @@ export const anchorProps = buildProps({
   selectScrollTop: Boolean,
 })
 
-export type AnchorProps = ExtractPropTypes<typeof anchorProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `AnchorProps` instead.
+ */
 export type AnchorPropsPublic = ExtractPublicPropTypes<typeof anchorProps>
 export type AnchorInstance = InstanceType<typeof Anchor> & unknown
 

--- a/packages/components/anchor/src/anchor.vue
+++ b/packages/components/anchor/src/anchor.vue
@@ -35,17 +35,25 @@ import {
   throttleByRaf,
 } from '@element-plus/utils'
 import { CHANGE_EVENT } from '@element-plus/constants'
-import { anchorEmits, anchorProps } from './anchor'
+import { anchorEmits } from './anchor'
 import { anchorKey } from './constants'
 
 import type { CSSProperties } from 'vue'
+import type { AnchorProps } from './anchor'
 import type { AnchorLinkState } from './constants'
 
 defineOptions({
   name: 'ElAnchor',
 })
 
-const props = defineProps(anchorProps)
+const props = withDefaults(defineProps<AnchorProps>(), {
+  offset: 0,
+  bound: 15,
+  duration: 300,
+  marker: true,
+  type: 'default',
+  direction: 'vertical',
+})
 const emit = defineEmits(anchorEmits)
 const slots = useSlots()
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Legacy prop type aliases for Anchor and AnchorLink are deprecated in favor of new public interfaces/types.

* **Improvements**
  * Strengthened TypeScript typing for Anchor and AnchorLink props.
  * Added public emit type definitions for Anchor.
  * Component props now include explicit default values (tightened prop contracts).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->