### PR TITLE
fix(components): [popconfirm] align icon with first line of multi-line text

### DIFF
--- a/packages/theme-chalk/src/popconfirm.scss
+++ b/packages/theme-chalk/src/popconfirm.scss
@@ -3,13 +3,18 @@
 
 @include b(popconfirm) {
   outline: none;
+
   @include e(main) {
     display: flex;
     align-items: center;
   }
+
   @include e(icon) {
     margin-right: 5px;
+    align-self: flex-start;
+    margin-top: 2px;
   }
+
   @include e(action) {
     text-align: right;
     margin-top: 8px;

--- a/packages/theme-chalk/src/popconfirm.scss
+++ b/packages/theme-chalk/src/popconfirm.scss
@@ -3,18 +3,15 @@
 
 @include b(popconfirm) {
   outline: none;
-
   @include e(main) {
     display: flex;
     align-items: center;
   }
-
   @include e(icon) {
     margin-right: 5px;
     align-self: flex-start;
     margin-top: 2px;
   }
-
   @include e(action) {
     text-align: right;
     margin-top: 8px;


### PR DESCRIPTION
## Description
fix #23651
Fix the issue that the icon of Popconfirm is not aligned with the first line of text when the content is multi-line.

## BREAKING CHANGES
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved vertical alignment and spacing of icons in confirmation dialogs, reducing visual shift and producing more consistent layout timing and appearance across placements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->