### PR TITLE
refactor(components): [empty] use type-based definitions

### DIFF
--- a/packages/components/empty/src/empty.ts
+++ b/packages/components/empty/src/empty.ts
@@ -1,7 +1,25 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 
+export interface EmptyProps {
+  /**
+   * @description image URL of empty
+   */
+  image?: string
+  /**
+   * @description image size (width) of empty
+   */
+  imageSize?: number
+  /**
+   * @description description of empty
+   */
+  description?: string
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `EmptyProps` instead.
+ */
 export const emptyProps = buildProps({
   /**
    * @description image URL of empty
@@ -23,5 +41,7 @@ export const emptyProps = buildProps({
   },
 } as const)
 
-export type EmptyProps = ExtractPropTypes<typeof emptyProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `EmptyProps` instead.
+ */
 export type EmptyPropsPublic = ExtractPublicPropTypes<typeof emptyProps>

--- a/packages/components/empty/src/empty.vue
+++ b/packages/components/empty/src/empty.vue
@@ -21,15 +21,18 @@ import { computed } from 'vue'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { addUnit } from '@element-plus/utils'
 import ImgEmpty from './img-empty.vue'
-import { emptyProps } from './empty'
 
 import type { CSSProperties } from 'vue'
+import type { EmptyProps } from './empty'
 
 defineOptions({
   name: 'ElEmpty',
 })
 
-const props = defineProps(emptyProps)
+const props = withDefaults(defineProps<EmptyProps>(), {
+  image: '',
+  description: '',
+})
 
 const { t } = useLocale()
 const ns = useNamespace('empty')


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

修复：#23399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript type definitions for the Empty component with enhanced type safety.
  * Deprecated legacy API exports; migrate to new public type interfaces for continued support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->