### PR TITLE
fix(components): [select/v2] stop change event bubbling

### DIFF
--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -2948,4 +2948,20 @@ describe('Select', () => {
       expect(inputWrapper.classes()).toContain('is-hidden')
     })
   })
+
+  it('should not bubble native change event from filter input', async () => {
+    const wrapper = createSelect({
+      data: () => ({ filterable: true }),
+    })
+
+    const nativeChangeHandler = vi.fn()
+    const parent = document.createElement('div')
+    parent.addEventListener('change', nativeChangeHandler)
+    parent.appendChild(wrapper.element)
+
+    await wrapper.find('input').trigger('change')
+    expect(nativeChangeHandler).not.toHaveBeenCalled()
+
+    parent.remove()
+  })
 })

--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -207,6 +207,7 @@
                 type="text"
                 :name="name"
                 @input="onInput"
+                @change.stop
                 @compositionstart="handleCompositionStart"
                 @compositionupdate="handleCompositionUpdate"
                 @compositionend="handleCompositionEnd"

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4401,4 +4401,29 @@ describe('Select', () => {
       expect(inputWrapper.classes()).toContain('is-hidden')
     })
   })
+
+  it('should not bubble native change event from filter input', async () => {
+    const wrapper = mount({
+      template: `
+        <div>
+          <el-select filterable v-model="value">
+            <el-option label="a" value="a" />
+          </el-select>
+        </div>
+      `,
+      components: { 'el-select': Select, 'el-option': Option },
+      setup() {
+        return {
+          value: ref(''),
+        }
+      },
+    })
+
+    const nativeChangeHandler = vi.fn()
+    const parent = wrapper.element as HTMLElement
+    parent.addEventListener('change', nativeChangeHandler)
+
+    await wrapper.find('input').trigger('change')
+    expect(nativeChangeHandler).not.toHaveBeenCalled()
+  })
 })

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -204,6 +204,7 @@
                 @compositionupdate="handleCompositionUpdate"
                 @compositionend="handleCompositionEnd"
                 @input="onInput"
+                @change.stop
                 @click.stop="toggleMenu"
               />
               <span


### PR DESCRIPTION
fix #13485

Like `@click`, stop event bubbling for `@change` event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Native change events from Select filter inputs no longer bubble to ancestor elements, preventing unintended propagation.

* **Tests**
  * Added tests to confirm filterable Selects do not emit native change events to parent elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->