### PR TITLE
fix(components): [select/select-v2] avoid triggering multiple `visible-change` during the first search

### DIFF
--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -164,7 +164,7 @@
               <input
                 :id="inputId"
                 ref="inputRef"
-                v-model="states.inputValue"
+                :value="states.inputValue"
                 :style="inputStyle"
                 :autocomplete="autocomplete"
                 :tabindex="tabindex"

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -164,7 +164,7 @@
               <input
                 :id="inputId"
                 ref="inputRef"
-                v-model="states.inputValue"
+                :value="states.inputValue"
                 type="text"
                 :name="name"
                 :class="[nsSelect.e('input'), nsSelect.is(selectSize)]"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #23503

[demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZGl2IGNsYXNzPVwiZmxleCBmbGV4LXdyYXBcIj5cbiAgICA8ZGl2IGNsYXNzPVwibS00XCI+XG4gICAgICA8cCBzdHlsZT1cImNvbG9yOiByZWQ7XCI+XG4gICAgICAgIDxzcGFuPnZpc2libGUtY2hhbmdlOiA8L3NwYW4+XG4gICAgICAgIDxzcGFuPnt7Y291bnR9fTwvc3Bhbj5cbiAgICAgIDwvcD5cbiAgICAgIDxlbC1zZWxlY3RcbiAgICAgICAgQHZpc2libGUtY2hhbmdlPVwib25DaGFuZ2VcIlxuICAgICAgICB2LW1vZGVsPVwidmFsdWVcIlxuICAgICAgICBzdHlsZT1cIndpZHRoOiAyNDBweFwiXG4gICAgICAgIG11bHRpcGxlXG4gICAgICAgIGZpbHRlcmFibGVcbiAgICAgICAgcmVtb3RlXG4gICAgICAgIDpyZW1vdGUtbWV0aG9kPVwicmVtb3RlTWV0aG9kXCJcbiAgICAgICAgY2xlYXJhYmxlXG4gICAgICAgIDpvcHRpb25zPVwib3B0aW9uc1wiXG4gICAgICAgIDpsb2FkaW5nPVwibG9hZGluZ1wiXG4gICAgICAgIHBsYWNlaG9sZGVyPVwiUGxlYXNlIGVudGVyIGEga2V5d29yZFwiXG4gICAgICAvPlxuICAgIDwvZGl2PlxuICA8L2Rpdj5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgbGFuZz1cInRzXCIgc2V0dXA+XG5pbXBvcnQgeyByZWYgfSBmcm9tICd2dWUnXG5cbmNvbnN0IHN0YXRlcyA9IFtcbiAgJ0FsYWJhbWEnLFxuICAnQWxhc2thJyxcbiAgJ0FyaXpvbmEnLFxuICAnQXJrYW5zYXMnLFxuICAnQ2FsaWZvcm5pYScsXG4gICdDb2xvcmFkbycsXG4gICdDb25uZWN0aWN1dCcsXG4gICdEZWxhd2FyZScsXG4gICdGbG9yaWRhJyxcbiAgJ0dlb3JnaWEnLFxuICAnSGF3YWlpJyxcbiAgJ0lkYWhvJyxcbiAgJ0lsbGlub2lzJyxcbiAgJ0luZGlhbmEnLFxuICAnSW93YScsXG4gICdLYW5zYXMnLFxuICAnS2VudHVja3knLFxuICAnTG91aXNpYW5hJyxcbiAgJ01haW5lJyxcbiAgJ01hcnlsYW5kJyxcbiAgJ01hc3NhY2h1c2V0dHMnLFxuICAnTWljaGlnYW4nLFxuICAnTWlubmVzb3RhJyxcbiAgJ01pc3Npc3NpcHBpJyxcbiAgJ01pc3NvdXJpJyxcbiAgJ01vbnRhbmEnLFxuICAnTmVicmFza2EnLFxuICAnTmV2YWRhJyxcbiAgJ05ldyBIYW1wc2hpcmUnLFxuICAnTmV3IEplcnNleScsXG4gICdOZXcgTWV4aWNvJyxcbiAgJ05ldyBZb3JrJyxcbiAgJ05vcnRoIENhcm9saW5hJyxcbiAgJ05vcnRoIERha290YScsXG4gICdPaGlvJyxcbiAgJ09rbGFob21hJyxcbiAgJ09yZWdvbicsXG4gICdQZW5uc3lsdmFuaWEnLFxuICAnUmhvZGUgSXNsYW5kJyxcbiAgJ1NvdXRoIENhcm9saW5hJyxcbiAgJ1NvdXRoIERha290YScsXG4gICdUZW5uZXNzZWUnLFxuICAnVGV4YXMnLFxuICAnVXRhaCcsXG4gICdWZXJtb250JyxcbiAgJ1ZpcmdpbmlhJyxcbiAgJ1dhc2hpbmd0b24nLFxuICAnV2VzdCBWaXJnaW5pYScsXG4gICdXaXNjb25zaW4nLFxuICAnV3lvbWluZycsXG5dXG5jb25zdCBsaXN0ID0gc3RhdGVzLm1hcCgoaXRlbSk6IExpc3RJdGVtID0+IHtcbiAgcmV0dXJuIHsgdmFsdWU6IGB2YWx1ZToke2l0ZW19YCwgbGFiZWw6IGBsYWJlbDoke2l0ZW19YCB9XG59KVxuXG5pbnRlcmZhY2UgTGlzdEl0ZW0ge1xuICB2YWx1ZTogc3RyaW5nXG4gIGxhYmVsOiBzdHJpbmdcbn1cblxuY29uc3QgdmFsdWUgPSByZWYoW10pXG5jb25zdCBvcHRpb25zID0gcmVmPExpc3RJdGVtW10+KFtdKVxuY29uc3QgbG9hZGluZyA9IHJlZihmYWxzZSlcbmNvbnN0IGNvdW50ID0gcmVmKDApXG5cbmNvbnN0IG9uQ2hhbmdlID0gKGZsYWc6YW55KSA9PntcbiAgY291bnQudmFsdWUrK1xuICBjb25zb2xlLmxvZyhmbGFnKVxufVxuY29uc3QgcmVtb3RlTWV0aG9kID0gKHF1ZXJ5OiBzdHJpbmcpID0+IHtcbiAgaWYgKHF1ZXJ5ICE9PSAnJykge1xuICAgIGxvYWRpbmcudmFsdWUgPSB0cnVlXG4gICAgc2V0VGltZW91dCgoKSA9PiB7XG4gICAgICBsb2FkaW5nLnZhbHVlID0gZmFsc2VcbiAgICAgIG9wdGlvbnMudmFsdWUgPSBsaXN0LmZpbHRlcigoaXRlbSkgPT4ge1xuICAgICAgICByZXR1cm4gaXRlbS5sYWJlbC50b0xvd2VyQ2FzZSgpLmluY2x1ZGVzKHF1ZXJ5LnRvTG93ZXJDYXNlKCkpXG4gICAgICB9KVxuICAgIH0sIDIwMClcbiAgfSBlbHNlIHtcbiAgICBvcHRpb25zLnZhbHVlID0gW11cbiAgfVxufVxuPC9zY3JpcHQ+XG4iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgY29uc3Qgc3R5bGVzID0gWydodHRwczovL3ByZXZpZXctMjM1MDctZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmNzcycsICdodHRwczovL3ByZXZpZXctMjM1MDctZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS90aGVtZS1jaGFsay9kYXJrL2Nzcy12YXJzLmNzcyddLm1hcCgoc3R5bGUpID0+IHtcbiAgICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICAgIGxpbmsuaHJlZiA9IHN0eWxlXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2xvYWQnLCByZXNvbHZlKVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdlcnJvcicsIHJlamVjdClcbiAgICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gICAgfSlcbiAgfSlcbiAgcmV0dXJuIFByb21pc2UuYWxsU2V0dGxlZChzdHlsZXMpXG59XG4iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcbiAgICBcImpzeFwiOiBcInByZXNlcnZlXCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJ0eXBlc1wiOiBbXCJlbGVtZW50LXBsdXMvZ2xvYmFsLmQudHNcIl0sXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwiUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3J1bnRpbWUtZG9tQGxhdGVzdC9kaXN0L3J1bnRpbWUtZG9tLmVzbS1icm93c2VyLmpzXCIsXG4gICAgXCJAdnVlL3NoYXJlZFwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9zaGFyZWRAbGF0ZXN0L2Rpc3Qvc2hhcmVkLmVzbS1idW5kbGVyLmpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL3ByZXZpZXctMjM1MDctZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcInVuc3VwcG9ydGVkXCIsXG4gICAgXCJAZWxlbWVudC1wbHVzL2ljb25zLXZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQGVsZW1lbnQtcGx1cy9pY29ucy12dWVAMi9kaXN0L2luZGV4Lm1pbi5qc1wiXG4gIH0sXG4gIFwic2NvcGVzXCI6IHt9XG59IiwiX28iOnsic2hvd0hpZGRlbiI6dHJ1ZSwic3R5bGVTb3VyY2UiOiJodHRwczovL3ByZXZpZXctMjM1MDctZWxlbWVudC1wbHVzLnN1cmdlLnNoL2J1bmRsZS9kaXN0L2luZGV4LmNzcyJ9fQ==)

Previously, using `v-model="states.inputValue"` caused `isRemoteSearchEmpty` to execute **before** `onInput` (since `states.inputValue` had already changed). At that point, `debouncing` was `false`, so `dropdownMenuVisible` would become `true`.
After the modification, `onInput` executes **before** `isRemoteSearchEmpty`, and since `debouncing` is `true` at that moment, `dropdownMenuVisible` remains `false`, thus avoiding multiple triggers of `visible-change`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined input binding mechanism in select components for improved state management consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->