### PR TITLE
refactor(components): [switch] use type-based definitions

### DIFF
--- a/packages/components/switch/src/switch.ts
+++ b/packages/components/switch/src/switch.ts
@@ -15,9 +15,95 @@ import {
 import { useAriaProps } from '@element-plus/hooks'
 
 import type { ComponentSize } from '@element-plus/constants'
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue'
 import type Switch from './switch.vue'
-import type { ExtractPropTypes, ExtractPublicPropTypes, PropType } from 'vue'
 
+export interface SwitchProps {
+  /**
+   * @description binding value, it should be equivalent to either `active-value` or `inactive-value`, by default it's `boolean` type
+   */
+  modelValue?: boolean | string | number
+  /**
+   * @description whether Switch is disabled
+   */
+  disabled?: boolean
+  /**
+   * @description whether Switch is in loading state
+   */
+  loading?: boolean
+  /**
+   * @description size of Switch
+   */
+  size?: ComponentSize
+  /**
+   * @description width of Switch
+   */
+  width?: string | number
+  /**
+   * @description whether icon or text is displayed inside dot, only the first character will be rendered for text
+   */
+  inlinePrompt?: boolean
+  /**
+   * @description component of the icon displayed in action when in `off` state
+   */
+  inactiveActionIcon?: string | Component
+  /**
+   * @description component of the icon displayed in action when in `on` state
+   */
+  activeActionIcon?: string | Component
+  /**
+   * @description component of the icon displayed when in `on` state, overrides `active-text`
+   */
+  activeIcon?: string | Component
+  /**
+   * @description component of the icon displayed when in `off` state, overrides `inactive-text`
+   */
+  inactiveIcon?: string | Component
+  /**
+   * @description text displayed when in `on` state
+   */
+  activeText?: string
+  /**
+   * @description text displayed when in `off` state
+   */
+  inactiveText?: string
+  /**
+   * @description switch value when in `on` state
+   */
+  activeValue?: boolean | string | number
+  /**
+   * @description switch value when in `off` state
+   */
+  inactiveValue?: boolean | string | number
+  /**
+   * @description input name of Switch
+   */
+  name?: string
+  /**
+   * @description whether to trigger form validation
+   */
+  validateEvent?: boolean
+  /**
+   * @description before-change hook before the switch state changes. If `false` is returned or a `Promise` is returned and then is rejected, will stop switching
+   */
+  beforeChange?: () => Promise<boolean> | boolean
+  /**
+   * @description id for input
+   */
+  id?: string
+  /**
+   * @description tabindex for input
+   */
+  tabindex?: string | number
+  /**
+   * @description native `aria-label` attribute
+   */
+  ariaLabel?: string
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `SwitchProps` instead.
+ */
 export const switchProps = buildProps({
   /**
    * @description binding value, it should be equivalent to either `active-value` or `inactive-value`, by default it's `boolean` type
@@ -140,7 +226,9 @@ export const switchProps = buildProps({
   ...useAriaProps(['ariaLabel']),
 } as const)
 
-export type SwitchProps = ExtractPropTypes<typeof switchProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `SwitchProps` instead.
+ */
 export type SwitchPropsPublic = ExtractPublicPropTypes<typeof switchProps>
 
 export const switchEmits = {

--- a/packages/components/switch/src/switch.vue
+++ b/packages/components/switch/src/switch.vue
@@ -104,16 +104,26 @@ import {
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
 import { useNamespace } from '@element-plus/hooks'
-import { switchEmits, switchProps } from './switch'
+import { switchEmits } from './switch'
 
 import type { CSSProperties } from 'vue'
+import type { SwitchProps } from './switch'
 
 const COMPONENT_NAME = 'ElSwitch'
 defineOptions({
   name: COMPONENT_NAME,
 })
 
-const props = defineProps(switchProps)
+const props = withDefaults(defineProps<SwitchProps>(), {
+  modelValue: false,
+  activeText: '',
+  inactiveText: '',
+  activeValue: true,
+  inactiveValue: false,
+  name: '',
+  validateEvent: true,
+  width: '',
+})
 const emit = defineEmits(switchEmits)
 
 const { formItem } = useFormItem()

--- a/packages/components/switch/src/switch.vue
+++ b/packages/components/switch/src/switch.vue
@@ -116,6 +116,7 @@ defineOptions({
 
 const props = withDefaults(defineProps<SwitchProps>(), {
   modelValue: false,
+  disabled: undefined,
   activeText: '',
   inactiveText: '',
   activeValue: true,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

修复：#23399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Switch component prop typing with a clear public interface and component-level default values; deprecation wrappers added to preserve runtime behavior.
* **Chores**
  * Replaced the older public prop alias with a new preferred type and marked the legacy public alias as deprecated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->