### PR TITLE
refactor(components): [tooltip] use type-based definitions

### DIFF
--- a/packages/components/tooltip/src/content.ts
+++ b/packages/components/tooltip/src/content.ts
@@ -1,11 +1,71 @@
 import { buildProps, definePropType } from '@element-plus/utils'
-import { popperContentProps } from '@element-plus/components/popper'
+import {
+  popperContentProps,
+  popperContentPropsDefaults,
+} from '@element-plus/components/popper'
 import { useAriaProps, useDelayedToggleProps } from '@element-plus/hooks'
 import { teleportProps } from '@element-plus/components/teleport'
 
+import type { TeleportProps } from '@element-plus/components/teleport'
+import type { AriaProps, UseDelayedToggleProps } from '@element-plus/hooks'
+import type { PopperContentProps } from '@element-plus/components/popper'
 import type TooltipContent from './content.vue'
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 
+export interface ElTooltipContentProps
+  extends UseDelayedToggleProps, Omit<PopperContentProps, 'visible'> {
+  /**
+   * @description which element the tooltip CONTENT appends to
+   */
+  appendTo?: TeleportProps['to']
+  /**
+   * @description display content, can be overridden by `slot#content`
+   */
+  content?: string
+  /**
+   * @description whether `content` is treated as HTML string
+   */
+  rawContent?: boolean
+  /**
+   * @description when tooltip inactive and `persistent` is `false` , popconfirm will be destroyed
+   */
+  persistent?: boolean
+  // because model toggle prop is generated dynamically
+  // so the typing cannot be evaluated by typescript as type:
+  // [name]: { type: Boolean, default: null }
+  // so we need to declare that again for type checking.
+  /**
+   * @description visibility of Tooltip
+   */
+  visible?: boolean | null
+  /**
+   * @description animation name
+   */
+  transition?: string
+  /**
+   * @description whether tooltip content is teleported, if `true` it will be teleported to where `append-to` sets
+   */
+  teleported?: boolean
+  /**
+   * @description whether Tooltip is disabled
+   */
+  disabled?: boolean
+  ariaLabel?: AriaProps['ariaLabel']
+}
+
+export const useTooltipContentPropsDefaults = {
+  showAfter: 0,
+  hideAfter: 200,
+  autoClose: 0,
+  ...popperContentPropsDefaults,
+  content: '',
+  visible: null,
+  teleported: true,
+} as const
+
+/**
+ * @deprecated Removed after 3.0.0, Use `ElTooltipContentProps` instead.
+ */
 export const useTooltipContentProps = buildProps({
   ...useDelayedToggleProps,
   ...popperContentProps,
@@ -59,9 +119,9 @@ export const useTooltipContentProps = buildProps({
   ...useAriaProps(['ariaLabel']),
 } as const)
 
-export type ElTooltipContentProps = ExtractPropTypes<
-  typeof useTooltipContentProps
->
+/**
+ * @deprecated Removed after 3.0.0, Use `ElTooltipContentProps` instead.
+ */
 export type ElTooltipContentPropsPublic = ExtractPublicPropTypes<
   typeof useTooltipContentProps
 >

--- a/packages/components/tooltip/src/content.ts
+++ b/packages/components/tooltip/src/content.ts
@@ -3,10 +3,13 @@ import {
   popperContentProps,
   popperContentPropsDefaults,
 } from '@element-plus/components/popper'
-import { useAriaProps, useDelayedToggleProps } from '@element-plus/hooks'
+import {
+  useAriaProps,
+  useDelayedToggleProps,
+  useDelayedTogglePropsDefaults,
+} from '@element-plus/hooks'
 import { teleportProps } from '@element-plus/components/teleport'
 
-import type { TeleportProps } from '@element-plus/components/teleport'
 import type { AriaProps, UseDelayedToggleProps } from '@element-plus/hooks'
 import type { PopperContentProps } from '@element-plus/components/popper'
 import type TooltipContent from './content.vue'
@@ -17,7 +20,7 @@ export interface ElTooltipContentProps
   /**
    * @description which element the tooltip CONTENT appends to
    */
-  appendTo?: TeleportProps['to']
+  appendTo?: string | HTMLElement
   /**
    * @description display content, can be overridden by `slot#content`
    */
@@ -54,9 +57,7 @@ export interface ElTooltipContentProps
 }
 
 export const useTooltipContentPropsDefaults = {
-  showAfter: 0,
-  hideAfter: 200,
-  autoClose: 0,
+  ...useDelayedTogglePropsDefaults,
   ...popperContentPropsDefaults,
   content: '',
   visible: null,

--- a/packages/components/tooltip/src/content.vue
+++ b/packages/components/tooltip/src/content.vue
@@ -57,9 +57,10 @@ import {
 import { ElPopperContent } from '@element-plus/components/popper'
 import ElTeleport from '@element-plus/components/teleport'
 import { TOOLTIP_INJECTION_KEY } from './constants'
-import { useTooltipContentProps } from './content'
 import { isTriggerType } from './utils'
+import { useTooltipContentPropsDefaults } from './content'
 
+import type { ElTooltipContentProps } from './content'
 import type { PopperContentInstance } from '@element-plus/components/popper'
 
 defineOptions({
@@ -67,7 +68,10 @@ defineOptions({
   inheritAttrs: false,
 })
 
-const props = defineProps(useTooltipContentProps)
+const props = withDefaults(
+  defineProps<ElTooltipContentProps>(),
+  useTooltipContentPropsDefaults
+)
 
 const { selector } = usePopperContainerId()
 const ns = useNamespace('tooltip')

--- a/packages/components/tooltip/src/tooltip.ts
+++ b/packages/components/tooltip/src/tooltip.ts
@@ -19,9 +19,15 @@ export const {
   useModelToggle: useTooltipModelToggle,
 } = createModelToggleComposable('visible' as const)
 
+type ModelToggleProps = ExtractPublicPropTypes<
+  // @vue-ignore
+  typeof useTooltipModelToggleProps
+>
+
 export interface UseTooltipProps
   extends
     PopperProps,
+    Omit<ModelToggleProps, 'visible'>,
     ElTooltipContentProps,
     UseTooltipTriggerProps,
     PopperArrowProps {

--- a/packages/components/tooltip/src/tooltip.ts
+++ b/packages/components/tooltip/src/tooltip.ts
@@ -4,8 +4,14 @@ import { popperArrowProps, popperProps } from '@element-plus/components/popper'
 import { useTooltipContentProps } from './content'
 import { useTooltipTriggerProps } from './trigger'
 
+import type {
+  PopperArrowProps,
+  PopperProps,
+} from '@element-plus/components/popper'
+import type { ElTooltipContentProps } from './content'
+import type { UseTooltipTriggerProps } from './trigger'
 import type Tooltip from './tooltip.vue'
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 
 export const {
   useModelToggleProps: useTooltipModelToggleProps,
@@ -13,6 +19,21 @@ export const {
   useModelToggle: useTooltipModelToggle,
 } = createModelToggleComposable('visible' as const)
 
+export interface UseTooltipProps
+  extends
+    PopperProps,
+    ElTooltipContentProps,
+    UseTooltipTriggerProps,
+    PopperArrowProps {
+  /**
+   * @description whether the tooltip content has an arrow
+   */
+  showArrow?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `UseTooltipProps` instead.
+ */
 export const useTooltipProps = buildProps({
   ...popperProps,
   ...useTooltipModelToggleProps,
@@ -38,7 +59,10 @@ export const tooltipEmits = [
   'close',
 ]
 
-export type ElTooltipProps = ExtractPropTypes<typeof useTooltipProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `UseTooltipProps` instead.
+ */
+export type ElTooltipProps = UseTooltipProps
 export type ElTooltipPropsPublic = ExtractPublicPropTypes<
   typeof useTooltipProps
 >

--- a/packages/components/tooltip/src/tooltip.ts
+++ b/packages/components/tooltip/src/tooltip.ts
@@ -19,15 +19,9 @@ export const {
   useModelToggle: useTooltipModelToggle,
 } = createModelToggleComposable('visible' as const)
 
-type ModelToggleProps = ExtractPublicPropTypes<
-  // @vue-ignore
-  typeof useTooltipModelToggleProps
->
-
 export interface UseTooltipProps
   extends
     PopperProps,
-    Omit<ModelToggleProps, 'visible'>,
     ElTooltipContentProps,
     UseTooltipTriggerProps,
     PopperArrowProps {
@@ -35,6 +29,7 @@ export interface UseTooltipProps
    * @description whether the tooltip content has an arrow
    */
   showArrow?: boolean
+  'onUpdate:visible'?: (value: boolean) => void
 }
 
 /**

--- a/packages/components/tooltip/src/tooltip.vue
+++ b/packages/components/tooltip/src/tooltip.vue
@@ -62,7 +62,11 @@ import {
   unref,
   watch,
 } from 'vue'
-import { ElPopper, ElPopperArrow } from '@element-plus/components/popper'
+import {
+  ElPopper,
+  ElPopperArrow,
+  popperArrowPropsDefaults,
+} from '@element-plus/components/popper'
 import { isBoolean } from '@element-plus/utils'
 import {
   useDelayedToggle,
@@ -71,18 +75,27 @@ import {
   usePopperContainer,
 } from '@element-plus/hooks'
 import { TOOLTIP_INJECTION_KEY } from './constants'
-import { tooltipEmits, useTooltipModelToggle, useTooltipProps } from './tooltip'
+import { tooltipEmits, useTooltipModelToggle } from './tooltip'
 import ElTooltipTrigger from './trigger.vue'
 import ElTooltipContent from './content.vue'
+import { useTooltipContentPropsDefaults } from './content'
+import { useTooltipTriggerPropsDefaults } from './trigger'
 
 import type { TooltipContentInstance } from './content'
+import type { UseTooltipProps } from './tooltip'
 import type { PopperInstance } from '@element-plus/components/popper'
 
 defineOptions({
   name: 'ElTooltip',
 })
 
-const props = defineProps(useTooltipProps)
+const props = withDefaults(defineProps<UseTooltipProps>(), {
+  role: 'tooltip',
+  ...useTooltipContentPropsDefaults,
+  ...useTooltipTriggerPropsDefaults,
+  ...popperArrowPropsDefaults,
+  showArrow: true,
+})
 const emit = defineEmits(tooltipEmits)
 
 usePopperContainer()

--- a/packages/components/tooltip/src/trigger.ts
+++ b/packages/components/tooltip/src/trigger.ts
@@ -2,11 +2,43 @@ import { buildProps, definePropType } from '@element-plus/utils'
 import { popperTriggerProps } from '@element-plus/components/popper'
 import { EVENT_CODE } from '@element-plus/constants'
 
+import type { PopperTriggerProps } from '@element-plus/components/popper'
 import type { Arrayable } from '@element-plus/utils'
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 
 export type TooltipTriggerType = 'hover' | 'focus' | 'click' | 'contextmenu'
 
+export interface UseTooltipTriggerProps extends PopperTriggerProps {
+  /**
+   * @description whether Tooltip is disabled
+   */
+  disabled?: boolean
+  /**
+   * @description How should the tooltip be triggered (to show), not valid in controlled mode
+   */
+  trigger?: Arrayable<TooltipTriggerType>
+  /**
+   * @description When you click the mouse to focus on the trigger element, you can define a set of keyboard codes to control the display of tooltip through the keyboard, not valid in controlled mode
+   */
+  triggerKeys?: string[]
+  /**
+   * @description when triggering tooltips through hover, whether to focus the trigger element, which improves accessibility
+   */
+  focusOnTarget?: boolean
+}
+
+export const useTooltipTriggerPropsDefaults = {
+  trigger: 'hover',
+  triggerKeys: () => [
+    EVENT_CODE.enter,
+    EVENT_CODE.numpadEnter,
+    EVENT_CODE.space,
+  ],
+} as const
+
+/**
+ * @deprecated Removed after 3.0.0, Use `UseTooltipTriggerProps` instead.
+ */
 export const useTooltipTriggerProps = buildProps({
   ...popperTriggerProps,
   /**
@@ -33,10 +65,14 @@ export const useTooltipTriggerProps = buildProps({
   focusOnTarget: Boolean,
 } as const)
 
-export type ElTooltipTriggerProps = ExtractPropTypes<
-  typeof useTooltipTriggerProps
->
+/**
+ * @deprecated Removed after 3.0.0, Use `UseTooltipTriggerProps` instead.
+ */
+export type ElTooltipTriggerProps = UseTooltipTriggerProps
 
+/**
+ * @deprecated Removed after 3.0.0, Use `UseTooltipTriggerProps` instead.
+ */
 export type ElTooltipTriggerPropsPublic = ExtractPublicPropTypes<
   typeof useTooltipTriggerProps
 >

--- a/packages/components/tooltip/src/trigger.vue
+++ b/packages/components/tooltip/src/trigger.vue
@@ -27,16 +27,20 @@ import {
 } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { TOOLTIP_INJECTION_KEY } from './constants'
-import { useTooltipTriggerProps } from './trigger'
 import { whenTrigger } from './utils'
+import { useTooltipTriggerPropsDefaults } from './trigger'
 
+import type { UseTooltipTriggerProps } from './trigger'
 import type { OnlyChildExpose } from '@element-plus/components/slot'
 
 defineOptions({
   name: 'ElTooltipTrigger',
 })
 
-const props = defineProps(useTooltipTriggerProps)
+const props = withDefaults(
+  defineProps<UseTooltipTriggerProps>(),
+  useTooltipTriggerPropsDefaults
+)
 
 const ns = useNamespace('tooltip')
 const { controlled, id, open, onOpen, onClose, onToggle } = inject(

--- a/packages/hooks/use-aria/index.ts
+++ b/packages/hooks/use-aria/index.ts
@@ -1,6 +1,21 @@
 import { pick } from 'lodash-unified'
 import { buildProps } from '@element-plus/utils'
 
+export interface AriaProps {
+  /**
+   * @description native `aria-label` attribute
+   */
+  ariaLabel?: string
+  /**
+   * @description native `aria-orientation` attribute
+   */
+  ariaOrientation?: 'horizontal' | 'vertical' | 'undefined'
+  /**
+   * @description native `aria-controls` attribute
+   */
+  ariaControls?: string
+}
+
 export const ariaProps = buildProps({
   /**
    * @description native `aria-label` attribute

--- a/packages/hooks/use-delayed-toggle/index.ts
+++ b/packages/hooks/use-delayed-toggle/index.ts
@@ -2,8 +2,26 @@ import { unref } from 'vue'
 import { buildProps, isNumber } from '@element-plus/utils'
 import { useTimeout } from '../use-timeout'
 
-import type { ExtractPropTypes, ToRefs } from 'vue'
+import type { ToRefs } from 'vue'
 
+export interface UseDelayedToggleProps {
+  /**
+   * @description delay of appearance, in millisecond, not valid in controlled mode
+   */
+  showAfter?: number
+  /**
+   * @description delay of disappear, in millisecond, not valid in controlled mode
+   */
+  hideAfter?: number
+  /**
+   * @description disappear automatically, in millisecond, not valid in controlled mode
+   */
+  autoClose?: number
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `UseDelayedToggleProps` instead.
+ */
 export const useDelayedToggleProps = buildProps({
   /**
    * @description delay of appearance, in millisecond, not valid in controlled mode
@@ -28,10 +46,10 @@ export const useDelayedToggleProps = buildProps({
   },
 } as const)
 
-export type UseDelayedToggleProps = {
+export type DelayedToggle = {
   open: (event?: Event) => void
   close: (event?: Event) => void
-} & ToRefs<ExtractPropTypes<typeof useDelayedToggleProps>>
+} & ToRefs<Required<UseDelayedToggleProps>>
 
 export const useDelayedToggle = ({
   showAfter,
@@ -39,7 +57,7 @@ export const useDelayedToggle = ({
   autoClose,
   open,
   close,
-}: UseDelayedToggleProps) => {
+}: DelayedToggle) => {
   const { registerTimeout } = useTimeout()
   const {
     registerTimeout: registerTimeoutForAutoClose,

--- a/packages/hooks/use-delayed-toggle/index.ts
+++ b/packages/hooks/use-delayed-toggle/index.ts
@@ -51,6 +51,12 @@ export type DelayedToggle = {
   close: (event?: Event) => void
 } & ToRefs<Required<UseDelayedToggleProps>>
 
+export const useDelayedTogglePropsDefaults = {
+  showAfter: 0,
+  hideAfter: 200,
+  autoClose: 0,
+} as const
+
 export const useDelayedToggle = ({
   showAfter,
   hideAfter,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
rel #23399 
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated tooltip, content and trigger prop definitions into typed, shared defaults; prop initialization is now type-safe and consistent. Public prop types were adjusted and older aliases marked deprecated.
* **New Features**
  * Added ARIA props (label/orientation/controls), refined trigger/visibility defaults, and enabled the tooltip arrow by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->