### PR TITLE
refactor(components): [link] use type-based definitions

### DIFF
--- a/packages/components/link/src/link.ts
+++ b/packages/components/link/src/link.ts
@@ -24,7 +24,12 @@ export interface LinkProps {
   /**
    * @description same as native hyperlink's `target`
    */
-  target?: '_blank' | '_parent' | '_self' | '_top' | string
+  target?:
+    | '_blank'
+    | '_parent'
+    | '_self'
+    | '_top'
+    | (string & NonNullable<unknown>)
 
   /**
    * @description icon component

--- a/packages/components/link/src/link.ts
+++ b/packages/components/link/src/link.ts
@@ -1,8 +1,40 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes, PropType } from 'vue'
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue'
 import type Link from './link.vue'
 
+export interface LinkProps {
+  /**
+   * @description type
+   */
+  type?: 'primary' | 'success' | 'warning' | 'info' | 'danger' | 'default'
+  /**
+   * @description when underlines should appear
+   */
+  underline?: boolean | 'always' | 'never' | 'hover'
+
+  /**
+   * @description whether the component is disabled
+   */
+  disabled?: boolean
+  /**
+   * @description same as native hyperlink's `href`
+   */
+  href?: string
+  /**
+   * @description same as native hyperlink's `target`
+   */
+  target?: '_blank' | '_parent' | '_self' | '_top' | string
+
+  /**
+   * @description icon component
+   */
+  icon?: string | Component
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `LinkProps` instead.
+ */
 export const linkProps = buildProps({
   /**
    * @description type
@@ -42,7 +74,10 @@ export const linkProps = buildProps({
     type: iconPropType,
   },
 } as const)
-export type LinkProps = ExtractPropTypes<typeof linkProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `LinkProps` instead.
+ */
 export type LinkPropsPublic = ExtractPublicPropTypes<typeof linkProps>
 
 export const linkEmits = {

--- a/packages/components/link/src/link.vue
+++ b/packages/components/link/src/link.vue
@@ -20,12 +20,19 @@ import { ElIcon } from '@element-plus/components/icon'
 import { useGlobalConfig } from '@element-plus/components/config-provider'
 import { useDeprecated, useNamespace } from '@element-plus/hooks'
 import { isBoolean } from '@element-plus/utils'
-import { linkEmits, linkProps } from './link'
+import { linkEmits } from './link'
+
+import type { LinkProps } from './link'
 
 defineOptions({
   name: 'ElLink',
 })
-const props = defineProps(linkProps)
+const props = withDefaults(defineProps<LinkProps>(), {
+  type: undefined,
+  underline: undefined,
+  href: '',
+  target: '_self',
+})
 const emit = defineEmits(linkEmits)
 const globalConfig = useGlobalConfig('link')
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Link component type safety and prop handling; introduced an explicit prop interface and default values (href defaults to empty, target defaults to '_self').

* **Deprecated**
  * Marked the previous prop builder and the old props type as deprecated in favor of the new public interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->