### PR TITLE
refactor(components): [popper] use type-based definitions

### DIFF
--- a/packages/components/popper/src/arrow.ts
+++ b/packages/components/popper/src/arrow.ts
@@ -1,18 +1,34 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 import type Arrow from './arrow.vue'
 
+export interface PopperArrowProps {
+  /**
+   * @description arrow offset
+   */
+  arrowOffset?: number
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `PopperArrowProps` instead.
+ */
 export const popperArrowProps = buildProps({
   arrowOffset: {
     type: Number,
     default: 5,
   },
 } as const)
-export type PopperArrowProps = ExtractPropTypes<typeof popperArrowProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `PopperArrowProps` instead.
+ */
 export type PopperArrowPropsPublic = ExtractPublicPropTypes<
   typeof popperArrowProps
 >
+
+export const popperArrowPropsDefaults = {
+  arrowOffset: 5,
+} as const
 
 export type PopperArrowInstance = InstanceType<typeof Arrow> & unknown
 

--- a/packages/components/popper/src/composables/use-content-dom.ts
+++ b/packages/components/popper/src/composables/use-content-dom.ts
@@ -26,7 +26,7 @@ export const usePopperContentDOM = (
   const contentClass = computed(() => [
     ns.b(),
     ns.is('pure', props.pure),
-    ns.is(props.effect),
+    ns.is(props.effect!),
     props.popperClass,
   ])
   const contentStyle = computed<StyleValue[]>(() => {

--- a/packages/components/popper/src/content.ts
+++ b/packages/components/popper/src/content.ts
@@ -187,6 +187,8 @@ export const popperContentPropsDefaults = {
   trapping: false,
   virtualTriggering: false,
   loop: false,
+  style: undefined,
+  popperStyle: undefined,
 } as const
 
 export const popperContentEmits = {

--- a/packages/components/popper/src/content.ts
+++ b/packages/components/popper/src/content.ts
@@ -1,13 +1,14 @@
 import { placements } from '@popperjs/core'
 import { buildProps, definePropType } from '@element-plus/utils'
 import { useAriaProps } from '@element-plus/hooks'
-import { popperArrowProps } from './arrow'
+import { popperArrowProps, popperArrowPropsDefaults } from './arrow'
 
 import type { PopperEffect } from './popper'
-import type { ExtractPropTypes, ExtractPublicPropTypes, StyleValue } from 'vue'
+import type { ExtractPublicPropTypes, StyleValue } from 'vue'
 import type { Options, Placement } from '@popperjs/core'
 import type { Measurable } from './constants'
 import type Content from './content.vue'
+import type { PopperArrowProps } from './arrow'
 
 type ClassObjectType = Record<string, boolean>
 type ClassType = string | ClassObjectType | ClassType[]
@@ -20,6 +21,28 @@ export interface CreatePopperInstanceParams {
   arrowEl: HTMLElement | undefined
 }
 
+export interface PopperCoreConfigProps {
+  boundariesPadding?: number
+  fallbackPlacements?: Placement[]
+  gpuAcceleration?: boolean
+  /**
+   * @description offset of the Tooltip
+   */
+  offset?: number
+  /**
+   * @description position of Tooltip
+   */
+  placement?: Placement
+  /**
+   * @description [popper.js](https://popper.js.org/docs/v2/) parameters
+   */
+  popperOptions?: Partial<Options>
+  strategy?: (typeof POSITIONING_STRATEGIES)[number]
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `PopperCoreConfigProps` instead.
+ */
 export const popperCoreConfigProps = buildProps({
   boundariesPadding: {
     type: Number,
@@ -61,13 +84,38 @@ export const popperCoreConfigProps = buildProps({
     default: 'absolute',
   },
 } as const)
-export type PopperCoreConfigProps = ExtractPropTypes<
-  typeof popperCoreConfigProps
->
+/**
+ * @deprecated Removed after 3.0.0, Use `PopperCoreConfigProps` instead.
+ */
 export type PopperCoreConfigPropsPublic = ExtractPublicPropTypes<
   typeof popperCoreConfigProps
 >
 
+export interface PopperContentProps
+  extends PopperCoreConfigProps, PopperArrowProps {
+  id?: string
+  style?: StyleValue
+  className?: ClassType
+  effect?: PopperEffect
+  visible?: boolean
+  enterable?: boolean
+  pure?: boolean
+  focusOnShow?: boolean
+  trapping?: boolean
+  popperClass?: ClassType
+  popperStyle?: StyleValue
+  referenceEl?: HTMLElement
+  triggerTargetEl?: HTMLElement
+  stopPopperMouseEvent?: boolean
+  virtualTriggering?: boolean
+  zIndex?: number
+  ariaLabel?: string
+  loop?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `PopperContentProps` instead.
+ */
 export const popperContentProps = buildProps({
   ...popperCoreConfigProps,
   ...popperArrowProps,
@@ -111,10 +159,35 @@ export const popperContentProps = buildProps({
   ...useAriaProps(['ariaLabel']),
   loop: Boolean,
 } as const)
-export type PopperContentProps = ExtractPropTypes<typeof popperContentProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `PopperContentProps` instead.
+ */
 export type PopperContentPropsPublic = ExtractPublicPropTypes<
   typeof popperContentProps
 >
+
+export const popperCoreConfigPropsDefaults = {
+  boundariesPadding: 0,
+  gpuAcceleration: true,
+  offset: 12,
+  placement: 'bottom',
+  popperOptions: () => ({}),
+  strategy: 'absolute',
+} as const
+
+export const popperContentPropsDefaults = {
+  ...popperCoreConfigPropsDefaults,
+  ...popperArrowPropsDefaults,
+  effect: 'dark',
+  enterable: true,
+  stopPopperMouseEvent: true,
+  visible: false,
+  pure: false,
+  focusOnShow: false,
+  trapping: false,
+  virtualTriggering: false,
+  loop: false,
+} as const
 
 export const popperContentEmits = {
   mouseenter: (evt: MouseEvent) => evt instanceof MouseEvent,

--- a/packages/components/popper/src/content.vue
+++ b/packages/components/popper/src/content.vue
@@ -32,7 +32,7 @@ import { NOOP, isElement } from '@element-plus/utils'
 import ElFocusTrap from '@element-plus/components/focus-trap'
 import { formItemContextKey } from '@element-plus/components/form'
 import { POPPER_CONTENT_INJECTION_KEY } from './constants'
-import { popperContentEmits, popperContentProps } from './content'
+import { popperContentEmits, popperContentPropsDefaults } from './content'
 import {
   usePopperContent,
   usePopperContentDOM,
@@ -40,6 +40,7 @@ import {
 } from './composables'
 
 import type { WatchStopHandle } from 'vue'
+import type { PopperContentProps } from './content'
 
 defineOptions({
   name: 'ElPopperContent',
@@ -47,7 +48,10 @@ defineOptions({
 
 const emit = defineEmits(popperContentEmits)
 
-const props = defineProps(popperContentProps)
+const props = withDefaults(
+  defineProps<PopperContentProps>(),
+  popperContentPropsDefaults
+)
 
 const {
   focusStartRef,

--- a/packages/components/popper/src/popper.ts
+++ b/packages/components/popper/src/popper.ts
@@ -2,7 +2,7 @@
 
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 import type Popper from './popper.vue'
 
 const effects = ['light', 'dark'] as const
@@ -29,6 +29,16 @@ export type PopperEffect =
   | (string & NonNullable<unknown>)
 export type PopperTrigger = (typeof triggers)[number]
 
+export interface PopperProps {
+  /**
+   * @description role determines how aria attributes are distributed
+   */
+  role?: (typeof roleTypes)[number]
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `PopperProps` instead.
+ */
 export const popperProps = buildProps({
   role: {
     type: String,
@@ -37,7 +47,9 @@ export const popperProps = buildProps({
   },
 } as const)
 
-export type PopperProps = ExtractPropTypes<typeof popperProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `PopperProps` instead.
+ */
 export type PopperPropsPublic = ExtractPublicPropTypes<typeof popperProps>
 
 export type PopperInstance = InstanceType<typeof Popper> & unknown

--- a/packages/components/popper/src/popper.vue
+++ b/packages/components/popper/src/popper.vue
@@ -5,16 +5,18 @@
 <script lang="ts" setup>
 import { computed, provide, ref } from 'vue'
 import { POPPER_INJECTION_KEY } from './constants'
-import { popperProps } from './popper'
 
 import type { Instance as PopperInstance } from '@popperjs/core'
 import type { ElPopperInjectionContext } from './constants'
+import type { PopperProps } from './popper'
 
 defineOptions({
   name: 'ElPopper',
   inheritAttrs: false,
 })
-const props = defineProps(popperProps)
+const props = withDefaults(defineProps<PopperProps>(), {
+  role: 'tooltip',
+})
 
 const triggerRef = ref<HTMLElement>()
 const popperInstanceRef = ref<PopperInstance>()

--- a/packages/components/popper/src/trigger.ts
+++ b/packages/components/popper/src/trigger.ts
@@ -3,6 +3,25 @@ import { buildProps, definePropType } from '@element-plus/utils'
 import type { Measurable } from './constants'
 import type Trigger from './trigger.vue'
 
+export interface PopperTriggerProps {
+  /** @description Indicates the reference element to which the popper is attached */
+  virtualRef?: Measurable
+  /** @description Indicates whether virtual triggering is enabled */
+  virtualTriggering?: boolean
+  onMouseenter?: (e: MouseEvent) => void
+  onMouseleave?: (e: MouseEvent) => void
+  onClick?: (e: PointerEvent) => void
+  onKeydown?: (e: KeyboardEvent) => void
+  onFocus?: (e: FocusEvent) => void
+  onBlur?: (e: FocusEvent) => void
+  onContextmenu?: (e: PointerEvent) => void
+  id?: string
+  open?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `PopperTriggerProps` instead.
+ */
 export const popperTriggerProps = buildProps({
   /** @description Indicates the reference element to which the popper is attached */
   virtualRef: {
@@ -34,8 +53,6 @@ export const popperTriggerProps = buildProps({
   id: String,
   open: Boolean,
 } as const)
-
-export type PopperTriggerProps = typeof popperTriggerProps
 
 export type PopperTriggerInstance = InstanceType<typeof Trigger> & unknown
 

--- a/packages/components/popper/src/trigger.vue
+++ b/packages/components/popper/src/trigger.vue
@@ -19,16 +19,16 @@ import { ElOnlyChild } from '@element-plus/components/slot'
 import { useForwardRef } from '@element-plus/hooks'
 import { isElement, isFocusable } from '@element-plus/utils'
 import { POPPER_INJECTION_KEY } from './constants'
-import { popperTriggerProps } from './trigger'
 
 import type { WatchStopHandle } from 'vue'
+import type { PopperTriggerProps } from './trigger'
 
 defineOptions({
   name: 'ElPopperTrigger',
   inheritAttrs: false,
 })
 
-const props = defineProps(popperTriggerProps)
+const props = withDefaults(defineProps<PopperTriggerProps>(), {})
 
 const { role, triggerRef } = inject(POPPER_INJECTION_KEY, undefined)!
 

--- a/packages/components/popper/src/utils.ts
+++ b/packages/components/popper/src/utils.ts
@@ -68,7 +68,7 @@ function genModifiers(options: PopperCoreConfigProps) {
 
 function deriveExtraModifiers(
   options: any,
-  modifiers: PopperCoreConfigProps['popperOptions']['modifiers']
+  modifiers: NonNullable<PopperCoreConfigProps['popperOptions']>['modifiers']
 ) {
   if (modifiers) {
     options.modifiers = [...options.modifiers, ...(modifiers ?? [])]


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

ref #23399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked Popper component props and defaults into explicit typed interfaces, simplifying prop typing and runtime defaults across Popper, Content, Trigger and Arrow.
  * Components now apply explicit default values (e.g., role/defaults for popper content/arrow offset) via typed defaults rather than inline prop descriptors, improving consistency.

* **Chores**
  * Removed legacy prop extraction usage and cleaned up type exports and imports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->