### PR TITLE
refactor(components): [card/calendar/carousel] use type-based definitions

### DIFF
--- a/docs/en-US/component/card.md
+++ b/docs/en-US/component/card.md
@@ -51,15 +51,15 @@ card/shadow
 
 ### Attributes
 
-| Name                  | Description                                                    | Type                              | Default |
-| --------------------- | -------------------------------------------------------------- | --------------------------------- | ------- |
-| header                | title of the card. Also accepts a DOM passed by `slot#header`  | ^[string]                         | —       |
-| footer ^(2.4.3)       | footer of the card. Also accepts a DOM passed by `slot#footer` | ^[string]                         | —       |
-| body-style            | CSS style of card body                                         | ^[object]`CSSProperties`          | —       |
-| header-class ^(2.9.8) | custom class name of card header                               | ^[string]                         | —       |
-| body-class ^(2.3.10)  | custom class name of card body                                 | ^[string]                         | —       |
-| footer-class ^(2.9.8) | custom class name of card footer                               | ^[string]                         | —       |
-| shadow                | when to show card shadows                                      | ^[enum]`always \| never \| hover` | always  |
+| Name                  | Description                                                    | Type                                                                | Default |
+| --------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------- | ------- |
+| header                | title of the card. Also accepts a DOM passed by `slot#header`  | ^[string]                                                           | —       |
+| footer ^(2.4.3)       | footer of the card. Also accepts a DOM passed by `slot#footer` | ^[string]                                                           | —       |
+| body-style            | CSS style of card body                                         | ^[string] / ^[object]`CSSProperties \| CSSProperties[] \| string[]` | {}      |
+| header-class ^(2.9.8) | custom class name of card header                               | ^[string]                                                           | —       |
+| body-class ^(2.3.10)  | custom class name of card body                                 | ^[string]                                                           | —       |
+| footer-class ^(2.9.8) | custom class name of card footer                               | ^[string]                                                           | —       |
+| shadow                | when to show card shadows                                      | ^[enum]`always \| never \| hover`                                   | always  |
 
 ### Slots
 

