### PR TITLE
refactor(components): [cascader] use type-based definitions

### DIFF
--- a/packages/components/cascader-panel/src/config.ts
+++ b/packages/components/cascader-panel/src/config.ts
@@ -2,7 +2,7 @@ import { computed } from 'vue'
 import { NOOP, buildProps, definePropType } from '@element-plus/utils'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
-import type { PropType } from 'vue'
+import type { ExtractPublicPropTypes, PropType } from 'vue'
 import type {
   CascaderConfig,
   CascaderNodePathValue,
@@ -11,6 +11,21 @@ import type {
   CascaderValue,
   RenderLabel,
 } from './types'
+
+export interface CascaderCommonProps {
+  /**
+   * @description specify which key of node object is used as the node's value
+   */
+  modelValue?: CascaderValue | null
+  /**
+   * @description data of the options, the key of `value` and `label` can be customize by `CascaderProps`.
+   */
+  options?: CascaderOption[]
+  /**
+   * @description configuration options, see the following `CascaderProps` table.
+   */
+  props?: CascaderProps
+}
 
 export const CommonProps = buildProps({
   /**
@@ -34,6 +49,11 @@ export const CommonProps = buildProps({
     default: () => ({}) as CascaderProps,
   },
 } as const)
+
+export interface CascaderPanelProps extends CascaderCommonProps {
+  border?: boolean
+  renderLabel?: RenderLabel
+}
 
 export const DefaultProps: CascaderConfig = {
   /**
@@ -98,6 +118,9 @@ export const DefaultProps: CascaderConfig = {
   showPrefix: true,
 }
 
+/**
+ * @deprecated Removed after 3.0.0, Use `CascaderPanelProps` instead.
+ */
 export const cascaderPanelProps = buildProps({
   ...CommonProps,
   border: {
@@ -108,6 +131,13 @@ export const cascaderPanelProps = buildProps({
     type: Function as PropType<RenderLabel>,
   },
 })
+
+/**
+ * @deprecated Removed after 3.0.0, Use `CascaderPanelProps` instead.
+ */
+export type CascaderPanelPropsPublic = ExtractPublicPropTypes<
+  typeof cascaderPanelProps
+>
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const emitChangeFn = (value: CascaderValue | undefined | null) => true

--- a/packages/components/cascader-panel/src/config.ts
+++ b/packages/components/cascader-panel/src/config.ts
@@ -2,7 +2,7 @@ import { computed } from 'vue'
 import { NOOP, buildProps, definePropType } from '@element-plus/utils'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
-import type { ExtractPublicPropTypes, PropType } from 'vue'
+import type { PropType } from 'vue'
 import type {
   CascaderConfig,
   CascaderNodePathValue,
@@ -131,13 +131,6 @@ export const cascaderPanelProps = buildProps({
     type: Function as PropType<RenderLabel>,
   },
 })
-
-/**
- * @deprecated Removed after 3.0.0, Use `CascaderPanelProps` instead.
- */
-export type CascaderPanelPropsPublic = ExtractPublicPropTypes<
-  typeof cascaderPanelProps
->
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const emitChangeFn = (value: CascaderValue | undefined | null) => true

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -49,11 +49,7 @@ import { useNamespace } from '@element-plus/hooks'
 import ElCascaderMenu from './menu.vue'
 import Store from './store'
 import Node from './node'
-import {
-  cascaderPanelEmits,
-  cascaderPanelProps,
-  useCascaderConfig,
-} from './config'
+import { cascaderPanelEmits, useCascaderConfig } from './config'
 import { checkNode, getMenuIndex, sortByOriginalOrder } from './utils'
 import { CASCADER_PANEL_INJECTION_KEY } from './types'
 
@@ -61,16 +57,22 @@ import type {
   CascaderNode,
   CascaderNodeValue,
   CascaderOption,
+  CascaderProps,
   CascaderValue,
   ElCascaderPanelContext,
 } from './types'
 import type { CascaderMenuInstance } from './instance'
+import type { CascaderPanelProps } from './config'
 
 defineOptions({
   name: 'ElCascaderPanel',
 })
 
-const props = defineProps(cascaderPanelProps)
+const props = withDefaults(defineProps<CascaderPanelProps>(), {
+  options: () => [] as CascaderOption[],
+  props: () => ({}) as CascaderProps,
+  border: true,
+})
 const emit = defineEmits(cascaderPanelEmits)
 
 // for interrupt sync check status in lazy mode

--- a/packages/components/cascader/src/cascader.ts
+++ b/packages/components/cascader/src/cascader.ts
@@ -6,18 +6,148 @@ import {
   iconPropType,
   isBoolean,
 } from '@element-plus/utils'
-import { useEmptyValuesProps, useSizeProp } from '@element-plus/hooks'
+import {
+  UseEmptyValuesProps,
+  useEmptyValuesProps,
+  useSizeProp,
+} from '@element-plus/hooks'
 import { useTooltipContentProps } from '@element-plus/components/tooltip'
 import { tagProps } from '@element-plus/components/tag'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { CircleClose } from '@element-plus/icons-vue'
 
 import type {
+  CascaderCommonProps,
   CascaderNode,
   CascaderValue,
 } from '@element-plus/components/cascader-panel'
 import type { Placement, PopperEffect } from '@element-plus/components/popper'
+import type { Component, ExtractPublicPropTypes, StyleValue } from 'vue'
+import type { ComponentSize } from '@element-plus/constants'
+import type { TagProps } from '@element-plus/components/tag'
 
+type CascaderClassType = string | Record<string, boolean> | CascaderClassType[]
+
+export interface CascaderComponentProps
+  extends CascaderCommonProps, UseEmptyValuesProps {
+  /**
+   * @description size of input
+   */
+  size?: ComponentSize
+  /**
+   * @description placeholder of input
+   */
+  placeholder?: string
+  /**
+   * @description whether Cascader is disabled
+   */
+  disabled?: boolean
+  /**
+   * @description whether selected value can be cleared
+   */
+  clearable?: boolean
+  /**
+   * @description custom clear icon component
+   */
+  clearIcon?: string | Component
+  /**
+   * @description whether the options can be searched
+   */
+  filterable?: boolean
+  /**
+   * @description customize search logic, the first parameter is `node`, the second is `keyword`, and need return a boolean value indicating whether it hits.
+   */
+  filterMethod?: (node: CascaderNode, keyword: string) => boolean
+  /**
+   * @description option label separator
+   */
+  separator?: string
+  /**
+   * @description whether to display all levels of the selected value in the input
+   */
+  showAllLevels?: boolean
+  /**
+   * @description whether to collapse tags in multiple selection mode
+   */
+  collapseTags?: boolean
+  /**
+   * @description The max tags number to be shown. To use this, collapse-tags must be true
+   */
+  maxCollapseTags?: number
+  /**
+   * @description whether show all selected tags when mouse hover text of collapse-tags. To use this, collapse-tags must be true
+   */
+  collapseTagsTooltip?: boolean
+  /**
+   * @description The max height of collapse tags tooltip, in pixels. To use this, collapse-tags-tooltip must be true
+   */
+  maxCollapseTagsTooltipHeight?: string | number
+  /**
+   * @description debounce delay when typing filter keyword, in milliseconds
+   */
+  debounce?: number
+  /**
+   * @description hook function before filtering with the value to be filtered as its parameter. If `false` is returned or a `Promise` is returned and then is rejected, filtering will be aborted
+   */
+  beforeFilter?: (value: string) => boolean | Promise<any>
+  /**
+   * @description position of dropdown
+   */
+  placement?: Placement
+  /**
+   * @description list of possible positions for dropdown
+   */
+  fallbackPlacements?: Placement[]
+  /**
+   * @description custom class name for Cascader's dropdown
+   */
+  popperClass?: CascaderClassType
+  /**
+   * @description custom style for Cascader's dropdown
+   */
+  popperStyle?: StyleValue
+  /**
+   * @description whether cascader popup is teleported
+   */
+  teleported?: boolean
+  /**
+   * @description tooltip theme, built-in theme: `dark` / `light`
+   */
+  effect?: PopperEffect
+  /**
+   * @description tag type
+   */
+  tagType?: TagProps['type']
+  /**
+   * @description tag effect
+   */
+  tagEffect?: TagProps['effect']
+  /**
+   * @description whether to trigger form validation
+   */
+  validateEvent?: boolean
+  /**
+   * @description when dropdown is inactive and `persistent` is `false`, dropdown will be destroyed
+   */
+  persistent?: boolean
+  /**
+   * @description Use `parent` when you want things tidy (like "Entire Collection" instead of listing 100 items)
+   * Use `child` when every single item matters (like important settings)
+   */
+  showCheckedStrategy?: 'parent' | 'child'
+  /**
+   * @description whether to check or uncheck node when clicking on the node
+   */
+  checkOnClickNode?: boolean
+  /**
+   * @description whether to show the radio or checkbox prefix
+   */
+  showPrefix?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `CascaderComponentProps` instead.
+ */
 export const cascaderProps = buildProps({
   ...CommonProps,
   /**
@@ -203,7 +333,9 @@ export const cascaderEmits = {
   removeTag: (val: CascaderNode['valueByOption']) => !!val,
 }
 
-// Type name is taken(cascader-panel/src/node), needs discussion
-// export type CascaderProps = ExtractPropTypes<typeof cascaderProps>
+/**
+ * @deprecated Removed after 3.0.0, Use `CascaderComponentProps` instead.
+ */
+export type CascaderPropsPublic = ExtractPublicPropTypes<typeof cascaderProps>
 
 export type CascaderEmits = typeof cascaderEmits

--- a/packages/components/cascader/src/cascader.ts
+++ b/packages/components/cascader/src/cascader.ts
@@ -22,7 +22,7 @@ import type {
   CascaderValue,
 } from '@element-plus/components/cascader-panel'
 import type { Placement, PopperEffect } from '@element-plus/components/popper'
-import type { Component, ExtractPublicPropTypes, StyleValue } from 'vue'
+import type { Component, StyleValue } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
 import type { TagProps } from '@element-plus/components/tag'
 
@@ -332,10 +332,5 @@ export const cascaderEmits = {
   expandChange: (val: CascaderValue) => !!val,
   removeTag: (val: CascaderNode['valueByOption']) => !!val,
 }
-
-/**
- * @deprecated Removed after 3.0.0, Use `CascaderComponentProps` instead.
- */
-export type CascaderPropsPublic = ExtractPublicPropTypes<typeof cascaderProps>
 
 export type CascaderEmits = typeof cascaderEmits

--- a/packages/components/cascader/src/cascader.ts
+++ b/packages/components/cascader/src/cascader.ts
@@ -6,24 +6,21 @@ import {
   iconPropType,
   isBoolean,
 } from '@element-plus/utils'
-import {
-  UseEmptyValuesProps,
-  useEmptyValuesProps,
-  useSizeProp,
-} from '@element-plus/hooks'
+import { useEmptyValuesProps, useSizeProp } from '@element-plus/hooks'
 import { useTooltipContentProps } from '@element-plus/components/tooltip'
 import { tagProps } from '@element-plus/components/tag'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { CircleClose } from '@element-plus/icons-vue'
 
+import type { Component, StyleValue } from 'vue'
+import type { UseEmptyValuesProps } from '@element-plus/hooks'
+import type { ComponentSize } from '@element-plus/constants'
+import type { Placement, PopperEffect } from '@element-plus/components/popper'
 import type {
   CascaderCommonProps,
   CascaderNode,
   CascaderValue,
 } from '@element-plus/components/cascader-panel'
-import type { Placement, PopperEffect } from '@element-plus/components/popper'
-import type { Component, StyleValue } from 'vue'
-import type { ComponentSize } from '@element-plus/constants'
 import type { TagProps } from '@element-plus/components/tag'
 
 type CascaderClassType = string | Record<string, boolean> | CascaderClassType[]

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -216,7 +216,15 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, onMounted, ref, useAttrs, watch } from 'vue'
+import {
+  computed,
+  markRaw,
+  nextTick,
+  onMounted,
+  ref,
+  useAttrs,
+  watch,
+} from 'vue'
 import { cloneDeep } from 'lodash-unified'
 import { useCssVar, useDebounceFn, useResizeObserver } from '@vueuse/core'
 import {
@@ -251,8 +259,8 @@ import {
   EVENT_CODE,
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
-import { ArrowDown, Check } from '@element-plus/icons-vue'
-import { cascaderEmits, cascaderProps } from './cascader'
+import { ArrowDown, Check, CircleClose } from '@element-plus/icons-vue'
+import { cascaderEmits } from './cascader'
 
 import type { Options } from '@element-plus/components/popper'
 import type { ComputedRef, StyleValue } from 'vue'
@@ -265,6 +273,7 @@ import type {
   CascaderValue,
   Tag,
 } from '@element-plus/components/cascader-panel'
+import type { CascaderComponentProps } from './cascader'
 
 const popperOptions: Partial<Options> = {
   modifiers: [
@@ -288,7 +297,37 @@ defineOptions({
   name: 'ElCascader',
 })
 
-const props = defineProps(cascaderProps)
+const props = withDefaults(defineProps<CascaderComponentProps>(), {
+  options: () => [],
+  props: () => ({}),
+  disabled: undefined,
+  clearIcon: markRaw(CircleClose),
+  filterMethod: (node, keyword) => node.text.includes(keyword),
+  separator: ' / ',
+  showAllLevels: true,
+  maxCollapseTags: 1,
+  debounce: 300,
+  beforeFilter: () => true,
+  placement: 'bottom-start',
+  fallbackPlacements: () => [
+    'bottom-start',
+    'bottom',
+    'top-start',
+    'top',
+    'right',
+    'left',
+  ],
+  teleported: true,
+  effect: 'light',
+  tagType: 'info',
+  tagEffect: 'light',
+  validateEvent: true,
+  persistent: true,
+  showCheckedStrategy: 'child',
+  showPrefix: true,
+  popperStyle: undefined,
+  valueOnClear: undefined,
+})
 const emit = defineEmits(cascaderEmits)
 const attrs = useAttrs()
 const slots = defineSlots()

--- a/packages/hooks/use-empty-values/index.ts
+++ b/packages/hooks/use-empty-values/index.ts
@@ -8,16 +8,31 @@ import {
 } from '@element-plus/utils'
 import { isEqual } from 'lodash-unified'
 
-import type { ExtractPropTypes, InjectionKey, Ref } from 'vue'
+import type { InjectionKey, Ref } from 'vue'
 
-type EmptyValuesContext = ExtractPropTypes<typeof useEmptyValuesProps>
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+type ValueOnClear = string | number | boolean | Function | null
 
-export const emptyValuesContextKey: InjectionKey<Ref<EmptyValuesContext>> =
+export interface UseEmptyValuesProps {
+  /**
+   * @description empty values supported by the component
+   */
+  emptyValues?: unknown[]
+  /**
+   * @description return value when cleared, if you want to set `undefined`, use `() => undefined`
+   */
+  valueOnClear?: ValueOnClear
+}
+
+export const emptyValuesContextKey: InjectionKey<Ref<UseEmptyValuesProps>> =
   Symbol('emptyValuesContextKey')
 export const SCOPE = 'use-empty-values'
 export const DEFAULT_EMPTY_VALUES = ['', undefined, null]
 export const DEFAULT_VALUE_ON_CLEAR = undefined
 
+/**
+ * @deprecated Removed after 3.0.0, Use `UseEmptyValuesProps` instead.
+ */
 export const useEmptyValuesProps = buildProps({
   /**
    * @description empty values supported by the component
@@ -46,12 +61,12 @@ export const useEmptyValuesProps = buildProps({
 } as const)
 
 export const useEmptyValues = (
-  props: EmptyValuesContext,
+  props: UseEmptyValuesProps,
   defaultValue?: null | undefined
 ) => {
   const config = getCurrentInstance()
-    ? inject(emptyValuesContextKey, ref<EmptyValuesContext>({}))
-    : ref<EmptyValuesContext>({})
+    ? inject(emptyValuesContextKey, ref<UseEmptyValuesProps>({}))
+    : ref<UseEmptyValuesProps>({})
 
   const emptyValues = computed(
     () => props.emptyValues || config.value.emptyValues || DEFAULT_EMPTY_VALUES


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

ref #23399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default clear icon set and many props now have sensible defaults for a more consistent UX.
  * Cascader components expose an expanded, configurable prop surface for richer behavior out of the box.

* **Refactor**
  * Public prop typings and component prop signatures consolidated and strengthened for clearer, safer configuration.

* **Chores**
  * Deprecation notices added for legacy prop shapes to guide migration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->