### PR TITLE
refactor(components): [badge/breadcrumb/button] use type-based definitions

### DIFF
--- a/docs/en-US/component/badge.md
+++ b/docs/en-US/component/badge.md
@@ -59,18 +59,18 @@ badge/offset
 
 ### Attributes
 
-| Name                 | Description                                                                   | Type                                                                | Default |
-| -------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------- |
-| value                | display value.                                                                | ^[string] / ^[number]                                               | ''      |
-| max                  | maximum value, shows `{max}+` when exceeded. Only works if value is a number. | ^[number]                                                           | 99      |
-| is-dot               | if a little dot is displayed.                                                 | ^[boolean]                                                          | false   |
-| hidden               | hidden badge.                                                                 | ^[boolean]                                                          | false   |
-| type                 | badge type.                                                                   | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info'`  | danger  |
-| show-zero ^(2.6.0)   | Whether to show badge when value is zero.                                     | ^[boolean]                                                          | true    |
-| color ^(2.6.3)       | background color of the dot                                                   | ^[string]                                                           |         |
-| offset ^(2.7.0)      | offset of badge                                                               | ^[array]`[number, number]`                                          | [0, 0]  |
-| badge-style ^(2.7.1) | custom style of badge                                                         | ^[string] / ^[object]`CSSProperties \| CSSProperties[] \| string[]` | {}      |
-| badge-class ^(2.7.1) | custom class of badge                                                         | ^[string]                                                           | —       |
+| Name                 | Description                                                                   | Type                                                               | Default |
+| -------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------- |
+| value                | display value.                                                                | ^[string] / ^[number]                                              | ''      |
+| max                  | maximum value, shows `{max}+` when exceeded. Only works if value is a number. | ^[number]                                                          | 99      |
+| is-dot               | if a little dot is displayed.                                                 | ^[boolean]                                                         | false   |
+| hidden               | hidden badge.                                                                 | ^[boolean]                                                         | false   |
+| type                 | badge type.                                                                   | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info'` | danger  |
+| show-zero ^(2.6.0)   | Whether to show badge when value is zero.                                     | ^[boolean]                                                         | true    |
+| color ^(2.6.3)       | background color of the dot                                                   | ^[string]                                                          |         |
+| offset ^(2.7.0)      | offset of badge                                                               | ^[array]`[number, number]`                                         | [0, 0]  |
+| badge-style ^(2.7.1) | custom style of badge                                                         | ^[object]`CSSProperties`                                           | —       |
+| badge-class ^(2.7.1) | custom class of badge                                                         | ^[string]                                                          | —       |
 
 ### Slots
 

--- a/docs/en-US/component/badge.md
+++ b/docs/en-US/component/badge.md
@@ -59,18 +59,18 @@ badge/offset
 
 ### Attributes
 
-| Name                 | Description                                                                   | Type                                                               | Default |
-| -------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------- |
-| value                | display value.                                                                | ^[string] / ^[number]                                              | ''      |
-| max                  | maximum value, shows `{max}+` when exceeded. Only works if value is a number. | ^[number]                                                          | 99      |
-| is-dot               | if a little dot is displayed.                                                 | ^[boolean]                                                         | false   |
-| hidden               | hidden badge.                                                                 | ^[boolean]                                                         | false   |
-| type                 | badge type.                                                                   | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info'` | danger  |
-| show-zero ^(2.6.0)   | Whether to show badge when value is zero.                                     | ^[boolean]                                                         | true    |
-| color ^(2.6.3)       | background color of the dot                                                   | ^[string]                                                          |         |
-| offset ^(2.7.0)      | offset of badge                                                               | ^[array]`[number, number]`                                         | —       |
-| badge-style ^(2.7.1) | custom style of badge                                                         | ^[object]`CSSProperties`                                           | —       |
-| badge-class ^(2.7.1) | custom class of badge                                                         | ^[string]                                                          | —       |
+| Name                 | Description                                                                   | Type                                                                | Default |
+| -------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------- |
+| value                | display value.                                                                | ^[string] / ^[number]                                               | ''      |
+| max                  | maximum value, shows `{max}+` when exceeded. Only works if value is a number. | ^[number]                                                           | 99      |
+| is-dot               | if a little dot is displayed.                                                 | ^[boolean]                                                          | false   |
+| hidden               | hidden badge.                                                                 | ^[boolean]                                                          | false   |
+| type                 | badge type.                                                                   | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info'`  | danger  |
+| show-zero ^(2.6.0)   | Whether to show badge when value is zero.                                     | ^[boolean]                                                          | true    |
+| color ^(2.6.3)       | background color of the dot                                                   | ^[string]                                                           |         |
+| offset ^(2.7.0)      | offset of badge                                                               | ^[array]`[number, number]`                                          | —       |
+| badge-style ^(2.7.1) | custom style of badge                                                         | ^[string] / ^[object]`CSSProperties \| CSSProperties[] \| string[]` | {}      |
+| badge-class ^(2.7.1) | custom class of badge                                                         | ^[string]                                                           | —       |
 
 ### Slots
 

