### PR TITLE
refactor(components): [radio] use type-based definitions

### DIFF
--- a/packages/components/radio/src/radio-button.ts
+++ b/packages/components/radio/src/radio-button.ts
@@ -1,15 +1,35 @@
 import { buildProps } from '@element-plus/utils'
 import { radioPropsBase } from './radio'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
+import type { RadioPropsBase } from './radio'
 import type RadioButton from './radio-button.vue'
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface RadioButtonProps extends RadioPropsBase {}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `RadioButtonProps` instead.
+ */
 export const radioButtonProps = buildProps({
   ...radioPropsBase,
 } as const)
 
-export type RadioButtonProps = ExtractPropTypes<typeof radioButtonProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `RadioButtonProps` instead.
+ */
 export type RadioButtonPropsPublic = ExtractPublicPropTypes<
   typeof radioButtonProps
 >
 export type RadioButtonInstance = InstanceType<typeof RadioButton> & unknown
+
+/**
+ * @description default values for RadioButtonProps
+ */
+export const radioButtonPropsDefaults = {
+  modelValue: undefined,
+  disabled: undefined,
+  label: undefined,
+  value: undefined,
+  name: undefined,
+} as const

--- a/packages/components/radio/src/radio-button.vue
+++ b/packages/components/radio/src/radio-button.vue
@@ -36,8 +36,9 @@
 import { computed } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { useRadio } from './use-radio'
-import { type RadioButtonProps, radioButtonPropsDefaults } from './radio-button'
+import { radioButtonPropsDefaults } from './radio-button'
 
