### PR TITLE
fix(components): [upload] append all values in formdata

### DIFF
--- a/docs/en-US/component/upload.md
+++ b/docs/en-US/component/upload.md
@@ -192,7 +192,7 @@ interface UploadRawFile extends File {
 interface UploadRequestOptions {
   action: string
   method: string
-  data: Record<string, string | Blob | [string | Blob, string]>
+  data: Record<string, string | Blob | [string | Blob, string] | string[]>
   filename: string
   file: UploadRawFile
   headers: Headers | Record<string, string | number | null | undefined>

--- a/packages/components/upload/src/ajax.ts
+++ b/packages/components/upload/src/ajax.ts
@@ -75,7 +75,7 @@ export const ajaxUpload: UploadRequestHandler = (option) => {
         if (
           value.length === 2 &&
           value[0] instanceof Blob &&
-          typeof value[1] === 'string'
+          isString(value[1])
         ) {
           formData.append(key, value[0], value[1])
         } else {

--- a/packages/components/upload/src/ajax.ts
+++ b/packages/components/upload/src/ajax.ts
@@ -71,7 +71,10 @@ export const ajaxUpload: UploadRequestHandler = (option) => {
   const formData = new FormData()
   if (option.data) {
     for (const [key, value] of Object.entries(option.data)) {
-      if (isArray(value)) value.forEach((item) => formData.append(key, item))
+      if (isArray(value))
+        value.forEach((item) => {
+          formData.append(key, item)
+        })
       else formData.append(key, value)
     }
   }

--- a/packages/components/upload/src/ajax.ts
+++ b/packages/components/upload/src/ajax.ts
@@ -1,5 +1,5 @@
 import { isNil } from 'lodash-unified'
-import { isArray, throwError } from '@element-plus/utils'
+import { isArray, isString, throwError } from '@element-plus/utils'
 
 import type {
   UploadProgressEvent,

--- a/packages/components/upload/src/ajax.ts
+++ b/packages/components/upload/src/ajax.ts
@@ -71,7 +71,7 @@ export const ajaxUpload: UploadRequestHandler = (option) => {
   const formData = new FormData()
   if (option.data) {
     for (const [key, value] of Object.entries(option.data)) {
-      if (isArray(value) && value.length) formData.append(key, ...value)
+      if (isArray(value)) value.forEach((item) => formData.append(key, item))
       else formData.append(key, value)
     }
   }

--- a/packages/components/upload/src/ajax.ts
+++ b/packages/components/upload/src/ajax.ts
@@ -71,11 +71,13 @@ export const ajaxUpload: UploadRequestHandler = (option) => {
   const formData = new FormData()
   if (option.data) {
     for (const [key, value] of Object.entries(option.data)) {
-      if (isArray(value))
-        value.forEach((item) => {
-          formData.append(key, item)
-        })
-      else formData.append(key, value)
+      if (isArray(value)) {
+        if (value.length === 2 && value[0] instanceof Blob) {
+          formData.append(key, ...value)
+        } else {
+          value.forEach((item) => formData.append(key, item))
+        }
+      } else formData.append(key, value)
     }
   }
   formData.append(option.filename, option.file, option.file.name)

--- a/packages/components/upload/src/ajax.ts
+++ b/packages/components/upload/src/ajax.ts
@@ -79,7 +79,9 @@ export const ajaxUpload: UploadRequestHandler = (option) => {
         ) {
           formData.append(key, value[0], value[1])
         } else {
-          value.forEach((item) => formData.append(key, item))
+          value.forEach((item) => {
+            formData.append(key, item)
+          })
         }
       } else formData.append(key, value)
     }

--- a/packages/components/upload/src/ajax.ts
+++ b/packages/components/upload/src/ajax.ts
@@ -72,8 +72,12 @@ export const ajaxUpload: UploadRequestHandler = (option) => {
   if (option.data) {
     for (const [key, value] of Object.entries(option.data)) {
       if (isArray(value)) {
-        if (value.length === 2 && value[0] instanceof Blob) {
-          formData.append(key, ...value)
+        if (
+          value.length === 2 &&
+          value[0] instanceof Blob &&
+          typeof value[1] === 'string'
+        ) {
+          formData.append(key, value[0], value[1])
         } else {
           value.forEach((item) => formData.append(key, item))
         }

--- a/packages/components/upload/src/upload.ts
+++ b/packages/components/upload/src/upload.ts
@@ -22,7 +22,7 @@ export interface UploadProgressEvent extends ProgressEvent {
 export interface UploadRequestOptions {
   action: string
   method: string
-  data: Record<string, string | Blob | [Blob, string]>
+  data: Record<string, string | Blob | [string | Blob, string] | string[]>
   filename: string
   file: UploadRawFile
   headers: Headers | Record<string, string | number | null | undefined>


### PR DESCRIPTION
fix #14226

FormData.append only takes 3 args max, spreading an array don't send them at this point. Append each item individually instead.

[demo before](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtdXBsb2FkIGFjdGlvbj1cImh0dHBzOi8vaHR0cGJpbi5vcmcvcG9zdFwiIDpkYXRhPVwiZGF0YVwiPlxuICAgIDxlbC1idXR0b24gdHlwZT1cInByaW1hcnlcIj5VcGxvYWQ8L2VsLWJ1dHRvbj5cbiAgPC9lbC11cGxvYWQ+XG48L3RlbXBsYXRlPlxuXG48c2NyaXB0IGxhbmc9XCJ0c1wiIHNldHVwPlxuY29uc3QgZGF0YSA9IHsgbmFtZTogJ3Rlc3QnLCB0YWdzOiBbJ2EnLCAnYicsICdjJ10gfVxuPC9zY3JpcHQ+XG4iLCJlbGVtZW50LXBsdXMuanMiOiJpbXBvcnQgRWxlbWVudFBsdXMgZnJvbSAnZWxlbWVudC1wbHVzJ1xuaW1wb3J0IHsgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlJ1xuXG5sZXQgaW5zdGFsbGVkID0gZmFsc2VcbmF3YWl0IGxvYWRTdHlsZSgpXG5cbmV4cG9ydCBmdW5jdGlvbiBzZXR1cEVsZW1lbnRQbHVzKCkge1xuICBpZiAoaW5zdGFsbGVkKSByZXR1cm5cbiAgY29uc3QgaW5zdGFuY2UgPSBnZXRDdXJyZW50SW5zdGFuY2UoKVxuICBpbnN0YW5jZS5hcHBDb250ZXh0LmFwcC51c2UoRWxlbWVudFBsdXMpXG4gIGluc3RhbGxlZCA9IHRydWVcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGxvYWRTdHlsZSgpIHtcbiAgY29uc3Qgc3R5bGVzID0gWydodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvZGlzdC9pbmRleC5jc3MnLCAnaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L3RoZW1lLWNoYWxrL2RhcmsvY3NzLXZhcnMuY3NzJ10ubWFwKChzdHlsZSkgPT4ge1xuICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgICAgbGluay5ocmVmID0gc3R5bGVcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgICB9KVxuICB9KVxuICByZXR1cm4gUHJvbWlzZS5hbGxTZXR0bGVkKHN0eWxlcylcbn1cbiIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AbGF0ZXN0L2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvc2hhcmVkXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9cIixcbiAgICBcIkBlbGVtZW50LXBsdXMvaWNvbnMtdnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AZWxlbWVudC1wbHVzL2ljb25zLXZ1ZUAyL2Rpc3QvaW5kZXgubWluLmpzXCJcbiAgfSxcbiAgXCJzY29wZXNcIjoge31cbn0iLCJfbyI6e319).

after:
<img width="501" height="203" alt="image" src="https://github.com/user-attachments/assets/ed288876-5358-4ad3-815f-a0c37e0b0734" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload handling for multi-value fields: arrays are submitted as separate entries; two-item file+name payloads remain bundled; empty arrays produce no entries.

* **Documentation**
  * Clarified that upload request data may include arrays of strings and that file tuples can include either a string or a Blob as the first element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->