### PR TITLE
style(components): [tabs] add disabled style for prev and next buttons

### DIFF
--- a/packages/theme-chalk/src/tabs.scss
+++ b/packages/theme-chalk/src/tabs.scss
@@ -395,6 +395,10 @@
         i {
           transform: rotateZ(90deg);
         }
+
+        @include when(disabled) {
+          cursor: not-allowed;
+        }
       }
 
       > .#{$namespace}-tabs__nav-prev {

--- a/packages/theme-chalk/src/tabs.scss
+++ b/packages/theme-chalk/src/tabs.scss
@@ -105,6 +105,11 @@
     color: getCssVar('text-color', 'secondary');
     width: 20px;
     text-align: center;
+
+    @include when(disabled) {
+      color: getCssVar('text-color', 'disabled');
+      cursor: not-allowed;
+    }
   }
   @include e(nav-next) {
     right: 0;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
<img width="296" height="89" alt="image" src="https://github.com/user-attachments/assets/88e7e699-3299-4bc5-aaa0-6844aebf9b37" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved disabled-state styling for tab navigation controls: disabled text color and a “not-allowed” cursor applied to navigation controls and wrappers for clearer visual feedback.
  * Purely visual change—no functional or behavioral changes to controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->