### PR TITLE
refactor(components): [input-tag] use type-based definitions

### DIFF
--- a/packages/components/input-tag/src/input-tag.ts
+++ b/packages/components/input-tag/src/input-tag.ts
@@ -1,172 +1,123 @@
-import {
-  buildProps,
-  definePropType,
-  iconPropType,
-  isArray,
-  isNumber,
-  isString,
-  isUndefined,
-} from '@element-plus/utils'
-import { useSizeProp } from '@element-plus/hooks'
+import { isArray, isNumber, isString, isUndefined } from '@element-plus/utils'
 import {
   CHANGE_EVENT,
-  EVENT_CODE,
   INPUT_EVENT,
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
-import { tagProps } from '@element-plus/components/tag/src/tag'
-import { CircleClose } from '@element-plus/icons-vue'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
 import type { PopperEffect } from '@element-plus/components/popper'
 
-export const inputTagProps = buildProps({
+/**
+ * @description input-tag component props
+ */
+export interface InputTagProps {
   /**
    * @description binding value
    */
-  modelValue: {
-    type: definePropType<string[]>(Array),
-  },
+  modelValue?: string[]
   /**
    * @description max number tags that can be enter
    */
-  max: Number,
+  max?: number
   /**
    * @description tag type
    */
-  tagType: { ...tagProps.type, default: 'info' },
+  tagType?: 'success' | 'info' | 'warning' | 'danger' | 'primary'
   /**
    * @description tag effect
    */
-  tagEffect: tagProps.effect,
+  tagEffect?: 'light' | 'dark' | 'plain'
   /**
    * @description tooltip theme, built-in theme: `dark` / `light`
    */
-  effect: {
-    type: definePropType<PopperEffect>(String),
-    default: 'light',
-  },
+  effect?: PopperEffect
   /**
    * @description the key to trigger input tag
    */
-  trigger: {
-    type: definePropType<'Enter' | 'Space'>(String),
-    default: EVENT_CODE.enter,
-  },
+  trigger?: string
   /**
    * @description whether tags can be dragged
    */
-  draggable: Boolean,
+  draggable?: boolean
   /**
    * @description add a tag when a delimiter is matched
    */
-  delimiter: {
-    type: [String, RegExp],
-    default: '',
-  },
+  delimiter?: string | RegExp
   /**
    * @description input box size
    */
-  size: useSizeProp,
+  size?: '' | 'large' | 'default' | 'small'
   /**
    * @description whether to show clear button
    */
-  clearable: Boolean,
+  clearable?: boolean
   /**
    * @description custom clear icon component
    */
-  clearIcon: {
-    type: iconPropType,
-    default: CircleClose,
-  },
+  clearIcon?: any
   /**
    * @description whether to disable input-tag
    */
-  disabled: {
-    type: Boolean,
-    default: undefined,
-  },
+  disabled?: boolean
   /**
    * @description whether to trigger form validation
    */
-  validateEvent: {
-    type: Boolean,
-    default: true,
-  },
+  validateEvent?: boolean
   /**
    * @description native input readonly
    */
-  readonly: Boolean,
+  readonly?: boolean
   /**
    * @description native input autofocus
    */
-  autofocus: Boolean,
+  autofocus?: boolean
   /**
    * @description same as `id` in native input
    */
-  id: {
-    type: String,
-    default: undefined,
-  },
+  id?: string
   /**
    * @description same as `tabindex` in native input
    */
-  tabindex: {
-    type: [String, Number],
-    default: 0,
-  },
+  tabindex?: string | number
   /**
    * @description same as `maxlength` in native input
    */
-  maxlength: {
-    type: [String, Number],
-  },
+  maxlength?: string | number
   /**
    * @description same as `minlength` in native input
    */
-  minlength: {
-    type: [String, Number],
-  },
+  minlength?: string | number
   /**
    * @description placeholder of input
    */
-  placeholder: String,
+  placeholder?: string
   /**
    * @description native input autocomplete
    */
-  autocomplete: {
-    type: definePropType<HTMLInputElement['autocomplete']>(String),
-    default: 'off',
-  },
+  autocomplete?: HTMLInputElement['autocomplete']
   /**
    * @description whether to save the input value when the input loses focus
    */
-  saveOnBlur: {
-    type: Boolean,
-    default: true,
-  },
+  saveOnBlur?: boolean
   /**
    * @description whether to collapse tags to a text
    */
-  collapseTags: Boolean,
+  collapseTags?: boolean
   /**
    * @description whether show all selected tags when mouse hover text of collapse-tags. To use this, `collapse-tags` must be true
    */
-  collapseTagsTooltip: Boolean,
+  collapseTagsTooltip?: boolean
   /**
    * @description the max tags number to be shown. To use this, `collapse-tags` must be true
    */
-  maxCollapseTags: {
-    type: Number,
-    default: 1,
-  },
+  maxCollapseTags?: number
   /**
    * @description native `aria-label` attribute
    */
-  ariaLabel: String,
-} as const)
-export type InputTagProps = ExtractPropTypes<typeof inputTagProps>
-export type InputTagPropsPublic = ExtractPublicPropTypes<typeof inputTagProps>
+  ariaLabel?: string
+}
+
+export type InputTagPropsPublic = InputTagProps
 
 export const inputTagEmits = {
   [UPDATE_MODEL_EVENT]: (value?: string[]) =>

--- a/packages/components/input-tag/src/input-tag.vue
+++ b/packages/components/input-tag/src/input-tag.vue
@@ -136,11 +136,13 @@
 import { computed, useSlots } from 'vue'
 import { useAttrs, useCalcInputWidth } from '@element-plus/hooks'
 import { NOOP, ValidateComponentsMap } from '@element-plus/utils'
+import { EVENT_CODE } from '@element-plus/constants'
+import { CircleClose } from '@element-plus/icons-vue'
 import ElTooltip from '@element-plus/components/tooltip'
 import ElIcon from '@element-plus/components/icon'
 import ElTag from '@element-plus/components/tag'
 import { useFormItem, useFormItemInputId } from '@element-plus/components/form'
-import { inputTagEmits, inputTagProps } from './input-tag'
+import { inputTagEmits } from './input-tag'
 import {
   useDragTag,
   useHovering,
@@ -148,12 +150,31 @@ import {
   useInputTagDom,
 } from './composables'
 
+import type { InputTagProps } from './input-tag'
+
 defineOptions({
   name: 'ElInputTag',
   inheritAttrs: false,
 })
 
-const props = defineProps(inputTagProps)
+const props = withDefaults(defineProps<InputTagProps>(), {
+  tagType: 'info',
+  effect: 'light',
+  trigger: EVENT_CODE.enter,
+  delimiter: '',
+  clearIcon: () => CircleClose,
+  validateEvent: true,
+  autofocus: false,
+  readonly: false,
+  draggable: false,
+  clearable: false,
+  collapseTags: false,
+  collapseTagsTooltip: false,
+  tabindex: 0,
+  autocomplete: 'off',
+  saveOnBlur: true,
+  maxCollapseTags: 1,
+})
 const emit = defineEmits(inputTagEmits)
 
 const attrs = useAttrs()


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

修复：#23399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated input-tag component's prop system with comprehensive default values applied across all properties (tagType, effect, trigger, delimiter, clearIcon, validateEvent, autofocus, readonly, draggable, clearable, collapseTags, tabindex, autocomplete, saveOnBlur, and others).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->