### PR TITLE
refactor(components): [statistic] use type-based definitions

### DIFF
--- a/packages/components/statistic/src/statistic.ts
+++ b/packages/components/statistic/src/statistic.ts
@@ -20,7 +20,7 @@ export interface StatisticProps {
   /**
    * @description Custom numerical presentation
    */
-  formatter?: (...args: any[]) => void
+  formatter?: (...args: any[]) => string | number
   /**
    * @description Numerical content
    */

--- a/packages/components/statistic/src/statistic.ts
+++ b/packages/components/statistic/src/statistic.ts
@@ -4,6 +4,10 @@ import type { ExtractPublicPropTypes, StyleValue } from 'vue'
 import type { Dayjs } from 'dayjs'
 import type Statistic from './statistic.vue'
 
+export type StatisticFormatter = {
+  formatter(value: number | Dayjs): string
+}['formatter']
+
 export interface StatisticProps {
   /**
    * @description Setting the decimal point
@@ -20,7 +24,7 @@ export interface StatisticProps {
   /**
    * @description Custom numerical presentation
    */
-  formatter?: (value: number | Dayjs) => string
+  formatter?: StatisticFormatter
   /**
    * @description Numerical content
    */

--- a/packages/components/statistic/src/statistic.ts
+++ b/packages/components/statistic/src/statistic.ts
@@ -4,10 +4,6 @@ import type { ExtractPublicPropTypes, StyleValue } from 'vue'
 import type { Dayjs } from 'dayjs'
 import type Statistic from './statistic.vue'
 
-export type StatisticFormatter = {
-  formatter(value: number | Dayjs): string
-}['formatter']
-
 export interface StatisticProps {
   /**
    * @description Setting the decimal point
@@ -24,7 +20,7 @@ export interface StatisticProps {
   /**
    * @description Custom numerical presentation
    */
-  formatter?: StatisticFormatter
+  formatter?: (...args: any[]) => void
   /**
    * @description Numerical content
    */

--- a/packages/components/statistic/src/statistic.ts
+++ b/packages/components/statistic/src/statistic.ts
@@ -1,9 +1,51 @@
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes, StyleValue } from 'vue'
+import type { ExtractPublicPropTypes, StyleValue } from 'vue'
 import type { Dayjs } from 'dayjs'
 import type Statistic from './statistic.vue'
 
+export interface StatisticProps {
+  /**
+   * @description Setting the decimal point
+   */
+  decimalSeparator?: string
+  /**
+   * @description Sets the thousandth identifier
+   */
+  groupSeparator?: string
+  /**
+   * @description numerical precision
+   */
+  precision?: number
+  /**
+   * @description Custom numerical presentation
+   */
+  formatter?: (value: number | Dayjs) => string
+  /**
+   * @description Numerical content
+   */
+  value?: number | Dayjs
+  /**
+   * @description Sets the prefix of a number
+   */
+  prefix?: string
+  /**
+   * @description  Sets the suffix of a number
+   */
+  suffix?: string
+  /**
+   * @description Numeric titles
+   */
+  title?: string
+  /**
+   * @description Styles numeric values
+   */
+  valueStyle?: StyleValue
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `StatisticProps` instead.
+ */
 export const statisticProps = buildProps({
   /**
    * @description Setting the decimal point
@@ -57,7 +99,10 @@ export const statisticProps = buildProps({
     type: definePropType<StyleValue>([String, Object, Array]),
   },
 } as const)
-export type StatisticProps = ExtractPropTypes<typeof statisticProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `StatisticProps` instead.
+ */
 export type StatisticPropsPublic = ExtractPublicPropTypes<typeof statisticProps>
 
 export type StatisticInstance = InstanceType<typeof Statistic> & unknown

--- a/packages/components/statistic/src/statistic.vue
+++ b/packages/components/statistic/src/statistic.vue
@@ -27,13 +27,20 @@
 import { computed } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { isFunction, isNumber } from '@element-plus/utils'
-import { statisticProps } from './statistic'
+
+import type { StatisticProps } from './statistic'
 
 defineOptions({
   name: 'ElStatistic',
 })
 
-const props = defineProps(statisticProps)
+const props = withDefaults(defineProps<StatisticProps>(), {
+  decimalSeparator: '.',
+  groupSeparator: ',',
+  precision: 0,
+  value: 0,
+  valueStyle: undefined,
+})
 const ns = useNamespace('statistic')
 
 const displayValue = computed(() => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

ref #23399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Clarified public typings for the Statistic component and introduced a new public props alias (old alias deprecated).
  * Switched the component to typed prop declarations with explicit default values for decimal/group separators, precision, value, and value style to standardize behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->