### PR TITLE
fix(components): [rate] avoid capturing focus when disabled

### DIFF
--- a/packages/components/rate/src/rate.vue
+++ b/packages/components/rate/src/rate.vue
@@ -11,8 +11,9 @@
     :aria-valuetext="text || undefined"
     aria-valuemin="0"
     :aria-valuemax="max"
-    tabindex="0"
     :style="rateStyles"
+    :tabindex="rateDisabled ? undefined : 0"
+    :aria-disabled="rateDisabled"
     @keydown="handleKey"
   >
     <span
@@ -273,9 +274,6 @@ function selectValue(value: number) {
 }
 
 function handleKey(e: KeyboardEvent) {
-  if (rateDisabled.value) {
-    return
-  }
   const code = getEventCode(e)
   const step = props.allowHalf ? 0.5 : 1
   let _currentValue = currentValue.value

--- a/packages/components/rate/src/rate.vue
+++ b/packages/components/rate/src/rate.vue
@@ -274,6 +274,9 @@ function selectValue(value: number) {
 }
 
 function handleKey(e: KeyboardEvent) {
+  if (rateDisabled.value) {
+    return
+  }
   const code = getEventCode(e)
   const step = props.allowHalf ? 0.5 : 1
   let _currentValue = currentValue.value


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Refer to this [PR](https://github.com/element-plus/element-plus/pull/22616/changes#diff-525a39c2bf055b2e6bb6be4d47f792bfb87bf74f5788ff1dc1838211bcd32c83R6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Rating control now removes focus when disabled, preventing accidental keyboard focus.
  * Added explicit aria-disabled state so assistive technologies recognize the disabled status.
  * Existing keyboard handling remains intact to avoid unexpected behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->