### PR TITLE
refactor(components): [row] use type-based definitions

### DIFF
--- a/packages/components/row/src/row.ts
+++ b/packages/components/row/src/row.ts
@@ -1,6 +1,6 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 import type Row from './row.vue'
 
 export const RowJustify = [
@@ -14,6 +14,28 @@ export const RowJustify = [
 
 export const RowAlign = ['top', 'middle', 'bottom'] as const
 
+export interface RowProps {
+  /**
+   * @description custom element tag
+   */
+  tag?: string
+  /**
+   * @description grid spacing
+   */
+  gutter?: number
+  /**
+   * @description horizontal alignment of flex layout
+   */
+  justify?: (typeof RowJustify)[number]
+  /**
+   * @description vertical alignment of flex layout
+   */
+  align?: (typeof RowAlign)[number]
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `RowProps` instead.
+ */
 export const rowProps = buildProps({
   /**
    * @description custom element tag
@@ -46,6 +68,8 @@ export const rowProps = buildProps({
   },
 } as const)
 
-export type RowProps = ExtractPropTypes<typeof rowProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `RowProps` instead.
+ */
 export type RowPropsPublic = ExtractPublicPropTypes<typeof rowProps>
 export type RowInstance = InstanceType<typeof Row> & unknown

--- a/packages/components/row/src/row.ts
+++ b/packages/components/row/src/row.ts
@@ -33,6 +33,9 @@ export interface RowProps {
   align?: (typeof RowAlign)[number]
 }
 
+/**
+ * @deprecated Removed after 3.0.0, Use `RowProps` instead.
+ */
 export const rowProps = buildProps({
   /**
    * @description custom element tag

--- a/packages/components/row/src/row.ts
+++ b/packages/components/row/src/row.ts
@@ -33,9 +33,6 @@ export interface RowProps {
   align?: (typeof RowAlign)[number]
 }
 
-/**
- * @deprecated Removed after 3.0.0, Use `RowProps` instead.
- */
 export const rowProps = buildProps({
   /**
    * @description custom element tag

--- a/packages/components/row/src/row.vue
+++ b/packages/components/row/src/row.vue
@@ -8,15 +8,19 @@
 import { computed, provide } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { rowContextKey } from './constants'
-import { rowProps } from './row'
 
 import type { CSSProperties } from 'vue'
+import type { RowProps } from './row'
 
 defineOptions({
   name: 'ElRow',
 })
 
-const props = defineProps(rowProps)
+const props = withDefaults(defineProps<RowProps>(), {
+  tag: 'div',
+  gutter: 0,
+  justify: 'start',
+})
 
 const ns = useNamespace('row')
 const gutter = computed(() => props.gutter)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

修复：#23399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Row component now has default prop values: tag = 'div', gutter = 0, justify = 'start'.

* **Refactor**
  * Prop typings for the Row component reorganized into a clearer, public-facing interface for improved type safety and maintainability.

* **Deprecated**
  * Legacy public prop type alias marked deprecated in favor of the new RowProps interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->