### PR TITLE
refactor(components): [popover] use type-based definitions

### DIFF
--- a/packages/components/popover/src/popover.ts
+++ b/packages/components/popover/src/popover.ts
@@ -4,10 +4,117 @@ import {
   useTooltipTriggerProps,
 } from '@element-plus/components/tooltip'
 import { dropdownProps } from '@element-plus/components/dropdown'
+import { EVENT_CODE } from '@element-plus/constants'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes, PropType } from 'vue'
+import type { ExtractPublicPropTypes, PropType, StyleValue } from 'vue'
 import type Popover from './popover.vue'
+import type { Placement } from '@element-plus/components/popper'
+import type { Options } from '@popperjs/core'
 
+export type PopoverTriggerType = 'click' | 'hover' | 'focus' | 'contextmenu'
+
+export interface PopoverProps {
+  /**
+   * @description how the popover is triggered, not valid in controlled mode
+   */
+  trigger?: PopoverTriggerType
+  /**
+   * @description When you click the mouse to focus on the trigger element, you can define a set of keyboard codes to control the display of popover through the keyboard, not valid in controlled mode
+   */
+  triggerKeys?: string[]
+  /**
+   * @description popover placement
+   */
+  placement?: Placement
+  /**
+   * @description whether Popover is disabled
+   */
+  disabled?: boolean
+  /**
+   * @description whether popover is visible
+   */
+  visible?: boolean | null
+  /**
+   * @description popover transition animation
+   */
+  transition?: string
+  /**
+   * @description parameters for [popper.js](https://popper.js.org/docs/v2/)
+   */
+  popperOptions?: Partial<Options>
+  /**
+   * @description [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) of Popover
+   */
+  tabindex?: string | number
+  /**
+   * @description popover content, can be replaced with a default `slot`
+   */
+  content?: string
+  /**
+   * @description custom style for popover
+   */
+  popperStyle?: StyleValue
+  /**
+   * @description custom class name for popover
+   */
+  popperClass?: string
+  /**
+   * @description whether the mouse can enter the popover
+   */
+  enterable?: boolean
+  /**
+   * @description Tooltip theme, built-in theme: `dark` / `light`
+   */
+  effect?: 'dark' | 'light' | string
+  /**
+   * @description whether popover dropdown is teleported to the body
+   */
+  teleported?: boolean
+  /**
+   * @description which select dropdown appends to
+   */
+  appendTo?: string | HTMLElement
+  /**
+   * @description popover title
+   */
+  title?: string
+  /**
+   * @description popover width
+   */
+  width?: string | number
+  /**
+   * @description popover offset
+   */
+  offset?: number
+  /**
+   * @description delay of appearance, in millisecond, not valid in controlled mode
+   */
+  showAfter?: number
+  /**
+   * @description delay of disappear, in millisecond, not valid in controlled mode
+   */
+  hideAfter?: number
+  /**
+   * @description timeout in milliseconds to hide tooltip, not valid in controlled mode
+   */
+  autoClose?: number
+  /**
+   * @description whether a tooltip arrow is displayed or not. For more info, please refer to [ElPopper](https://github.com/element-plus/element-plus/tree/dev/packages/components/popper)
+   */
+  showArrow?: boolean
+  /**
+   * @description when popover inactive and `persistent` is `false` , popover will be destroyed
+   */
+  persistent?: boolean
+  /**
+   * @description update:visible event handler
+   */
+  'onUpdate:visible'?: (visible: boolean) => void
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `PopoverProps` instead.
+ */
 export const popoverProps = buildProps({
   /**
    * @description how the popover is triggered, not valid in controlled mode
@@ -129,7 +236,10 @@ export const popoverProps = buildProps({
     type: Function as PropType<(visible: boolean) => void>,
   },
 } as const)
-export type PopoverProps = ExtractPropTypes<typeof popoverProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `PopoverProps` instead.
+ */
 export type PopoverPropsPublic = ExtractPublicPropTypes<typeof popoverProps>
 
 export const popoverEmits = {
@@ -142,3 +252,30 @@ export const popoverEmits = {
 export type PopoverEmits = typeof popoverEmits
 
 export type PopoverInstance = InstanceType<typeof Popover> & unknown
+
+/**
+ * @description default values for PopoverProps
+ */
+export const popoverPropsDefaults = {
+  trigger: 'hover' as PopoverTriggerType,
+  triggerKeys: () => [
+    EVENT_CODE.enter,
+    EVENT_CODE.numpadEnter,
+    EVENT_CODE.space,
+  ],
+  placement: 'bottom' as Placement,
+  popperOptions: () => ({}),
+  tabindex: 0,
+  content: '',
+  visible: null,
+  teleported: true,
+  enterable: true,
+  effect: 'light' as const,
+  width: 150,
+  offset: undefined,
+  showAfter: 0,
+  hideAfter: 200,
+  autoClose: 0,
+  showArrow: true,
+  persistent: true,
+}

--- a/packages/components/popover/src/popover.ts
+++ b/packages/components/popover/src/popover.ts
@@ -6,20 +6,24 @@ import {
 import { dropdownProps } from '@element-plus/components/dropdown'
 import { EVENT_CODE } from '@element-plus/constants'
 
-import type { ExtractPublicPropTypes, PropType, StyleValue } from 'vue'
+import type { ExtractPublicPropTypes, PropType } from 'vue'
 import type Popover from './popover.vue'
 import type { Placement } from '@element-plus/components/popper'
 import type { Options } from '@popperjs/core'
+import type {
+  ElTooltipContentProps,
+  UseTooltipTriggerProps,
+} from '@element-plus/components/tooltip'
 
 export interface PopoverProps {
   /**
    * @description how the popover is triggered, not valid in controlled mode
    */
-  trigger?: 'click' | 'hover' | 'focus' | 'contextmenu'
+  trigger?: UseTooltipTriggerProps['trigger']
   /**
    * @description When you click the mouse to focus on the trigger element, you can define a set of keyboard codes to control the display of popover through the keyboard, not valid in controlled mode
    */
-  triggerKeys?: string[]
+  triggerKeys?: UseTooltipTriggerProps['triggerKeys']
   /**
    * @description popover placement
    */
@@ -27,15 +31,15 @@ export interface PopoverProps {
   /**
    * @description whether Popover is disabled
    */
-  disabled?: boolean
+  disabled?: UseTooltipTriggerProps['disabled']
   /**
    * @description whether popover is visible
    */
-  visible?: boolean | null
+  visible?: ElTooltipContentProps['visible']
   /**
    * @description popover transition animation
    */
-  transition?: string
+  transition?: ElTooltipContentProps['transition']
   /**
    * @description parameters for [popper.js](https://popper.js.org/docs/v2/)
    */
@@ -47,31 +51,31 @@ export interface PopoverProps {
   /**
    * @description popover content, can be replaced with a default `slot`
    */
-  content?: string
+  content?: ElTooltipContentProps['content']
   /**
    * @description custom style for popover
    */
-  popperStyle?: StyleValue
+  popperStyle?: ElTooltipContentProps['popperStyle']
   /**
    * @description custom class name for popover
    */
-  popperClass?: string
+  popperClass?: ElTooltipContentProps['popperClass']
   /**
    * @description whether the mouse can enter the popover
    */
-  enterable?: boolean
+  enterable?: ElTooltipContentProps['enterable']
   /**
    * @description Tooltip theme, built-in theme: `dark` / `light`
    */
-  effect?: 'dark' | 'light' | string
+  effect?: ElTooltipContentProps['effect']
   /**
    * @description whether popover dropdown is teleported to the body
    */
-  teleported?: boolean
+  teleported?: ElTooltipContentProps['teleported']
   /**
    * @description which select dropdown appends to
    */
-  appendTo?: string | HTMLElement
+  appendTo?: ElTooltipContentProps['appendTo']
   /**
    * @description popover title
    */
@@ -255,20 +259,21 @@ export type PopoverInstance = InstanceType<typeof Popover> & unknown
  * @description default values for PopoverProps
  */
 export const popoverPropsDefaults = {
-  trigger: 'hover' as const,
+  trigger: 'hover',
   triggerKeys: () => [
     EVENT_CODE.enter,
     EVENT_CODE.numpadEnter,
     EVENT_CODE.space,
   ],
-  placement: 'bottom' as Placement,
+  placement: 'bottom',
+  visible: null,
   popperOptions: () => ({}),
   tabindex: 0,
   content: '',
-  visible: null,
-  teleported: true,
+  popperStyle: undefined,
   enterable: true,
-  effect: 'light' as const,
+  effect: 'light',
+  teleported: true,
   width: 150,
   offset: undefined,
   showAfter: 0,
@@ -276,4 +281,4 @@ export const popoverPropsDefaults = {
   autoClose: 0,
   showArrow: true,
   persistent: true,
-}
+} as const

--- a/packages/components/popover/src/popover.ts
+++ b/packages/components/popover/src/popover.ts
@@ -11,13 +11,11 @@ import type Popover from './popover.vue'
 import type { Placement } from '@element-plus/components/popper'
 import type { Options } from '@popperjs/core'
 
-export type PopoverTriggerType = 'click' | 'hover' | 'focus' | 'contextmenu'
-
 export interface PopoverProps {
   /**
    * @description how the popover is triggered, not valid in controlled mode
    */
-  trigger?: PopoverTriggerType
+  trigger?: 'click' | 'hover' | 'focus' | 'contextmenu'
   /**
    * @description When you click the mouse to focus on the trigger element, you can define a set of keyboard codes to control the display of popover through the keyboard, not valid in controlled mode
    */
@@ -257,7 +255,7 @@ export type PopoverInstance = InstanceType<typeof Popover> & unknown
  * @description default values for PopoverProps
  */
 export const popoverPropsDefaults = {
-  trigger: 'hover' as PopoverTriggerType,
+  trigger: 'hover' as const,
   triggerKeys: () => [
     EVENT_CODE.enter,
     EVENT_CODE.numpadEnter,

--- a/packages/components/popover/src/popover.vue
+++ b/packages/components/popover/src/popover.vue
@@ -60,9 +60,7 @@ defineOptions({
   name: 'ElPopover',
 })
 
-const props = withDefaults(defineProps<PopoverProps>(), {
-  ...popoverPropsDefaults,
-})
+const props = withDefaults(defineProps<PopoverProps>(), popoverPropsDefaults)
 const emit = defineEmits(popoverEmits)
 
 const updateEventKeyRaw = `onUpdate:visible` as const

--- a/packages/components/popover/src/popover.vue
+++ b/packages/components/popover/src/popover.vue
@@ -51,15 +51,18 @@ import { computed, ref, unref } from 'vue'
 import { ElTooltip } from '@element-plus/components/tooltip'
 import { addUnit } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
-import { popoverEmits, popoverProps } from './popover'
+import { popoverEmits, popoverPropsDefaults } from './popover'
 
 import type { TooltipInstance } from '@element-plus/components/tooltip'
+import type { PopoverProps } from './popover'
 
 defineOptions({
   name: 'ElPopover',
 })
 
-const props = defineProps(popoverProps)
+const props = withDefaults(defineProps<PopoverProps>(), {
+  ...popoverPropsDefaults,
+})
 const emit = defineEmits(popoverEmits)
 
 const updateEventKeyRaw = `onUpdate:visible` as const


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

修复：#23399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Popover configuration with many new props for triggers, keyboard keys, placement, timing, arrow, size, persistence and styling.

* **Improvements**
  * Typed Popover props and a dedicated set of default values for more predictable behavior and better TypeScript ergonomics.
  * Deprecated the older public prop alias in favor of the new typed props surface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->