### PR TITLE
fix(components): [watermark] correct fontWeight type definition

### DIFF
--- a/docs/en-US/component/watermark.md
+++ b/docs/en-US/component/watermark.md
@@ -69,7 +69,7 @@ watermark/custom
 | ----------------- | ------------- | ------------------------------------------------------------------------------------ | --------------- |
 | color             | font color    | ^[string]                                                                            | rgba(0,0,0,.15) |
 | fontSize          | font size     | ^[number] / ^[string]                                                                | 16              |
-| fontWeight        | font weight   | ^[enum]`'normal' \| 'light' \| 'weight' \| number`                                   | normal          |
+| fontWeight        | font weight   | ^[enum]`'normal' \| 'bold' \| 'lighter' \| 'bolder' \| number`                       | normal          |
 | fontFamily        | font family   | ^[string]                                                                            | sans-serif      |
 | fontGap ^(2.11.5) | font gap      | ^[number]                                                                            | 3               |
 | fontStyle         | font style    | ^[enum]`'none' \| 'normal' \| 'italic' \| 'oblique'`                                 | normal          |

--- a/packages/components/watermark/src/watermark.ts
+++ b/packages/components/watermark/src/watermark.ts
@@ -6,7 +6,7 @@ import type Watermark from './watermark.vue'
 export interface WatermarkFontType {
   color?: string
   fontSize?: number | string
-  fontWeight?: 'normal' | 'light' | 'weight' | number
+  fontWeight?: 'normal' | 'bold' | 'lighter' | 'bolder' | number
   fontStyle?: 'none' | 'normal' | 'italic' | 'oblique'
   fontFamily?: string
   fontGap?: number


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

The `fontWeight` property type had incorrect values `light` and `weight`, which are not valid CSS `font-weight` values. Changed to the correct values: `'normal' | 'bold' | 'lighter' | 'bolder' | number`.

See: [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-weight#normal)

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
