### PR TITLE
feat(components): [popover] expose hide() through slot

### DIFF
--- a/docs/en-US/component/popover.md
+++ b/docs/en-US/component/popover.md
@@ -108,7 +108,7 @@ popover/directive-usage
 
 | Name              | Description                                                                | Type                          |
 | ----------------- | -------------------------------------------------------------------------- | ----------------------------- |
-| default ^(2.13.3) | content of popover                                                         | ^[object]`{hide: () => void}` |
+| default | content of popover, version ^(2.13.3) and later can receive the hide parameter.                                                         | ^[object]`{hide: () => void}` |
 | reference         | HTML element that triggers popover, only a single root element is accepted | -                             |
 
 ### Events

--- a/docs/en-US/component/popover.md
+++ b/docs/en-US/component/popover.md
@@ -108,7 +108,7 @@ popover/directive-usage
 
 | Name      | Description                                                                     | Type                          |
 | --------- | ------------------------------------------------------------------------------- | ----------------------------- |
-| default   | content of popover, version ^(2.13.3) and later can receive the hide parameter. | ^[object]`{hide: () => void}` |
+| default   | content of popover, version ^(2.13.4) and later can receive the hide parameter. | ^[object]`{hide: () => void}` |
 | reference | HTML element that triggers popover, only a single root element is accepted      | -                             |
 
 ### Events

--- a/docs/en-US/component/popover.md
+++ b/docs/en-US/component/popover.md
@@ -106,10 +106,10 @@ popover/directive-usage
 
 ### Slots
 
-| Name              | Description                                                                | Type                          |
-| ----------------- | -------------------------------------------------------------------------- | ----------------------------- |
-| default | content of popover, version ^(2.13.3) and later can receive the hide parameter.                                                         | ^[object]`{hide: () => void}` |
-| reference         | HTML element that triggers popover, only a single root element is accepted | -                             |
+| Name      | Description                                                                     | Type                          |
+| --------- | ------------------------------------------------------------------------------- | ----------------------------- |
+| default   | content of popover, version ^(2.13.3) and later can receive the hide parameter. | ^[object]`{hide: () => void}` |
+| reference | HTML element that triggers popover, only a single root element is accepted      | -                             |
 
 ### Events
 

--- a/docs/en-US/component/popover.md
+++ b/docs/en-US/component/popover.md
@@ -106,10 +106,10 @@ popover/directive-usage
 
 ### Slots
 
-| Name      | Description                                                                |
-| --------- | -------------------------------------------------------------------------- |
-| default   | text content of popover                                                    |
-| reference | HTML element that triggers popover, only a single root element is accepted |
+| Name              | Description                                                                | Type                          |
+| ----------------- | -------------------------------------------------------------------------- | ----------------------------- |
+| default ^(2.13.3) | content of popover                                                         | ^[object]`{hide: () => void}` |
+| reference         | HTML element that triggers popover, only a single root element is accepted | -                             |
 
 ### Events
 

--- a/packages/components/popover/src/popover.vue
+++ b/packages/components/popover/src/popover.vue
@@ -39,7 +39,7 @@
       <div v-if="title" :class="ns.e('title')" role="title">
         {{ title }}
       </div>
-      <slot>
+      <slot :hide="hide">
         {{ content }}
       </slot>
     </template>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

close #23690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Popover's default slot now exposes a hide function, allowing custom slot content to close the popover programmatically.

* **Documentation**
  * Popover docs updated: Slots table adds a Type column and clarifies the default slot description to reflect the exposed slot properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->