### PR TITLE
fix(components): [message-box] handle IME composition on Enter key

### DIFF
--- a/packages/components/message-box/__tests__/message-box.test.ts
+++ b/packages/components/message-box/__tests__/message-box.test.ts
@@ -210,6 +210,32 @@ describe('MessageBox', () => {
     expect(msgAction).toEqual('cancel')
   })
 
+  test('prompt: should not confirm when pressing Enter during IME composition', async () => {
+    const callback = vi.fn()
+    MessageBox.prompt('请输入内容', {
+      title: '标题',
+      callback,
+    })
+    await rAF()
+    const input = document
+      .querySelector(selector)!
+      .querySelector('.el-message-box__input input') as HTMLInputElement
+    input.dispatchEvent(
+      new CompositionEvent('compositionstart', { bubbles: true })
+    )
+    await rAF()
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+    await rAF()
+    expect(callback).not.toHaveBeenCalled()
+    expect(document.querySelector(selector)).not.toBeNull()
+  })
+
   test('beforeClose', async () => {
     let msgAction = ''
     MessageBox({

--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -411,8 +411,7 @@ export default defineComponent({
     const overlayEvent = useSameTarget(handleWrapperClick)
 
     const handleInputEnter = (e: KeyboardEvent | Event) => {
-      if ((e as KeyboardEvent).isComposing) return
-      if (state.inputType !== 'textarea') {
+      if (state.inputType !== 'textarea' && !inputRef.value?.isComposing) {
         e.preventDefault()
         return handleAction('confirm')
       }

--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -93,6 +93,7 @@
                 </div>
               </div>
               <div v-show="showInput" :class="ns.e('input')">
+                123
                 <el-input
                   :id="inputId"
                   ref="inputRef"
@@ -411,6 +412,7 @@ export default defineComponent({
     const overlayEvent = useSameTarget(handleWrapperClick)
 
     const handleInputEnter = (e: KeyboardEvent | Event) => {
+      if ((e as KeyboardEvent).isComposing) return
       if (state.inputType !== 'textarea') {
         e.preventDefault()
         return handleAction('confirm')

--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -194,6 +194,7 @@ import type {
   MessageBoxState,
   MessageBoxType,
 } from './message-box.type'
+import type { InputInstance } from '@element-plus/components/input'
 
 export default defineComponent({
   name: 'ElMessageBox',
@@ -330,7 +331,7 @@ export default defineComponent({
     const rootRef = ref<HTMLElement>()
     const headerRef = ref<HTMLElement>()
     const focusStartRef = ref<HTMLElement>()
-    const inputRef = ref<ComponentPublicInstance>()
+    const inputRef = ref<InputInstance>()
     const confirmRef = ref<ComponentPublicInstance>()
 
     const confirmButtonClasses = computed(() => state.confirmButtonClass)

--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -93,7 +93,6 @@
                 </div>
               </div>
               <div v-show="showInput" :class="ns.e('input')">
-                123
                 <el-input
                   :id="inputId"
                   ref="inputRef"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

This PR prevents `ElMessageBox.prompt` from closing when pressing Enter during IME composition.
The `Enter` key is now ignored while `e.isComposing` is true, ensuring candidate confirmation does not trigger the message box action.
fixed #23522 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented confirmation/send from triggering when pressing Enter during IME composition (e.g., Chinese/Japanese/Korean). Composed input will not be submitted until composition completes; normal Enter behavior unchanged otherwise.
* **Tests**
  * Added tests verifying Enter during composition does not trigger confirmation and the prompt remains open.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->