### PR TITLE
refactor(components): [menu-item] use type-based definitions

### DIFF
--- a/packages/components/menu/src/menu-item-group.ts
+++ b/packages/components/menu/src/menu-item-group.ts
@@ -1,12 +1,25 @@
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 
+export interface MenuItemGroupProps {
+  /**
+   * @description group title
+   */
+  title?: string
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `MenuItemGroupProps` instead.
+ */
 export const menuItemGroupProps = {
   /**
    * @description group title
    */
   title: String,
 } as const
-export type MenuItemGroupProps = ExtractPropTypes<typeof menuItemGroupProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `MenuItemGroupProps` instead.
+ */
 export type MenuItemGroupPropsPublic = ExtractPublicPropTypes<
   typeof menuItemGroupProps
 >

--- a/packages/components/menu/src/menu-item-group.vue
+++ b/packages/components/menu/src/menu-item-group.vue
@@ -12,11 +12,13 @@
 
 <script lang="ts" setup>
 import { useNamespace } from '@element-plus/hooks'
-import { menuItemGroupProps } from './menu-item-group'
+
+import type { MenuItemGroupProps } from './menu-item-group'
 
 defineOptions({
   name: 'ElMenuItemGroup',
 })
-defineProps(menuItemGroupProps)
+defineProps<MenuItemGroupProps>()
+
 const ns = useNamespace('menu-item-group')
 </script>

--- a/packages/components/menu/src/menu-item.ts
+++ b/packages/components/menu/src/menu-item.ts
@@ -12,6 +12,8 @@ import type { MenuItemRegistered } from './types'
 export interface MenuItemProps {
   /**
    * @description unique identification
+   * - will be required in the next major version
+   * - required: true
    */
   index?: string | null
   /**

--- a/packages/components/menu/src/menu-item.ts
+++ b/packages/components/menu/src/menu-item.ts
@@ -5,10 +5,28 @@ import {
   isString,
 } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
 import type { MenuItemRegistered } from './types'
 
+export interface MenuItemProps {
+  /**
+   * @description unique identification
+   */
+  index?: string | null
+  /**
+   * @description Vue Router object
+   */
+  route?: RouteLocationRaw
+  /**
+   * @description whether disabled
+   */
+  disabled?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `MenuItemProps` instead.
+ */
 export const menuItemProps = buildProps({
   /**
    * @description unique identification
@@ -30,7 +48,10 @@ export const menuItemProps = buildProps({
    */
   disabled: Boolean,
 } as const)
-export type MenuItemProps = ExtractPropTypes<typeof menuItemProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `MenuItemProps` instead.
+ */
 export type MenuItemPropsPublic = ExtractPublicPropTypes<typeof menuItemProps>
 
 export const menuItemEmits = {

--- a/packages/components/menu/src/menu-item.vue
+++ b/packages/components/menu/src/menu-item.vue
@@ -52,16 +52,19 @@ import ElTooltip from '@element-plus/components/tooltip'
 import { debugWarn, isPropAbsent, throwError } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import useMenu from './use-menu'
-import { menuItemEmits, menuItemProps } from './menu-item'
+import { menuItemEmits } from './menu-item'
 import { MENU_INJECTION_KEY, SUB_MENU_INJECTION_KEY } from './tokens'
 
+import type { MenuItemProps } from './menu-item'
 import type { MenuItemRegistered, MenuProvider, SubMenuProvider } from './types'
 
 const COMPONENT_NAME = 'ElMenuItem'
 defineOptions({
   name: COMPONENT_NAME,
 })
-const props = defineProps(menuItemProps)
+const props = withDefaults(defineProps<MenuItemProps>(), {
+  index: null,
+})
 const emit = defineEmits(menuItemEmits)
 
 isPropAbsent(props.index) &&


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
ref #23399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Menu and Menu Item Group components now use explicit TypeScript interfaces for props; typing is compile-time only.
  * Deprecated older public type aliases—migrate to the new MenuItemProps and MenuItemGroupProps interfaces.
  * Component behavior and public APIs remain unchanged for end users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->