### PR TITLE
docs(components): [switch] fix inactive-action-icon attribute typo

### DIFF
--- a/docs/en-US/component/switch.md
+++ b/docs/en-US/component/switch.md
@@ -81,7 +81,7 @@ switch/prevent-switching
 
 ## Custom action icon ^(2.3.9)
 
-:::demo You can add `active-action-icon` and `inactive-active-icon` attribute to show icons.
+:::demo You can add `active-action-icon` and `inactive-action-icon` attribute to show icons.
 
 switch/custom-action-icon
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the Switch component documentation for the custom action icon section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->