### PR TITLE
refactor(components): [splitter] use type-based definitions

### DIFF
--- a/packages/components/splitter/src/split-panel.ts
+++ b/packages/components/splitter/src/split-panel.ts
@@ -1,8 +1,19 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 import type SplitterPanel from './split-panel.vue'
 
+export interface SplitterPanelProps {
+  min?: string | number
+  max?: string | number
+  size?: string | number
+  resizable?: boolean
+  collapsible?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `SplitterPanelProps` instead.
+ */
 export const splitterPanelProps = buildProps({
   min: {
     type: [String, Number],
@@ -20,7 +31,9 @@ export const splitterPanelProps = buildProps({
   collapsible: Boolean,
 } as const)
 
-export type SplitterPanelProps = ExtractPropTypes<typeof splitterPanelProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `SplitterPanelProps` instead.
+ */
 export type SplitterPanelPropsPublic = ExtractPublicPropTypes<
   typeof splitterPanelProps
 >

--- a/packages/components/splitter/src/split-panel.vue
+++ b/packages/components/splitter/src/split-panel.vue
@@ -14,9 +14,11 @@ import { useNamespace } from '@element-plus/hooks'
 import { throwError } from '@element-plus/utils'
 import { getCollapsible, isCollapsible } from './hooks/usePanel'
 import SplitBar from './split-bar.vue'
-import { splitterPanelEmits, splitterPanelProps } from './split-panel'
+import { splitterPanelEmits } from './split-panel'
 import { getPct, getPx, isPct, isPx } from './hooks'
 import { splitterRootContextKey } from './type'
+
+import type { SplitterPanelProps } from './split-panel'
 
 const ns = useNamespace('splitter-panel')
 
@@ -25,7 +27,9 @@ defineOptions({
   name: COMPONENT_NAME,
 })
 
-const props = defineProps(splitterPanelProps)
+const props = withDefaults(defineProps<SplitterPanelProps>(), {
+  resizable: true,
+})
 
 const emits = defineEmits(splitterPanelEmits)
 const splitterContext = inject(splitterRootContextKey)

--- a/packages/components/splitter/src/splitter.ts
+++ b/packages/components/splitter/src/splitter.ts
@@ -1,8 +1,17 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 import type Splitter from './splitter.vue'
+import type { Layout } from './type'
 
+export interface SplitterProps {
+  layout?: Layout
+  lazy?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `SplitterProps` instead.
+ */
 export const splitterProps = buildProps({
   layout: {
     type: String,
@@ -12,7 +21,9 @@ export const splitterProps = buildProps({
   lazy: Boolean,
 } as const)
 
-export type SplitterProps = ExtractPropTypes<typeof splitterProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `SplitterProps` instead.
+ */
 export type SplitterPropsPublic = ExtractPublicPropTypes<typeof splitterProps>
 export type SplitterInstance = InstanceType<typeof Splitter> & unknown
 

--- a/packages/components/splitter/src/splitter.vue
+++ b/packages/components/splitter/src/splitter.vue
@@ -10,10 +10,11 @@ import {
 } from 'vue'
 import { useNamespace, useOrderedChildren } from '@element-plus/hooks'
 import { useContainer, useResize, useSize } from './hooks'
-import { splitterEmits, splitterProps } from './splitter'
+import { splitterEmits } from './splitter'
 import { splitterRootContextKey } from './type'
 
 import type { PanelItemState } from './type'
+import type { SplitterProps } from './splitter'
 
 const ns = useNamespace('splitter')
 
@@ -23,7 +24,9 @@ defineOptions({
 
 const emits = defineEmits(splitterEmits)
 
-const props = defineProps(splitterProps)
+const props = withDefaults(defineProps<SplitterProps>(), {
+  layout: 'horizontal',
+})
 const layout = toRef(props, 'layout')
 const lazy = toRef(props, 'lazy')
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
ref #23399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type definitions for Splitter and SplitterPanel components with explicit prop interfaces
  * Updated default values: SplitterPanel `resizable` now defaults to `true`; Splitter `layout` defaults to `horizontal`
  * Enhanced TypeScript support with explicit event definitions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->