### PR TITLE
refactor(components): [input-tag] use type-based definitions

### DIFF
--- a/packages/components/input-tag/src/composables/use-input-tag.ts
+++ b/packages/components/input-tag/src/composables/use-input-tag.ts
@@ -68,7 +68,7 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
 
   const getDelimitedTags = (input: string) => {
     const tags = input
-      .split(props.delimiter)
+      .split(props.delimiter!)
       .filter((val) => val && val !== input)
     if (props.max) {
       const maxInsert = props.max - (props.modelValue?.length ?? 0)

--- a/packages/components/input-tag/src/input-tag.ts
+++ b/packages/components/input-tag/src/input-tag.ts
@@ -17,9 +17,121 @@ import {
 import { tagProps } from '@element-plus/components/tag/src/tag'
 import { CircleClose } from '@element-plus/icons-vue'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { Component, ExtractPublicPropTypes } from 'vue'
+import type { ComponentSize } from '@element-plus/constants'
 import type { PopperEffect } from '@element-plus/components/popper'
+import type { TagProps } from '@element-plus/components/tag'
 
+export interface InputTagProps {
+  /**
+   * @description binding value
+   */
+  modelValue?: string[]
+  /**
+   * @description max number tags that can be enter
+   */
+  max?: number
+  /**
+   * @description tag type
+   */
+  tagType?: TagProps['type']
+  /**
+   * @description tag effect
+   */
+  tagEffect?: TagProps['effect']
+  /**
+   * @description tooltip theme, built-in theme: `dark` / `light`
+   */
+  effect?: PopperEffect
+  /**
+   * @description the key to trigger input tag
+   */
+  trigger?: 'Enter' | 'Space'
+  /**
+   * @description whether tags can be dragged
+   */
+  draggable?: boolean
+  /**
+   * @description add a tag when a delimiter is matched
+   */
+  delimiter?: string | RegExp
+  /**
+   * @description input box size
+   */
+  size?: ComponentSize
+  /**
+   * @description whether to show clear button
+   */
+  clearable?: boolean
+  /**
+   * @description custom clear icon component
+   */
+  clearIcon?: string | Component
+  /**
+   * @description whether to disable input-tag
+   */
+  disabled?: boolean
+  /**
+   * @description whether to trigger form validation
+   */
+  validateEvent?: boolean
+  /**
+   * @description native input readonly
+   */
+  readonly?: boolean
+  /**
+   * @description native input autofocus
+   */
+  autofocus?: boolean
+  /**
+   * @description same as `id` in native input
+   */
+  id?: string
+  /**
+   * @description same as `tabindex` in native input
+   */
+  tabindex?: string | number
+  /**
+   * @description same as `maxlength` in native input
+   */
+  maxlength?: string | number
+  /**
+   * @description same as `minlength` in native input
+   */
+  minlength?: string | number
+  /**
+   * @description placeholder of input
+   */
+  placeholder?: string
+  /**
+   * @description native input autocomplete
+   */
+  autocomplete?: string
+  /**
+   * @description whether to save the input value when the input loses focus
+   */
+  saveOnBlur?: boolean
+  /**
+   * @description whether to collapse tags to a text
+   */
+  collapseTags?: boolean
+  /**
+   * @description whether show all selected tags when mouse hover text of collapse-tags. To use this, `collapse-tags` must be true
+   */
+  collapseTagsTooltip?: boolean
+  /**
+   * @description the max tags number to be shown. To use this, `collapse-tags` must be true
+   */
+  maxCollapseTags?: number
+  /**
+   * @description native `aria-label` attribute
+   */
+  ariaLabel?: string
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `InputTagProps` instead.
+ */
 export const inputTagProps = buildProps({
   /**
    * @description binding value
@@ -165,7 +277,10 @@ export const inputTagProps = buildProps({
    */
   ariaLabel: String,
 } as const)
-export type InputTagProps = ExtractPropTypes<typeof inputTagProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `InputTagProps` instead.
+ */
 export type InputTagPropsPublic = ExtractPublicPropTypes<typeof inputTagProps>
 
 export const inputTagEmits = {

--- a/packages/components/input-tag/src/input-tag.ts
+++ b/packages/components/input-tag/src/input-tag.ts
@@ -105,8 +105,9 @@ export interface InputTagProps {
   placeholder?: string
   /**
    * @description native input autocomplete
+   * - When the number of literal types in a union exceeds 315, the TS2590 error occurs. see: https://github.com/vuejs/core/issues/10514
    */
-  autocomplete?: string
+  autocomplete?: string // HTMLInputElement['autocomplete']
   /**
    * @description whether to save the input value when the input loses focus
    */

--- a/packages/components/input-tag/src/input-tag.vue
+++ b/packages/components/input-tag/src/input-tag.vue
@@ -158,16 +158,17 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<InputTagProps>(), {
-  disabled: undefined,
   tagType: 'info',
+  tagEffect: 'light',
   effect: 'light',
   trigger: EVENT_CODE.enter as 'Enter',
   delimiter: '',
   clearIcon: markRaw(IconCircleClose),
+  disabled: undefined,
+  validateEvent: true,
   id: undefined,
   tabindex: 0,
   autocomplete: 'off',
-  validateEvent: true,
   saveOnBlur: true,
   maxCollapseTags: 1,
 })

--- a/packages/components/input-tag/src/input-tag.vue
+++ b/packages/components/input-tag/src/input-tag.vue
@@ -136,8 +136,7 @@
 import { computed, markRaw, useSlots } from 'vue'
 import { useAttrs, useCalcInputWidth } from '@element-plus/hooks'
 import { NOOP, ValidateComponentsMap } from '@element-plus/utils'
-import { EVENT_CODE } from '@element-plus/constants'
-import { CircleClose as IconCircleClose } from '@element-plus/icons-vue'
+import { CircleClose } from '@element-plus/icons-vue'
 import ElTooltip from '@element-plus/components/tooltip'
 import ElIcon from '@element-plus/components/icon'
 import ElTag from '@element-plus/components/tag'
@@ -161,9 +160,9 @@ const props = withDefaults(defineProps<InputTagProps>(), {
   tagType: 'info',
   tagEffect: 'light',
   effect: 'light',
-  trigger: EVENT_CODE.enter as 'Enter',
+  trigger: 'Enter',
   delimiter: '',
-  clearIcon: markRaw(IconCircleClose),
+  clearIcon: markRaw(CircleClose),
   disabled: undefined,
   validateEvent: true,
   id: undefined,

--- a/packages/components/input-tag/src/input-tag.vue
+++ b/packages/components/input-tag/src/input-tag.vue
@@ -133,14 +133,16 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, useSlots } from 'vue'
+import { computed, markRaw, useSlots } from 'vue'
 import { useAttrs, useCalcInputWidth } from '@element-plus/hooks'
 import { NOOP, ValidateComponentsMap } from '@element-plus/utils'
+import { EVENT_CODE } from '@element-plus/constants'
+import { CircleClose as IconCircleClose } from '@element-plus/icons-vue'
 import ElTooltip from '@element-plus/components/tooltip'
 import ElIcon from '@element-plus/components/icon'
 import ElTag from '@element-plus/components/tag'
 import { useFormItem, useFormItemInputId } from '@element-plus/components/form'
-import { inputTagEmits, inputTagProps } from './input-tag'
+import { inputTagEmits } from './input-tag'
 import {
   useDragTag,
   useHovering,
@@ -148,12 +150,27 @@ import {
   useInputTagDom,
 } from './composables'
 
+import type { InputTagProps } from './input-tag'
+
 defineOptions({
   name: 'ElInputTag',
   inheritAttrs: false,
 })
 
-const props = defineProps(inputTagProps)
+const props = withDefaults(defineProps<InputTagProps>(), {
+  disabled: undefined,
+  tagType: 'info',
+  effect: 'light',
+  trigger: EVENT_CODE.enter as 'Enter',
+  delimiter: '',
+  clearIcon: markRaw(IconCircleClose),
+  id: undefined,
+  tabindex: 0,
+  autocomplete: 'off',
+  validateEvent: true,
+  saveOnBlur: true,
+  maxCollapseTags: 1,
+})
 const emit = defineEmits(inputTagEmits)
 
 const attrs = useAttrs()


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

修复：#23399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal type definitions and prop declarations for the input-tag component, enhancing type safety and consistency across the component.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->