--- a/docs/en-US/component/badge.md
+++ b/docs/en-US/component/badge.md
@@ -68,7 +68,7 @@ badge/offset
 | type                 | badge type.                                                                   | ^[enum]`'primary' \| 'success' \| 'warning' \| 'danger' \| 'info'`  | danger  |
 | show-zero ^(2.6.0)   | Whether to show badge when value is zero.                                     | ^[boolean]                                                          | true    |
 | color ^(2.6.3)       | background color of the dot                                                   | ^[string]                                                           |         |
-| offset ^(2.7.0)      | offset of badge                                                               | ^[array]`[number, number]`                                          | —       |
+| offset ^(2.7.0)      | offset of badge                                                               | ^[array]`[number, number]`                                          | [0, 0]  |
 | badge-style ^(2.7.1) | custom style of badge                                                         | ^[string] / ^[object]`CSSProperties \| CSSProperties[] \| string[]` | {}      |
 | badge-class ^(2.7.1) | custom class of badge                                                         | ^[string]                                                           | —       |
 

--- a/packages/components/badge/src/badge.ts
+++ b/packages/components/badge/src/badge.ts
@@ -1,4 +1,4 @@
-import { buildProps, definePropType } from '@element-plus/utils'
+import { buildProps, definePropType, mutable } from '@element-plus/utils'
 
 import type { ExtractPublicPropTypes, StyleValue } from 'vue'
 
