### PR TITLE
perf(docs): described for missed `footer` slot

### DIFF
--- a/docs/en-US/component/color-picker-panel.md
+++ b/docs/en-US/component/color-picker-panel.md
@@ -55,15 +55,17 @@ color-picker-panel/disabled
 
 ### Attributes
 
-| Name                     | Description                                | Type                                                                                                             | Default |
-| ------------------------ | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------- |
-| model-value / v-model    | binding value                              | ^[string]                                                                                                        | —       |
-| border                   | whether the color picker panel is bordered | ^[boolean]                                                                                                       | true    |
-| disabled                 | whether to disable the color picker        | ^[boolean]                                                                                                       | false   |
-| show-alpha               | whether to display the alpha slider        | ^[boolean]                                                                                                       | false   |
-| color-format             | color format of v-model                    | ^[enum]`'hsl' \| 'hsv' \| 'hex' \| 'rgb' \| 'hex' (when show-alpha is false) \| 'rgb' (when show-alpha is true)` | —       |
-| predefine                | predefined color options                   | ^[array]`string[]`                                                                                               | —       |
-| validate-event ^(2.11.7) | whether to trigger form validation         | ^[boolean]                                                                                                       | true    |
+| Name                       | Description                                | Type                                                                                                             | Default |
+| -------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------- |
+| model-value / v-model      | binding value                              | ^[string]                                                                                                        | —       |
+| border                     | whether the color picker panel is bordered | ^[boolean]                                                                                                       | true    |
+| disabled                   | whether to disable the color picker        | ^[boolean]                                                                                                       | false   |
+| show-alpha                 | whether to display the alpha slider        | ^[boolean]                                                                                                       | false   |
+| color-format               | color format of v-model                    | ^[enum]`'hsl' \| 'hsv' \| 'hex' \| 'rgb' \| 'hex' (when show-alpha is false) \| 'rgb' (when show-alpha is true)` | —       |
+| predefine                  | predefined color options                   | ^[array]`string[]`                                                                                               | —       |
+| validate-event ^(2.11.7)   | whether to trigger form validation         | ^[boolean]                                                                                                       | true    |
+| hue-slider-class ^(2.13.2) | class names will append to hue-slider      | ^[object]`string \|string[] \| Record<string, boolean>`                                                          | —       |
+| hue-slider-style ^(2.13.2) | styles will append to hue-slider           | ^[string] / ^[object]`StyleValue`                                                                                | —       |
 
 ### Exposes
 

--- a/docs/en-US/component/color-picker-panel.md
+++ b/docs/en-US/component/color-picker-panel.md
@@ -67,6 +67,12 @@ color-picker-panel/disabled
 | hue-slider-class ^(2.13.2) | class names will append to hue-slider      | ^[object]`string \|string[] \| Record<string, boolean>`                                                          | —       |
 | hue-slider-style ^(2.13.2) | styles will append to hue-slider           | ^[string] / ^[object]`StyleValue`                                                                                | —       |
 
+### Slots
+
+| Name   | Description                    |
+| ------ | ------------------------------ |
+| footer | content append after the Input |
+
 ### Exposes
 
 | Name             | Description           | Type                     |

--- a/packages/components/color-picker-panel/src/__tests__/color-picker-panel.test.tsx
+++ b/packages/components/color-picker-panel/src/__tests__/color-picker-panel.test.tsx
@@ -1,6 +1,6 @@
 import { nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
-import { afterAll, describe, expect, it, vi } from 'vitest'
+import { afterAll, assert, describe, expect, it, vi } from 'vitest'
 import { EVENT_CODE } from '@element-plus/constants'
 import ColorPickerPanel from '../color-picker-panel.vue'
 import HueSlider from '../components/hue-slider.vue'
@@ -684,5 +684,24 @@ describe('Color-picker-panel', () => {
 
       wrapper.unmount()
     })
+  })
+
+  it('passed class names and styles into hue-slider', async () => {
+    const TEST_STYLE = '--test: 1px'
+    const wrapper = mount(() => (
+      <ColorPickerPanel hueSliderClass={'custom'} hueSliderStyle={TEST_STYLE} />
+    ))
+    await nextTick()
+
+    const hueSlider = wrapper.find('.el-color-hue-slider')
+    assert.isNotNull(hueSlider)
+
+    // Got class name
+    expect(hueSlider.attributes('class')).toContain('custom')
+
+    // Got style
+    expect(hueSlider.attributes('style')).toContain(TEST_STYLE)
+
+    wrapper.unmount()
   })
 })

--- a/packages/components/color-picker-panel/src/color-picker-panel.ts
+++ b/packages/components/color-picker-panel/src/color-picker-panel.ts
@@ -35,6 +35,14 @@ export interface ColorPickerPanelProps {
    * @description whether to trigger form validation
    */
   validateEvent?: boolean
+  /**
+   * @description class names will passed to <hue-slider />
+   */
+  hueSliderClass?: any
+  /**
+   * @description styles will passed to <hue-slider />
+   */
+  hueSliderStyle?: CSSStyleValue
 }
 
 /**

--- a/packages/components/color-picker-panel/src/color-picker-panel.ts
+++ b/packages/components/color-picker-panel/src/color-picker-panel.ts
@@ -2,7 +2,12 @@ import { isNil } from 'lodash-unified'
 import { buildProps, definePropType, isString } from '@element-plus/utils'
 import { UPDATE_MODEL_EVENT } from '@element-plus/constants'
 
-import type { ComputedRef, ExtractPublicPropTypes, InjectionKey } from 'vue'
+import type {
+  ComputedRef,
+  ExtractPublicPropTypes,
+  InjectionKey,
+  StyleValue,
+} from 'vue'
 import type ColorPickerPanel from './color-picker-panel.vue'
 import type Color from './utils/color'
 
@@ -38,11 +43,11 @@ export interface ColorPickerPanelProps {
   /**
    * @description class names will passed to <hue-slider />
    */
-  hueSliderClass?: any
+  hueSliderClass?: string | string[] | Record<string, boolean>
   /**
    * @description styles will passed to <hue-slider />
    */
-  hueSliderStyle?: CSSStyleValue
+  hueSliderStyle?: StyleValue
 }
 
 /**

--- a/packages/components/color-picker-panel/src/color-picker-panel.vue
+++ b/packages/components/color-picker-panel/src/color-picker-panel.vue
@@ -6,10 +6,11 @@
     <div :class="ns.e('wrapper')">
       <hue-slider
         ref="hueRef"
-        class="hue-slider"
         :color="color"
         vertical
         :disabled="disabled"
+        :class="['hue-slider', props.hueSliderClass]"
+        :style="props.hueSliderStyle"
       />
       <sv-panel ref="svRef" :color="color" :disabled="disabled" />
     </div>

--- a/packages/theme-chalk/src/color-picker-panel.scss
+++ b/packages/theme-chalk/src/color-picker-panel.scss
@@ -175,7 +175,6 @@
   box-sizing: border-box;
   width: 280px;
   height: 12px;
-  background-color: #f00;
   padding: 0 2px;
   float: right;
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

There was already a `footer` slot existed, but no description on the document:
<img width="1236" height="836" alt="image" src="https://github.com/user-attachments/assets/13b63648-095d-4f2d-ae30-314c64e5cb17" />
<img width="1956" height="1021" alt="image" src="https://github.com/user-attachments/assets/e776ea59-2c68-457e-842d-5a3ce10a8f98" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customization options for the color picker panel's hue slider. Users can now apply custom classes and styles to the hue slider to match their application's design.

* **Documentation**
  * Updated API documentation with new hue slider customization attributes and public component exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->