### PR TITLE
fix(components): [input-tag] delimiter does not support pasted line breaks

### DIFF
--- a/packages/components/input-tag/__tests__/input-tag.test.tsx
+++ b/packages/components/input-tag/__tests__/input-tag.test.tsx
@@ -298,6 +298,36 @@ describe('InputTag.vue', () => {
         .forEach((tag) => expect(tag.text()).toBe(AXIOM))
       expect(inputValue.value).toEqual(result)
     })
+
+    test('paste multiple /\r?\n/ delimiter', async () => {
+      const inputValue = ref<string[]>()
+      const addTag = vi.fn()
+      const wrapper = mount(() => (
+        <InputTag
+          v-model={inputValue.value}
+          delimiter={/\r?\n/}
+          onAdd-tag={addTag}
+        />
+      ))
+
+      await wrapper.find('input').trigger('paste', {
+        clipboardData: {
+          getData: () => `
+                          ${AXIOM}
+                          ${AXIOM}
+                          ${AXIOM}
+                        `,
+        },
+      })
+
+      const result = [AXIOM, AXIOM, AXIOM]
+      expect(wrapper.findAll('.el-tag').length).toBe(3)
+      expect(addTag).toBeCalledWith(result)
+      wrapper
+        .findAll('.el-tag')
+        .forEach((tag) => expect(tag.text()).toBe(AXIOM))
+      expect(inputValue.value).toEqual(result)
+    })
   })
 
   describe('events', () => {

--- a/packages/components/input-tag/__tests__/input-tag.test.tsx
+++ b/packages/components/input-tag/__tests__/input-tag.test.tsx
@@ -313,10 +313,10 @@ describe('InputTag.vue', () => {
       await wrapper.find('input').trigger('paste', {
         clipboardData: {
           getData: () => `
-                          ${AXIOM}
-                          ${AXIOM}
-                          ${AXIOM}
-                        `,
+            ${AXIOM}
+            ${AXIOM}
+            ${AXIOM}
+          `,
         },
       })
 

--- a/packages/components/input-tag/src/composables/use-input-tag.ts
+++ b/packages/components/input-tag/src/composables/use-input-tag.ts
@@ -69,12 +69,26 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
   const getDelimitedTags = (input: string) => {
     const tags = input
       .split(props.delimiter!)
+      .map((tag) => tag.trim())
       .filter((val) => val && val !== input)
     if (props.max) {
       const maxInsert = props.max - (props.modelValue?.length ?? 0)
       tags.splice(maxInsert)
     }
     return tags.length === 1 ? tags[0] : tags
+  }
+
+  const handlePaste = (event: ClipboardEvent) => {
+    const value = event.clipboardData?.getData('text')
+    if (!props.delimiter || !value) {
+      return
+    }
+    const tags = getDelimitedTags(value)
+    if (tags.length) {
+      addTagsEmit(tags)
+      emit(INPUT_EVENT, value)
+      event.preventDefault()
+    }
   }
 
   const handleInput = (event: Event) => {
@@ -235,6 +249,7 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
     showTagList,
     collapseTagList,
     handleDragged,
+    handlePaste,
     handleInput,
     handleKeydown,
     handleKeyup,

--- a/packages/components/input-tag/src/composables/use-input-tag.ts
+++ b/packages/components/input-tag/src/composables/use-input-tag.ts
@@ -80,7 +80,7 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
 
   const handlePaste = (event: ClipboardEvent) => {
     const value = event.clipboardData?.getData('text')
-    if (!props.delimiter || !value) {
+    if (props.readonly || inputLimit.value || !props.delimiter || !value) {
       return
     }
     const tags = getDelimitedTags(value)

--- a/packages/components/input-tag/src/composables/use-input-tag.ts
+++ b/packages/components/input-tag/src/composables/use-input-tag.ts
@@ -67,10 +67,9 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
   }
 
   const getDelimitedTags = (input: string) => {
-    const tags = input
-      .split(props.delimiter!)
-      .map((tag) => tag.trim())
-      .filter((val) => val && val !== input)
+    const parts = input.split(props.delimiter!)
+    const tags =
+      parts.length > 1 ? parts.map((val) => val.trim()).filter(Boolean) : []
     if (props.max) {
       const maxInsert = props.max - (props.modelValue?.length ?? 0)
       tags.splice(maxInsert)
@@ -79,14 +78,21 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
   }
 
   const handlePaste = (event: ClipboardEvent) => {
-    const value = event.clipboardData?.getData('text')
-    if (props.readonly || inputLimit.value || !props.delimiter || !value) {
+    const pasted = event.clipboardData?.getData('text')
+    if (props.readonly || inputLimit.value || !props.delimiter || !pasted) {
       return
     }
-    const tags = getDelimitedTags(value)
+    const {
+      selectionStart = 0,
+      selectionEnd = 0,
+      value,
+    } = event.target as HTMLInputElement
+    const nextValue =
+      value.slice(0, selectionStart!) + pasted + value.slice(selectionEnd!)
+    const tags = getDelimitedTags(nextValue)
     if (tags.length) {
       addTagsEmit(tags)
-      emit(INPUT_EVENT, value)
+      emit(INPUT_EVENT, nextValue)
       event.preventDefault()
     }
   }

--- a/packages/components/input-tag/src/input-tag.vue
+++ b/packages/components/input-tag/src/input-tag.vue
@@ -91,6 +91,7 @@
           @compositionstart="handleCompositionStart"
           @compositionupdate="handleCompositionUpdate"
           @compositionend="handleCompositionEnd"
+          @paste="handlePaste"
           @input="handleInput"
           @keydown="handleKeydown"
           @keyup="handleKeyup"
@@ -198,6 +199,7 @@ const {
   showTagList,
   collapseTagList,
   handleDragged,
+  handlePaste,
   handleInput,
   handleKeydown,
   handleKeyup,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fix #23063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Input supports pasting multiple newline-delimited items: pasted text is split on newlines, trimmed, and each item becomes its own tag immediately; paste action is handled to update input state and create tags.

* **Tests**
  * Added tests verifying multiline paste behavior, creation and display of individual tags from pasted lines, correct calls for adding tags, and updated input state after paste.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->