### PR TITLE
refactor(components): [dialog] use type-based definitions

### DIFF
--- a/packages/components/dialog/src/dialog-content.ts
+++ b/packages/components/dialog/src/dialog-content.ts
@@ -1,6 +1,6 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 
-import type { Component, ExtractPropTypes } from 'vue'
+import type { Component } from 'vue'
 
 /**
  * @description dialog-content component props
@@ -129,13 +129,6 @@ export const dialogContentProps = buildProps({
     default: '2',
   },
 } as const)
-
-/**
- * @deprecated Removed after 3.0.0, Use `DialogContentProps` instead.
- */
-export type DialogContentPropsLegacy = ExtractPropTypes<
-  typeof dialogContentProps
->
 
 export const dialogContentEmits = {
   close: () => true,

--- a/packages/components/dialog/src/dialog-content.ts
+++ b/packages/components/dialog/src/dialog-content.ts
@@ -1,5 +1,64 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 
+import type { Component, ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+
+/**
+ * @description dialog-content component props
+ */
+export interface DialogContentProps {
+  /**
+   * @description whether to align the header and footer in center
+   */
+  center?: boolean
+  /**
+   * @description whether to align the dialog both horizontally and vertically
+   */
+  alignCenter?: boolean
+  /**
+   * @description custom close icon, default is Close
+   */
+  closeIcon?: string | Component
+  /**
+   * @description enable dragging feature for Dialog
+   */
+  draggable?: boolean
+  /**
+   * @description draggable Dialog can overflow the viewport
+   */
+  overflow?: boolean
+  /**
+   * @description whether the Dialog takes up full screen
+   */
+  fullscreen?: boolean
+  /**
+   * @description custom class names for header wrapper
+   */
+  headerClass?: string
+  /**
+   * @description custom class names for body wrapper
+   */
+  bodyClass?: string
+  /**
+   * @description custom class names for footer wrapper
+   */
+  footerClass?: string
+  /**
+   * @description whether to show a close button
+   */
+  showClose?: boolean
+  /**
+   * @description title of Dialog. Can also be passed with a named slot (see the following table)
+   */
+  title?: string
+  /**
+   * @description header's aria-level attribute
+   */
+  ariaLevel?: string
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `DialogContentProps` instead.
+ */
 export const dialogContentProps = buildProps({
   /**
    * @description whether to align the header and footer in center
@@ -70,6 +129,19 @@ export const dialogContentProps = buildProps({
     default: '2',
   },
 } as const)
+
+/**
+ * @deprecated Removed after 3.0.0, Use `DialogContentProps` instead.
+ */
+export type DialogContentPropsLegacy = ExtractPropTypes<
+  typeof dialogContentProps
+>
+/**
+ * @deprecated Removed after 3.0.0, Use `DialogContentProps` instead.
+ */
+export type DialogContentPropsPublic = ExtractPublicPropTypes<
+  typeof dialogContentProps
+>
 
 export const dialogContentEmits = {
   close: () => true,

--- a/packages/components/dialog/src/dialog-content.ts
+++ b/packages/components/dialog/src/dialog-content.ts
@@ -133,3 +133,12 @@ export const dialogContentProps = buildProps({
 export const dialogContentEmits = {
   close: () => true,
 }
+
+export const dialogContentPropsDefaults = {
+  alignCenter: undefined,
+  draggable: undefined,
+  overflow: undefined,
+  showClose: true,
+  title: '',
+  ariaLevel: '2',
+} as const

--- a/packages/components/dialog/src/dialog-content.ts
+++ b/packages/components/dialog/src/dialog-content.ts
@@ -1,6 +1,6 @@
 import { buildProps, iconPropType } from '@element-plus/utils'
 
-import type { Component, ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { Component, ExtractPropTypes } from 'vue'
 
 /**
  * @description dialog-content component props
@@ -134,12 +134,6 @@ export const dialogContentProps = buildProps({
  * @deprecated Removed after 3.0.0, Use `DialogContentProps` instead.
  */
 export type DialogContentPropsLegacy = ExtractPropTypes<
-  typeof dialogContentProps
->
-/**
- * @deprecated Removed after 3.0.0, Use `DialogContentProps` instead.
- */
-export type DialogContentPropsPublic = ExtractPublicPropTypes<
   typeof dialogContentProps
 >
 

--- a/packages/components/dialog/src/dialog-content.vue
+++ b/packages/components/dialog/src/dialog-content.vue
@@ -46,11 +46,12 @@ const { Close } = CloseComponents
 
 defineOptions({ name: 'ElDialogContent' })
 const props = withDefaults(defineProps<DialogContentProps>(), {
+  alignCenter: undefined,
+  draggable: undefined,
+  overflow: undefined,
   showClose: true,
   title: '',
   ariaLevel: '2',
-  center: false,
-  fullscreen: false,
 })
 defineEmits(dialogContentEmits)
 

--- a/packages/components/dialog/src/dialog-content.vue
+++ b/packages/components/dialog/src/dialog-content.vue
@@ -37,7 +37,10 @@ import { FOCUS_TRAP_INJECTION_KEY } from '@element-plus/components/focus-trap'
 import { useDraggable, useLocale } from '@element-plus/hooks'
 import { CloseComponents, composeRefs } from '@element-plus/utils'
 import { dialogInjectionKey } from './constants'
-import { dialogContentEmits } from './dialog-content'
+import {
+  dialogContentEmits,
+  dialogContentPropsDefaults,
+} from './dialog-content'
 
 import type { DialogContentProps } from './dialog-content'
 
@@ -45,14 +48,10 @@ const { t } = useLocale()
 const { Close } = CloseComponents
 
 defineOptions({ name: 'ElDialogContent' })
-const props = withDefaults(defineProps<DialogContentProps>(), {
-  alignCenter: undefined,
-  draggable: undefined,
-  overflow: undefined,
-  showClose: true,
-  title: '',
-  ariaLevel: '2',
-})
+const props = withDefaults(
+  defineProps<DialogContentProps>(),
+  dialogContentPropsDefaults
+)
 defineEmits(dialogContentEmits)
 
 const { dialogRef, headerRef, bodyId, ns, style } = inject(dialogInjectionKey)!

--- a/packages/components/dialog/src/dialog-content.vue
+++ b/packages/components/dialog/src/dialog-content.vue
@@ -37,13 +37,21 @@ import { FOCUS_TRAP_INJECTION_KEY } from '@element-plus/components/focus-trap'
 import { useDraggable, useLocale } from '@element-plus/hooks'
 import { CloseComponents, composeRefs } from '@element-plus/utils'
 import { dialogInjectionKey } from './constants'
-import { dialogContentEmits, dialogContentProps } from './dialog-content'
+import { dialogContentEmits } from './dialog-content'
+
+import type { DialogContentProps } from './dialog-content'
 
 const { t } = useLocale()
 const { Close } = CloseComponents
 
 defineOptions({ name: 'ElDialogContent' })
-const props = defineProps(dialogContentProps)
+const props = withDefaults(defineProps<DialogContentProps>(), {
+  showClose: true,
+  title: '',
+  ariaLevel: '2',
+  center: false,
+  fullscreen: false,
+})
 defineEmits(dialogContentEmits)
 
 const { dialogRef, headerRef, bodyId, ns, style } = inject(dialogInjectionKey)!

--- a/packages/components/dialog/src/dialog.ts
+++ b/packages/components/dialog/src/dialog.ts
@@ -3,12 +3,8 @@ import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { teleportProps } from '@element-plus/components/teleport'
 import { dialogContentProps } from './dialog-content'
 
-import type {
-  ExtractPropTypes,
-  ExtractPublicPropTypes,
-  InjectionKey,
-  TransitionProps,
-} from 'vue'
+import type { ExtractPublicPropTypes, InjectionKey, TransitionProps } from 'vue'
+import type { DialogContentProps } from './dialog-content'
 import type Dialog from './dialog.vue'
 
 type DoneFn = (cancel?: boolean) => void
@@ -17,6 +13,91 @@ export type DialogBeforeCloseFn = (done: DoneFn) => void
 
 export type DialogTransition = string | TransitionProps
 
+/**
+ * @description dialog component props
+ */
+export interface DialogProps extends DialogContentProps {
+  /**
+   * @description whether to append Dialog itself to body. A nested Dialog should have this attribute set to `true`
+   */
+  appendToBody?: boolean
+  /**
+   * @description which element the Dialog appends to
+   */
+  appendTo?: string | HTMLElement
+  /**
+   * @description callback before Dialog closes, and it will prevent Dialog from closing, use done to close the dialog
+   */
+  beforeClose?: DialogBeforeCloseFn
+  /**
+   * @description destroy elements in Dialog when closed
+   */
+  destroyOnClose?: boolean
+  /**
+   * @description whether the Dialog can be closed by clicking the mask
+   */
+  closeOnClickModal?: boolean
+  /**
+   * @description whether the Dialog can be closed by pressing ESC
+   */
+  closeOnPressEscape?: boolean
+  /**
+   * @description whether scroll of body is disabled while Dialog is displayed
+   */
+  lockScroll?: boolean
+  /**
+   * @description whether a mask is displayed
+   */
+  modal?: boolean
+  /**
+   * @description whether the mask is penetrable
+   */
+  modalPenetrable?: boolean
+  /**
+   * @description the Time(milliseconds) before open
+   */
+  openDelay?: number
+  /**
+   * @description the Time(milliseconds) before close
+   */
+  closeDelay?: number
+  /**
+   * @description value for `margin-top` of Dialog CSS, default is 15vh
+   */
+  top?: string
+  /**
+   * @description visibility of Dialog
+   */
+  modelValue?: boolean
+  /**
+   * @description custom class names for mask
+   */
+  modalClass?: string
+  /**
+   * @description width of Dialog, default is 50%
+   */
+  width?: string | number
+  /**
+   * @description same as z-index in native CSS, z-order of dialog
+   */
+  zIndex?: number
+  /**
+   * @description trap focus within dialog
+   */
+  trapFocus?: boolean
+  /**
+   * @description header's aria-level attribute
+   */
+  headerAriaLevel?: string
+  /**
+   * @description custom transition configuration for dialog animation, it can be a string (transition name) or an object with Vue transition props
+   */
+  transition?: DialogTransition
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `DialogProps` instead.
+ */
 export const dialogProps = buildProps({
   ...dialogContentProps,
   /**
@@ -141,7 +222,9 @@ export const dialogProps = buildProps({
   },
 } as const)
 
-export type DialogProps = ExtractPropTypes<typeof dialogProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `DialogProps` instead.
+ */
 export type DialogPropsPublic = ExtractPublicPropTypes<typeof dialogProps>
 
 export const dialogEmits = {

--- a/packages/components/dialog/src/dialog.vue
+++ b/packages/components/dialog/src/dialog.vue
@@ -115,6 +115,9 @@ const props = withDefaults(defineProps<DialogProps>(), {
   title: '',
   ariaLevel: '2',
   center: false,
+  alignCenter: undefined,
+  draggable: undefined,
+  overflow: undefined,
   fullscreen: false,
 })
 defineEmits(dialogEmits)

--- a/packages/components/dialog/src/dialog.vue
+++ b/packages/components/dialog/src/dialog.vue
@@ -89,6 +89,7 @@ import ElDialogContent from './dialog-content.vue'
 import { dialogInjectionKey } from './constants'
 import { dialogEmits } from './dialog'
 import { useDialog } from './use-dialog'
+import { dialogContentPropsDefaults } from './dialog-content'
 
 import type { DialogProps } from './dialog'
 
@@ -98,6 +99,7 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<DialogProps>(), {
+  ...dialogContentPropsDefaults,
   appendTo: 'body',
   closeOnClickModal: true,
   closeOnPressEscape: true,
@@ -106,12 +108,7 @@ const props = withDefaults(defineProps<DialogProps>(), {
   openDelay: 0,
   closeDelay: 0,
   headerAriaLevel: '2',
-  showClose: true,
-  title: '',
-  ariaLevel: '2',
-  alignCenter: undefined,
-  draggable: undefined,
-  overflow: undefined,
+  transition: undefined,
 })
 defineEmits(dialogEmits)
 const slots = useSlots()

--- a/packages/components/dialog/src/dialog.vue
+++ b/packages/components/dialog/src/dialog.vue
@@ -98,27 +98,20 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<DialogProps>(), {
-  appendToBody: false,
   appendTo: 'body',
-  destroyOnClose: false,
   closeOnClickModal: true,
   closeOnPressEscape: true,
   lockScroll: true,
   modal: true,
-  modalPenetrable: false,
   openDelay: 0,
   closeDelay: 0,
-  modelValue: false,
-  trapFocus: false,
   headerAriaLevel: '2',
   showClose: true,
   title: '',
   ariaLevel: '2',
-  center: false,
   alignCenter: undefined,
   draggable: undefined,
   overflow: undefined,
-  fullscreen: false,
 })
 defineEmits(dialogEmits)
 const slots = useSlots()

--- a/packages/components/dialog/src/dialog.vue
+++ b/packages/components/dialog/src/dialog.vue
@@ -87,15 +87,36 @@ import ElFocusTrap from '@element-plus/components/focus-trap'
 import ElTeleport from '@element-plus/components/teleport'
 import ElDialogContent from './dialog-content.vue'
 import { dialogInjectionKey } from './constants'
-import { dialogEmits, dialogProps } from './dialog'
+import { dialogEmits } from './dialog'
 import { useDialog } from './use-dialog'
+
+import type { DialogProps } from './dialog'
 
 defineOptions({
   name: 'ElDialog',
   inheritAttrs: false,
 })
 
-const props = defineProps(dialogProps)
+const props = withDefaults(defineProps<DialogProps>(), {
+  appendToBody: false,
+  appendTo: 'body',
+  destroyOnClose: false,
+  closeOnClickModal: true,
+  closeOnPressEscape: true,
+  lockScroll: true,
+  modal: true,
+  modalPenetrable: false,
+  openDelay: 0,
+  closeDelay: 0,
+  modelValue: false,
+  trapFocus: false,
+  headerAriaLevel: '2',
+  showClose: true,
+  title: '',
+  ariaLevel: '2',
+  center: false,
+  fullscreen: false,
+})
 defineEmits(dialogEmits)
 const slots = useSlots()
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

修复：#23399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated dialog prop definitions into explicit, strongly typed public contracts to improve type safety.
  * Introduced centralized default values for dialog content and dialog props, applied across components for consistent behavior.
  * Marked legacy/older prop shapes as deprecated while preserving runtime behavior and backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->