### PR TITLE
fix: correct type definitions for ElMessageBox

### DIFF
--- a/packages/components/message-box/src/message-box.type.ts
+++ b/packages/components/message-box/src/message-box.type.ts
@@ -9,7 +9,7 @@ type MessageBoxButtonType = (typeof buttonTypes)[number]
 
 export type Action = 'confirm' | 'close' | 'cancel'
 export type MessageBoxType = '' | 'prompt' | 'alert' | 'confirm'
-export type MessageBoxData = MessageBoxInputData & Action
+export type MessageBoxData = MessageBoxInputData | Action
 export interface MessageBoxInputData {
   value: string
   action: Action


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

What was done?
- Correct type definitions for return type of `ElMessageBoxShortcutMethod`. Use union (`|`) instead of intersection (`&`) for type definition. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit support for different message box types: prompt, alert, and confirm.
  * Improved message box payload handling for greater flexibility and compatibility with varied inputs.
  * Validators are now optional for message box input.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->