### PR TITLE
fix(components): [carousel] avoid stopping autoplay after children change

### DIFF
--- a/packages/components/carousel/__tests__/carousel.test.tsx
+++ b/packages/components/carousel/__tests__/carousel.test.tsx
@@ -411,4 +411,43 @@ describe('Carousel', () => {
     vm.$refs.carousel.prev()
     expect(vm.$refs.carousel.activeIndex).toBe(1)
   })
+
+  it('should continue auto play after adding new items dynamically', async () => {
+    const data = reactive([1, 2, 3])
+
+    wrapper = mount({
+      setup() {
+        return () => (
+          <div>
+            <Carousel interval={30} ref={'carousel'}>
+              {data.map((value) => (
+                <CarouselItem label={value} key={value}>
+                  {value}
+                </CarouselItem>
+              ))}
+            </Carousel>
+          </div>
+        )
+      },
+    })
+
+    await nextTick()
+    const vm = wrapper.vm
+
+    expect(vm.$refs.carousel.activeIndex).toBe(0)
+
+    await wait(40)
+    expect(vm.$refs.carousel.activeIndex).toBe(1)
+
+    data.push(4)
+    await nextTick()
+
+    expect(wrapper.findAll('.el-carousel__item').length).toBe(4)
+    expect(vm.$refs.carousel.activeIndex).toBe(0)
+
+    await wait(80)
+    const currentIndex = vm.$refs.carousel.activeIndex
+    expect(currentIndex).toBeGreaterThan(0)
+    expect(currentIndex).toBeLessThanOrEqual(3)
+  })
 })

--- a/packages/components/carousel/__tests__/carousel.test.tsx
+++ b/packages/components/carousel/__tests__/carousel.test.tsx
@@ -446,8 +446,6 @@ describe('Carousel', () => {
     expect(vm.$refs.carousel.activeIndex).toBe(0)
 
     await wait(80)
-    const currentIndex = vm.$refs.carousel.activeIndex
-    expect(currentIndex).toBeGreaterThan(0)
-    expect(currentIndex).toBeLessThanOrEqual(3)
+    expect(vm.$refs.carousel.activeIndex).toBe(2)
   })
 })

--- a/packages/components/carousel/src/use-carousel.ts
+++ b/packages/components/carousel/src/use-carousel.ts
@@ -214,7 +214,7 @@ export const useCarousel = (
 
   function resetTimer() {
     pauseTimer()
-    if (!props.pauseOnHover) startTimer()
+    if (!props.pauseOnHover || !hover.value) startTimer()
   }
 
   function setContainerHeight(height: number) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix  #23493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Carousel auto-play now reliably restarts after a reset when the pointer leaves the carousel, even with pause-on-hover enabled.
* **Tests**
  * Added a test verifying auto-play continues correctly after items are added dynamically and the active slide advances as expected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->