### PR TITLE
refactor(components): [popconfirm] use type-based definitions

### DIFF
--- a/packages/components/popconfirm/src/popconfirm.ts
+++ b/packages/components/popconfirm/src/popconfirm.ts
@@ -8,7 +8,10 @@ import {
 
 import type { Component, ExtractPublicPropTypes } from 'vue'
 import type { ButtonType } from '@element-plus/components/button'
-import type { Measurable } from '@element-plus/components/popper'
+import type {
+  ElTooltipContentProps,
+  ElTooltipTriggerProps,
+} from '@element-plus/components/tooltip'
 import type Popconfirm from './popconfirm.vue'
 
 export interface PopconfirmProps {
@@ -51,15 +54,15 @@ export interface PopconfirmProps {
   /**
    * @description Tooltip theme, built-in theme: `dark` / `light`
    */
-  effect?: 'light' | 'dark'
+  effect?: ElTooltipContentProps['effect']
   /**
    * @description whether popconfirm is teleported to the body
    */
-  teleported?: boolean
+  teleported?: ElTooltipContentProps['teleported']
   /**
    * @description when popconfirm inactive and `persistent` is `false` , popconfirm will be destroyed
    */
-  persistent?: boolean
+  persistent?: ElTooltipContentProps['persistent']
   /**
    * @description popconfirm width, min width 150px
    */
@@ -67,11 +70,11 @@ export interface PopconfirmProps {
   /**
    * @description Indicates whether virtual triggering is enabled
    */
-  virtualTriggering?: boolean
+  virtualTriggering?: ElTooltipTriggerProps['virtualTriggering']
   /**
    * @description Indicates the reference element to which the popper is attached
    */
-  virtualRef?: Measurable
+  virtualRef?: ElTooltipTriggerProps['virtualRef']
 }
 
 /**

--- a/packages/components/popconfirm/src/popconfirm.ts
+++ b/packages/components/popconfirm/src/popconfirm.ts
@@ -7,10 +7,9 @@ import {
 } from '@element-plus/components/tooltip'
 
 import type { Component, ExtractPublicPropTypes } from 'vue'
+import type { ButtonType } from '@element-plus/components/button'
 import type { Measurable } from '@element-plus/components/popper'
 import type Popconfirm from './popconfirm.vue'
-
-export type ButtonType = (typeof buttonTypes)[number]
 
 export interface PopconfirmProps {
   /**

--- a/packages/components/popconfirm/src/popconfirm.ts
+++ b/packages/components/popconfirm/src/popconfirm.ts
@@ -6,9 +6,78 @@ import {
   useTooltipTriggerProps,
 } from '@element-plus/components/tooltip'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { Component, ExtractPublicPropTypes } from 'vue'
+import type { Measurable } from '@element-plus/components/popper'
 import type Popconfirm from './popconfirm.vue'
 
+export type ButtonType = (typeof buttonTypes)[number]
+
+export interface PopconfirmProps {
+  /**
+   * @description Title
+   */
+  title?: string
+  /**
+   * @description Confirm button text
+   */
+  confirmButtonText?: string
+  /**
+   * @description Cancel button text
+   */
+  cancelButtonText?: string
+  /**
+   * @description Confirm button type
+   */
+  confirmButtonType?: ButtonType
+  /**
+   * @description Cancel button type
+   */
+  cancelButtonType?: ButtonType
+  /**
+   * @description Icon Component
+   */
+  icon?: string | Component
+  /**
+   * @description Icon color
+   */
+  iconColor?: string
+  /**
+   * @description is hide Icon
+   */
+  hideIcon?: boolean
+  /**
+   * @description delay of disappear, in millisecond
+   */
+  hideAfter?: number
+  /**
+   * @description Tooltip theme, built-in theme: `dark` / `light`
+   */
+  effect?: 'light' | 'dark'
+  /**
+   * @description whether popconfirm is teleported to the body
+   */
+  teleported?: boolean
+  /**
+   * @description when popconfirm inactive and `persistent` is `false` , popconfirm will be destroyed
+   */
+  persistent?: boolean
+  /**
+   * @description popconfirm width, min width 150px
+   */
+  width?: string | number
+  /**
+   * @description Indicates whether virtual triggering is enabled
+   */
+  virtualTriggering?: boolean
+  /**
+   * @description Indicates the reference element to which the popper is attached
+   */
+  virtualRef?: Measurable
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `PopconfirmProps` instead.
+ */
 export const popconfirmProps = buildProps({
   /**
    * @description Title
@@ -102,7 +171,9 @@ export const popconfirmEmits = {
 
 export type PopconfirmEmits = typeof popconfirmEmits
 
-export type PopconfirmProps = ExtractPropTypes<typeof popconfirmProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `PopconfirmProps` instead.
+ */
 export type PopconfirmPropsPublic = ExtractPublicPropTypes<
   typeof popconfirmProps
 >

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, markRaw, ref, unref } from 'vue'
+import { computed, ref, unref } from 'vue'
 import ElButton from '@element-plus/components/button'
 import ElIcon from '@element-plus/components/icon'
 import ElTooltip from '@element-plus/components/tooltip'
@@ -75,7 +75,7 @@ defineOptions({
 const props = withDefaults(defineProps<PopconfirmProps>(), {
   confirmButtonType: 'primary',
   cancelButtonType: 'text',
-  icon: markRaw(QuestionFilled),
+  icon: () => QuestionFilled,
   iconColor: '#f90',
   hideAfter: 200,
   effect: 'light',

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -62,15 +62,25 @@ import ElIcon from '@element-plus/components/icon'
 import ElTooltip from '@element-plus/components/tooltip'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { addUnit } from '@element-plus/utils'
-import { popconfirmEmits, popconfirmProps } from './popconfirm'
+import { QuestionFilled } from '@element-plus/icons-vue'
+import { popconfirmEmits } from './popconfirm'
 
 import type { TooltipInstance } from '@element-plus/components/tooltip'
+import type { PopconfirmProps } from './popconfirm'
 
 defineOptions({
   name: 'ElPopconfirm',
 })
 
-const props = defineProps(popconfirmProps)
+const props = withDefaults(defineProps<PopconfirmProps>(), {
+  confirmButtonType: 'primary',
+  cancelButtonType: 'text',
+  icon: () => QuestionFilled,
+  iconColor: '#f90',
+  hideAfter: 200,
+  effect: 'light',
+  width: 150,
+})
 const emit = defineEmits(popconfirmEmits)
 
 const { t } = useLocale()

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, unref, markRaw } from 'vue'
+import { computed, markRaw, ref, unref } from 'vue'
 import ElButton from '@element-plus/components/button'
 import ElIcon from '@element-plus/components/icon'
 import ElTooltip from '@element-plus/components/tooltip'

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -79,6 +79,7 @@ const props = withDefaults(defineProps<PopconfirmProps>(), {
   iconColor: '#f90',
   hideAfter: 200,
   effect: 'light',
+  teleported: true,
   width: 150,
 })
 const emit = defineEmits(popconfirmEmits)

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, unref } from 'vue'
+import { computed, ref, unref, markRaw } from 'vue'
 import ElButton from '@element-plus/components/button'
 import ElIcon from '@element-plus/components/icon'
 import ElTooltip from '@element-plus/components/tooltip'

--- a/packages/components/popconfirm/src/popconfirm.vue
+++ b/packages/components/popconfirm/src/popconfirm.vue
@@ -75,7 +75,7 @@ defineOptions({
 const props = withDefaults(defineProps<PopconfirmProps>(), {
   confirmButtonType: 'primary',
   cancelButtonType: 'text',
-  icon: () => QuestionFilled,
+  icon: markRaw(QuestionFilled),
   iconColor: '#f90',
   hideAfter: 200,
   effect: 'light',


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

ref  #23399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Popconfirm now exposes a formal public prop interface and uses explicit, strongly-typed props with defaults—standardizing button styles, default icon and color, auto-hide timing, visual effect, teleporting, and width for more consistent runtime behavior.
* **Chores**
  * Clarified public-facing prop typings and added deprecation guidance for legacy type aliases to ease migration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->