### PR TITLE
refactor(components): [transfer] use type-based definitions

### DIFF
--- a/packages/components/transfer/src/composables/use-check.ts
+++ b/packages/components/transfer/src/composables/use-check.ts
@@ -20,7 +20,7 @@ export const useCheck = (
   const propsAlias = usePropsAlias(props)
 
   const filteredData = computed(() => {
-    return props.data.filter((item) => {
+    return props.data?.filter((item) => {
       if (isFunction(props.filterMethod)) {
         return props.filterMethod(panelState.query, item)
       } else {
@@ -33,13 +33,13 @@ export const useCheck = (
   })
 
   const checkableData = computed(() =>
-    filteredData.value.filter((item) => !item[propsAlias.value.disabled])
+    filteredData.value?.filter((item) => !item[propsAlias.value.disabled])
   )
 
   const checkedSummary = computed(() => {
     const checkedLength = panelState.checked.length
-    const dataLength = props.data.length
-    const { noChecked, hasChecked } = props.format
+    const dataLength = props.data!.length
+    const { noChecked, hasChecked } = props.format!
 
     if (noChecked && hasChecked) {
       return checkedLength > 0
@@ -54,11 +54,11 @@ export const useCheck = (
 
   const isIndeterminate = computed(() => {
     const checkedLength = panelState.checked.length
-    return checkedLength > 0 && checkedLength < checkableData.value.length
+    return checkedLength > 0 && checkedLength < checkableData.value!.length
   })
 
   const updateAllChecked = () => {
-    const checkableDataKeys = checkableData.value.map(
+    const checkableDataKeys = checkableData.value!.map(
       (item) => item[propsAlias.value.key]
     )
     panelState.allChecked =
@@ -68,7 +68,7 @@ export const useCheck = (
 
   const handleAllCheckedChange = (value: CheckboxValueType) => {
     panelState.checked = value
-      ? checkableData.value.map((item) => item[propsAlias.value.key])
+      ? checkableData.value!.map((item) => item[propsAlias.value.key])
       : []
   }
 
@@ -97,7 +97,7 @@ export const useCheck = (
     () => props.data,
     () => {
       const checked: TransferKey[] = []
-      const filteredDataKeys = filteredData.value.map(
+      const filteredDataKeys = filteredData.value!.map(
         (item) => item[propsAlias.value.key]
       )
       panelState.checked.forEach((item) => {
@@ -115,17 +115,17 @@ export const useCheck = (
     (val, oldVal) => {
       if (
         oldVal &&
-        val.length === oldVal.length &&
+        val?.length === oldVal.length &&
         val.every((item) => oldVal.includes(item))
       )
         return
 
       const checked: TransferKey[] = []
-      const checkableDataKeys = checkableData.value.map(
+      const checkableDataKeys = checkableData.value!.map(
         (item) => item[propsAlias.value.key]
       )
 
-      val.forEach((item) => {
+      val?.forEach((item) => {
         if (checkableDataKeys.includes(item)) {
           checked.push(item)
         }

--- a/packages/components/transfer/src/composables/use-check.ts
+++ b/packages/components/transfer/src/composables/use-check.ts
@@ -13,7 +13,9 @@ import type {
 } from '../transfer-panel'
 
 export const useCheck = (
-  props: Required<TransferPanelProps>,
+  props: Required<
+    Pick<TransferPanelProps, 'data' | 'format' | 'defaultChecked'>
+  > & { filterMethod: TransferPanelProps['filterMethod'] },
   panelState: TransferPanelState,
   emit: SetupContext<TransferPanelEmits>['emit']
 ) => {

--- a/packages/components/transfer/src/composables/use-check.ts
+++ b/packages/components/transfer/src/composables/use-check.ts
@@ -13,14 +13,14 @@ import type {
 } from '../transfer-panel'
 
 export const useCheck = (
-  props: TransferPanelProps,
+  props: Required<TransferPanelProps>,
   panelState: TransferPanelState,
   emit: SetupContext<TransferPanelEmits>['emit']
 ) => {
   const propsAlias = usePropsAlias(props)
 
   const filteredData = computed(() => {
-    return props.data?.filter((item) => {
+    return props.data.filter((item) => {
       if (isFunction(props.filterMethod)) {
         return props.filterMethod(panelState.query, item)
       } else {
@@ -33,13 +33,13 @@ export const useCheck = (
   })
 
   const checkableData = computed(() =>
-    filteredData.value?.filter((item) => !item[propsAlias.value.disabled])
+    filteredData.value.filter((item) => !item[propsAlias.value.disabled])
   )
 
   const checkedSummary = computed(() => {
     const checkedLength = panelState.checked.length
-    const dataLength = props.data!.length
-    const { noChecked, hasChecked } = props.format!
+    const dataLength = props.data.length
+    const { noChecked, hasChecked } = props.format
 
     if (noChecked && hasChecked) {
       return checkedLength > 0
@@ -54,11 +54,11 @@ export const useCheck = (
 
   const isIndeterminate = computed(() => {
     const checkedLength = panelState.checked.length
-    return checkedLength > 0 && checkedLength < checkableData.value!.length
+    return checkedLength > 0 && checkedLength < checkableData.value.length
   })
 
   const updateAllChecked = () => {
-    const checkableDataKeys = checkableData.value!.map(
+    const checkableDataKeys = checkableData.value.map(
       (item) => item[propsAlias.value.key]
     )
     panelState.allChecked =
@@ -68,7 +68,7 @@ export const useCheck = (
 
   const handleAllCheckedChange = (value: CheckboxValueType) => {
     panelState.checked = value
-      ? checkableData.value!.map((item) => item[propsAlias.value.key])
+      ? checkableData.value.map((item) => item[propsAlias.value.key])
       : []
   }
 
@@ -97,7 +97,7 @@ export const useCheck = (
     () => props.data,
     () => {
       const checked: TransferKey[] = []
-      const filteredDataKeys = filteredData.value!.map(
+      const filteredDataKeys = filteredData.value.map(
         (item) => item[propsAlias.value.key]
       )
       panelState.checked.forEach((item) => {
@@ -115,17 +115,17 @@ export const useCheck = (
     (val, oldVal) => {
       if (
         oldVal &&
-        val?.length === oldVal.length &&
+        val.length === oldVal.length &&
         val.every((item) => oldVal.includes(item))
       )
         return
 
       const checked: TransferKey[] = []
-      const checkableDataKeys = checkableData.value!.map(
+      const checkableDataKeys = checkableData.value.map(
         (item) => item[propsAlias.value.key]
       )
 
-      val?.forEach((item) => {
+      val.forEach((item) => {
         if (checkableDataKeys.includes(item)) {
           checked.push(item)
         }

--- a/packages/components/transfer/src/composables/use-computed-data.ts
+++ b/packages/components/transfer/src/composables/use-computed-data.ts
@@ -3,7 +3,11 @@ import { usePropsAlias } from './use-props-alias'
 
 import type { TransferDataItem, TransferKey, TransferProps } from '../transfer'
 
-export const useComputedData = (props: Required<TransferProps>) => {
+export const useComputedData = (
+  props: Required<
+    Omit<TransferProps, 'filterPlaceholder' | 'filterMethod' | 'renderContent'>
+  >
+) => {
   const propsAlias = usePropsAlias(props)
 
   const dataObj = computed(() =>

--- a/packages/components/transfer/src/composables/use-computed-data.ts
+++ b/packages/components/transfer/src/composables/use-computed-data.ts
@@ -3,31 +3,28 @@ import { usePropsAlias } from './use-props-alias'
 
 import type { TransferDataItem, TransferKey, TransferProps } from '../transfer'
 
-export const useComputedData = (props: TransferProps) => {
+export const useComputedData = (props: Required<TransferProps>) => {
   const propsAlias = usePropsAlias(props)
 
   const dataObj = computed(() =>
-    props.data?.reduce(
-      (o, cur) => (o[cur[propsAlias.value.key]] = cur) && o,
-      {}
-    )
+    props.data.reduce((o, cur) => (o[cur[propsAlias.value.key]] = cur) && o, {})
   )
 
   const sourceData = computed(() =>
-    props.data?.filter(
-      (item) => !props.modelValue?.includes(item[propsAlias.value.key])
+    props.data.filter(
+      (item) => !props.modelValue.includes(item[propsAlias.value.key])
     )
   )
 
   const targetData = computed(() => {
     if (props.targetOrder === 'original') {
-      return props.data?.filter((item) =>
-        props.modelValue?.includes(item[propsAlias.value.key])
+      return props.data.filter((item) =>
+        props.modelValue.includes(item[propsAlias.value.key])
       )
     } else {
-      return props.modelValue?.reduce(
+      return props.modelValue.reduce(
         (arr: TransferDataItem[], cur: TransferKey) => {
-          const val = dataObj.value?.[cur]
+          const val = dataObj.value[cur]
           if (val) {
             arr.push(val)
           }

--- a/packages/components/transfer/src/composables/use-computed-data.ts
+++ b/packages/components/transfer/src/composables/use-computed-data.ts
@@ -7,24 +7,27 @@ export const useComputedData = (props: TransferProps) => {
   const propsAlias = usePropsAlias(props)
 
   const dataObj = computed(() =>
-    props.data.reduce((o, cur) => (o[cur[propsAlias.value.key]] = cur) && o, {})
+    props.data?.reduce(
+      (o, cur) => (o[cur[propsAlias.value.key]] = cur) && o,
+      {}
+    )
   )
 
   const sourceData = computed(() =>
-    props.data.filter(
-      (item) => !props.modelValue.includes(item[propsAlias.value.key])
+    props.data?.filter(
+      (item) => !props.modelValue?.includes(item[propsAlias.value.key])
     )
   )
 
   const targetData = computed(() => {
     if (props.targetOrder === 'original') {
-      return props.data.filter((item) =>
-        props.modelValue.includes(item[propsAlias.value.key])
+      return props.data?.filter((item) =>
+        props.modelValue?.includes(item[propsAlias.value.key])
       )
     } else {
-      return props.modelValue.reduce(
+      return props.modelValue?.reduce(
         (arr: TransferDataItem[], cur: TransferKey) => {
-          const val = dataObj.value[cur]
+          const val = dataObj.value?.[cur]
           if (val) {
             arr.push(val)
           }

--- a/packages/components/transfer/src/composables/use-move.ts
+++ b/packages/components/transfer/src/composables/use-move.ts
@@ -28,7 +28,7 @@ export const useMove = (
   }
 
   const addToLeft = () => {
-    const currentValue = props.modelValue.slice()
+    const currentValue = props.modelValue!.slice()
 
     checkedState.rightChecked.forEach((item) => {
       const index = currentValue.indexOf(item)
@@ -40,14 +40,14 @@ export const useMove = (
   }
 
   const addToRight = () => {
-    let currentValue = props.modelValue.slice()
+    let currentValue = props.modelValue!.slice()
 
-    const itemsToBeMoved = props.data
-      .filter((item: TransferDataItem) => {
+    const itemsToBeMoved = props
+      .data!.filter((item: TransferDataItem) => {
         const itemKey = item[propsAlias.value.key]
         return (
           checkedState.leftChecked.includes(itemKey) &&
-          !props.modelValue.includes(itemKey)
+          !props.modelValue?.includes(itemKey)
         )
       })
       .map((item) => item[propsAlias.value.key])
@@ -58,8 +58,10 @@ export const useMove = (
         : currentValue.concat(itemsToBeMoved)
 
     if (props.targetOrder === 'original') {
-      currentValue = props.data
-        .filter((item) => currentValue.includes(item[propsAlias.value.key]))
+      currentValue = props
+        .data!.filter((item) =>
+          currentValue?.includes(item[propsAlias.value.key])
+        )
         .map((item) => item[propsAlias.value.key])
     }
 

--- a/packages/components/transfer/src/composables/use-move.ts
+++ b/packages/components/transfer/src/composables/use-move.ts
@@ -12,7 +12,7 @@ import type {
 } from '../transfer'
 
 export const useMove = (
-  props: TransferProps,
+  props: Required<TransferProps>,
   checkedState: TransferCheckedState,
   emit: SetupContext<TransferEmits>['emit']
 ) => {
@@ -28,7 +28,7 @@ export const useMove = (
   }
 
   const addToLeft = () => {
-    const currentValue = props.modelValue!.slice()
+    const currentValue = props.modelValue.slice()
 
     checkedState.rightChecked.forEach((item) => {
       const index = currentValue.indexOf(item)
@@ -40,14 +40,14 @@ export const useMove = (
   }
 
   const addToRight = () => {
-    let currentValue = props.modelValue!.slice()
+    let currentValue = props.modelValue.slice()
 
-    const itemsToBeMoved = props
-      .data!.filter((item: TransferDataItem) => {
+    const itemsToBeMoved = props.data
+      .filter((item: TransferDataItem) => {
         const itemKey = item[propsAlias.value.key]
         return (
           checkedState.leftChecked.includes(itemKey) &&
-          !props.modelValue?.includes(itemKey)
+          !props.modelValue.includes(itemKey)
         )
       })
       .map((item) => item[propsAlias.value.key])
@@ -58,10 +58,8 @@ export const useMove = (
         : currentValue.concat(itemsToBeMoved)
 
     if (props.targetOrder === 'original') {
-      currentValue = props
-        .data!.filter((item) =>
-          currentValue?.includes(item[propsAlias.value.key])
-        )
+      currentValue = props.data
+        .filter((item) => currentValue.includes(item[propsAlias.value.key]))
         .map((item) => item[propsAlias.value.key])
     }
 

--- a/packages/components/transfer/src/composables/use-move.ts
+++ b/packages/components/transfer/src/composables/use-move.ts
@@ -12,7 +12,9 @@ import type {
 } from '../transfer'
 
 export const useMove = (
-  props: Required<TransferProps>,
+  props: Required<
+    Omit<TransferProps, 'filterPlaceholder' | 'filterMethod' | 'renderContent'>
+  >,
   checkedState: TransferCheckedState,
   emit: SetupContext<TransferEmits>['emit']
 ) => {

--- a/packages/components/transfer/src/composables/use-props-alias.ts
+++ b/packages/components/transfer/src/composables/use-props-alias.ts
@@ -1,8 +1,8 @@
 import { computed } from 'vue'
 
-import type { TransferPropsAlias } from '../transfer'
+import type { TransferProps, TransferPropsAlias } from '../transfer'
 
-export const usePropsAlias = (props: { props: TransferPropsAlias }) => {
+export const usePropsAlias = (props: TransferProps) => {
   const initProps: Required<TransferPropsAlias> = {
     label: 'label',
     key: 'key',

--- a/packages/components/transfer/src/transfer-panel.ts
+++ b/packages/components/transfer/src/transfer-panel.ts
@@ -1,7 +1,11 @@
 import { buildProps, definePropType } from '@element-plus/utils'
-import { transferCheckedChangeFn, transferProps } from './transfer'
+import {
+  TransferProps,
+  transferCheckedChangeFn,
+  transferProps,
+} from './transfer'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes, VNode } from 'vue'
+import type { ExtractPublicPropTypes, VNode } from 'vue'
 import type { TransferDataItem, TransferKey } from './transfer'
 import type TransferPanel from './transfer-panel.vue'
 
@@ -14,6 +18,21 @@ export interface TransferPanelState {
 
 export const CHECKED_CHANGE_EVENT = 'checked-change'
 
+export interface TransferPanelProps {
+  data?: TransferProps['data']
+  optionRender?: (option: TransferDataItem) => VNode | VNode[]
+  placeholder?: string
+  title?: string
+  filterable?: boolean
+  format?: TransferProps['format']
+  filterMethod?: TransferProps['filterMethod']
+  defaultChecked?: TransferProps['leftDefaultChecked']
+  props?: TransferProps['props']
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `TransferPanelProps` instead.
+ */
 export const transferPanelProps = buildProps({
   data: transferProps.data,
   optionRender: {
@@ -29,7 +48,10 @@ export const transferPanelProps = buildProps({
   defaultChecked: transferProps.leftDefaultChecked,
   props: transferProps.props,
 } as const)
-export type TransferPanelProps = ExtractPropTypes<typeof transferPanelProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `TransferPanelProps` instead.
+ */
 export type TransferPanelPropsPublic = ExtractPublicPropTypes<
   typeof transferPanelProps
 >

--- a/packages/components/transfer/src/transfer-panel.ts
+++ b/packages/components/transfer/src/transfer-panel.ts
@@ -1,12 +1,8 @@
 import { buildProps, definePropType } from '@element-plus/utils'
-import {
-  TransferProps,
-  transferCheckedChangeFn,
-  transferProps,
-} from './transfer'
+import { transferCheckedChangeFn, transferProps } from './transfer'
 
 import type { ExtractPublicPropTypes, VNode } from 'vue'
-import type { TransferDataItem, TransferKey } from './transfer'
+import type { TransferDataItem, TransferKey, TransferProps } from './transfer'
 import type TransferPanel from './transfer-panel.vue'
 
 export interface TransferPanelState {

--- a/packages/components/transfer/src/transfer-panel.vue
+++ b/packages/components/transfer/src/transfer-panel.vue
@@ -57,22 +57,32 @@
 
 <script lang="ts" setup>
 import { computed, reactive, toRefs, useSlots } from 'vue'
-import { isEmpty } from '@element-plus/utils'
+import { isEmpty, mutable } from '@element-plus/utils'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { ElCheckbox, ElCheckboxGroup } from '@element-plus/components/checkbox'
 import { ElInput } from '@element-plus/components/input'
 import { Search } from '@element-plus/icons-vue'
-import { transferPanelEmits, transferPanelProps } from './transfer-panel'
+import { transferPanelEmits } from './transfer-panel'
 import { useCheck, usePropsAlias } from './composables'
 
 import type { VNode } from 'vue'
-import type { TransferPanelState } from './transfer-panel'
+import type { TransferPanelProps, TransferPanelState } from './transfer-panel'
 
 defineOptions({
   name: 'ElTransferPanel',
 })
 
-const props = defineProps(transferPanelProps)
+const props = withDefaults(defineProps<TransferPanelProps>(), {
+  data: () => [],
+  format: () => ({}),
+  defaultChecked: () => [],
+  props: () =>
+    mutable({
+      label: 'label',
+      key: 'key',
+      disabled: 'disabled',
+    }),
+})
 const emit = defineEmits(transferPanelEmits)
 const slots = useSlots()
 

--- a/packages/components/transfer/src/transfer.ts
+++ b/packages/components/transfer/src/transfer.ts
@@ -7,12 +7,7 @@ import {
 } from '@element-plus/utils'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
-import type {
-  ExtractPropTypes,
-  ExtractPublicPropTypes,
-  h as H,
-  VNode,
-} from 'vue'
+import type { ExtractPublicPropTypes, h as H, VNode } from 'vue'
 import type Transfer from './transfer.vue'
 
 export type TransferKey = string | number
@@ -44,6 +39,68 @@ export interface TransferCheckedState {
 export const LEFT_CHECK_CHANGE_EVENT = 'left-check-change'
 export const RIGHT_CHECK_CHANGE_EVENT = 'right-check-change'
 
+export interface TransferProps {
+  /**
+   * @description data source
+   */
+  data?: TransferDataItem[]
+  /**
+   * @description custom list titles
+   */
+  titles?: [string, string]
+  /**
+   * @description custom button texts
+   */
+  buttonTexts?: [string, string]
+  /**
+   * @description placeholder for the filter input
+   */
+  filterPlaceholder?: string
+  /**
+   * @description custom filter method
+   */
+  filterMethod?: (query: string, item: TransferDataItem) => boolean
+  /**
+   * @description key array of initially checked data items of the left list
+   */
+  leftDefaultChecked?: TransferKey[]
+  /**
+   * @description key array of initially checked data items of the right list
+   */
+  rightDefaultChecked?: TransferKey[]
+  /**
+   * @description custom render function for data items
+   */
+  renderContent?: renderContent
+  /**
+   * @description binding value
+   */
+  modelValue?: TransferKey[]
+  /**
+   * @description texts for checking status in list header
+   */
+  format?: TransferFormat
+  /**
+   * @description whether Transfer is filterable
+   */
+  filterable?: boolean
+  /**
+   * @description prop aliases for data source
+   */
+  props?: TransferPropsAlias
+  /**
+   * @description order strategy for elements in the target list. If set to `original`, the elements will keep the same order as the data source. If set to `push`, the newly added elements will be pushed to the bottom. If set to `unshift`, the newly added elements will be inserted on the top
+   */
+  targetOrder?: 'original' | 'push' | 'unshift'
+  /**
+   * @description whether to trigger form validation
+   */
+  validateEvent?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `TransferProps` instead.
+ */
 export const transferProps = buildProps({
   /**
    * @description data source
@@ -144,7 +201,10 @@ export const transferProps = buildProps({
     default: true,
   },
 } as const)
-export type TransferProps = ExtractPropTypes<typeof transferProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `TransferProps` instead.
+ */
 export type TransferPropsPublic = ExtractPublicPropTypes<typeof transferProps>
 
 export const transferCheckedChangeFn = (

--- a/packages/components/transfer/src/transfer.vue
+++ b/packages/components/transfer/src/transfer.vue
@@ -61,13 +61,13 @@
 
 <script lang="ts" setup>
 import { Comment, computed, h, reactive, ref, useSlots, watch } from 'vue'
-import { debugWarn, isEmpty, isUndefined } from '@element-plus/utils'
+import { debugWarn, isEmpty, isUndefined, mutable } from '@element-plus/utils'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { ElButton } from '@element-plus/components/button'
 import { ElIcon } from '@element-plus/components/icon'
 import { useFormItem } from '@element-plus/components/form'
 import { ArrowLeft, ArrowRight } from '@element-plus/icons-vue'
-import { transferEmits, transferProps } from './transfer'
+import { transferEmits } from './transfer'
 import {
   useCheckedChange,
   useComputedData,
@@ -80,6 +80,7 @@ import type {
   TransferCheckedState,
   TransferDataItem,
   TransferDirection,
+  TransferProps,
 } from './transfer'
 import type { TransferPanelInstance } from './transfer-panel'
 
@@ -87,7 +88,23 @@ defineOptions({
   name: 'ElTransfer',
 })
 
-const props = defineProps(transferProps)
+const props = withDefaults(defineProps<TransferProps>(), {
+  data: () => [],
+  titles: () => ['', ''],
+  buttonTexts: () => ['', ''],
+  leftDefaultChecked: () => [],
+  rightDefaultChecked: () => [],
+  modelValue: () => [],
+  format: () => ({}),
+  props: () =>
+    mutable({
+      label: 'label',
+      key: 'key',
+      disabled: 'disabled',
+    }),
+  targetOrder: 'original',
+  validateEvent: true,
+})
 const emit = defineEmits(transferEmits)
 const slots = useSlots()
 

--- a/packages/components/transfer/src/transfer.vue
+++ b/packages/components/transfer/src/transfer.vue
@@ -61,7 +61,7 @@
 
 <script lang="ts" setup>
 import { Comment, computed, h, reactive, ref, useSlots, watch } from 'vue'
-import { debugWarn, isEmpty, isUndefined, mutable } from '@element-plus/utils'
+import { debugWarn, isEmpty, isUndefined } from '@element-plus/utils'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { ElButton } from '@element-plus/components/button'
 import { ElIcon } from '@element-plus/components/icon'
@@ -90,18 +90,17 @@ defineOptions({
 
 const props = withDefaults(defineProps<TransferProps>(), {
   data: () => [],
-  titles: () => ['', ''],
-  buttonTexts: () => ['', ''],
+  titles: () => [] as unknown as [string, string],
+  buttonTexts: () => [] as unknown as [string, string],
   leftDefaultChecked: () => [],
   rightDefaultChecked: () => [],
   modelValue: () => [],
   format: () => ({}),
-  props: () =>
-    mutable({
-      label: 'label',
-      key: 'key',
-      disabled: 'disabled',
-    }),
+  props: () => ({
+    label: 'label',
+    key: 'key',
+    disabled: 'disabled',
+  }),
   targetOrder: 'original',
   validateEvent: true,
 })
@@ -142,11 +141,7 @@ const clearQuery = (which: TransferDirection) => {
   }
 }
 
-const hasButtonTexts = computed(
-  () =>
-    props.buttonTexts.length === 2 &&
-    props.buttonTexts.every((text) => text !== '')
-)
+const hasButtonTexts = computed(() => props.buttonTexts.length === 2)
 
 const leftPanelTitle = computed(
   () => props.titles[0] || t('el.transfer.titles.0')

--- a/packages/components/transfer/src/transfer.vue
+++ b/packages/components/transfer/src/transfer.vue
@@ -142,7 +142,11 @@ const clearQuery = (which: TransferDirection) => {
   }
 }
 
-const hasButtonTexts = computed(() => props.buttonTexts.length === 2)
+const hasButtonTexts = computed(
+  () =>
+    props.buttonTexts.length === 2 &&
+    props.buttonTexts.every((text) => text !== '')
+)
 
 const leftPanelTitle = computed(
   () => props.titles[0] || t('el.transfer.titles.0')


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
rel #23399 
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added explicit public prop interfaces for Transfer and marked older prop aliases as deprecated.
  * Tightened prop typings across transfer utilities, requiring specific prop subsets for stronger compile-time checks.

* **Chores**
  * Components now supply explicit default values for nested props and stabilize initialization without runtime behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->