### PR TITLE
refactor(components): [segmented] remove `intoAny` workaround

### DIFF
--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -24,7 +24,7 @@
           @change="handleChange($event, item)"
         />
         <div :class="ns.e('item-label')">
-          <slot :item="intoAny(item)">{{ getLabel(item) }}</slot>
+          <slot :item="item">{{ getLabel(item) }}</slot>
         </div>
       </label>
     </div>
@@ -91,9 +91,6 @@ const handleChange = (evt: Event, item: Option) => {
 }
 
 const aliasProps = computed(() => ({ ...defaultProps, ...props.props }))
-
-//FIXME: remove this when vue >=3.3
-const intoAny = (item: any) => item
 
 const getValue = (item: Option) => {
   return isObject(item) ? item[aliasProps.value.value] : item


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

Remove `intoAny` helper and pass item directly to the default slot; no longer needed with `Vue 3.3+` slot typing.

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal implementation of the segmented component slot handling to remove unnecessary indirection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->