### PR TITLE
fix(hooks): Use top and left instead of transform

### DIFF
--- a/packages/hooks/use-draggable/index.ts
+++ b/packages/hooks/use-draggable/index.ts
@@ -45,9 +45,8 @@ export const useDraggable = (
       transform.offsetX = moveX
       transform.offsetY = moveY
 
-      targetRef.value.style.transform = `translate(${addUnit(moveX)}, ${addUnit(
-        moveY
-      )})`
+      targetRef.value.style.top = addUnit(moveY)!
+      targetRef.value.style.left = addUnit(moveX)!
     }
   }
 
@@ -95,7 +94,8 @@ export const useDraggable = (
     transform.offsetY = 0
 
     if (targetRef.value) {
-      targetRef.value.style.transform = ''
+      targetRef.value.style.top = '0px'
+      targetRef.value.style.left = '0px'
     }
   }
 


### PR DESCRIPTION
Use the top and left values ​​of the positioning property instead of transform to fix the impact of positioning context in nested dialogs.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized draggable element positioning mechanism for improved drag operation stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->