### PR TITLE
fix(style): [form-item] remove trailing inline margin

### DIFF
--- a/packages/theme-chalk/src/form.scss
+++ b/packages/theme-chalk/src/form.scss
@@ -10,6 +10,10 @@
       display: inline-flex;
       vertical-align: middle;
       margin-right: 32px;
+
+      &:last-child {
+        margin-right: 0;
+      }
     }
 
     &.#{$namespace}-form--label-top {


### PR DESCRIPTION
fix #5212

before
<img width="850" height="83" alt="image" src="https://github.com/user-attachments/assets/62496b5e-f859-4032-bc59-509a601999c7" />

after

<img width="805" height="97" alt="image" src="https://github.com/user-attachments/assets/e2c2f5e5-6756-4c29-8f0d-b49418b87793" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual spacing in inline form layouts by removing excess margin from the final form item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->