### PR TITLE
fix(components): [tree-v2] update expanded state when `defaultExpandedKeys` change

### DIFF
--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -313,8 +313,16 @@ export function useTree(
 
   watch(
     () => props.defaultExpandedKeys,
-    (key) => {
-      expandedKeySet.value = new Set<TreeKey>(key)
+    (keys) => {
+      const newSet = new Set<TreeKey>(keys)
+      expandedKeySet.value = newSet
+      // Update the expanded state of existing tree nodes
+      const nodeMap = tree.value?.treeNodeMap
+      if (nodeMap) {
+        nodeMap.forEach((node) => {
+          node.expanded = newSet.has(node.key)
+        })
+      }
     },
     {
       immediate: true,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #23546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tree node expansion synchronization to ensure that when default expanded keys are updated, all existing tree nodes properly reflect their expanded/collapsed state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->