### PR TITLE
refactor(components): [form/form-item] use type-based definitions

### DIFF
--- a/packages/components/form/src/form-item.ts
+++ b/packages/components/form/src/form-item.ts
@@ -1,7 +1,7 @@
-import { ExtractPublicPropTypes } from 'vue'
 import { componentSizes } from '@element-plus/constants'
 import { buildProps, definePropType } from '@element-plus/utils'
 
+import type { ExtractPublicPropTypes } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
 import type { Arrayable } from '@element-plus/utils'
 import type { FormItemRule } from './types'

--- a/packages/components/form/src/form-item.ts
+++ b/packages/components/form/src/form-item.ts
@@ -1,3 +1,4 @@
+import { ExtractPublicPropTypes } from 'vue'
 import { componentSizes } from '@element-plus/constants'
 import { buildProps, definePropType } from '@element-plus/utils'
 
@@ -144,3 +145,8 @@ export const formItemProps = buildProps({
     values: componentSizes,
   },
 } as const)
+
+/**
+ * @deprecated Removed after 3.0.0, Use `FormItemProps` instead.
+ */
+export type FormItemPropsPublic = ExtractPublicPropTypes<typeof formItemProps>

--- a/packages/components/form/src/form-item.ts
+++ b/packages/components/form/src/form-item.ts
@@ -1,7 +1,7 @@
 import { componentSizes } from '@element-plus/constants'
 import { buildProps, definePropType } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ComponentSize } from '@element-plus/constants'
 import type { Arrayable } from '@element-plus/utils'
 import type { FormItemRule } from './types'
 
@@ -15,6 +15,60 @@ export type FormItemValidateState = (typeof formItemValidateStates)[number]
 
 export type FormItemProp = Arrayable<string>
 
