### PR TITLE
refactor(components): [tab-pane/bar] use type-based definitions

### DIFF
--- a/packages/components/tabs/src/tab-bar.ts
+++ b/packages/components/tabs/src/tab-bar.ts
@@ -1,9 +1,12 @@
 import { buildProps, definePropType, mutable } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 import type { TabPaneName, TabsPaneContext } from './constants'
 import type TabBar from './tab-bar.vue'
 
+/**
+ * @deprecated Removed after 3.0.0, Use `TabBarProps` instead.
+ */
 export const tabBarProps = buildProps({
   tabs: {
     type: definePropType<TabsPaneContext[]>(Array),
@@ -15,6 +18,12 @@ export const tabBarProps = buildProps({
   },
 } as const)
 
-export type TabBarProps = ExtractPropTypes<typeof tabBarProps>
+export type TabBarProps = {
+  tabs?: TabsPaneContext[]
+  tabRefs?: { [key: TabPaneName]: HTMLDivElement }
+}
+/**
+ * @deprecated Removed after 3.0.0, Use `TabBarProps` instead.
+ */
 export type TabBarPropsPublic = ExtractPublicPropTypes<typeof tabBarProps>
 export type TabBarInstance = InstanceType<typeof TabBar> & unknown

--- a/packages/components/tabs/src/tab-bar.vue
+++ b/packages/components/tabs/src/tab-bar.vue
@@ -13,15 +13,18 @@ import { useResizeObserver } from '@vueuse/core'
 import { capitalize, isUndefined, throwError } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { tabsRootContextKey } from './constants'
-import { tabBarProps } from './tab-bar'
 
+import type { TabBarProps } from './tab-bar'
 import type { CSSProperties } from 'vue'
 
 const COMPONENT_NAME = 'ElTabBar'
 defineOptions({
   name: COMPONENT_NAME,
 })
-const props = defineProps(tabBarProps)
+const props = withDefaults(defineProps<TabBarProps>(), {
+  tabs: () => [],
+  tabRefs: () => ({}),
+})
 
 const rootTabs = inject(tabsRootContextKey)
 if (!rootTabs) throwError(COMPONENT_NAME, '<el-tabs><el-tab-bar /></el-tabs>')

--- a/packages/components/tabs/src/tab-pane.ts
+++ b/packages/components/tabs/src/tab-pane.ts
@@ -38,10 +38,25 @@ export const tabPaneProps = buildProps({
 } as const)
 
 export type TabPaneProps = {
+  /**
+   * @description title of the tab
+   */
   label?: string
+  /**
+   * @description identifier corresponding to the name of Tabs, representing the alias of the tab-pane, the default is ordinal number of the tab-pane in the sequence, e.g. the first tab-pane is '0'
+   */
   name?: string | number
+  /**
+   * @description whether Tab is closable
+   */
   closable?: boolean
+  /**
+   * @description whether Tab is disabled
+   */
   disabled?: boolean
+  /**
+   * @description whether Tab is lazily rendered
+   */
   lazy?: boolean
 }
 /**

--- a/packages/components/tabs/src/tab-pane.ts
+++ b/packages/components/tabs/src/tab-pane.ts
@@ -1,8 +1,11 @@
 import { buildProps } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ExtractPublicPropTypes } from 'vue'
 import type TabPane from './tab-pane.vue'
 
+/**
+ * @deprecated Removed after 3.0.0, Use `TabPaneProps` instead.
+ */
 export const tabPaneProps = buildProps({
   /**
    * @description title of the tab
@@ -34,7 +37,16 @@ export const tabPaneProps = buildProps({
   lazy: Boolean,
 } as const)
 
-export type TabPaneProps = ExtractPropTypes<typeof tabPaneProps>
+export type TabPaneProps = {
+  label?: string
+  name?: string | number
+  closable?: boolean
+  disabled?: boolean
+  lazy?: boolean
+}
+/**
+ * @deprecated Removed after 3.0.0, Use `TabPaneProps` instead.
+ */
 export type TabPanePropsPublic = ExtractPublicPropTypes<typeof tabPaneProps>
 
 export type TabPaneInstance = InstanceType<typeof TabPane> & unknown

--- a/packages/components/tabs/src/tab-pane.vue
+++ b/packages/components/tabs/src/tab-pane.vue
@@ -28,13 +28,17 @@ import {
 import { throwError } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { tabsRootContextKey } from './constants'
-import { tabPaneProps } from './tab-pane'
+
+import type { TabPaneProps } from './tab-pane'
 
 const COMPONENT_NAME = 'ElTabPane'
 defineOptions({
   name: COMPONENT_NAME,
 })
-const props = defineProps(tabPaneProps)
+const props = withDefaults(defineProps<TabPaneProps>(), {
+  label: '',
+  closable: undefined,
+})
 
 const instance = getCurrentInstance()!
 const slots = useSlots()


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deprecated legacy prop definitions across Tabs; migrate to the new prop type names by v3.0.0.
  * Introduced explicit, strongly-typed prop shapes for tab bar and tab pane public types.
  * Applied default values for tabs, tabRefs and pane props to improve runtime defaults and type safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->