### PR TITLE
feat(components): [el-sub-menu] add `expand` slot

### DIFF
--- a/packages/components/menu/src/sub-menu.ts
+++ b/packages/components/menu/src/sub-menu.ts
@@ -359,28 +359,29 @@ export default defineComponent({
     return () => {
       const titleTag: VNodeArrayChildren = [
         slots.title?.(),
-        h(
-          ElIcon,
-          {
-            class: nsSubMenu.e('icon-arrow'),
-            style: {
-              transform: opened.value
-                ? (props.expandCloseIcon && props.expandOpenIcon) ||
-                  (props.collapseCloseIcon &&
-                    props.collapseOpenIcon &&
-                    rootMenu.props.collapse)
-                  ? 'none'
-                  : 'rotateZ(180deg)'
-                : 'none',
+        slots.expand?.() ??
+          h(
+            ElIcon,
+            {
+              class: nsSubMenu.e('icon-arrow'),
+              style: {
+                transform: opened.value
+                  ? (props.expandCloseIcon && props.expandOpenIcon) ||
+                    (props.collapseCloseIcon &&
+                      props.collapseOpenIcon &&
+                      rootMenu.props.collapse)
+                    ? 'none'
+                    : 'rotateZ(180deg)'
+                  : 'none',
+              },
             },
-          },
-          {
-            default: () =>
-              isString(subMenuTitleIcon.value)
-                ? h(instance.appContext.components[subMenuTitleIcon.value])
-                : h(subMenuTitleIcon.value),
-          }
-        ),
+            {
+              default: () =>
+                isString(subMenuTitleIcon.value)
+                  ? h(instance.appContext.components[subMenuTitleIcon.value])
+                  : h(subMenuTitleIcon.value),
+            }
+          ),
       ]
 
       // this render function is only used for bypass `Vue`'s compiler caused patching issue.


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Desc:
Refer to the type="expand" in el-table-column. Sometimes we don’t want to display an icon, or we only want to show a button, switch (to control whether the sub-menu is enabled ) or others


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sub-menus now support customizable expand icons. Users can provide their own icon for the expand/collapse indicator, while the default icon behavior is preserved if customization is not used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->