+import type { RadioButtonProps } from './radio-button'
 import type { CSSProperties } from 'vue'
 
 defineOptions({

--- a/packages/components/radio/src/radio-button.vue
+++ b/packages/components/radio/src/radio-button.vue
@@ -36,7 +36,7 @@
 import { computed } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { useRadio } from './use-radio'
-import { radioButtonProps } from './radio-button'
+import { type RadioButtonProps, radioButtonPropsDefaults } from './radio-button'
 
 import type { CSSProperties } from 'vue'
 
@@ -44,7 +44,9 @@ defineOptions({
   name: 'ElRadioButton',
 })
 
-const props = defineProps(radioButtonProps)
+const props = withDefaults(defineProps<RadioButtonProps>(), {
+  ...radioButtonPropsDefaults,
+})
 
 const ns = useNamespace('radio')
 const { radioRef, focus, size, disabled, modelValue, radioGroup, actualValue } =

--- a/packages/components/radio/src/radio-group.ts
+++ b/packages/components/radio/src/radio-group.ts
@@ -2,10 +2,78 @@ import { buildProps, definePropType } from '@element-plus/utils'
 import { useAriaProps, useSizeProp } from '@element-plus/hooks'
 import { radioEmits } from './radio'
 
-import type { RadioPropsPublic } from './radio'
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ComponentSize } from '@element-plus/constants'
+import type { ExtractPublicPropTypes } from 'vue'
 import type RadioGroup from './radio-group.vue'
 
+export type radioOptionProp = {
+  value?: string
+  label?: string
+  disabled?: string
+}
+
+export const radioDefaultProps: Required<radioOptionProp> = {
+  label: 'label',
+  value: 'value',
+  disabled: 'disabled',
+}
+
+export type radioOption = Record<string, any>
+
+export interface RadioGroupProps {
+  /**
+   * @description native `id` attribute
+   */
+  id?: string
+  /**
+   * @description the size of radio buttons or bordered radios
+   */
+  size?: ComponentSize
+  /**
+   * @description whether the nesting radios are disabled
+   */
+  disabled?: boolean
+  /**
+   * @description binding value
+   */
+  modelValue?: string | number | boolean
+  /**
+   * @description border and background color when button is active
+   */
+  fill?: string
+  /**
+   * @description font color when button is active
+   */
+  textColor?: string
+  /**
+   * @description native `name` attribute
+   */
+  name?: string
+  /**
+   * @description whether to trigger form validation
+   */
+  validateEvent?: boolean
+  /**
+   * @description radio options
+   */
+  options?: radioOption[]
+  /**
+   * @description custom prop names for options
+   */
+  props?: radioOptionProp
+  /**
+   * @description radio type
+   */
+  type?: 'radio' | 'button'
+  /**
+   * @description native `aria-label` attribute
+   */
+  ariaLabel?: string
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `RadioGroupProps` instead.
+ */
 export const radioGroupProps = buildProps({
   /**
    * @description native `id` attribute
@@ -74,7 +142,10 @@ export const radioGroupProps = buildProps({
   },
   ...useAriaProps(['ariaLabel']),
 } as const)
-export type RadioGroupProps = ExtractPropTypes<typeof radioGroupProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `RadioGroupProps` instead.
+ */
 export type RadioGroupPropsPublic = ExtractPublicPropTypes<
   typeof radioGroupProps
 >
@@ -83,15 +154,17 @@ export const radioGroupEmits = radioEmits
 export type RadioGroupEmits = typeof radioGroupEmits
 export type RadioGroupInstance = InstanceType<typeof RadioGroup> & unknown
 
-export type radioOption = RadioPropsPublic & Record<string, any>
-
-export const radioDefaultProps: Required<radioOptionProp> = {
-  label: 'label',
-  value: 'value',
-  disabled: 'disabled',
-}
-export type radioOptionProp = {
-  value?: string
-  label?: string
-  disabled?: string
-}
+/**
+ * @description default values for RadioGroupProps
+ */
+export const radioGroupPropsDefaults = {
+  id: undefined,
+  disabled: undefined,
+  modelValue: undefined,
+  fill: '',
+  textColor: '',
+  name: undefined,
+  validateEvent: true,
+  props: () => radioDefaultProps,
+  type: 'radio' as const,
+} as const

--- a/packages/components/radio/src/radio-group.ts
+++ b/packages/components/radio/src/radio-group.ts
@@ -166,5 +166,5 @@ export const radioGroupPropsDefaults = {
   name: undefined,
   validateEvent: true,
   props: () => radioDefaultProps,
-  type: 'radio' as const,
+  type: 'radio',
 } as const

--- a/packages/components/radio/src/radio-group.vue
+++ b/packages/components/radio/src/radio-group.vue
@@ -34,22 +34,23 @@ import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { useId, useNamespace } from '@element-plus/hooks'
 import { debugWarn } from '@element-plus/utils'
 import {
+  type RadioGroupProps,
   radioDefaultProps,
   radioGroupEmits,
-  radioGroupProps,
+  radioGroupPropsDefaults,
 } from './radio-group'
 import { radioGroupKey } from './constants'
 import { isEqual, omit } from 'lodash-unified'
 import ElRadio from './radio.vue'
 import ElRadioButton from './radio-button.vue'
 
-import type { RadioGroupProps } from './radio-group'
-
 defineOptions({
   name: 'ElRadioGroup',
 })
 
-const props = defineProps(radioGroupProps)
+const props = withDefaults(defineProps<RadioGroupProps>(), {
+  ...radioGroupPropsDefaults,
+})
 const emit = defineEmits(radioGroupEmits)
 
 const ns = useNamespace('radio')

--- a/packages/components/radio/src/radio.ts
+++ b/packages/components/radio/src/radio.ts
@@ -2,9 +2,47 @@ import { buildProps, isBoolean, isNumber, isString } from '@element-plus/utils'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { useSizeProp } from '@element-plus/hooks'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
+import type { ComponentSize } from '@element-plus/constants'
 import type Radio from './radio.vue'
 
+export interface RadioPropsBase {
+  /**
+   * @description binding value
+   */
+  modelValue?: string | number | boolean
+  /**
+   * @description size of the Radio
+   */
+  size?: ComponentSize
+  /**
+   * @description whether Radio is disabled
+   */
+  disabled?: boolean
+  /**
+   * @description the label of Radio
+   */
+  label?: string | number | boolean
+  /**
+   * @description the value of Radio
+   */
+  value?: string | number | boolean
+  /**
+   * @description native `name` attribute
+   */
+  name?: string
+}
+
+export interface RadioProps extends RadioPropsBase {
+  /**
+   * @description whether to add a border around Radio
+   */
+  border?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `RadioPropsBase` instead.
+ */
 export const radioPropsBase = buildProps({
   /**
    * @description binding value
@@ -47,6 +85,9 @@ export const radioPropsBase = buildProps({
   },
 })
 
+/**
+ * @deprecated Removed after 3.0.0, Use `RadioProps` instead.
+ */
 export const radioProps = buildProps({
   ...radioPropsBase,
   /**
@@ -62,7 +103,21 @@ export const radioEmits = {
     isString(val) || isNumber(val) || isBoolean(val),
 }
 
-export type RadioProps = ExtractPropTypes<typeof radioProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `RadioProps` instead.
+ */
 export type RadioPropsPublic = ExtractPublicPropTypes<typeof radioProps>
 export type RadioEmits = typeof radioEmits
 export type RadioInstance = InstanceType<typeof Radio> & unknown
+
+/**
+ * @description default values for RadioProps
+ */
+export const radioPropsDefaults = {
+  modelValue: undefined,
+  disabled: undefined,
+  label: undefined,
+  value: undefined,
+  name: undefined,
+  border: false,
+} as const

--- a/packages/components/radio/src/radio.vue
+++ b/packages/components/radio/src/radio.vue
@@ -44,14 +44,16 @@
 import { nextTick } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { CHANGE_EVENT } from '@element-plus/constants'
-import { radioEmits, radioProps } from './radio'
+import { type RadioProps, radioEmits, radioPropsDefaults } from './radio'
 import { useRadio } from './use-radio'
 
 defineOptions({
   name: 'ElRadio',
 })
 
-const props = defineProps(radioProps)
+const props = withDefaults(defineProps<RadioProps>(), {
+  ...radioPropsDefaults,
+})
 const emit = defineEmits(radioEmits)
 
 const ns = useNamespace('radio')


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

修复：#23399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved public API and typing for radio components to enhance type safety and consistency.
  * Centralized default prop values for radios, radio buttons, and radio groups to standardize initialization.
  * Added deprecation notices and migration guidance for legacy prop typings; runtime behavior remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->