+export interface FormItemProps {
+  /**
+   * @description Label text.
+   */
+  label?: string
+  /**
+   * @description Width of label, e.g. `'50px'`. `'auto'` is supported.
+   */
+  labelWidth?: string | number
+  /**
+   * @description Position of label. If set to `'left'` or `'right'`, `label-width` prop is also required. The default is extend from `form label-position`.
+   */
+  labelPosition?: 'left' | 'right' | 'top' | ''
+  /**
+   * @description  A key of `model`. It could be an array of property paths (e.g `['a', 'b', '0']`). In the use of `validate` and `resetFields` method, the attribute is required.
+   */
+  prop?: FormItemProp
+  /**
+   * @description Whether the field is required or not, will be determined by validation rules if omitted.
+   */
+  required?: boolean
+  /**
+   * @description Validation rules of form, see the [following table](#formitemrule), more advanced usage at [async-validator](https://github.com/yiminghe/async-validator).
+   */
+  rules?: Arrayable<FormItemRule>
+  /**
+   * @description Field error message, set its value and the field will validate error and show this message immediately.
+   */
+  error?: string
+  /**
+   * @description Validation state of formItem.
+   */
+  validateStatus?: FormItemValidateState
+  /**
+   * @description Same as for in native label.
+   */
+  for?: string
+  /**
+   * @description Inline style validate message.
+   */
+  inlineMessage?: boolean
+  /**
+   * @description Whether to show the error message.
+   */
+  showMessage?: boolean
+  /**
+   * @description Control the size of components in this form-item.
+   */
+  size?: ComponentSize
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `FormItemProps` instead.
+ */
 export const formItemProps = buildProps({
   /**
    * @description Label text.
@@ -90,5 +144,3 @@ export const formItemProps = buildProps({
     values: componentSizes,
   },
 } as const)
-export type FormItemProps = ExtractPropTypes<typeof formItemProps>
-export type FormItemPropsPublic = ExtractPublicPropTypes<typeof formItemProps>

--- a/packages/components/form/src/form-item.vue
+++ b/packages/components/form/src/form-item.vue
@@ -63,7 +63,6 @@ import {
 } from '@element-plus/utils'
 import { useId, useNamespace } from '@element-plus/hooks'
 import { useFormSize } from './hooks'
-import { formItemProps } from './form-item'
 import FormLabelWrap from './form-label-wrap'
 import { formContextKey, formItemContextKey } from './constants'
 
@@ -75,12 +74,17 @@ import type {
   FormItemRule,
   FormValidateFailure,
 } from './types'
-import type { FormItemValidateState } from './form-item'
+import type { FormItemProps, FormItemValidateState } from './form-item'
 
 defineOptions({
   name: 'ElFormItem',
 })
-const props = defineProps(formItemProps)
+const props = withDefaults(defineProps<FormItemProps>(), {
+  labelPosition: '',
+  showMessage: true,
+  required: undefined,
+  inlineMessage: undefined,
+})
 const slots = useSlots()
 
 const formContext = inject(formContextKey, undefined)

--- a/packages/components/form/src/form.ts
+++ b/packages/components/form/src/form.ts
@@ -7,10 +7,24 @@ import {
   isString,
 } from '@element-plus/utils'
 
-import type { ExtractPropTypes, ExtractPublicPropTypes } from 'vue'
+import type { ComponentSize } from '@element-plus/constants'
 import type { FormItemProp } from './form-item'
 import type { FormRules } from './types'
 
+export interface FormMetaProps {
+  /**
+   * @description Control the size of components in this form.
+   */
+  size?: ComponentSize
+  /**
+   * @description Whether to disable all components in this form. If set to `true`, it will override the `disabled` prop of the inner component.
+   */
+  disabled?: boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `FormMetaProps` instead.
+ */
 export const formMetaProps = buildProps({
   /**
    * @description Control the size of components in this form.
@@ -25,6 +39,68 @@ export const formMetaProps = buildProps({
   disabled: Boolean,
 } as const)
 
+export interface FormProps extends FormMetaProps {
+  /**
+   * @description Data of form component.
+   */
+  model?: Record<string, any>
+  /**
+   * @description Validation rules of form.
+   */
+  rules?: FormRules
+  /**
+   * @description Position of label. If set to `'left'` or `'right'`, `label-width` prop is also required.
+   */
+  labelPosition?: 'left' | 'right' | 'top'
+  /**
+   * @description Position of asterisk.
+   */
+  requireAsteriskPosition?: 'left' | 'right'
+  /**
+   * @description Width of label, e.g. `'50px'`. All its direct child form items will inherit this value. `auto` is supported.
+   */
+  labelWidth?: string | number
+  /**
+   * @description Suffix of the label.
+   */
+  labelSuffix?: string
+  /**
+   * @description Whether the form is inline.
+   */
+  inline?: boolean
+  /**
+   * @description Whether to display the error message inline with the form item.
+   */
+  inlineMessage?: boolean
+  /**
+   * @description Whether to display an icon indicating the validation result.
+   */
+  statusIcon?: boolean
+  /**
+   * @description Whether to show the error message.
+   */
+  showMessage?: boolean
+  /**
+   * @description Whether to trigger validation when the `rules` prop is changed.
+   */
+  validateOnRuleChange?: boolean
+  /**
+   * @description Whether to hide required fields should have a red asterisk (star) beside their labels.
+   */
+  hideRequiredAsterisk?: boolean
+  /**
+   * @description When validation fails, scroll to the first error form entry.
+   */
+  scrollToError?: boolean
+  /**
+   * @description When validation fails, it scrolls to the first error item based on the scrollIntoView option.
+   */
+  scrollIntoViewOptions?: ScrollIntoViewOptions | boolean
+}
+
+/**
+ * @deprecated Removed after 3.0.0, Use `FormProps` instead.
+ */
 export const formProps = buildProps({
   ...formMetaProps,
   /**
@@ -109,11 +185,6 @@ export const formProps = buildProps({
     default: true,
   },
 } as const)
-export type FormProps = ExtractPropTypes<typeof formProps>
-export type FormPropsPublic = ExtractPublicPropTypes<typeof formProps>
-
-export type FormMetaProps = ExtractPropTypes<typeof formMetaProps>
-export type FormMetaPropsPublic = ExtractPublicPropTypes<typeof formMetaProps>
 
 export const formEmits = {
   validate: (prop: FormItemProp, isValid: boolean, message: string) =>

--- a/packages/components/form/src/form.ts
+++ b/packages/components/form/src/form.ts
@@ -1,3 +1,4 @@
+import { ExtractPublicPropTypes } from 'vue'
 import { componentSizes } from '@element-plus/constants'
 import {
   buildProps,
@@ -185,6 +186,16 @@ export const formProps = buildProps({
     default: true,
   },
 } as const)
+
+/**
+ * @deprecated Removed after 3.0.0, Use `FormProps` instead.
+ */
+export type FormPropsPublic = ExtractPublicPropTypes<typeof formProps>
+
+/**
+ * @deprecated Removed after 3.0.0, Use `FormMetaProps` instead.
+ */
+export type FormMetaPropsPublic = ExtractPublicPropTypes<typeof formMetaProps>
 
 export const formEmits = {
   validate: (prop: FormItemProp, isValid: boolean, message: string) =>

--- a/packages/components/form/src/form.ts
+++ b/packages/components/form/src/form.ts
@@ -1,4 +1,3 @@
-import { ExtractPublicPropTypes } from 'vue'
 import { componentSizes } from '@element-plus/constants'
 import {
   buildProps,
@@ -8,6 +7,7 @@ import {
   isString,
 } from '@element-plus/utils'
 
+import type { ExtractPublicPropTypes } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
 import type { FormItemProp } from './form-item'
 import type { FormRules } from './types'

--- a/packages/components/form/src/form.vue
+++ b/packages/components/form/src/form.vue
@@ -11,11 +11,12 @@ import { debugWarn, getProp, isFunction } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { useFormSize } from './hooks'
 import { formContextKey } from './constants'
-import { formEmits, formProps } from './form'
+import { formEmits } from './form'
 import { filterFields, useFormLabelWidth } from './utils'
 
 import type { ValidateFieldsError } from 'async-validator'
 import type { Arrayable } from '@element-plus/utils'
+import type { FormProps } from './form'
 import type {
   FormContext,
   FormItemContext,
@@ -28,7 +29,15 @@ const COMPONENT_NAME = 'ElForm'
 defineOptions({
   name: COMPONENT_NAME,
 })
-const props = defineProps(formProps)
+const props = withDefaults(defineProps<FormProps>(), {
+  labelPosition: 'right',
+  requireAsteriskPosition: 'left',
+  labelWidth: '',
+  labelSuffix: '',
+  showMessage: true,
+  validateOnRuleChange: true,
+  scrollIntoViewOptions: true,
+})
 const emit = defineEmits(formEmits)
 
 const formRef = ref<HTMLElement>()


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
ref #23399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Converted Form and FormItem public prop typings to explicit TypeScript interfaces (FormProps, FormMetaProps, FormItemProps) with deprecation notices for prior types.
  * Switched components to typed props with defaults for several fields (e.g., labelPosition, showMessage, required, inlineMessage, labelWidth).
  * Preserved runtime behavior and backward compatibility while clarifying exported prop shapes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->