### PR TITLE
fix(components): [autocomplete] reset ignoreFocusEvent on outside click

### DIFF
--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -295,7 +295,6 @@ const handleBlur = (evt: FocusEvent) => {
       ignoreFocusEvent = true
       return
     }
-    ignoreFocusEvent = false
     activated.value && close()
     emit('blur', evt)
   })
@@ -398,8 +397,13 @@ const getSuggestionContext = () => {
   return [suggestion, suggestionList] as const
 }
 
-const stopHandle = onClickOutside(listboxRef, () => {
-  handleBlur(new FocusEvent('blur'))
+const stopHandle = onClickOutside(listboxRef, (event: FocusEvent) => {
+  // Prevent closing if focus is inside popper content
+  if (popperRef.value?.isFocusInsideContent()) return
+  if (suggestionVisible.value) {
+    ignoreFocusEvent = false
+    handleBlur(new FocusEvent('blur', event))
+  }
 })
 
 const handleKeydown = (e: KeyboardEvent | Event) => {

--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -295,6 +295,7 @@ const handleBlur = (evt: FocusEvent) => {
       ignoreFocusEvent = true
       return
     }
+    ignoreFocusEvent = false
     activated.value && close()
     emit('blur', evt)
   })
@@ -400,10 +401,7 @@ const getSuggestionContext = () => {
 const stopHandle = onClickOutside(listboxRef, () => {
   // Prevent closing if focus is inside popper content
   if (popperRef.value?.isFocusInsideContent()) return
-  if (suggestionVisible.value) {
-    ignoreFocusEvent = false
-    close()
-  }
+  handleBlur(new FocusEvent('blur'))
 })
 
 const handleKeydown = (e: KeyboardEvent | Event) => {

--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -399,8 +399,6 @@ const getSuggestionContext = () => {
 }
 
 const stopHandle = onClickOutside(listboxRef, () => {
-  // Prevent closing if focus is inside popper content
-  if (popperRef.value?.isFocusInsideContent()) return
   handleBlur(new FocusEvent('blur'))
 })
 

--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -400,7 +400,10 @@ const getSuggestionContext = () => {
 const stopHandle = onClickOutside(listboxRef, () => {
   // Prevent closing if focus is inside popper content
   if (popperRef.value?.isFocusInsideContent()) return
-  suggestionVisible.value && close()
+  if (suggestionVisible.value) {
+    ignoreFocusEvent = false
+    close()
+  }
 })
 
 const handleKeydown = (e: KeyboardEvent | Event) => {

--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -400,9 +400,13 @@ const getSuggestionContext = () => {
 const stopHandle = onClickOutside(listboxRef, (event: FocusEvent) => {
   // Prevent closing if focus is inside popper content
   if (popperRef.value?.isFocusInsideContent()) return
-  if (suggestionVisible.value) {
-    ignoreFocusEvent = false
+  const hadIgnoredFocus = ignoreFocusEvent
+  ignoreFocusEvent = false
+  if (!suggestionVisible.value) return
+  if (hadIgnoredFocus) {
     handleBlur(new FocusEvent('blur', event))
+  } else {
+    close()
   }
 })
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

fix: #23512
Reset ignoreFocusEvent flag when clicking outside the autocomplete, regardless of suggestionVisible state, to ensure dropdown can open normally on next focus after clicking non-selectable areas in dropdown.

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outside-click and blur handling for the autocomplete so suggestions and focus transitions no longer close unexpectedly; focus-aware logic prevents incorrect dismissals in edge cases.

* **Chores**
  * No changes to public APIs or visible interactions; users should see fewer unexpected dismissals or focus glitches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->