### PR TITLE
style(theme-chalk): [checkbox-button] add disabled+checked visual distinction

### DIFF
--- a/packages/theme-chalk/src/checkbox-button.scss
+++ b/packages/theme-chalk/src/checkbox-button.scss
@@ -98,6 +98,12 @@
         map.get($button, 'disabled-border-color')
       );
     }
+
+    @include when(checked) {
+      .#{$namespace}-checkbox-button__inner {
+        background-color: getCssVar('checkbox-button-disabled-checked-fill');
+      }
+    }
   }
 
   &:first-child {

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -297,6 +297,7 @@ $checkbox-button: map.merge(
     'checked-bg-color': getCssVar('color-primary'),
     'checked-text-color': getCssVar('color-white'),
     'checked-border-color': getCssVar('color-primary'),
+    'disabled-checked-fill': getCssVar('border-color-extra-light'),
   ),
   $checkbox-button
 );


### PR DESCRIPTION
fix #4461

This with other disabled-checked state like radio:
https://github.com/element-plus/element-plus/blob/0192470da631247ff43f43a9493dd1f69fb15843/packages/theme-chalk/src/common/var.scss#L352

Before:
<img width="304" height="129" alt="image" src="https://github.com/user-attachments/assets/fb2e0ccd-0646-43d0-9f2d-7e53fb4646eb" />

After:
<img width="174" height="149" alt="image" src="https://github.com/user-attachments/assets/7fadc5c0-7f16-4c6f-ac15-9f362d69a0e6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved theme styling for checkbox buttons. Disabled, checked checkbox buttons now display with a distinct fill color derived from the light border color to provide better visual feedback and distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->