### PR TITLE
refactor(components): [tree-v2] use type-based definitions

### DIFF
--- a/packages/components/tree-v2/src/composables/useCheck.ts
+++ b/packages/components/tree-v2/src/composables/useCheck.ts
@@ -18,7 +18,7 @@ export function useCheck(props: TreeProps, tree: Ref<Tree | undefined>) {
     [() => tree.value, () => props.defaultCheckedKeys],
     () => {
       return nextTick(() => {
-        _setCheckedKeys(props.defaultCheckedKeys)
+        _setCheckedKeys(props.defaultCheckedKeys!)
       })
     },
     {

--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -322,7 +322,7 @@ export function useTree(
   )
 
   watch(
-    () => props.data,
+    () => props.data!,
     (data: TreeData) => {
       setData(data)
     },

--- a/packages/components/tree-v2/src/tree-node.vue
+++ b/packages/components/tree-v2/src/tree-node.vue
@@ -87,7 +87,7 @@ const indent = computed(() => tree?.props.indent ?? 16)
 const icon = computed(() => tree?.props.icon ?? CaretRight)
 
 const getNodeClass = (node: TreeNode) => {
-  const nodeClassFunc = tree?.props.props.class
+  const nodeClassFunc = tree?.props.props!.class
   if (!nodeClassFunc) return {}
 
   let className

--- a/packages/components/tree-v2/src/tree-node.vue
+++ b/packages/components/tree-v2/src/tree-node.vue
@@ -61,23 +61,26 @@ import ElIcon from '@element-plus/components/icon'
 import { CaretRight } from '@element-plus/icons-vue'
 import ElCheckbox from '@element-plus/components/checkbox'
 import { useNamespace } from '@element-plus/hooks'
-import { isFunction, isString } from '@element-plus/utils'
+import { isFunction, isString, mutable } from '@element-plus/utils'
 import ElNodeContent from './tree-node-content'
 import {
+  EMPTY_NODE,
   NODE_CONTEXTMENU,
   ROOT_TREE_INJECTION_KEY,
   treeNodeEmits,
-  treeNodeProps,
 } from './virtual-tree'
 
+import type { TreeNode, TreeNodeProps } from './types'
 import type { CheckboxValueType } from '@element-plus/components/checkbox'
-import type { TreeNode } from './types'
 
 defineOptions({
   name: 'ElTreeNode',
 })
 
-const props = defineProps(treeNodeProps)
+const props = withDefaults(defineProps<TreeNodeProps>(), {
+  node: () => mutable(EMPTY_NODE),
+  itemSize: 26,
+})
 const emit = defineEmits(treeNodeEmits)
 
 const tree = inject(ROOT_TREE_INJECTION_KEY)
@@ -87,7 +90,7 @@ const indent = computed(() => tree?.props.indent ?? 16)
 const icon = computed(() => tree?.props.icon ?? CaretRight)
 
 const getNodeClass = (node: TreeNode) => {
-  const nodeClassFunc = tree?.props.props!.class
+  const nodeClassFunc = tree?.props.props?.class
   if (!nodeClassFunc) return {}
 
   let className

--- a/packages/components/tree-v2/src/tree.vue
+++ b/packages/components/tree-v2/src/tree.vue
@@ -51,13 +51,38 @@ import { formItemContextKey } from '@element-plus/components/form'
 import { FixedSizeList } from '@element-plus/components/virtual-list'
 import { useTree } from './composables/useTree'
 import ElTreeNode from './tree-node.vue'
-import { ROOT_TREE_INJECTION_KEY, treeEmits, treeProps } from './virtual-tree'
+import {
+  ROOT_TREE_INJECTION_KEY,
+  TreeOptionsEnum,
+  treeEmits,
+} from './virtual-tree'
+import { mutable } from '@element-plus/utils'
+
+import type { TreeProps } from './types'
 
 defineOptions({
   name: 'ElTreeV2',
 })
 
-const props = defineProps(treeProps)
+const props = withDefaults(defineProps<TreeProps>(), {
+  data: () => mutable([]),
+  height: 200,
+  props: () =>
+    mutable({
+      children: TreeOptionsEnum.CHILDREN,
+      label: TreeOptionsEnum.LABEL,
+      disabled: TreeOptionsEnum.DISABLED,
+      value: TreeOptionsEnum.KEY,
+      class: TreeOptionsEnum.CLASS,
+    }),
+  defaultCheckedKeys: () => mutable([]),
+  defaultExpandedKeys: () => mutable([]),
+  indent: 16,
+  itemSize: 26,
+  expandOnClickNode: true,
+  checkOnClickLeaf: true,
+  perfMode: true,
+})
 const emit = defineEmits(treeEmits)
 
 const slots = useSlots()

--- a/packages/components/tree-v2/src/types.ts
+++ b/packages/components/tree-v2/src/types.ts
@@ -45,7 +45,6 @@ export interface TreeProps {
   checkOnClickNode?: boolean
   checkOnClickLeaf?: boolean
   currentNodeKey?: string | number
-  // TODO need to optimization
   accordion?: boolean
   filterMethod?: FilterMethod
   // Performance mode will increase memory usage, but scrolling will be smoother

--- a/packages/components/tree-v2/src/types.ts
+++ b/packages/components/tree-v2/src/types.ts
@@ -67,10 +67,6 @@ export interface TreeNodeProps {
   itemSize?: number
 }
 
-export interface TreeNodeContentProps {
-  node?: TreeNode
-}
-
 /**
  * @deprecated Removed after 3.0.0, Use `TreeProps` instead.
  */

--- a/packages/components/tree-v2/src/types.ts
+++ b/packages/components/tree-v2/src/types.ts
@@ -1,6 +1,7 @@
+import { IconPropType } from '@element-plus/utils'
+
 import type {
   ComponentInternalInstance,
-  ExtractPropTypes,
   ExtractPublicPropTypes,
   SetupContext,
 } from 'vue'
@@ -17,13 +18,63 @@ export interface TreeOptionProps {
   label?: string
   value?: string
   disabled?: string
-  class?: (
-    data: TreeNodeData,
-    node: TreeNode
-  ) => string | { [key: string]: boolean }
+  class?:
+    | ((
+        data: TreeNodeData,
+        node: TreeNode
+      ) => string | { [key: string]: boolean })
+    | string
 }
 
-export type TreeProps = ExtractPropTypes<typeof treeProps>
+export interface TreeProps {
+  data?: TreeData
+  emptyText?: string
+  height?: number
+  props?: TreeOptionProps
+  highlightCurrent?: boolean
+  showCheckbox?: boolean
+  defaultCheckedKeys?: TreeKey[]
+  // Whether checked state of a node not affects its father and
+  // child nodes when show-checkbox is true
+  checkStrictly?: boolean
+  defaultExpandedKeys?: TreeKey[]
+  indent?: number
+  itemSize?: number
+  icon?: IconPropType
+  expandOnClickNode?: boolean
+  checkOnClickNode?: boolean
+  checkOnClickLeaf?: boolean
+  currentNodeKey?: string | number
+  // TODO need to optimization
+  accordion?: boolean
+  filterMethod?: FilterMethod
+  // Performance mode will increase memory usage, but scrolling will be smoother
+  perfMode?: boolean
+  /**
+   * @description always show scrollbar
+   */
+  scrollbarAlwaysOn?: boolean
+}
+
+export interface TreeNodeProps {
+  node?: TreeNode
+  expanded?: boolean
+  checked?: boolean
+  indeterminate?: boolean
+  showCheckbox?: boolean
+  disabled?: boolean
+  current?: boolean
+  hiddenExpandIcon?: boolean
+  itemSize?: number
+}
+
+export interface TreeNodeContentProps {
+  node?: TreeNode
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `TreeProps` instead.
+ */
 export type TreePropsPublic = ExtractPublicPropTypes<typeof treeProps>
 
 export interface TreeNode {

--- a/packages/components/tree-v2/src/virtual-tree.ts
+++ b/packages/components/tree-v2/src/virtual-tree.ts
@@ -46,7 +46,9 @@ const itemSize = {
   default: 26,
 }
 
-// props
+/**
+ * @deprecated Removed after 3.0.0, Use `TreeProps` instead.
+ */
 export const treeProps = buildProps({
   data: {
     type: definePropType<TreeData>(Array),
@@ -119,6 +121,9 @@ export const treeProps = buildProps({
   scrollbarAlwaysOn: Boolean,
 } as const)
 
+/**
+ * @deprecated Removed after 3.0.0, Use `TreeNodeProps` instead.
+ */
 export const treeNodeProps = buildProps({
   node: {
     type: definePropType<TreeNode>(Object),
@@ -134,6 +139,9 @@ export const treeNodeProps = buildProps({
   itemSize,
 } as const)
 
+/**
+ * @deprecated Removed after 3.0.0, Use `TreeNodeContentProps` instead.
+ */
 export const treeNodeContentProps = buildProps({
   node: {
     type: definePropType<TreeNode>(Object),

--- a/packages/components/tree-v2/src/virtual-tree.ts
+++ b/packages/components/tree-v2/src/virtual-tree.ts
@@ -21,7 +21,7 @@ import type {
 
 // constants
 export const ROOT_TREE_INJECTION_KEY: InjectionKey<TreeContext> = Symbol()
-const EMPTY_NODE = {
+export const EMPTY_NODE = {
   key: -1,
   level: -1,
   data: {},

--- a/packages/components/tree-v2/src/virtual-tree.ts
+++ b/packages/components/tree-v2/src/virtual-tree.ts
@@ -139,9 +139,6 @@ export const treeNodeProps = buildProps({
   itemSize,
 } as const)
 
-/**
- * @deprecated Removed after 3.0.0, Use `TreeNodeContentProps` instead.
- */
 export const treeNodeContentProps = buildProps({
   node: {
     type: definePropType<TreeNode>(Object),

--- a/packages/utils/vue/icon.ts
+++ b/packages/utils/vue/icon.ts
@@ -12,6 +12,8 @@ import { definePropType } from './props'
 
 import type { Component } from 'vue'
 
+export type IconPropType = string | Component
+
 export const iconPropType = definePropType<string | Component>([
   String,
   Object,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
rel #23399 
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tree node component exposes new public props for node data and item size with sensible defaults.
* **Improvements**
  * Stronger, more explicit TypeScript typings and default values across the Tree components for more predictable behavior.
  * Icon property accepts additional types for greater flexibility.
  * Shared empty-node placeholder made available for consumers.
* **Deprecations**
  * Legacy prop-definition exports marked deprecated with guidance to migrate to new typed props.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->