### PR TITLE
docs(components): [color-picker-panel] add missing `footer` slot

### DIFF
--- a/docs/en-US/component/color-picker-panel.md
+++ b/docs/en-US/component/color-picker-panel.md
@@ -67,9 +67,9 @@ color-picker-panel/disabled
 
 ### Slots
 
-| Name   | Description                    |
-| ------ | ------------------------------ |
-| footer | content append after the Input |
+| Name   | Description                       |
+| ------ | --------------------------------- |
+| footer | content to append after the Input |
 
 ### Exposes
 

--- a/docs/en-US/component/color-picker-panel.md
+++ b/docs/en-US/component/color-picker-panel.md
@@ -65,6 +65,12 @@ color-picker-panel/disabled
 | predefine                | predefined color options                   | ^[array]`string[]`                                                                                               | —       |
 | validate-event ^(2.11.7) | whether to trigger form validation         | ^[boolean]                                                                                                       | true    |
 
+### Slots
+
+| Name   | Description                    |
+| ------ | ------------------------------ |
+| footer | content append after the Input |
+
 ### Exposes
 
 | Name             | Description           | Type                     |


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

There was already a `footer` slot existed, but no description on the document:
<img width="1236" height="836" alt="image" src="https://github.com/user-attachments/assets/13b63648-095d-4f2d-ae30-314c64e5cb17" />
<img width="1956" height="1021" alt="image" src="https://github.com/user-attachments/assets/e776ea59-2c68-457e-842d-5a3ce10a8f98" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Slots" section to the ColorPickerPanel API docs, documenting a new footer slot for appending content after the input.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->