### PR TITLE
refactor(components): [descriptions] use type-based definitions

### DIFF
--- a/packages/components/descriptions/src/description.ts
+++ b/packages/components/descriptions/src/description.ts
@@ -91,6 +91,9 @@ export const descriptionProps = buildProps({
   },
 } as const)
 
+/**
+ * @deprecated Removed after 3.0.0, Use `DescriptionProps` instead.
+ */
 export type DescriptionPropsPublic = ExtractPublicPropTypes<
   typeof descriptionProps
 >

--- a/packages/components/descriptions/src/description.ts
+++ b/packages/components/descriptions/src/description.ts
@@ -1,9 +1,50 @@
 import { buildProps } from '@element-plus/utils'
 import { useSizeProp } from '@element-plus/hooks'
+import { ComponentSize } from '@element-plus/constants'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 import type Description from './description.vue'
 
+export interface DescriptionProps {
+  /**
+   * @description with or without border
+   * @default false
+   */
+  border?: boolean
+  /**
+   * @description numbers of `Descriptions Item` in one line
+   * @default 3
+   */
+  column?: number
+  /**
+   * @description direction of list
+   * @default 'horizontal'
+   */
+  direction?: 'horizontal' | 'vertical'
+  /**
+   * @description size of list
+   * @default ''
+   */
+  size?: ComponentSize
+  /**
+   * @description title text, display on the top left
+   * @default ''
+   */
+  title?: string
+  /**
+   * @description extra text, display on the top right
+   * @default ''
+   */
+  extra?: string
+  /**
+   * @description width of every label column
+   */
+  labelWidth?: string | number
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `DescriptionProps` instead.
+ */
 export const descriptionProps = buildProps({
   /**
    * @description with or without border
@@ -50,7 +91,6 @@ export const descriptionProps = buildProps({
   },
 } as const)
 
-export type DescriptionProps = ExtractPropTypes<typeof descriptionProps>
 export type DescriptionPropsPublic = ExtractPublicPropTypes<
   typeof descriptionProps
 >

--- a/packages/components/descriptions/src/description.vue
+++ b/packages/components/descriptions/src/description.vue
@@ -42,10 +42,8 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<DescriptionProps>(), {
-  border: false,
   column: 3,
   direction: 'horizontal',
-  size: '',
   title: '',
   extra: '',
 })

--- a/packages/components/descriptions/src/description.vue
+++ b/packages/components/descriptions/src/description.vue
@@ -48,7 +48,6 @@ const props = withDefaults(defineProps<DescriptionProps>(), {
   size: '',
   title: '',
   extra: '',
-  labelWidth: '',
 })
 
 const ns = useNamespace('descriptions')

--- a/packages/components/descriptions/src/description.vue
+++ b/packages/components/descriptions/src/description.vue
@@ -31,9 +31,9 @@ import { useNamespace } from '@element-plus/hooks'
 import { useFormSize } from '@element-plus/components/form'
 import ElDescriptionsRow from './descriptions-row.vue'
 import { descriptionsKey } from './token'
-import { descriptionProps } from './description'
 import { COMPONENT_NAME } from './constants'
 
+import type { DescriptionProps } from './description'
 import type { IDescriptionsInject } from './descriptions.type'
 import type { DescriptionItemVNode } from './description-item'
 
@@ -41,7 +41,15 @@ defineOptions({
   name: 'ElDescriptions',
 })
 
-const props = defineProps(descriptionProps)
+const props = withDefaults(defineProps<DescriptionProps>(), {
+  border: false,
+  column: 3,
+  direction: 'horizontal',
+  size: '',
+  title: '',
+  extra: '',
+  labelWidth: '',
+})
 
 const ns = useNamespace('descriptions')
 

--- a/packages/components/descriptions/src/descriptions-row.ts
+++ b/packages/components/descriptions/src/descriptions-row.ts
@@ -2,6 +2,13 @@ import { buildProps, definePropType } from '@element-plus/utils'
 
 import type { DescriptionItemVNode } from './description-item'
 
+export interface DescriptionsRowProps {
+  row?: DescriptionItemVNode[]
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `DescriptionProps` instead.
+ */
 export const descriptionsRowProps = buildProps({
   row: {
     type: definePropType<DescriptionItemVNode[]>(Array),

--- a/packages/components/descriptions/src/descriptions-row.vue
+++ b/packages/components/descriptions/src/descriptions-row.vue
@@ -26,15 +26,17 @@
 import { inject } from 'vue'
 import ElDescriptionsCell from './descriptions-cell'
 import { descriptionsKey } from './token'
-import { descriptionsRowProps } from './descriptions-row'
 
+import type { DescriptionsRowProps } from './descriptions-row'
 import type { IDescriptionsInject } from './descriptions.type'
 
 defineOptions({
   name: 'ElDescriptionsRow',
 })
 
-defineProps(descriptionsRowProps)
+withDefaults(defineProps<DescriptionsRowProps>(), {
+  row: () => [],
+})
 
 const descriptions = inject(descriptionsKey, {} as IDescriptionsInject)
 </script>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

ref #23399 

### Other Notes
`descriptionitem` was not refactored because of `defineComponent`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Converted runtime prop definitions to exported typed interfaces and switched components to use typed props with explicit default values for common options, improving type safety and consistency.
  * Added new public interfaces for instances and row data shapes.

* **Deprecations**
  * Marked legacy prop-definition aliases as deprecated and advised migration to the new public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->