### PR TITLE
feat(components): [input-number] add `tabindex` prop

### DIFF
--- a/docs/en-US/component/input-number.md
+++ b/docs/en-US/component/input-number.md
@@ -128,6 +128,7 @@ For precision purposes, the input number is limited from [Number.MIN_SAFE_INTEGE
 | inputmode ^(2.10.3)           | same as `inputmode` in native input              | ^[string]                                     | —                       |
 | align ^(2.10.5)               | alignment for the inner input text               | ^[enum]`'left' \| 'center' \| 'right'`        | 'center'                |
 | disabled-scientific ^(2.10.5) | disables input of scientific notation (e.g. 'e') | ^[boolean]                                    | false                   |
+| tabindex ^(2.14.0)            | same as `tabindex` in native input               | ^[string] / ^[number]                         | 0                       |
 
 ### Slots
 

--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -724,4 +724,9 @@ describe('InputNumber.vue', () => {
     await input.trigger('keydown', { key: EVENT_CODE.down })
     expect(input.element.value).toBe('10')
   })
+
+  test('tabindex', async () => {
+    const wrapper = mount(() => <InputNumber tabindex={1} />)
+    expect(wrapper.find('input').attributes('tabindex')).toBe('1')
+  })
 })

--- a/packages/components/input-number/src/input-number.ts
+++ b/packages/components/input-number/src/input-number.ts
@@ -95,6 +95,10 @@ export interface InputNumberProps {
    * @description whether to disable scientific notation input (e.g. 'e', 'E')
    */
   disabledScientific?: boolean
+  /**
+   * @description same as `tabindex` in native input
+   */
+  tabindex?: string | number
 }
 
 /**
@@ -220,6 +224,13 @@ export const inputNumberProps = buildProps({
    * @description whether to disable scientific notation input (e.g. 'e', 'E')
    */
   disabledScientific: Boolean,
+  /**
+   * @description same as `tabindex` in native input
+   */
+  tabindex: {
+    type: [String, Number],
+    default: 0,
+  },
 } as const)
 
 /**

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -56,6 +56,7 @@
       :aria-label="ariaLabel"
       :validate-event="false"
       :inputmode="inputmode"
+      :tabindex="tabindex"
       @keydown="handleKeydown"
       @blur="handleBlur"
       @focus="handleFocus"
@@ -123,6 +124,7 @@ const props = withDefaults(defineProps<InputNumberProps>(), {
   validateEvent: true,
   inputmode: undefined,
   align: 'center',
+  tabindex: 0,
 })
 const emit = defineEmits(inputNumberEmits)
 


### PR DESCRIPTION
resolves #23580

Breaking change: The `tabindex` of input-number has been moved from `.el-input-number` to `.el-input__inner`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `tabindex` attribute to the Input Number component, enabling customization of keyboard navigation order for the input field.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->