### PR TITLE
chore(components): [split-panel] remove unused el props

### DIFF
--- a/packages/components/splitter/src/split-panel.vue
+++ b/packages/components/splitter/src/split-panel.vue
@@ -160,7 +160,6 @@ watch(
 )
 
 const _panel = reactive({
-  el: panelEl.value!,
   uid,
   getVnode: () => instance.vnode,
   setIndex,

--- a/packages/components/splitter/src/type.ts
+++ b/packages/components/splitter/src/type.ts
@@ -5,7 +5,6 @@ export type Layout = 'horizontal' | 'vertical'
 export type PanelItemState = UnwrapRef<{
   uid: number
   getVnode: () => VNode
-  el: HTMLElement
   collapsible: { start?: boolean; end?: boolean }
   max?: number | string
   min?: number | string


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

[Reactivity](https://play.vuejs.org/#eNp9Ul1LwzAU/SvXvKyD0T3o01gHKgMV/EAFXwJS2tuamSYhSeug9L97k251D7K35nzcnHObnl0bk3YtshVbu8IK48Ghb82GK9EYbT30YLFaWMwLLzpcaPWoW+WxhAEqqxuYkXvGVaGV89C4GrJgSGZ3KKWGD21leTGbc3WUmFyh3MqDjIgR/ox4RMebkp4rAJSrgyHtctkiVwNZphBJModsA1Ea5miJqdR1Mk5LUZI4GNbLsRzVooPHxsjcI50A1qXoQpSMs8NNnG36PlYZhvWS6Kjr+2koZFkGrSqxEgrLYQjzT2ayBfOO0lSiTndOK9ptDMhZoRsjJNpn4wWl5Ww1Rg9cTuv6eYiYty0ujnjxhcX3P/jO7QPG2YtFh7ZDzibO57ZGP9Lbtyfc0/dENrpsJanPkK9Im2xDxlF2Q2Up9okupr2PL0So+t1t9x6VO5YKQYNyiHrO6Incnqn+F/cyvYo++mts+AVPL+It) is lost here, so the value remains `undefined`. Since the code uses [child.getVnode().el!](https://github.com/snowbitx/element-plus/blob/dev/packages/hooks/use-ordered-children/index.ts#L46) instead, I suggest removing the redundant definition.

<img width="2738" height="1434" alt="869852bd79bafa0cdd0a76a5ae998f75" src="https://github.com/user-attachments/assets/9f2b039b-d03d-48a4-8940-769249c35149" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to the splitter component's panel structure. No changes to functionality or public API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->