### PR TITLE
fix(components): [tree] focus error after switching tree

### DIFF
--- a/packages/components/tree/__tests__/tree.test.ts
+++ b/packages/components/tree/__tests__/tree.test.ts
@@ -1514,12 +1514,13 @@ describe('Tree.vue', () => {
       components: { 'el-tree': Tree },
       data: () => ({ data }),
     })
-    const treeNodes = wrapper
-      .findAllComponents({ name: 'ElTree' })[1]
-      .findAll('.is-focusable[role=treeitem]')
-    await treeNodes[0].trigger('click')
+    await nextTick()
+    let focused = false
+    const secondTree = wrapper.findAllComponents({ name: 'ElTree' })[1]
+    const treeNodes = secondTree.findAll('.is-focusable[role=treeitem]')
+    defineGetter(treeNodes[1].element, 'focus', () => () => (focused = true))
     await treeNodes[0].trigger('keydown', { code: 'ArrowDown' })
-    expect(treeNodes[0].classes()).toContain('is-current')
+    expect(focused).toBe(true)
   })
 
   test('collapse and navigate down and up', async () => {

--- a/packages/components/tree/__tests__/tree.test.ts
+++ b/packages/components/tree/__tests__/tree.test.ts
@@ -1502,6 +1502,26 @@ describe('Tree.vue', () => {
     expect(flag).toBe(true)
   })
 
+  test('navigate down with multiple trees', async () => {
+    const data = [{ label: 'one' }, { label: 'two' }]
+    const wrapper = mount({
+      template: `
+        <div>
+          <el-tree :data="data" default-expand-all />
+          <el-tree :data="data" default-expand-all />
+        </div>
+      `,
+      components: { 'el-tree': Tree },
+      data: () => ({ data }),
+    })
+    const treeNodes = wrapper
+      .findAllComponents({ name: 'ElTree' })[1]
+      .findAll('.is-focusable[role=treeitem]')
+    await treeNodes[0].trigger('click')
+    await treeNodes[0].trigger('keydown', { code: 'ArrowDown' })
+    expect(treeNodes[0].classes()).toContain('is-current')
+  })
+
   test('collapse and navigate down and up', async () => {
     const { wrapper } = getTreeVm(``, {
       template: `

--- a/packages/components/tree/src/tree-node.vue
+++ b/packages/components/tree/src/tree-node.vue
@@ -197,7 +197,9 @@ export default defineComponent({
     )
 
     const getNodeKey = (node: Node): any => {
-      return getNodeKeyUtil(tree.props.nodeKey, node.data)
+      return tree.props.nodeKey
+        ? getNodeKeyUtil(tree.props.nodeKey, node.data)
+        : node.id
     }
 
     const getNodeClass = (node: Node) => {

--- a/packages/components/tree/src/tree.vue
+++ b/packages/components/tree/src/tree.vue
@@ -176,7 +176,7 @@ export default defineComponent({
     }
 
     const getNodeKey = (node: Node) => {
-      return getNodeKeyUtil(props.nodeKey, node.data)
+      return props.nodeKey ? getNodeKeyUtil(props.nodeKey, node.data) : node.id
     }
 
     const requireNodeKey = (methodName: string) => {


### PR DESCRIPTION
After switching focus + keyboard navigation an error can occurs:

![Peek 2026-02-15 16-51](https://github.com/user-attachments/assets/a8912852-89a4-4a26-bad3-300252c0b98d)

[Before Demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuXG4gIDxlbC10cmVlXG4gICAgOmRhdGE9XCJkYXRhXCJcbiAgICA6cHJvcHM9XCJkZWZhdWx0UHJvcHNcIlxuICAgIGRlZmF1bHQtZXhwYW5kLWFsbFxuICAvPlxuXG4gIDxlbC10cmVlXG4gICAgOmRhdGE9XCJkYXRhXCJcbiAgICA6cHJvcHM9XCJkZWZhdWx0UHJvcHNcIlxuICAgIGRlZmF1bHQtZXhwYW5kLWFsbFxuICAvPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmltcG9ydCB7IHJlZiwgd2F0Y2ggfSBmcm9tICd2dWUnXG5cbmltcG9ydCB0eXBlIHsgVHJlZUluc3RhbmNlIH0gZnJvbSAnZWxlbWVudC1wbHVzJ1xuXG5pbnRlcmZhY2UgVHJlZSB7XG4gIFtrZXk6IHN0cmluZ106IGFueVxufVxuXG5jb25zdCBmaWx0ZXJUZXh0ID0gcmVmKCcnKVxuY29uc3QgdHJlZVJlZiA9IHJlZjxUcmVlSW5zdGFuY2U+KClcblxuY29uc3QgZGVmYXVsdFByb3BzID0ge1xuICBjaGlsZHJlbjogJ2NoaWxkcmVuJyxcbiAgbGFiZWw6ICdsYWJlbCcsXG59XG5cbndhdGNoKGZpbHRlclRleHQsICh2YWwpID0+IHtcbiAgdHJlZVJlZi52YWx1ZSEuZmlsdGVyKHZhbClcbn0pXG5cbmNvbnN0IGRhdGE6IFRyZWVbXSA9IFtcbiAge1xuICAgIGlkOiAxLFxuICAgIGxhYmVsOiAnTGV2ZWwgb25lIDEnLFxuICAgIGNoaWxkcmVuOiBbXG4gICAgICB7XG4gICAgICAgIGlkOiA0LFxuICAgICAgICBsYWJlbDogJ0xldmVsIHR3byAxLTEnLFxuICAgICAgICBjaGlsZHJlbjogW1xuICAgICAgICAgIHtcbiAgICAgICAgICAgIGlkOiA5LFxuICAgICAgICAgICAgbGFiZWw6ICdMZXZlbCB0aHJlZSAxLTEtMScsXG4gICAgICAgICAgfSxcbiAgICAgICAgICB7XG4gICAgICAgICAgICBpZDogMTAsXG4gICAgICAgICAgICBsYWJlbDogJ0xldmVsIHRocmVlIDEtMS0yJyxcbiAgICAgICAgICB9LFxuICAgICAgICBdLFxuICAgICAgfSxcbiAgICBdLFxuICB9LFxuICB7XG4gICAgaWQ6IDIsXG4gICAgbGFiZWw6ICdMZXZlbCBvbmUgMicsXG4gICAgY2hpbGRyZW46IFtcbiAgICAgIHtcbiAgICAgICAgaWQ6IDUsXG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDItMScsXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICBpZDogNixcbiAgICAgICAgbGFiZWw6ICdMZXZlbCB0d28gMi0yJyxcbiAgICAgIH0sXG4gICAgXSxcbiAgfSxcbiAge1xuICAgIGlkOiAzLFxuICAgIGxhYmVsOiAnTGV2ZWwgb25lIDMnLFxuICAgIGNoaWxkcmVuOiBbXG4gICAgICB7XG4gICAgICAgIGlkOiA3LFxuICAgICAgICBsYWJlbDogJ0xldmVsIHR3byAzLTEnLFxuICAgICAgfSxcbiAgICAgIHtcbiAgICAgICAgaWQ6IDgsXG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDMtMicsXG4gICAgICB9LFxuICAgIF0sXG4gIH0sXG5dXG48L3NjcmlwdD5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9ydW50aW1lLWRvbUBsYXRlc3QvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L2Rpc3QvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L1wiLFxuICAgIFwiQGVsZW1lbnQtcGx1cy9pY29ucy12dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJDb21wLnZ1ZSI6IiIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmNzcycsICdodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvdGhlbWUtY2hhbGsvZGFyay9jc3MtdmFycy5jc3MnXS5tYXAoKHN0eWxlKSA9PiB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgICBsaW5rLmhyZWYgPSBzdHlsZVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICAgIH0pXG4gIH0pXG4gIHJldHVybiBQcm9taXNlLmFsbFNldHRsZWQoc3R5bGVzKVxufVxuIiwiUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiX28iOnt9fQ==).
reproduction:
1. hit tab
2. hit tab
3. arrow down

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node identification in tree components by adding a reliable fallback when a custom node key isn’t provided, reducing incorrect/missing selection or rendering issues.

* **Tests**
  * Added tests verifying keyboard navigation works correctly when multiple tree widgets are present, ensuring focus and arrow-key behavior across adjacent trees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->