### PR TITLE
fix(select-v2): resolve teleported tooltip target element timing issue

### DIFF
--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -53,7 +53,7 @@
               nsSelect.e('selection'),
               nsSelect.is(
                 'near',
-                multiple && !$slots.prefix && !!modelValue.length
+                multiple && !$slots.prefix && !!states.cachedOptions.length
               ),
             ]"
           >
@@ -92,7 +92,9 @@
               </div>
 
               <el-tooltip
-                v-if="collapseTags && modelValue.length > maxCollapseTags"
+                v-if="
+                  collapseTags && states.cachedOptions.length > maxCollapseTags
+                "
                 ref="tagTooltipRef"
                 :disabled="dropdownMenuVisible || !collapseTagsTooltip"
                 :fallback-placements="['bottom', 'top', 'right', 'left']"
@@ -117,7 +119,7 @@
                       disable-transitions
                     >
                       <span :class="nsSelect.e('tags-text')">
-                        + {{ modelValue.length - maxCollapseTags }}
+                        + {{ states.cachedOptions.length - maxCollapseTags }}
                       </span>
                     </el-tag>
                   </div>


### PR DESCRIPTION
fix: #23640

## 🐛 Problem Description

Fixed the TypeError: Cannot read properties of null (reading 'insertBefore') Failed to locate Teleport target with selector ".select-v2-box"

### Root Cause Analysis

The issue occurred because:

1. **Synchronous Evaluation**: `modelValue.length` was evaluated synchronously during component creation
2. **Timing Mismatch**: Tooltip attempted to teleport to target element (`.select-v2-box`) before DOM was ready
3. **Missing Target**: Target element didn't exist when tooltip tried to mount

**Error Flow:**

1.Instantiation: Vue creates the component instance.
2.Immediate Evaluation: v-if="modelValue.length > maxCollapseTags" is evaluated during the initial render.
3.Tooltip Creation: The condition is true, so el-tooltip is initialized.
4.Teleportation: el-tooltip attempts to teleport its content to .select-v2-box.
5.DOM Absence: ❌ The target element does not exist in the DOM yet!
6.Error: Vue Warning: "Failed to locate Teleport target".

**Fixed Flow:**
1.Instantiation: Vue creates the component instance.
2.Initialization: states.cachedOptions starts as an empty array [].
3.Evaluation: Vue evaluates v-if="states.cachedOptions.length > maxCollapseTags".
4.Conditional Skip: The condition is false (0 > 1), so el-tooltip is not created during the initial render. ← Key Step!
5.Lifecycle Hook: The onMounted() hook is triggered.
6.Data Population: initStates() executes and populates states.cachedOptions.
7.Reactive Update: The change in states.cachedOptions.length triggers a re-render.
8.Safe Creation: By this time, the target element already exists in the DOM, allowing el-tooltip to be safely instantiated.
9.✅ Success: Teleportation succeeds without errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated multi-select tag display behavior in the select component to properly reflect active states, collapse-tag tooltips, and the count of additional collapsed tags based on available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->