### PR TITLE
fix(components): [tree-v2] update expanded state when defaultExpandedKeys change

### DIFF
--- a/packages/components/tree-v2/__tests__/tree.test.ts
+++ b/packages/components/tree-v2/__tests__/tree.test.ts
@@ -864,6 +864,82 @@ describe('Virtual Tree', () => {
     expect(nodes.length).toBe(5)
   })
 
+  test('defaultExpandedKeys change should update expand icon state', async () => {
+    const defaultExpandedKeys = ref<string[]>([])
+    const { wrapper } = createTree({
+      data() {
+        return {
+          height: 400,
+          data: [
+            {
+              id: '1',
+              label: 'node-1',
+              children: [
+                {
+                  id: '1-1',
+                  label: 'node-1-1',
+                },
+              ],
+            },
+            {
+              id: '2',
+              label: 'node-2',
+            },
+          ],
+          defaultExpandedKeys,
+        }
+      },
+    })
+    await nextTick()
+    let expandIcons = wrapper.findAll(TREE_NODE_EXPAND_ICON_CLASS_NAME)
+    expect(expandIcons.length).toBe(2)
+    expect(expandIcons[0].classes()).not.toContain('expanded')
+    defaultExpandedKeys.value = ['1']
+    await nextTick()
+    expandIcons = wrapper.findAll(TREE_NODE_EXPAND_ICON_CLASS_NAME)
+    expect(expandIcons[0].classes()).toContain('expanded')
+    defaultExpandedKeys.value = []
+    await nextTick()
+    expandIcons = wrapper.findAll(TREE_NODE_EXPAND_ICON_CLASS_NAME)
+    expect(expandIcons[0].classes()).not.toContain('expanded')
+  })
+
+  test('defaultExpandedKeys with child key should expand parent nodes', async () => {
+    const { wrapper } = createTree({
+      data() {
+        return {
+          height: 400,
+          data: [
+            {
+              id: '1',
+              label: 'node-1',
+              children: [
+                {
+                  id: '1-1',
+                  label: 'node-1-1',
+                  children: [
+                    { id: '1-1-1', label: 'node-1-1-1' },
+                    { id: '1-1-2', label: 'node-1-1-2' },
+                  ],
+                },
+                { id: '1-2', label: 'node-1-2' },
+                { id: '1-3', label: 'node-1-3' },
+              ],
+            },
+            { id: '2', label: 'node-2' },
+          ],
+          defaultExpandedKeys: ['1-1-1'],
+        }
+      },
+    })
+    await nextTick()
+    const nodes = wrapper.findAll(TREE_NODE_CLASS_NAME)
+    expect(nodes.length).toBe(7)
+    const expandIcons = wrapper.findAll(TREE_NODE_EXPAND_ICON_CLASS_NAME)
+    expect(expandIcons[0].classes()).toContain('expanded')
+    expect(expandIcons[1].classes()).toContain('expanded')
+  })
+
   test('setExpandedKeys', async () => {
     const { treeRef, wrapper } = createTree({
       data() {

--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -311,19 +311,17 @@ export function useTree(
   )
 
   watch(
-    () => props.data!,
-    (data: TreeData) => {
-      setData(data)
-    },
-    {
-      immediate: true,
+    () => props.defaultExpandedKeys,
+    (keys) => {
+      setExpandedKeys(keys || [])
     }
   )
 
   watch(
-    () => props.defaultExpandedKeys,
-    (keys) => {
-      setExpandedKeys(keys || [])
+    () => props.data!,
+    (data: TreeData) => {
+      setData(data)
+      setExpandedKeys(props.defaultExpandedKeys || [])
     },
     {
       immediate: true,

--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -182,9 +182,8 @@ export function useTree(
     const nodeMap = tree.value!.treeNodeMap
 
     expandedKeySet.value.forEach((key) => {
-      const node = nodeMap.get(key)!
-      expandedKeySet.value.delete(node.key)
-      node.expanded = false
+      const node = nodeMap.get(key)
+      if (node) node.expanded = false
     })
 
     keys.forEach((k) => {
@@ -313,8 +312,10 @@ export function useTree(
 
   watch(
     () => props.defaultExpandedKeys,
-    (key) => {
-      expandedKeySet.value = new Set<TreeKey>(key)
+    (keys) => {
+      if (tree.value) {
+        setExpandedKeys(keys || [])
+      }
     },
     {
       immediate: true,
@@ -325,6 +326,9 @@ export function useTree(
     () => props.data!,
     (data: TreeData) => {
       setData(data)
+      if (props.defaultExpandedKeys?.length) {
+        setExpandedKeys(props.defaultExpandedKeys)
+      }
     },
     {
       immediate: true,

--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -311,11 +311,9 @@ export function useTree(
   )
 
   watch(
-    () => props.defaultExpandedKeys,
-    (keys) => {
-      if (tree.value) {
-        setExpandedKeys(keys || [])
-      }
+    () => props.data!,
+    (data: TreeData) => {
+      setData(data)
     },
     {
       immediate: true,
@@ -323,10 +321,9 @@ export function useTree(
   )
 
   watch(
-    () => props.data!,
-    (data: TreeData) => {
-      setData(data)
-      setExpandedKeys(props.defaultExpandedKeys || [])
+    () => props.defaultExpandedKeys,
+    (keys) => {
+      setExpandedKeys(keys || [])
     },
     {
       immediate: true,

--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -326,9 +326,7 @@ export function useTree(
     () => props.data!,
     (data: TreeData) => {
       setData(data)
-      if (props.defaultExpandedKeys?.length) {
-        setExpandedKeys(props.defaultExpandedKeys)
-      }
+      setExpandedKeys(props.defaultExpandedKeys || [])
     },
     {
       immediate: true,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #23546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added tests validating Virtual Tree expand/collapse icon state updates when defaultExpandedKeys change dynamically.
  * Added tests ensuring parent nodes properly expand when child node keys are specified.

* **Bug Fixes**
  * Improved node collapse handling to prevent errors with missing nodes.
  * Ensured expansion state properly reapplies following tree data updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->