### PR TITLE
refactor(components): [input-number] use type-based definitions

### DIFF
--- a/docs/en-US/component/input-number.md
+++ b/docs/en-US/component/input-number.md
@@ -113,7 +113,7 @@ For precision purposes, the input number is limited from [Number.MIN_SAFE_INTEGE
 | step                          | incremental step                                 | ^[number]                                     | 1                       |
 | step-strictly                 | whether input value can only be multiple of step | ^[boolean]                                    | false                   |
 | precision                     | precision of input value                         | ^[number]                                     | —                       |
-| size                          | size of the component                            | ^[enum]`'large' \| 'default' \| 'small'`      | —                       |
+| size                          | size of the component                            | ^[enum]`'large' \| 'default' \| 'small'`      | default                 |
 | readonly ^(2.2.16)            | same as `readonly` in native input               | ^[boolean]                                    | false                   |
 | disabled                      | whether the component is disabled                | ^[boolean]                                    | false                   |
 | controls                      | whether to enable the control buttons            | ^[boolean]                                    | true                    |

--- a/docs/en-US/component/input-number.md
+++ b/docs/en-US/component/input-number.md
@@ -105,29 +105,29 @@ For precision purposes, the input number is limited from [Number.MIN_SAFE_INTEGE
 
 ### Attributes
 
-| Name                          | Description                                      | Type                                           | Default                 |
-| ----------------------------- | ------------------------------------------------ | ---------------------------------------------- | ----------------------- |
-| model-value / v-model         | binding value                                    | ^[number] / ^[null]                            | —                       |
-| min                           | the minimum allowed value                        | ^[number]                                      | Number.MIN_SAFE_INTEGER |
-| max                           | the maximum allowed value                        | ^[number]                                      | Number.MAX_SAFE_INTEGER |
-| step                          | incremental step                                 | ^[number]                                      | 1                       |
-| step-strictly                 | whether input value can only be multiple of step | ^[boolean]                                     | false                   |
-| precision                     | precision of input value                         | ^[number]                                      | —                       |
-| size                          | size of the component                            | ^[enum]`'' \| 'large' \| 'default' \| 'small'` | —                       |
-| readonly ^(2.2.16)            | same as `readonly` in native input               | ^[boolean]                                     | false                   |
-| disabled                      | whether the component is disabled                | ^[boolean]                                     | false                   |
-| controls                      | whether to enable the control buttons            | ^[boolean]                                     | true                    |
-| controls-position             | position of the control buttons                  | ^[enum]`'' \| 'right'`                         | —                       |
-| name                          | same as `name` in native input                   | ^[string]                                      | —                       |
-| aria-label ^(a11y) ^(2.7.2)   | same as `aria-label` in native input             | ^[string]                                      | —                       |
-| placeholder                   | same as `placeholder` in native input            | ^[string]                                      | —                       |
-| id                            | same as `id` in native input                     | ^[string]                                      | —                       |
-| value-on-clear ^(2.2.0)       | value should be set when input box is cleared    | ^[number] / ^[null] / ^[enum]`'min' \| 'max'`  | —                       |
-| validate-event                | whether to trigger form validation               | ^[boolean]                                     | true                    |
-| label ^(a11y) ^(deprecated)   | same as `aria-label` in native input             | ^[string]                                      | —                       |
-| inputmode ^(2.10.3)           | same as `inputmode` in native input              | ^[string]                                      | —                       |
-| align ^(2.10.5)               | alignment for the inner input text               | ^[enum]`'left' \| 'center' \| 'right'`         | 'center'                |
-| disabled-scientific ^(2.10.5) | disables input of scientific notation (e.g. 'e') | ^[boolean]                                     | false                   |
+| Name                          | Description                                      | Type                                          | Default                 |
+| ----------------------------- | ------------------------------------------------ | --------------------------------------------- | ----------------------- |
+| model-value / v-model         | binding value                                    | ^[number] / ^[null]                           | —                       |
+| min                           | the minimum allowed value                        | ^[number]                                     | Number.MIN_SAFE_INTEGER |
+| max                           | the maximum allowed value                        | ^[number]                                     | Number.MAX_SAFE_INTEGER |
+| step                          | incremental step                                 | ^[number]                                     | 1                       |
+| step-strictly                 | whether input value can only be multiple of step | ^[boolean]                                    | false                   |
+| precision                     | precision of input value                         | ^[number]                                     | —                       |
+| size                          | size of the component                            | ^[enum]`'large' \| 'default' \| 'small'`      | —                       |
+| readonly ^(2.2.16)            | same as `readonly` in native input               | ^[boolean]                                    | false                   |
+| disabled                      | whether the component is disabled                | ^[boolean]                                    | false                   |
+| controls                      | whether to enable the control buttons            | ^[boolean]                                    | true                    |
+| controls-position             | position of the control buttons                  | ^[enum]`'' \| 'right'`                        | —                       |
+| name                          | same as `name` in native input                   | ^[string]                                     | —                       |
+| aria-label ^(a11y) ^(2.7.2)   | same as `aria-label` in native input             | ^[string]                                     | —                       |
+| placeholder                   | same as `placeholder` in native input            | ^[string]                                     | —                       |
+| id                            | same as `id` in native input                     | ^[string]                                     | —                       |
+| value-on-clear ^(2.2.0)       | value should be set when input box is cleared    | ^[number] / ^[null] / ^[enum]`'min' \| 'max'` | —                       |
+| validate-event                | whether to trigger form validation               | ^[boolean]                                    | true                    |
+| label ^(a11y) ^(deprecated)   | same as `aria-label` in native input             | ^[string]                                     | —                       |
+| inputmode ^(2.10.3)           | same as `inputmode` in native input              | ^[string]                                     | —                       |
+| align ^(2.10.5)               | alignment for the inner input text               | ^[enum]`'left' \| 'center' \| 'right'`        | 'center'                |
+| disabled-scientific ^(2.10.5) | disables input of scientific notation (e.g. 'e') | ^[boolean]                                    | false                   |
 
 ### Slots
 

--- a/docs/en-US/component/input-number.md
+++ b/docs/en-US/component/input-number.md
@@ -105,29 +105,29 @@ For precision purposes, the input number is limited from [Number.MIN_SAFE_INTEGE
 
 ### Attributes
 
-| Name                          | Description                                      | Type                                          | Default                 |
-| ----------------------------- | ------------------------------------------------ | --------------------------------------------- | ----------------------- |
-| model-value / v-model         | binding value                                    | ^[number] / ^[null]                           | —                       |
-| min                           | the minimum allowed value                        | ^[number]                                     | Number.MIN_SAFE_INTEGER |
-| max                           | the maximum allowed value                        | ^[number]                                     | Number.MAX_SAFE_INTEGER |
-| step                          | incremental step                                 | ^[number]                                     | 1                       |
-| step-strictly                 | whether input value can only be multiple of step | ^[boolean]                                    | false                   |
-| precision                     | precision of input value                         | ^[number]                                     | —                       |
-| size                          | size of the component                            | ^[enum]`'large' \| 'default' \| 'small'`      | default                 |
-| readonly ^(2.2.16)            | same as `readonly` in native input               | ^[boolean]                                    | false                   |
-| disabled                      | whether the component is disabled                | ^[boolean]                                    | false                   |
-| controls                      | whether to enable the control buttons            | ^[boolean]                                    | true                    |
-| controls-position             | position of the control buttons                  | ^[enum]`'' \| 'right'`                        | —                       |
-| name                          | same as `name` in native input                   | ^[string]                                     | —                       |
-| aria-label ^(a11y) ^(2.7.2)   | same as `aria-label` in native input             | ^[string]                                     | —                       |
-| placeholder                   | same as `placeholder` in native input            | ^[string]                                     | —                       |
-| id                            | same as `id` in native input                     | ^[string]                                     | —                       |
-| value-on-clear ^(2.2.0)       | value should be set when input box is cleared    | ^[number] / ^[null] / ^[enum]`'min' \| 'max'` | —                       |
-| validate-event                | whether to trigger form validation               | ^[boolean]                                    | true                    |
-| label ^(a11y) ^(deprecated)   | same as `aria-label` in native input             | ^[string]                                     | —                       |
-| inputmode ^(2.10.3)           | same as `inputmode` in native input              | ^[string]                                     | —                       |
-| align ^(2.10.5)               | alignment for the inner input text               | ^[enum]`'left' \| 'center' \| 'right'`        | 'center'                |
-| disabled-scientific ^(2.10.5) | disables input of scientific notation (e.g. 'e') | ^[boolean]                                    | false                   |
+| Name                          | Description                                      | Type                                           | Default                 |
+| ----------------------------- | ------------------------------------------------ | ---------------------------------------------- | ----------------------- |
+| model-value / v-model         | binding value                                    | ^[number] / ^[null]                            | —                       |
+| min                           | the minimum allowed value                        | ^[number]                                      | Number.MIN_SAFE_INTEGER |
+| max                           | the maximum allowed value                        | ^[number]                                      | Number.MAX_SAFE_INTEGER |
+| step                          | incremental step                                 | ^[number]                                      | 1                       |
+| step-strictly                 | whether input value can only be multiple of step | ^[boolean]                                     | false                   |
+| precision                     | precision of input value                         | ^[number]                                      | —                       |
+| size                          | size of the component                            | ^[enum]`'' \| 'large' \| 'default' \| 'small'` | —                       |
+| readonly ^(2.2.16)            | same as `readonly` in native input               | ^[boolean]                                     | false                   |
+| disabled                      | whether the component is disabled                | ^[boolean]                                     | false                   |
+| controls                      | whether to enable the control buttons            | ^[boolean]                                     | true                    |
+| controls-position             | position of the control buttons                  | ^[enum]`'' \| 'right'`                         | —                       |
+| name                          | same as `name` in native input                   | ^[string]                                      | —                       |
+| aria-label ^(a11y) ^(2.7.2)   | same as `aria-label` in native input             | ^[string]                                      | —                       |
+| placeholder                   | same as `placeholder` in native input            | ^[string]                                      | —                       |
+| id                            | same as `id` in native input                     | ^[string]                                      | —                       |
+| value-on-clear ^(2.2.0)       | value should be set when input box is cleared    | ^[number] / ^[null] / ^[enum]`'min' \| 'max'`  | —                       |
+| validate-event                | whether to trigger form validation               | ^[boolean]                                     | true                    |
+| label ^(a11y) ^(deprecated)   | same as `aria-label` in native input             | ^[string]                                      | —                       |
+| inputmode ^(2.10.3)           | same as `inputmode` in native input              | ^[string]                                      | —                       |
+| align ^(2.10.5)               | alignment for the inner input text               | ^[enum]`'left' \| 'center' \| 'right'`         | 'center'                |
+| disabled-scientific ^(2.10.5) | disables input of scientific notation (e.g. 'e') | ^[boolean]                                     | false                   |
 
 ### Slots
 

--- a/packages/components/input-number/src/input-number.ts
+++ b/packages/components/input-number/src/input-number.ts
@@ -84,6 +84,11 @@ export interface InputNumberProps {
    */
   ariaLabel?: string
   /**
+   * @deprecated Use `ariaLabel` instead.
+   * @description same as `aria-label` in native input
+   */
+  label?: string
+  /**
    * @description native input mode for virtual keyboards
    */
   inputmode?: HTMLAttributes['inputmode']
@@ -202,6 +207,11 @@ export const inputNumberProps = buildProps({
     default: true,
   },
   ...useAriaProps(['ariaLabel']),
+  /**
+   * @deprecated Use `ariaLabel` instead.
+   * @description same as `aria-label` in native input
+   */
+  label: String,
   /**
    * @description native input mode for virtual keyboards
    */

--- a/packages/components/input-number/src/input-number.ts
+++ b/packages/components/input-number/src/input-number.ts
@@ -1,144 +1,101 @@
 import { isNil } from 'lodash-unified'
-import { useAriaProps, useSizeProp } from '@element-plus/hooks'
-import { buildProps, definePropType, isNumber } from '@element-plus/utils'
+import { isNumber } from '@element-plus/utils'
 import {
   CHANGE_EVENT,
   INPUT_EVENT,
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
 
-import type {
-  ExtractPropTypes,
-  ExtractPublicPropTypes,
-  HTMLAttributes,
-} from 'vue'
+import type { HTMLAttributes } from 'vue'
 import type InputNumber from './input-number.vue'
 
-export const inputNumberProps = buildProps({
+/**
+ * @description input-number component props
+ */
+export interface InputNumberProps {
   /**
    * @description same as `id` in native input
    */
-  id: {
-    type: String,
-    default: undefined,
-  },
+  id?: string
   /**
    * @description incremental step
    */
-  step: {
-    type: Number,
-    default: 1,
-  },
+  step?: number
   /**
    * @description whether input value can only be multiple of step
    */
-  stepStrictly: Boolean,
+  stepStrictly?: boolean
   /**
    * @description the maximum allowed value
    */
-  max: {
-    type: Number,
-    default: Number.MAX_SAFE_INTEGER,
-  },
+  max?: number
   /**
    * @description the minimum allowed value
    */
-  min: {
-    type: Number,
-    default: Number.MIN_SAFE_INTEGER,
-  },
+  min?: number
   /**
    * @description binding value
    */
-  modelValue: {
-    type: [Number, null],
-  },
+  modelValue?: number | null
   /**
    * @description same as `readonly` in native input
    */
-  readonly: Boolean,
+  readonly?: boolean
   /**
    * @description whether the component is disabled
    */
-  disabled: {
-    type: Boolean,
-    default: undefined,
-  },
+  disabled?: boolean
   /**
    * @description size of the component
    */
-  size: useSizeProp,
+  size?: '' | 'large' | 'default' | 'small'
   /**
    * @description whether to enable the control buttons
    */
-  controls: {
-    type: Boolean,
-    default: true,
-  },
+  controls?: boolean
   /**
    * @description position of the control buttons
    */
-  controlsPosition: {
-    type: String,
-    default: '',
-    values: ['', 'right'],
-  },
+  controlsPosition?: '' | 'right'
   /**
    * @description value should be set when input box is cleared
    */
-  valueOnClear: {
-    type: definePropType<'min' | 'max' | number | null>([String, Number, null]),
-    validator: (val: 'min' | 'max' | number | null) =>
-      val === null || isNumber(val) || ['min', 'max'].includes(val),
-    default: null,
-  },
+  valueOnClear?: 'min' | 'max' | number | null
   /**
    * @description same as `name` in native input
    */
-  name: String,
+  name?: string
   /**
    * @description same as `placeholder` in native input
    */
-  placeholder: String,
+  placeholder?: string
   /**
    * @description precision of input value
    */
-  precision: {
-    type: Number,
-    validator: (val: number) =>
-      val >= 0 && val === Number.parseInt(`${val}`, 10),
-  },
+  precision?: number
   /**
    * @description whether to trigger form validation
    */
-  validateEvent: {
-    type: Boolean,
-    default: true,
-  },
-  ...useAriaProps(['ariaLabel']),
+  validateEvent?: boolean
+  /**
+   * @description native aria-label attribute
+   */
+  ariaLabel?: string
   /**
    * @description native input mode for virtual keyboards
    */
-  inputmode: {
-    type: definePropType<HTMLAttributes['inputmode']>(String),
-    default: undefined,
-  },
+  inputmode?: HTMLAttributes['inputmode']
   /**
    * @description alignment for the inner input text
    */
-  align: {
-    type: definePropType<'left' | 'right' | 'center'>(String),
-    default: 'center',
-  },
+  align?: 'left' | 'right' | 'center'
   /**
    * @description whether to disable scientific notation input (e.g. 'e', 'E')
    */
-  disabledScientific: Boolean,
-} as const)
-export type InputNumberProps = ExtractPropTypes<typeof inputNumberProps>
-export type InputNumberPropsPublic = ExtractPublicPropTypes<
-  typeof inputNumberProps
->
+  disabledScientific?: boolean
+}
+
+export type InputNumberPropsPublic = InputNumberProps
 
 export const inputNumberEmits = {
   [CHANGE_EVENT]: (cur: number | undefined, prev: number | undefined) =>

--- a/packages/components/input-number/src/input-number.ts
+++ b/packages/components/input-number/src/input-number.ts
@@ -84,11 +84,6 @@ export interface InputNumberProps {
    */
   ariaLabel?: string
   /**
-   * @deprecated Use `ariaLabel` instead.
-   * @description same as `aria-label` in native input
-   */
-  label?: string
-  /**
    * @description native input mode for virtual keyboards
    */
   inputmode?: HTMLAttributes['inputmode']
@@ -207,11 +202,6 @@ export const inputNumberProps = buildProps({
     default: true,
   },
   ...useAriaProps(['ariaLabel']),
-  /**
-   * @deprecated Use `ariaLabel` instead.
-   * @description same as `aria-label` in native input
-   */
-  label: String,
   /**
    * @description native input mode for virtual keyboards
    */

--- a/packages/components/input-number/src/input-number.ts
+++ b/packages/components/input-number/src/input-number.ts
@@ -1,12 +1,14 @@
 import { isNil } from 'lodash-unified'
-import { isNumber } from '@element-plus/utils'
+import { buildProps, definePropType, isNumber } from '@element-plus/utils'
+import { useAriaProps, useSizeProp } from '@element-plus/hooks'
 import {
   CHANGE_EVENT,
   INPUT_EVENT,
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
 
-import type { HTMLAttributes } from 'vue'
+import type { ExtractPublicPropTypes, HTMLAttributes } from 'vue'
+import type { ComponentSize } from '@element-plus/constants'
 import type InputNumber from './input-number.vue'
 
 /**
@@ -48,7 +50,7 @@ export interface InputNumberProps {
   /**
    * @description size of the component
    */
-  size?: '' | 'large' | 'default' | 'small'
+  size?: ComponentSize
   /**
    * @description whether to enable the control buttons
    */
@@ -95,7 +97,134 @@ export interface InputNumberProps {
   disabledScientific?: boolean
 }
 
-export type InputNumberPropsPublic = InputNumberProps
+/**
+ * @deprecated Removed after 3.0.0, Use `InputNumberProps` instead.
+ */
+export const inputNumberProps = buildProps({
+  /**
+   * @description same as `id` in native input
+   */
+  id: {
+    type: String,
+    default: undefined,
+  },
+  /**
+   * @description incremental step
+   */
+  step: {
+    type: Number,
+    default: 1,
+  },
+  /**
+   * @description whether input value can only be multiple of step
+   */
+  stepStrictly: Boolean,
+  /**
+   * @description the maximum allowed value
+   */
+  max: {
+    type: Number,
+    default: Number.MAX_SAFE_INTEGER,
+  },
+  /**
+   * @description the minimum allowed value
+   */
+  min: {
+    type: Number,
+    default: Number.MIN_SAFE_INTEGER,
+  },
+  /**
+   * @description binding value
+   */
+  modelValue: {
+    type: [Number, null],
+  },
+  /**
+   * @description same as `readonly` in native input
+   */
+  readonly: Boolean,
+  /**
+   * @description whether the component is disabled
+   */
+  disabled: {
+    type: Boolean,
+    default: undefined,
+  },
+  /**
+   * @description size of the component
+   */
+  size: useSizeProp,
+  /**
+   * @description whether to enable the control buttons
+   */
+  controls: {
+    type: Boolean,
+    default: true,
+  },
+  /**
+   * @description position of the control buttons
+   */
+  controlsPosition: {
+    type: String,
+    default: '',
+    values: ['', 'right'],
+  },
+  /**
+   * @description value should be set when input box is cleared
+   */
+  valueOnClear: {
+    type: definePropType<'min' | 'max' | number | null>([String, Number, null]),
+    validator: (val: 'min' | 'max' | number | null) =>
+      val === null || isNumber(val) || ['min', 'max'].includes(val),
+    default: null,
+  },
+  /**
+   * @description same as `name` in native input
+   */
+  name: String,
+  /**
+   * @description same as `placeholder` in native input
+   */
+  placeholder: String,
+  /**
+   * @description precision of input value
+   */
+  precision: {
+    type: Number,
+    validator: (val: number) =>
+      val >= 0 && val === Number.parseInt(`${val}`, 10),
+  },
+  /**
+   * @description whether to trigger form validation
+   */
+  validateEvent: {
+    type: Boolean,
+    default: true,
+  },
+  ...useAriaProps(['ariaLabel']),
+  /**
+   * @description native input mode for virtual keyboards
+   */
+  inputmode: {
+    type: definePropType<HTMLAttributes['inputmode']>(String),
+    default: undefined,
+  },
+  /**
+   * @description alignment for the inner input text
+   */
+  align: {
+    type: definePropType<'left' | 'right' | 'center'>(String),
+    default: 'center',
+  },
+  /**
+   * @description whether to disable scientific notation input (e.g. 'e', 'E')
+   */
+  disabledScientific: Boolean,
+} as const)
+
+export type InputNumberPropsPublic = ExtractPublicPropTypes<
+  typeof inputNumberProps
+>
 
 export const inputNumberEmits = {
   [CHANGE_EVENT]: (cur: number | undefined, prev: number | undefined) =>

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -122,7 +122,6 @@ const props = withDefaults(defineProps<InputNumberProps>(), {
   valueOnClear: null,
   validateEvent: true,
   align: 'center',
-  disabledScientific: false,
 })
 const emit = defineEmits(inputNumberEmits)
 

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -110,6 +110,7 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<InputNumberProps>(), {
+  disabled: undefined,
   step: 1,
   max: Number.MAX_SAFE_INTEGER,
   min: Number.MIN_SAFE_INTEGER,

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -100,15 +100,28 @@ import {
   INPUT_EVENT,
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
-import { inputNumberEmits, inputNumberProps } from './input-number'
+import { inputNumberEmits } from './input-number'
 
 import type { InputInstance } from '@element-plus/components/input'
+import type { InputNumberProps } from './input-number'
 
 defineOptions({
   name: 'ElInputNumber',
 })
 
-const props = defineProps(inputNumberProps)
+const props = withDefaults(defineProps<InputNumberProps>(), {
+  step: 1,
+  max: Number.MAX_SAFE_INTEGER,
+  min: Number.MIN_SAFE_INTEGER,
+  stepStrictly: false,
+  readonly: false,
+  controls: true,
+  controlsPosition: '',
+  valueOnClear: null,
+  validateEvent: true,
+  align: 'center',
+  disabledScientific: false,
+})
 const emit = defineEmits(inputNumberEmits)
 
 const { t } = useLocale()

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -121,6 +121,7 @@ const props = withDefaults(defineProps<InputNumberProps>(), {
   controlsPosition: '',
   valueOnClear: null,
   validateEvent: true,
+  inputmode: undefined,
   align: 'center',
 })
 const emit = defineEmits(inputNumberEmits)

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -110,7 +110,7 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<InputNumberProps>(), {
-  id: '',
+  id: undefined,
   disabled: undefined,
   step: 1,
   max: Number.MAX_SAFE_INTEGER,

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -110,6 +110,7 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<InputNumberProps>(), {
+  id: '',
   disabled: undefined,
   step: 1,
   max: Number.MAX_SAFE_INTEGER,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

修复：#23399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a new public props interface and a new public props type for the input-number component.
  * Applied explicit default values to multiple input-number properties to make defaults clearer.
  * Added deprecation notices for legacy props/type usage while preserving existing runtime behavior and emits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->