### PR TITLE
refactor(components): [check-tag] use type-based definitions

### DIFF
--- a/packages/components/check-tag/src/check-tag.ts
+++ b/packages/components/check-tag/src/check-tag.ts
@@ -2,8 +2,26 @@ import { buildProps, isBoolean } from '@element-plus/utils'
 import { CHANGE_EVENT } from '@element-plus/constants'
 
 import type CheckTag from './check-tag.vue'
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 
+export interface CheckTagProps {
+  /**
+   * @description is checked
+   */
+  checked?: boolean
+  /**
+   * @description whether the check-tag is disabled
+   */
+  disabled?: boolean
+  /**
+   * @description type of Tag
+   */
+  type?: 'primary' | 'success' | 'info' | 'warning' | 'danger'
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `CheckTagProps` instead.
+ */
 export const checkTagProps = buildProps({
   /**
    * @description is checked
@@ -22,7 +40,10 @@ export const checkTagProps = buildProps({
     default: 'primary',
   },
 } as const)
-export type CheckTagProps = ExtractPropTypes<typeof checkTagProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `CheckTagProps` instead.
+ */
 export type CheckTagPropsPublic = ExtractPublicPropTypes<typeof checkTagProps>
 
 export const checkTagEmits = {

--- a/packages/components/check-tag/src/check-tag.vue
+++ b/packages/components/check-tag/src/check-tag.vue
@@ -8,12 +8,16 @@
 import { computed } from 'vue'
 import { CHANGE_EVENT } from '@element-plus/constants'
 import { useNamespace } from '@element-plus/hooks'
-import { checkTagEmits, checkTagProps } from './check-tag'
+import { checkTagEmits } from './check-tag'
+
+import type { CheckTagProps } from './check-tag'
 
 defineOptions({
   name: 'ElCheckTag',
 })
-const props = defineProps(checkTagProps)
+const props = withDefaults(defineProps<CheckTagProps>(), {
+  type: 'primary',
+})
 const emit = defineEmits(checkTagEmits)
 
 const ns = useNamespace('check-tag')


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

ref #23399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CheckTag component now defaults to 'primary' type when not explicitly specified.

* **Refactor**
  * Enhanced type safety and prop definitions for CheckTag component, improving consistency and developer experience with better type support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->