### PR TITLE
refactor(components): [divider/result/page-header] use type-based definitions

### DIFF
--- a/packages/components/divider/src/divider.ts
+++ b/packages/components/divider/src/divider.ts
@@ -6,8 +6,17 @@ import type Divider from './divider.vue'
 export type BorderStyle = CSSStyleDeclaration['borderStyle']
 
 export interface DividerProps {
+  /**
+   * @description Set divider's direction
+   */
   direction?: 'horizontal' | 'vertical'
+  /**
+   * @description Set the style of divider
+   */
   contentPosition?: 'left' | 'center' | 'right'
+  /**
+   * @description the position of the customized content on the divider line
+   */
   borderStyle?: BorderStyle
 }
 

--- a/packages/components/divider/src/divider.ts
+++ b/packages/components/divider/src/divider.ts
@@ -1,9 +1,15 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 import type Divider from './divider.vue'
 
 export type BorderStyle = CSSStyleDeclaration['borderStyle']
+
+export interface DividerProps {
+  direction?: 'horizontal' | 'vertical'
+  contentPosition?: 'left' | 'center' | 'right'
+  borderStyle?: BorderStyle
+}
 
 export const dividerProps = buildProps({
   /**
@@ -30,7 +36,6 @@ export const dividerProps = buildProps({
     default: 'solid',
   },
 } as const)
-export type DividerProps = ExtractPropTypes<typeof dividerProps>
 export type DividerPropsPublic = ExtractPublicPropTypes<typeof dividerProps>
 
 export type DividerInstance = InstanceType<typeof Divider> & unknown

--- a/packages/components/divider/src/divider.vue
+++ b/packages/components/divider/src/divider.vue
@@ -16,14 +16,18 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
-import { dividerProps } from './divider'
 
 import type { CSSProperties } from 'vue'
+import type { DividerProps } from './divider'
 
 defineOptions({
   name: 'ElDivider',
 })
-const props = defineProps(dividerProps)
+const props = withDefaults(defineProps<DividerProps>(), {
+  direction: 'horizontal',
+  contentPosition: 'center',
+  borderStyle: 'solid',
+})
 const ns = useNamespace('divider')
 const dividerStyle = computed(() => {
   return ns.cssVar({

--- a/packages/components/page-header/src/page-header.ts
+++ b/packages/components/page-header/src/page-header.ts
@@ -5,8 +5,17 @@ import type { Component, ExtractPublicPropTypes } from 'vue'
 import type PageHeader from './page-header.vue'
 
 export interface PageHeaderProps {
+  /**
+   * @description icon component of page header
+   */
   icon?: string | Component
+  /**
+   * @description main title of page header
+   */
   title?: string
+  /**
+   * @description content of page header
+   */
   content?: string
 }
 

--- a/packages/components/page-header/src/page-header.ts
+++ b/packages/components/page-header/src/page-header.ts
@@ -1,8 +1,14 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 import { Back } from '@element-plus/icons-vue'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { Component, ExtractPublicPropTypes } from 'vue'
 import type PageHeader from './page-header.vue'
+
+export interface PageHeaderProps {
+  icon?: string | Component
+  title?: string
+  content?: string
+}
 
 export const pageHeaderProps = buildProps({
   /**
@@ -24,7 +30,6 @@ export const pageHeaderProps = buildProps({
     default: '',
   },
 } as const)
-export type PageHeaderProps = ExtractPropTypes<typeof pageHeaderProps>
 export type PageHeaderPropsPublic = ExtractPublicPropTypes<
   typeof pageHeaderProps
 >

--- a/packages/components/page-header/src/page-header.vue
+++ b/packages/components/page-header/src/page-header.vue
@@ -56,13 +56,19 @@
 import { ElIcon } from '@element-plus/components/icon'
 import { ElDivider } from '@element-plus/components/divider'
 import { useLocale, useNamespace } from '@element-plus/hooks'
-import { pageHeaderEmits, pageHeaderProps } from './page-header'
+import { Back } from '@element-plus/icons-vue'
+import { pageHeaderEmits } from './page-header'
+
+import type { PageHeaderProps } from './page-header'
 
 defineOptions({
   name: 'ElPageHeader',
 })
 
-defineProps(pageHeaderProps)
+withDefaults(defineProps<PageHeaderProps>(), {
+  icon: Back,
+  content: '',
+})
 const emit = defineEmits(pageHeaderEmits)
 
 const { t } = useLocale()

--- a/packages/components/page-header/src/page-header.vue
+++ b/packages/components/page-header/src/page-header.vue
@@ -56,7 +56,7 @@
 import { ElIcon } from '@element-plus/components/icon'
 import { ElDivider } from '@element-plus/components/divider'
 import { useLocale, useNamespace } from '@element-plus/hooks'
-import { Back } from '@element-plus/icons-vue'
+import { Back as IconBack } from '@element-plus/icons-vue'
 import { pageHeaderEmits } from './page-header'
 
 import type { PageHeaderProps } from './page-header'
@@ -66,7 +66,7 @@ defineOptions({
 })
 
 withDefaults(defineProps<PageHeaderProps>(), {
-  icon: Back,
+  icon: () => IconBack,
   content: '',
 })
 const emit = defineEmits(pageHeaderEmits)

--- a/packages/components/result/src/result.ts
+++ b/packages/components/result/src/result.ts
@@ -6,7 +6,7 @@ import {
   WarningFilled,
 } from '@element-plus/icons-vue'
 
-import type { Component, ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { Component, ExtractPublicPropTypes } from 'vue'
 import type Result from './result.vue'
 
 export const IconMap = {
@@ -26,6 +26,12 @@ export const IconComponentMap: Record<
   [IconMap.warning]: WarningFilled,
   [IconMap.error]: CircleCloseFilled,
   [IconMap.info]: InfoFilled,
+}
+
+export interface ResultProps {
+  title?: string
+  subTitle?: string
+  icon?: 'primary' | 'success' | 'warning' | 'info' | 'error'
 }
 
 export const resultProps = buildProps({
@@ -53,7 +59,6 @@ export const resultProps = buildProps({
   },
 } as const)
 
-export type ResultProps = ExtractPropTypes<typeof resultProps>
 export type ResultPropsPublic = ExtractPublicPropTypes<typeof resultProps>
 
 export type ResultInstance = InstanceType<typeof Result> & unknown

--- a/packages/components/result/src/result.ts
+++ b/packages/components/result/src/result.ts
@@ -29,8 +29,17 @@ export const IconComponentMap: Record<
 }
 
 export interface ResultProps {
+  /**
+   * @description title of result
+   */
   title?: string
+  /**
+   * @description sub title of result
+   */
   subTitle?: string
+  /**
+   * @description icon type of result
+   */
   icon?: 'primary' | 'success' | 'warning' | 'info' | 'error'
 }
 

--- a/packages/components/result/src/result.vue
+++ b/packages/components/result/src/result.vue
@@ -28,19 +28,25 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
-import { IconComponentMap, IconMap, resultProps } from './result'
+import { IconComponentMap, IconMap } from './result'
+
+import type { ResultProps } from './result'
 
 defineOptions({
   name: 'ElResult',
 })
 
-const props = defineProps(resultProps)
+const props = withDefaults(defineProps<ResultProps>(), {
+  title: '',
+  subTitle: '',
+  icon: 'info',
+})
 
 const ns = useNamespace('result')
 
 const resultIcon = computed(() => {
-  const icon = props.icon
-  const iconClass = icon && IconMap[icon] ? IconMap[icon] : 'icon-info'
+  const icon = props.icon ?? 'info'
+  const iconClass = IconMap[icon] ?? 'icon-info'
   const iconComponent =
     IconComponentMap[iconClass] || IconComponentMap['icon-info']
 

--- a/packages/components/result/src/result.vue
+++ b/packages/components/result/src/result.vue
@@ -45,8 +45,8 @@ const props = withDefaults(defineProps<ResultProps>(), {
 const ns = useNamespace('result')
 
 const resultIcon = computed(() => {
-  const icon = props.icon ?? 'info'
-  const iconClass = IconMap[icon] ?? 'icon-info'
+  const icon = props.icon
+  const iconClass = icon && IconMap[icon] ? IconMap[icon] : 'icon-info'
   const iconComponent =
     IconComponentMap[iconClass] || IconComponentMap['icon-info']
 


### PR DESCRIPTION
将组件props类型从ExtractPropTypes改为直接定义接口
使用withDefaults为props提供默认值
统一组件中props的类型导入和使用方式

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced explicit public prop interfaces for Divider, Page Header, and Result components.
  * Components now use typed props with built-in default values (including default visuals/content for Page Header and default divider/result defaults).
  * Result icon handling standardized for more consistent display and safer fallbacks.
* **Chores**
  * Simplified prop-related exports to rely on public-type interfaces only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->