### PR TITLE
fix(components): [table-v2] navigation back triggered by trackpad scrolling

### DIFF
--- a/packages/components/virtual-list/src/hooks/use-grid-wheel.ts
+++ b/packages/components/virtual-list/src/hooks/use-grid-wheel.ts
@@ -19,19 +19,22 @@ export const useGridWheel = (
   let xOffset = 0
   let yOffset = 0
 
+  const hasXReachedEdge = (x: number) => {
+    return (x < 0 && atXStartEdge.value) || (x > 0 && atXEndEdge.value)
+  }
+  const hasYReachedEdge = (y: number) => {
+    return (y < 0 && atYStartEdge.value) || (y > 0 && atYEndEdge.value)
+  }
   const hasReachedEdge = (x: number, y: number) => {
-    const xEdgeReached =
-      (x < 0 && atXStartEdge.value) || (x > 0 && atXEndEdge.value)
-    const yEdgeReached =
-      (y < 0 && atYStartEdge.value) || (y > 0 && atYEndEdge.value)
-    return xEdgeReached || yEdgeReached
+    return hasXReachedEdge(x) || hasYReachedEdge(y)
   }
 
   const onWheel = (e: WheelEvent) => {
     cAF(frameHandle!)
 
-    let x = e.deltaX
-    let y = e.deltaY
+    const { deltaX, deltaY } = e
+    let x = deltaX
+    let y = deltaY
     // Simulate native behavior when using touch pad/track pad for wheeling.
     if (Math.abs(x) > Math.abs(y)) {
       y = 0
@@ -45,7 +48,18 @@ export const useGridWheel = (
       y = 0
     }
 
-    if (hasReachedEdge(x, y)) return
+    if (hasReachedEdge(x, y)) {
+      // #23524
+      if (
+        deltaX < 0 &&
+        deltaY < 0 &&
+        !hasXReachedEdge(deltaX) &&
+        hasYReachedEdge(deltaY)
+      ) {
+        e.preventDefault()
+      }
+      return
+    }
 
     xOffset += x
     yOffset += y

--- a/packages/components/virtual-list/src/hooks/use-grid-wheel.ts
+++ b/packages/components/virtual-list/src/hooks/use-grid-wheel.ts
@@ -19,22 +19,19 @@ export const useGridWheel = (
   let xOffset = 0
   let yOffset = 0
 
-  const hasXReachedEdge = (x: number) => {
-    return (x < 0 && atXStartEdge.value) || (x > 0 && atXEndEdge.value)
-  }
-  const hasYReachedEdge = (y: number) => {
-    return (y < 0 && atYStartEdge.value) || (y > 0 && atYEndEdge.value)
-  }
   const hasReachedEdge = (x: number, y: number) => {
-    return hasXReachedEdge(x) || hasYReachedEdge(y)
+    const xEdgeReached =
+      (x < 0 && atXStartEdge.value) || (x > 0 && atXEndEdge.value)
+    const yEdgeReached =
+      (y < 0 && atYStartEdge.value) || (y > 0 && atYEndEdge.value)
+    return xEdgeReached || yEdgeReached
   }
 
   const onWheel = (e: WheelEvent) => {
     cAF(frameHandle!)
 
-    const { deltaX, deltaY } = e
-    let x = deltaX
-    let y = deltaY
+    let x = e.deltaX
+    let y = e.deltaY
     // Simulate native behavior when using touch pad/track pad for wheeling.
     if (Math.abs(x) > Math.abs(y)) {
       y = 0
@@ -51,11 +48,8 @@ export const useGridWheel = (
     if (hasReachedEdge(x, y)) {
       // #23524
       // Prevent browser back navigation when the table can still scroll
-      // horizontally but the Y-axis normalization dropped the X delta and the Y
-      // edge was hit instead. Intentionally *not* preventing default when
-      // hasXReachedEdge(deltaX) is true — at the genuine left edge, allowing
-      // the browser back gesture is acceptable UX.
-      if (deltaX < 0 && !hasXReachedEdge(deltaX) && hasYReachedEdge(deltaY)) {
+      // horizontally but the Y-axis normalization dropped the X delta and the Y edge was hit instead.
+      if (e.deltaX !== 0 && x === 0) {
         e.preventDefault()
       }
       return

--- a/packages/components/virtual-list/src/hooks/use-grid-wheel.ts
+++ b/packages/components/virtual-list/src/hooks/use-grid-wheel.ts
@@ -50,12 +50,12 @@ export const useGridWheel = (
 
     if (hasReachedEdge(x, y)) {
       // #23524
-      if (
-        deltaX < 0 &&
-        deltaY < 0 &&
-        !hasXReachedEdge(deltaX) &&
-        hasYReachedEdge(deltaY)
-      ) {
+      // Prevent browser back navigation when the table can still scroll
+      // horizontally but the Y-axis normalization dropped the X delta and the Y
+      // edge was hit instead. Intentionally *not* preventing default when
+      // hasXReachedEdge(deltaX) is true — at the genuine left edge, allowing
+      // the browser back gesture is acceptable UX.
+      if (deltaX < 0 && !hasXReachedEdge(deltaX) && hasYReachedEdge(deltaY)) {
         e.preventDefault()
       }
       return


### PR DESCRIPTION
fix #23524

Simply set `x` and `y` to `-1` [here](https://github.com/element-plus/element-plus/blob/e53399fae4d2ea336ccb8e12150bcaab73a513bf/packages/components/virtual-list/src/hooks/use-grid-wheel.ts#L33-L34), then try scrolling with the trackpad to reproduce the issue.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved wheel handling in virtual lists: refined edge detection to avoid unintended browser back navigation in specific horizontal-wheel scenarios, while preserving existing edge behavior and outward API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->