@@ -94,7 +94,8 @@ export const badgeProps = buildProps({
    * @description CSS style of badge
    */
   badgeStyle: {
-    type: definePropType<StyleValue>([String, Object, Array]),
+    type: definePropType<StyleValue>([Object, Array, String]),
+    default: () => mutable({} as const),
   },
   /**
    * @description set offset of the badge

--- a/packages/components/badge/src/badge.ts
+++ b/packages/components/badge/src/badge.ts
@@ -1,7 +1,53 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes, StyleValue } from 'vue'
+import type { ExtractPublicPropTypes, StyleValue } from 'vue'
 
+export interface BadgeProps {
+  /**
+   * @description display value.
+   */
+  value?: string | number
+  /**
+   * @description maximum value, shows `{max}+` when exceeded. Only works if value is a number.
+   */
+  max?: number
+  /**
+   * @description if a little dot is displayed.
+   */
+  isDot?: boolean
+  /**
+   * @description hidden badge.
+   */
+  hidden?: boolean
+  /**
+   * @description badge type.
+   */
+  type?: 'primary' | 'success' | 'warning' | 'info' | 'danger'
+  /**
+   * @description whether to show badge when value is zero.
+   */
+  showZero?: boolean
+  /**
+   * @description customize dot background color
+   */
+  color?: string
+  /**
+   * @description CSS style of badge
+   */
+  badgeStyle?: StyleValue
+  /**
+   * @description set offset of the badge
+   */
+  offset?: [number, number]
+  /**
+   * @description custom class name of badge
+   */
+  badgeClass?: string
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `BadgeProps` instead.
+ */
 export const badgeProps = buildProps({
   /**
    * @description display value.
@@ -64,5 +110,8 @@ export const badgeProps = buildProps({
     type: String,
   },
 } as const)
-export type BadgeProps = ExtractPropTypes<typeof badgeProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `BadgeProps` instead.
+ */
 export type BadgePropsPublic = ExtractPublicPropTypes<typeof badgeProps>

--- a/packages/components/badge/src/badge.ts
+++ b/packages/components/badge/src/badge.ts
@@ -1,4 +1,4 @@
-import { buildProps, definePropType, mutable } from '@element-plus/utils'
+import { buildProps, definePropType } from '@element-plus/utils'
 
 import type { ExtractPublicPropTypes, StyleValue } from 'vue'
 
@@ -94,8 +94,7 @@ export const badgeProps = buildProps({
    * @description CSS style of badge
    */
   badgeStyle: {
-    type: definePropType<StyleValue>([Object, Array, String]),
-    default: () => mutable({} as const),
+    type: definePropType<StyleValue>([String, Object, Array]),
   },
   /**
    * @description set offset of the badge

--- a/packages/components/badge/src/badge.vue
+++ b/packages/components/badge/src/badge.vue
@@ -37,8 +37,6 @@ defineOptions({
 const props = withDefaults(defineProps<BadgeProps>(), {
   value: '',
   max: 99,
-  isDot: false,
-  hidden: false,
   type: 'danger',
   showZero: true,
   offset: () => [0, 0],

--- a/packages/components/badge/src/badge.vue
+++ b/packages/components/badge/src/badge.vue
@@ -42,6 +42,7 @@ const props = withDefaults(defineProps<BadgeProps>(), {
   type: 'danger',
   showZero: true,
   offset: () => [0, 0],
+  badgeStyle: false,
 })
 
 const ns = useNamespace('badge')

--- a/packages/components/badge/src/badge.vue
+++ b/packages/components/badge/src/badge.vue
@@ -26,15 +26,23 @@
 import { computed } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { addUnit, isNumber } from '@element-plus/utils'
-import { badgeProps } from './badge'
 
+import type { BadgeProps } from './badge'
 import type { StyleValue } from 'vue'
 
 defineOptions({
   name: 'ElBadge',
 })
 
-const props = defineProps(badgeProps)
+const props = withDefaults(defineProps<BadgeProps>(), {
+  value: '',
+  max: 99,
+  isDot: false,
+  hidden: false,
+  type: 'danger',
+  showZero: true,
+  offset: () => [0, 0],
+})
 
 const ns = useNamespace('badge')
 

--- a/packages/components/badge/src/badge.vue
+++ b/packages/components/badge/src/badge.vue
@@ -42,7 +42,7 @@ const props = withDefaults(defineProps<BadgeProps>(), {
   type: 'danger',
   showZero: true,
   offset: () => [0, 0],
-  badgeStyle: false,
+  badgeStyle: () => ({}),
 })
 
 const ns = useNamespace('badge')

--- a/packages/components/badge/src/badge.vue
+++ b/packages/components/badge/src/badge.vue
@@ -27,8 +27,8 @@ import { computed } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { addUnit, isNumber } from '@element-plus/utils'
 
-import type { BadgeProps } from './badge'
 import type { StyleValue } from 'vue'
+import type { BadgeProps } from './badge'
 
 defineOptions({
   name: 'ElBadge',

--- a/packages/components/badge/src/badge.vue
+++ b/packages/components/badge/src/badge.vue
@@ -40,7 +40,6 @@ const props = withDefaults(defineProps<BadgeProps>(), {
   type: 'danger',
   showZero: true,
   offset: () => [0, 0],
-  badgeStyle: () => ({}),
 })
 
 const ns = useNamespace('badge')

--- a/packages/components/breadcrumb/src/breadcrumb-item.ts
+++ b/packages/components/breadcrumb/src/breadcrumb-item.ts
@@ -1,8 +1,22 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
 
+export interface BreadcrumbItemProps {
+  /**
+   * @description target route of the link, same as `to` of `vue-router`
+   */
+  to?: RouteLocationRaw
+  /**
+   * @description if `true`, the navigation will not leave a history record
+   */
+  replace?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `BreadcrumbItemProps` instead.
+ */
 export const breadcrumbItemProps = buildProps({
   /**
    * @description target route of the link, same as `to` of `vue-router`
@@ -16,7 +30,10 @@ export const breadcrumbItemProps = buildProps({
    */
   replace: Boolean,
 } as const)
-export type BreadcrumbItemProps = ExtractPropTypes<typeof breadcrumbItemProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `BreadcrumbItemProps` instead.
+ */
 export type BreadcrumbItemPropsPublic = ExtractPublicPropTypes<
   typeof breadcrumbItemProps
 >

--- a/packages/components/breadcrumb/src/breadcrumb-item.vue
+++ b/packages/components/breadcrumb/src/breadcrumb-item.vue
@@ -21,15 +21,18 @@ import { getCurrentInstance, inject } from 'vue'
 import ElIcon from '@element-plus/components/icon'
 import { useNamespace } from '@element-plus/hooks'
 import { breadcrumbKey } from './constants'
-import { breadcrumbItemProps } from './breadcrumb-item'
 
+import type { BreadcrumbItemProps } from './breadcrumb-item'
 import type { Router } from 'vue-router'
 
 defineOptions({
   name: 'ElBreadcrumbItem',
 })
 
-const props = defineProps(breadcrumbItemProps)
+const props = withDefaults(defineProps<BreadcrumbItemProps>(), {
+  to: '',
+  replace: false,
+})
 
 const instance = getCurrentInstance()!
 const breadcrumbContext = inject(breadcrumbKey, undefined)

--- a/packages/components/breadcrumb/src/breadcrumb-item.vue
+++ b/packages/components/breadcrumb/src/breadcrumb-item.vue
@@ -31,7 +31,6 @@ defineOptions({
 
 const props = withDefaults(defineProps<BreadcrumbItemProps>(), {
   to: '',
-  replace: false,
 })
 
 const instance = getCurrentInstance()!

--- a/packages/components/breadcrumb/src/breadcrumb-item.vue
+++ b/packages/components/breadcrumb/src/breadcrumb-item.vue
@@ -22,8 +22,8 @@ import ElIcon from '@element-plus/components/icon'
 import { useNamespace } from '@element-plus/hooks'
 import { breadcrumbKey } from './constants'
 
-import type { BreadcrumbItemProps } from './breadcrumb-item'
 import type { Router } from 'vue-router'
+import type { BreadcrumbItemProps } from './breadcrumb-item'
 
 defineOptions({
   name: 'ElBreadcrumbItem',

--- a/packages/components/breadcrumb/src/breadcrumb.ts
+++ b/packages/components/breadcrumb/src/breadcrumb.ts
@@ -1,7 +1,21 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { Component, ExtractPublicPropTypes } from 'vue'
 
+export interface BreadcrumbProps {
+  /**
+   * @description separator character
+   */
+  separator?: string
+  /**
+   * @description icon component of icon separator
+   */
+  separatorIcon?: string | Component
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `BreadcrumbProps` instead.
+ */
 export const breadcrumbProps = buildProps({
   /**
    * @description separator character
@@ -17,7 +31,10 @@ export const breadcrumbProps = buildProps({
     type: iconPropType,
   },
 } as const)
-export type BreadcrumbProps = ExtractPropTypes<typeof breadcrumbProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `BreadcrumbProps` instead.
+ */
 export type BreadcrumbPropsPublic = ExtractPublicPropTypes<
   typeof breadcrumbProps
 >

--- a/packages/components/breadcrumb/src/breadcrumb.vue
+++ b/packages/components/breadcrumb/src/breadcrumb.vue
@@ -13,14 +13,17 @@
 import { onMounted, provide, ref } from 'vue'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { breadcrumbKey } from './constants'
-import { breadcrumbProps } from './breadcrumb'
+
+import type { BreadcrumbProps } from './breadcrumb'
 
 defineOptions({
   name: 'ElBreadcrumb',
 })
 
 const { t } = useLocale()
-const props = defineProps(breadcrumbProps)
+const props = withDefaults(defineProps<BreadcrumbProps>(), {
+  separator: '/',
+})
 
 const ns = useNamespace('breadcrumb')
 const breadcrumb = ref<HTMLDivElement>()

--- a/packages/components/button/src/button-group.ts
+++ b/packages/components/button/src/button-group.ts
@@ -1,8 +1,27 @@
 import { definePropType } from '@element-plus/utils'
 import { buttonProps } from './button'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
+import type { ButtonProps } from './button'
 
+export interface ButtonGroupProps {
+  /**
+   * @description control the size of buttons in this button-group
+   */
+  size?: ButtonProps['size']
+  /**
+   * @description control the type of buttons in this button-group
+   */
+  type?: ButtonProps['type']
+  /**
+   * @description display direction
+   */
+  direction?: 'horizontal' | 'vertical'
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `ButtonGroupProps` instead.
+ */
 export const buttonGroupProps = {
   /**
    * @description control the size of buttons in this button-group
@@ -21,7 +40,10 @@ export const buttonGroupProps = {
     default: 'horizontal',
   },
 } as const
-export type ButtonGroupProps = ExtractPropTypes<typeof buttonGroupProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `ButtonGroupProps` instead.
+ */
 export type ButtonGroupPropsPublic = ExtractPublicPropTypes<
   typeof buttonGroupProps
 >

--- a/packages/components/button/src/button-group.vue
+++ b/packages/components/button/src/button-group.vue
@@ -7,13 +7,16 @@
 <script lang="ts" setup>
 import { provide, reactive, toRef } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
-import { buttonGroupProps } from './button-group'
 import { buttonGroupContextKey } from './constants'
+
+import type { ButtonGroupProps } from './button-group'
 
 defineOptions({
   name: 'ElButtonGroup',
 })
-const props = defineProps(buttonGroupProps)
+const props = withDefaults(defineProps<ButtonGroupProps>(), {
+  direction: 'horizontal',
+})
 provide(
   buttonGroupContextKey,
   reactive({

--- a/packages/components/button/src/button-group.vue
+++ b/packages/components/button/src/button-group.vue
@@ -16,6 +16,7 @@ defineOptions({
 })
 const props = withDefaults(defineProps<ButtonGroupProps>(), {
   direction: 'horizontal',
+  type: '',
 })
 provide(
   buttonGroupContextKey,

--- a/packages/components/button/src/button.ts
+++ b/packages/components/button/src/button.ts
@@ -2,7 +2,8 @@ import { useSizeProp } from '@element-plus/hooks'
 import { buildProps, definePropType, iconPropType } from '@element-plus/utils'
 import { Loading } from '@element-plus/icons-vue'
 
-import type { Component, ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { Component, ExtractPublicPropTypes } from 'vue'
+import type { ComponentSize } from '@element-plus/constants'
 
 export const buttonTypes = [
   'default',
@@ -20,6 +21,87 @@ export const buttonTypes = [
 ] as const
 export const buttonNativeTypes = ['button', 'submit', 'reset'] as const
 
+export type ButtonType = (typeof buttonTypes)[number]
+export type ButtonNativeType = (typeof buttonNativeTypes)[number]
+
+export interface ButtonProps {
+  /**
+   * @description button size
+   */
+  size?: ComponentSize
+  /**
+   * @description disable the button
+   */
+  disabled?: boolean
+  /**
+   * @description button type
+   */
+  type?: ButtonType
+  /**
+   * @description icon component
+   */
+  icon?: string | Component
+  /**
+   * @description native button type
+   */
+  nativeType?: ButtonNativeType
+  /**
+   * @description determine whether it's loading
+   */
+  loading?: boolean
+  /**
+   * @description customize loading icon component
+   */
+  loadingIcon?: string | Component
+  /**
+   * @description determine whether it's a plain button
+   */
+  plain?: boolean
+  /**
+   * @description determine whether it's a text button
+   */
+  text?: boolean
+  /**
+   * @description determine whether it's a link button
+   */
+  link?: boolean
+  /**
+   * @description determine whether the text button background color is always on
+   */
+  bg?: boolean
+  /**
+   * @description native button autofocus
+   */
+  autofocus?: boolean
+  /**
+   * @description determine whether it's a round button
+   */
+  round?: boolean
+  /**
+   * @description determine whether it's a circle button
+   */
+  circle?: boolean
+  /**
+   * @description custom button color, automatically calculate `hover` and `active` color
+   */
+  color?: string
+  /**
+   * @description dark mode, which automatically converts `color` to dark mode colors
+   */
+  dark?: boolean
+  /**
+   * @description automatically insert a space between two chinese characters
+   */
+  autoInsertSpace?: boolean
+  /**
+   * @description custom element tag
+   */
+  tag?: string | Component
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `ButtonProps` instead.
+ */
 export const buttonProps = buildProps({
   /**
    * @description button size
@@ -129,12 +211,11 @@ export const buttonEmits = {
   click: (evt: MouseEvent) => evt instanceof MouseEvent,
 }
 
-export type ButtonProps = ExtractPropTypes<typeof buttonProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `ButtonProps` instead.
+ */
 export type ButtonPropsPublic = ExtractPublicPropTypes<typeof buttonProps>
 export type ButtonEmits = typeof buttonEmits
-
-export type ButtonType = ButtonProps['type']
-export type ButtonNativeType = ButtonProps['nativeType']
 
 export interface ButtonConfigContext {
   type?: string

--- a/packages/components/button/src/button.vue
+++ b/packages/components/button/src/button.vue
@@ -27,18 +27,26 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, markRaw } from 'vue'
 import { ElIcon } from '@element-plus/components/icon'
+import { Loading } from '@element-plus/icons-vue'
 import { useNamespace } from '@element-plus/hooks'
 import { useButton } from './use-button'
-import { buttonEmits, buttonProps } from './button'
+import { buttonEmits } from './button'
 import { useButtonCustomStyle } from './button-custom'
+
+import type { ButtonProps } from './button'
 
 defineOptions({
   name: 'ElButton',
 })
 
-const props = defineProps(buttonProps)
+const props = withDefaults(defineProps<ButtonProps>(), {
+  type: '',
+  nativeType: 'button',
+  loadingIcon: markRaw(Loading),
+  tag: 'button',
+})
 const emit = defineEmits(buttonEmits)
 
 const buttonStyle = useButtonCustomStyle(props)

--- a/packages/components/button/src/button.vue
+++ b/packages/components/button/src/button.vue
@@ -42,11 +42,17 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<ButtonProps>(), {
+  disabled: undefined,
   type: '',
   nativeType: 'button',
   loadingIcon: markRaw(Loading),
+  plain: undefined,
+  text: undefined,
+  round: undefined,
+  autoInsertSpace: undefined,
   tag: 'button',
 })
+
 const emit = defineEmits(buttonEmits)
 
 const buttonStyle = useButtonCustomStyle(props)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

ref:#23399.  badge & breadcrumb / breadcrumb-item & button / button-group



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Strengthened public TypeScript interfaces across Badge, Breadcrumb, Button, and ButtonGroup; components now use explicit typed props with inline defaults.

* **Chores**
  * Marked legacy prop type aliases and public typings as deprecated to guide migration to the new interfaces.

* **User-facing**
  * Components now expose explicit runtime defaults (badge offset [0, 0], breadcrumb separator '/', button defaults including direction, type, nativeType and loading icon) with preserved behavior.

* **Documentation**
  * Badge docs: offset default updated to [0, 0].

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->