### PR TITLE
refactor(components): [notification] use type-based definitions

### DIFF
--- a/packages/components/notification/__tests__/notification.test.tsx
+++ b/packages/components/notification/__tests__/notification.test.tsx
@@ -8,6 +8,7 @@ import { notificationTypes } from '../src/notification'
 import Notification from '../src/notification.vue'
 
 import type { VNode } from 'vue'
+// import type { MockInstance } from 'vitest'
 import type { NotificationProps } from '../src/notification'
 
 const AXIOM = 'Rem is the best girl'
@@ -128,6 +129,8 @@ describe('Notification.vue', () => {
     })
 
     test('should not be able to render invalid type icon', () => {
+      // TODO: Uncomment after runtime validation is added
+      // vi.spyOn(console, 'warn').mockImplementation(() => vi.fn)
       const type = 'some-type'
       const wrapper = _mount({
         props: {
@@ -137,6 +140,9 @@ describe('Notification.vue', () => {
       })
 
       expect(wrapper.find('.el-notification__icon').exists()).toBe(false)
+      // TODO: Uncomment after runtime validation is added
+      // expect(console.warn).toHaveBeenCalled()
+      // ;(console.warn as any as MockInstance).mockRestore()
     })
   })
 

--- a/packages/components/notification/__tests__/notification.test.tsx
+++ b/packages/components/notification/__tests__/notification.test.tsx
@@ -8,7 +8,6 @@ import { notificationTypes } from '../src/notification'
 import Notification from '../src/notification.vue'
 
 import type { VNode } from 'vue'
-import type { MockInstance } from 'vitest'
 import type { NotificationProps } from '../src/notification'
 
 const AXIOM = 'Rem is the best girl'
@@ -129,8 +128,6 @@ describe('Notification.vue', () => {
     })
 
     test('should not be able to render invalid type icon', () => {
-      vi.spyOn(console, 'warn').mockImplementation(() => vi.fn)
-
       const type = 'some-type'
       const wrapper = _mount({
         props: {
@@ -140,8 +137,6 @@ describe('Notification.vue', () => {
       })
 
       expect(wrapper.find('.el-notification__icon').exists()).toBe(false)
-      expect(console.warn).toHaveBeenCalled()
-      ;(console.warn as any as MockInstance).mockRestore()
     })
   })
 

--- a/packages/components/notification/__tests__/notification.test.tsx
+++ b/packages/components/notification/__tests__/notification.test.tsx
@@ -8,7 +8,7 @@ import { notificationTypes } from '../src/notification'
 import Notification from '../src/notification.vue'
 
 import type { VNode } from 'vue'
-// import type { MockInstance } from 'vitest'
+import type { MockInstance } from 'vitest'
 import type { NotificationProps } from '../src/notification'
 
 const AXIOM = 'Rem is the best girl'
@@ -129,8 +129,7 @@ describe('Notification.vue', () => {
     })
 
     test('should not be able to render invalid type icon', () => {
-      // TODO: Uncomment after runtime validation is added
-      // vi.spyOn(console, 'warn').mockImplementation(() => vi.fn)
+      vi.spyOn(console, 'warn').mockImplementation(() => vi.fn)
       const type = 'some-type'
       const wrapper = _mount({
         props: {
@@ -142,7 +141,7 @@ describe('Notification.vue', () => {
       expect(wrapper.find('.el-notification__icon').exists()).toBe(false)
       // TODO: Uncomment after runtime validation is added
       // expect(console.warn).toHaveBeenCalled()
-      // ;(console.warn as any as MockInstance).mockRestore()
+      ;(console.warn as any as MockInstance).mockRestore()
     })
   })
 

--- a/packages/components/notification/src/notification.ts
+++ b/packages/components/notification/src/notification.ts
@@ -1,12 +1,7 @@
 import { Close } from '@element-plus/icons-vue'
 import { buildProps, definePropType, iconPropType } from '@element-plus/utils'
 
-import type {
-  AppContext,
-  ExtractPropTypes,
-  ExtractPublicPropTypes,
-  VNode,
-} from 'vue'
+import type { AppContext, Component, ExtractPublicPropTypes, VNode } from 'vue'
 import type Notification from './notification.vue'
 
 export const notificationTypes = [
@@ -17,6 +12,80 @@ export const notificationTypes = [
   'error',
 ] as const
 
+export type NotificationType = (typeof notificationTypes)[number] | ''
+
+export type NotificationPosition =
+  | 'top-right'
+  | 'top-left'
+  | 'bottom-right'
+  | 'bottom-left'
+
+export interface NotificationProps {
+  /**
+   * @description custom class name for Notification
+   */
+  customClass?: string
+  /**
+   * @description whether `message` is treated as HTML string
+   */
+  dangerouslyUseHTMLString?: boolean
+  /**
+   * @description duration before close. It will not automatically close if set 0
+   */
+  duration?: number
+  /**
+   * @description custom icon component. It will be overridden by `type`
+   */
+  icon?: string | Component
+  /**
+   * @description notification dom id
+   */
+  id?: string
+  /**
+   * @description description text
+   */
+  message?: string | VNode | (() => VNode)
+  /**
+   * @description offset from the top edge of the screen. Every Notification instance of the same moment should have the same offset
+   */
+  offset?: number
+  /**
+   * @description callback function when notification clicked
+   */
+  onClick?: () => void
+  /**
+   * @description callback function when closed
+   */
+  onClose: () => void
+  /**
+   * @description custom position
+   */
+  position?: NotificationPosition
+  /**
+   * @description whether to show a close button
+   */
+  showClose?: boolean
+  /**
+   * @description title
+   */
+  title?: string
+  /**
+   * @description notification type
+   */
+  type?: NotificationType
+  /**
+   * @description initial zIndex
+   */
+  zIndex?: number
+  /**
+   * @description custom close icon, default is Close
+   */
+  closeIcon?: string | Component
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `NotificationProps` instead.
+ */
 export const notificationProps = buildProps({
   /**
    * @description custom class name for Notification
@@ -123,7 +192,10 @@ export const notificationProps = buildProps({
     default: Close,
   },
 } as const)
-export type NotificationProps = ExtractPropTypes<typeof notificationProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `NotificationProps` instead.
+ */
 export type NotificationPropsPublic = ExtractPublicPropTypes<
   typeof notificationProps
 >

--- a/packages/components/notification/src/notification.vue
+++ b/packages/components/notification/src/notification.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, markRaw, onMounted, ref } from 'vue'
 import { useEventListener, useTimeoutFn } from '@vueuse/core'
 import { TypeComponentsMap, getEventCode } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
@@ -66,7 +66,7 @@ const props = withDefaults(defineProps<NotificationProps>(), {
   showClose: true,
   title: '',
   type: '',
-  closeIcon: Close,
+  closeIcon: markRaw(Close),
 })
 defineEmits(notificationEmits)
 

--- a/packages/components/notification/src/notification.vue
+++ b/packages/components/notification/src/notification.vue
@@ -45,15 +45,29 @@ import { TypeComponentsMap, getEventCode } from '@element-plus/utils'
 import { EVENT_CODE } from '@element-plus/constants'
 import { ElIcon } from '@element-plus/components/icon'
 import { useGlobalComponentSettings } from '@element-plus/components/config-provider'
-import { notificationEmits, notificationProps } from './notification'
+import { notificationEmits } from './notification'
+import { Close } from '@element-plus/icons-vue'
 
 import type { CSSProperties } from 'vue'
+import type { NotificationProps } from './notification'
 
 defineOptions({
   name: 'ElNotification',
 })
 
-const props = defineProps(notificationProps)
+const props = withDefaults(defineProps<NotificationProps>(), {
+  customClass: '',
+  duration: 4500,
+  id: '',
+  message: '',
+  offset: 0,
+  onClick: () => undefined,
+  position: 'top-right',
+  showClose: true,
+  title: '',
+  type: '',
+  closeIcon: Close,
+})
 defineEmits(notificationEmits)
 
 const { ns, zIndex } = useGlobalComponentSettings('notification')

--- a/packages/components/notification/src/notify.ts
+++ b/packages/components/notification/src/notify.ts
@@ -12,7 +12,7 @@ import { notificationTypes } from './notification'
 
 import type { Ref, VNode } from 'vue'
 import type {
-  NotificationOptions,
+  NotificationPosition,
   NotificationProps,
   NotificationQueue,
   Notify,
@@ -20,10 +20,7 @@ import type {
 } from './notification'
 
 // This should be a queue but considering there were `non-autoclosable` notifications.
-const notifications: Record<
-  NotificationOptions['position'],
-  NotificationQueue
-> = {
+const notifications: Record<NotificationPosition, NotificationQueue> = {
   'top-left': [],
   'top-right': [],
   'bottom-left': [],
@@ -129,7 +126,7 @@ notificationTypes.forEach((type) => {
  */
 export function close(
   id: string,
-  position: NotificationOptions['position'],
+  position: NotificationPosition,
   userOnClose?: (vm: VNode) => void
 ): void {
   // maybe we can store the index when inserting the vm to notification list.
@@ -170,9 +167,7 @@ export function closeAll(): void {
   }
 }
 
-export function updateOffsets(
-  position: NotificationOptions['position'] = 'top-right'
-) {
+export function updateOffsets(position: NotificationPosition = 'top-right') {
   let verticalOffset =
     notifications[position][0]?.vm.component?.props?.offset || 0
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
ref  #23399

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clearer, explicit typing and a unified prop surface for notifications.
  * Added explicit notification types and four corner positions (now including bottom-right).
  * Default values declared for all props and a refined default close icon for better dismissal UX.
  * Positioning/offset handling updated to support all corner positions.
  * Legacy prop alias marked as deprecated to guide migration.

* **Tests**
  * Simplified tests: removed assertion of console warning for invalid icon types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->