### PR TITLE
fix(components): [badge] dot becomes rectangle on transition leave

### DIFF
--- a/packages/components/badge/__tests__/badge.test.tsx
+++ b/packages/components/badge/__tests__/badge.test.tsx
@@ -16,13 +16,14 @@ describe('Badge', () => {
   test('is fixed', () => {
     const wrapper = mount(() => (
       <Badge
+        value={1}
         v-slots={{
           default: () => AXIOM,
         }}
       />
     ))
     expect(wrapper.find('.el-badge__content.is-fixed').exists()).toBe(true)
-    expect(wrapper.find('.el-badge').text()).toBe(AXIOM)
+    expect(wrapper.find('.el-badge').text()).toContain(AXIOM)
   })
 
   test('is dot', () => {
@@ -59,10 +60,10 @@ describe('Badge', () => {
   test('hidden', async () => {
     const hidden = ref(true)
     const wrapper = mount(() => <Badge hidden={hidden.value} value={10} />)
-    expect(wrapper.find('.el-badge__content').isVisible()).toBe(false)
+    expect(wrapper.find('.el-badge__content').exists()).toBe(false)
     hidden.value = false
     await nextTick()
-    expect(wrapper.find('.el-badge__content').isVisible()).toBe(true)
+    expect(wrapper.find('.el-badge__content').exists()).toBe(true)
   })
 
   test('max', async () => {

--- a/packages/components/badge/src/badge.vue
+++ b/packages/components/badge/src/badge.vue
@@ -4,6 +4,7 @@
     <transition :name="`${ns.namespace.value}-zoom-in-center`">
       <sup
         v-show="!hidden && (content || isDot || $slots.content)"
+        :key="isDot"
         :class="[
           ns.e('content'),
           ns.em('content', type),

--- a/packages/components/badge/src/badge.vue
+++ b/packages/components/badge/src/badge.vue
@@ -4,7 +4,7 @@
     <transition :name="`${ns.namespace.value}-zoom-in-center`">
       <sup
         v-show="!hidden && (content || isDot || $slots.content)"
-        :key="isDot"
+        :key="isDot ? 'dot' : 'badge'"
         :class="[
           ns.e('content'),
           ns.em('content', type),

--- a/packages/components/badge/src/badge.vue
+++ b/packages/components/badge/src/badge.vue
@@ -3,8 +3,7 @@
     <slot />
     <transition :name="`${ns.namespace.value}-zoom-in-center`">
       <sup
-        v-show="!hidden && (content || isDot || $slots.content)"
-        :key="isDot ? 'dot' : 'badge'"
+        v-if="!hidden && (content || isDot || $slots.content)"
         :class="[
           ns.e('content'),
           ns.em('content', type),


### PR DESCRIPTION
closed #11166

Before:
![Peek 2026-02-16 19-59](https://github.com/user-attachments/assets/3f966066-c55a-4785-9ea6-bdff6967675f)


[demo before](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtYmFkZ2UgOmlzLWRvdD1cImRvdFwiPlxuICAgIDxlbC1idXR0b24+Y29tbWVudHM8L2VsLWJ1dHRvbj5cbiAgPC9lbC1iYWRnZT5cbiAgPGVsLWJ1dHRvbiBAY2xpY2s9XCJkb3QgPSAhZG90XCIgc3R5bGU9XCJtYXJnaW4tbGVmdDogMTZweFwiPlxuICAgIHRvZ2dsZSBkb3RcbiAgPC9lbC1idXR0b24+XG48L3RlbXBsYXRlPlxuXG48c2NyaXB0IGxhbmc9XCJ0c1wiIHNldHVwPlxuaW1wb3J0IHsgcmVmIH0gZnJvbSAndnVlJ1xuXG5jb25zdCBkb3QgPSByZWYodHJ1ZSlcbjwvc2NyaXB0PlxuIiwiZWxlbWVudC1wbHVzLmpzIjoiaW1wb3J0IEVsZW1lbnRQbHVzIGZyb20gJ2VsZW1lbnQtcGx1cydcbmltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcblxubGV0IGluc3RhbGxlZCA9IGZhbHNlXG5hd2FpdCBsb2FkU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gc2V0dXBFbGVtZW50UGx1cygpIHtcbiAgaWYgKGluc3RhbGxlZCkgcmV0dXJuXG4gIGNvbnN0IGluc3RhbmNlID0gZ2V0Q3VycmVudEluc3RhbmNlKClcbiAgaW5zdGFuY2UuYXBwQ29udGV4dC5hcHAudXNlKEVsZW1lbnRQbHVzKVxuICBpbnN0YWxsZWQgPSB0cnVlXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkU3R5bGUoKSB7XG4gIGNvbnN0IHN0eWxlcyA9IFsnaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L2Rpc3QvaW5kZXguY3NzJywgJ2h0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC90aGVtZS1jaGFsay9kYXJrL2Nzcy12YXJzLmNzcyddLm1hcCgoc3R5bGUpID0+IHtcbiAgICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICAgIGxpbmsuaHJlZiA9IHN0eWxlXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2xvYWQnLCByZXNvbHZlKVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdlcnJvcicsIHJlamVjdClcbiAgICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gICAgfSlcbiAgfSlcbiAgcmV0dXJuIFByb21pc2UuYWxsU2V0dGxlZChzdHlsZXMpXG59XG4iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcbiAgICBcImpzeFwiOiBcInByZXNlcnZlXCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJ0eXBlc1wiOiBbXCJlbGVtZW50LXBsdXMvZ2xvYmFsLmQudHNcIl0sXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwiUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3J1bnRpbWUtZG9tQGxhdGVzdC9kaXN0L3J1bnRpbWUtZG9tLmVzbS1icm93c2VyLmpzXCIsXG4gICAgXCJAdnVlL3NoYXJlZFwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9zaGFyZWRAbGF0ZXN0L2Rpc3Qvc2hhcmVkLmVzbS1idW5kbGVyLmpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvZGlzdC9pbmRleC5mdWxsLm1pbi5tanNcIixcbiAgICBcImVsZW1lbnQtcGx1cy9cIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvXCIsXG4gICAgXCJAZWxlbWVudC1wbHVzL2ljb25zLXZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQGVsZW1lbnQtcGx1cy9pY29ucy12dWVAMi9kaXN0L2luZGV4Lm1pbi5qc1wiXG4gIH0sXG4gIFwic2NvcGVzXCI6IHt9XG59IiwiX28iOnt9fQ==)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved badge rendering so the indicator is conditionally rendered (removed from the DOM when hidden), ensuring consistent behavior between compact "dot" badges and standard numeric badges and reducing unexpected visual artifacts.

* **Chores**
  * No public API or exported declarations were changed; this is an internal rendering improvement with no impact on integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->