--- a/packages/components/calendar/src/calendar.ts
+++ b/packages/components/calendar/src/calendar.ts
@@ -6,7 +6,7 @@ import {
 } from '@element-plus/utils'
 import { INPUT_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 
 export type CalendarDateType =
   | 'prev-month'
@@ -18,6 +18,29 @@ export type CalendarDateType =
 const isValidRange = (range: unknown): range is [Date, Date] =>
   isArray(range) && range.length === 2 && range.every((item) => isDate(item))
 
+export interface CalendarProps {
+  /**
+   * @description binding value
+   */
+  modelValue?: Date
+  /**
+   * @description time range, including start time and end time.
+   *   Start time must be start day of week, end time must be end day of week, the time span cannot exceed two months.
+   */
+  range?: [Date, Date]
+  /**
+   * @description type of the controller for the Calendar header
+   */
+  controllerType?: 'button' | 'select'
+  /**
+   * @description format label when `controller-type` is 'select'
+   */
+  formatter?: (value: number, type: 'year' | 'month') => string | number
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `CalendarProps` instead.
+ */
 export const calendarProps = buildProps({
   /**
    * @description binding value
@@ -50,7 +73,10 @@ export const calendarProps = buildProps({
     >(Function),
   },
 } as const)
-export type CalendarProps = ExtractPropTypes<typeof calendarProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `CalendarProps` instead.
+ */
 export type CalendarPropsPublic = ExtractPublicPropTypes<typeof calendarProps>
 
 export const calendarEmits = {

--- a/packages/components/calendar/src/calendar.vue
+++ b/packages/components/calendar/src/calendar.vue
@@ -62,8 +62,10 @@ import { ElButton, ElButtonGroup } from '@element-plus/components/button'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import DateTable from './date-table.vue'
 import { useCalendar } from './use-calendar'
-import { calendarEmits, calendarProps } from './calendar'
+import { calendarEmits } from './calendar'
 import SelectController from './select-controller.vue'
+
+import type { CalendarProps } from './calendar'
 
 const ns = useNamespace('calendar')
 
@@ -72,7 +74,9 @@ defineOptions({
   name: COMPONENT_NAME,
 })
 
-const props = defineProps(calendarProps)
+const props = withDefaults(defineProps<CalendarProps>(), {
+  controllerType: 'button',
+})
 const emit = defineEmits(calendarEmits)
 
 const {

--- a/packages/components/card/src/card.ts
+++ b/packages/components/card/src/card.ts
@@ -16,7 +16,7 @@ export interface CardProps {
    */
   bodyStyle?: StyleValue
   /**
-   * @description custom class name of card footer
+   * @description custom class name of card header
    */
   headerClass?: string
   /**
@@ -59,7 +59,7 @@ export const cardProps = buildProps({
     default: () => mutable({} as const),
   },
   /**
-   * @description custom class name of card footer
+   * @description custom class name of card header
    */
   headerClass: String,
   /**

--- a/packages/components/card/src/card.ts
+++ b/packages/components/card/src/card.ts
@@ -1,12 +1,41 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type {
-  ExtractPropTypes,
-  ExtractPublicPropTypes,
-  InjectionKey,
-  StyleValue,
-} from 'vue'
+import type { ExtractPublicPropTypes, InjectionKey, StyleValue } from 'vue'
 
+export interface CardProps {
+  /**
+   * @description title of the card. Also accepts a DOM passed by `slot#header`
+   */
+  header?: string
+  /**
+   * @description content of footer. Also accepts a DOM passed by `slot#footer`
+   */
+  footer?: string
+  /**
+   * @description CSS style of card body
+   */
+  bodyStyle?: StyleValue
+  /**
+   * @description custom class name of card footer
+   */
+  headerClass?: string
+  /**
+   * @description custom class name of card body
+   */
+  bodyClass?: string
+  /**
+   * @description custom class name of card footer
+   */
+  footerClass?: string
+  /**
+   * @description when to show card shadows
+   */
+  shadow?: 'always' | 'hover' | 'never'
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `CardProps` instead.
+ */
 export const cardProps = buildProps({
   /**
    * @description title of the card. Also accepts a DOM passed by `slot#header`
@@ -50,7 +79,10 @@ export const cardProps = buildProps({
     default: undefined,
   },
 } as const)
-export type CardProps = ExtractPropTypes<typeof cardProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `CardProps` instead.
+ */
 export type CardPropsPublic = ExtractPublicPropTypes<typeof cardProps>
 export interface CardConfigContext {
   shadow?: string

--- a/packages/components/card/src/card.ts
+++ b/packages/components/card/src/card.ts
@@ -1,4 +1,4 @@
-import { buildProps, definePropType } from '@element-plus/utils'
+import { buildProps, definePropType, mutable } from '@element-plus/utils'
 
 import type { ExtractPublicPropTypes, InjectionKey, StyleValue } from 'vue'
 
@@ -55,8 +55,8 @@ export const cardProps = buildProps({
    * @description CSS style of card body
    */
   bodyStyle: {
-    type: definePropType<StyleValue>([String, Object, Array]),
-    default: '',
+    type: definePropType<StyleValue>([Object, Array, String]),
+    default: () => mutable({} as const),
   },
   /**
    * @description custom class name of card footer

--- a/packages/components/card/src/card.vue
+++ b/packages/components/card/src/card.vue
@@ -20,7 +20,8 @@
 <script lang="ts" setup>
 import { useNamespace } from '@element-plus/hooks'
 import { useGlobalConfig } from '@element-plus/components/config-provider'
-import { cardProps } from './card'
+
+import type { CardProps } from './card'
 
 const globalConfig = useGlobalConfig('card')
 
@@ -28,7 +29,11 @@ defineOptions({
   name: 'ElCard',
 })
 
-defineProps(cardProps)
+withDefaults(defineProps<CardProps>(), {
+  header: '',
+  footer: '',
+  bodyStyle: '',
+})
 
 const ns = useNamespace('card')
 </script>

--- a/packages/components/card/src/card.vue
+++ b/packages/components/card/src/card.vue
@@ -32,7 +32,7 @@ defineOptions({
 withDefaults(defineProps<CardProps>(), {
   header: '',
   footer: '',
-  bodyStyle: '',
+  bodyStyle: () => ({}),
 })
 
 const ns = useNamespace('card')

--- a/packages/components/carousel/src/carousel-item.ts
+++ b/packages/components/carousel/src/carousel-item.ts
@@ -1,7 +1,21 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 
+export interface CarouselItemProps {
+  /**
+   * @description name of the item, can be used in `setActiveItem`
+   */
+  name?: string
+  /**
+   * @description text content for the corresponding indicator
+   */
+  label?: string | number
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `CarouselItemProps` instead.
+ */
 export const carouselItemProps = buildProps({
   /**
    * @description name of the item, can be used in `setActiveItem`
@@ -16,7 +30,9 @@ export const carouselItemProps = buildProps({
   },
 } as const)
 
-export type CarouselItemProps = ExtractPropTypes<typeof carouselItemProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `CarouselItemProps` instead.
+ */
 export type CarouselItemPropsPublic = ExtractPublicPropTypes<
   typeof carouselItemProps
 >

--- a/packages/components/carousel/src/carousel-item.vue
+++ b/packages/components/carousel/src/carousel-item.vue
@@ -14,17 +14,20 @@
 <script lang="ts" setup>
 import { computed, unref } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
-import { carouselItemProps } from './carousel-item'
 import { useCarouselItem } from './use-carousel-item'
 import { CAROUSEL_ITEM_NAME } from './constants'
 
 import type { CSSProperties } from 'vue'
+import type { CarouselItemProps } from './carousel-item'
 
 defineOptions({
   name: CAROUSEL_ITEM_NAME,
 })
 
-const props = defineProps(carouselItemProps)
+const props = withDefaults(defineProps<CarouselItemProps>(), {
+  name: '',
+  label: '',
+})
 const ns = useNamespace('carousel')
 
 // inject

--- a/packages/components/carousel/src/carousel.ts
+++ b/packages/components/carousel/src/carousel.ts
@@ -1,7 +1,65 @@
 import { buildProps, isNumber } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 
+export interface CarouselProps {
+  /**
+   * @description index of the initially active slide (starting from 0)
+   */
+  initialIndex?: number
+  /**
+   * @description height of the carousel
+   */
+  height?: string
+  /**
+   * @description how indicators are triggered
+   */
+  trigger?: 'hover' | 'click'
+  /**
+   * @description whether automatically loop the slides
+   */
+  autoplay?: boolean
+  /**
+   * @description interval of the auto loop, in milliseconds
+   */
+  interval?: number
+  /**
+   * @description position of the indicators
+   */
+  indicatorPosition?: '' | 'none' | 'outside'
+  /**
+   * @description when arrows are shown
+   */
+  arrow?: 'always' | 'hover' | 'never'
+  /**
+   * @description type of the Carousel
+   */
+  type?: '' | 'card'
+  /**
+   * @description when type is card, scaled size of secondary cards
+   */
+  cardScale?: number
+  /**
+   * @description display the items in loop
+   */
+  loop?: boolean
+  /**
+   * @description display direction
+   */
+  direction?: 'horizontal' | 'vertical'
+  /**
+   * @description pause autoplay when hover
+   */
+  pauseOnHover?: boolean
+  /**
+   * @description infuse dynamism and smoothness into the carousel
+   */
+  motionBlur?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `CarouselProps` instead.
+ */
 export const carouselProps = buildProps({
   /**
    * @description index of the initially active slide (starting from 0)
@@ -107,6 +165,8 @@ export const carouselEmits = {
   change: (current: number, prev: number) => [current, prev].every(isNumber),
 }
 
-export type CarouselProps = ExtractPropTypes<typeof carouselProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `CarouselProps` instead.
+ */
 export type CarouselPropsPublic = ExtractPublicPropTypes<typeof carouselProps>
 export type CarouselEmits = typeof carouselEmits

--- a/packages/components/carousel/src/carousel.vue
+++ b/packages/components/carousel/src/carousel.vue
@@ -93,15 +93,31 @@ import { computed, unref } from 'vue'
 import { ElIcon } from '@element-plus/components/icon'
 import { ArrowLeft, ArrowRight } from '@element-plus/icons-vue'
 import { useLocale, useNamespace } from '@element-plus/hooks'
-import { carouselEmits, carouselProps } from './carousel'
+import { carouselEmits } from './carousel'
 import { useCarousel } from './use-carousel'
+
+import type { CarouselProps } from './carousel'
 
 const COMPONENT_NAME = 'ElCarousel'
 defineOptions({
   name: COMPONENT_NAME,
 })
 
-const props = defineProps(carouselProps)
+const props = withDefaults(defineProps<CarouselProps>(), {
+  initialIndex: 0,
+  height: '',
+  trigger: 'hover',
+  autoplay: true,
+  interval: 3000,
+  indicatorPosition: '',
+  arrow: 'hover',
+  type: '',
+  cardScale: 0.83,
+  loop: true,
+  direction: 'horizontal',
+  pauseOnHover: true,
+  motionBlur: false,
+})
 const emit = defineEmits(carouselEmits)
 const {
   root,

--- a/packages/components/carousel/src/use-carousel.ts
+++ b/packages/components/carousel/src/use-carousel.ts
@@ -55,8 +55,12 @@ export const useCarousel = (
   )
 
   const hasLabel = computed(() => {
-    return items.value.some((item) => item.props.label.toString().length > 0)
+    return items.value.some(
+      (item) => (item.props.label ?? '').toString().length > 0
+    )
   })
+
+  const interval = computed(() => props.interval ?? 3000)
 
   const isCardType = computed(() => props.type === 'card')
   const isVertical = computed(() => props.direction === 'vertical')
@@ -99,8 +103,8 @@ export const useCarousel = (
   }
 
   function startTimer() {
-    if (props.interval <= 0 || !props.autoplay || timer.value) return
-    timer.value = setInterval(() => playSlides(), props.interval)
+    if (interval.value <= 0 || !props.autoplay || timer.value) return
+    timer.value = setInterval(() => playSlides(), interval.value)
   }
 
   const playSlides = () => {
@@ -276,12 +280,9 @@ export const useCarousel = (
     }
   )
 
-  watch(
-    () => props.interval,
-    () => {
-      resetTimer()
-    }
-  )
+  watch(interval, () => {
+    resetTimer()
+  })
 
   const resizeObserver = shallowRef<ReturnType<typeof useResizeObserver>>()
   // lifecycle
@@ -289,7 +290,7 @@ export const useCarousel = (
     watch(
       () => items.value,
       () => {
-        if (items.value.length > 0) setActiveItem(props.initialIndex)
+        if (items.value.length > 0) setActiveItem(props.initialIndex ?? 0)
       },
       {
         immediate: true,
@@ -313,8 +314,8 @@ export const useCarousel = (
     isCardType,
     isVertical,
     items,
-    loop: props.loop,
-    cardScale: props.cardScale,
+    loop: props.loop ?? true,
+    cardScale: props.cardScale ?? 0.83,
     addItem,
     removeItem,
     setActiveItem,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

ref: #23399  #23414 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reformatted Card API attributes table and updated body-style type/default.

* **New Features**
  * Card: header/footer defaults, headerClass/bodyClass/footerClass added; body-style accepts object/array/string and defaults to {}.
  * Carousel & CarouselItem: standardized defaults for many props (including interval, initial index, loop, card scale) and defaulted name/label.
  * Calendar: controllerType now defaults to "button".

* **Deprecations**
  * Legacy prop-type exports marked deprecated; migrate to new public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->