### PR TITLE
feat(components): [input] emit clear event pass event parameter

### DIFF
--- a/docs/en-US/component/input.md
+++ b/docs/en-US/component/input.md
@@ -156,19 +156,19 @@ input/length-limiting
 
 ### Events
 
-| Name              | Description                                                                                           | Type                                                        |
-| ----------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| blur              | triggers when Input blurs                                                                             | ^[Function]`(event: FocusEvent) => void`                    |
-| focus             | triggers when Input focuses                                                                           | ^[Function]`(event: FocusEvent) => void`                    |
-| change            | triggers when the input box loses focus or the user presses Enter, only if the modelValue has changed | ^[Function]`(value: string \| number, evt?: Event) => void` |
-| input             | triggers when the Input value change                                                                  | ^[Function]`(value: string \| number) => void`              |
-| clear             | triggers when the Input is cleared by clicking the clear button                                       | ^[Function]`() => void`                                     |
-| keydown           | triggers when a key is pressed down                                                                   | ^[Function]`(event: KeyboardEvent \| Event) => void`        |
-| mouseleave        | triggers when the mouse leaves the Input element                                                      | ^[Function]`(event: MouseEvent) => void`                    |
-| mouseenter        | triggers when the mouse enters the Input element                                                      | ^[Function]`(event: MouseEvent) => void`                    |
-| compositionstart  | triggers when the composition starts                                                                  | ^[Function]`(event: CompositionEvent) => void`              |
-| compositionupdate | triggers when the composition is updated                                                              | ^[Function]`(event: CompositionEvent) => void`              |
-| compositionend    | triggers when the composition ends                                                                    | ^[Function]`(event: CompositionEvent) => void`              |
+| Name              | Description                                                                                           | Type                                                                                              |
+| ----------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| blur              | triggers when Input blurs                                                                             | ^[Function]`(event: FocusEvent) => void`                                                          |
+| focus             | triggers when Input focuses                                                                           | ^[Function]`(event: FocusEvent) => void`                                                          |
+| change            | triggers when the input box loses focus or the user presses Enter, only if the modelValue has changed | ^[Function]`(value: string \| number, evt?: Event) => void`                                       |
+| input             | triggers when the Input value change                                                                  | ^[Function]`(value: string \| number) => void`                                                    |
+| clear             | triggers when the Input is cleared by clicking the clear button                                       | ^[Function]`(evt?: MouseEvent) => void (After version 2.13.4, the evt parameter can be received)` |
+| keydown           | triggers when a key is pressed down                                                                   | ^[Function]`(event: KeyboardEvent \| Event) => void`                                              |
+| mouseleave        | triggers when the mouse leaves the Input element                                                      | ^[Function]`(event: MouseEvent) => void`                                                          |
+| mouseenter        | triggers when the mouse enters the Input element                                                      | ^[Function]`(event: MouseEvent) => void`                                                          |
+| compositionstart  | triggers when the composition starts                                                                  | ^[Function]`(event: CompositionEvent) => void`                                                    |
+| compositionupdate | triggers when the composition is updated                                                              | ^[Function]`(event: CompositionEvent) => void`                                                    |
+| compositionend    | triggers when the composition ends                                                                    | ^[Function]`(event: CompositionEvent) => void`                                                    |
 
 ### Slots
 

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -477,6 +477,7 @@ describe('Input.vue', () => {
       await nextTick()
       expect(content.value).toEqual('')
       expect(handleClear).toBeCalled()
+      expect(handleClear).toBeCalledWith(expect.any(MouseEvent))
       expect(handleInput).toBeCalled()
     })
 

--- a/packages/components/input/src/input.ts
+++ b/packages/components/input/src/input.ts
@@ -373,7 +373,7 @@ export const inputEmits = {
     isString(value) && (evt instanceof Event || evt === undefined),
   focus: (evt: FocusEvent) => evt instanceof FocusEvent,
   blur: (evt: FocusEvent) => evt instanceof FocusEvent,
-  clear: () => true,
+  clear: (evt: MouseEvent) => evt instanceof MouseEvent,
   mouseleave: (evt: MouseEvent) => evt instanceof MouseEvent,
   mouseenter: (evt: MouseEvent) => evt instanceof MouseEvent,
   // NOTE: when autofill by browser, the keydown event is instanceof Event, not KeyboardEvent

--- a/packages/components/input/src/input.ts
+++ b/packages/components/input/src/input.ts
@@ -373,7 +373,8 @@ export const inputEmits = {
     isString(value) && (evt instanceof Event || evt === undefined),
   focus: (evt: FocusEvent) => evt instanceof FocusEvent,
   blur: (evt: FocusEvent) => evt instanceof FocusEvent,
-  clear: (evt: MouseEvent) => evt instanceof MouseEvent,
+  clear: (evt: MouseEvent | undefined) =>
+    evt === undefined || evt instanceof MouseEvent,
   mouseleave: (evt: MouseEvent) => evt instanceof MouseEvent,
   mouseenter: (evt: MouseEvent) => evt instanceof MouseEvent,
   // NOTE: when autofill by browser, the keydown event is instanceof Event, not KeyboardEvent

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -59,7 +59,7 @@
 
         <!-- suffix slot -->
         <span v-if="suffixVisible" :class="nsInput.e('suffix')">
-          <span :class="nsInput.e('suffix-inner')">
+          <span :class="nsInput.e('suffix-inner')" @click.capture="handleClick">
             <template
               v-if="!showClear || !showPwdVisible || !isWordLimitVisible"
             >
@@ -505,6 +505,11 @@ const clear = () => {
   emit(CHANGE_EVENT, '')
   emit('clear')
   emit(INPUT_EVENT, '')
+}
+
+const handleClick = (evt: MouseEvent) => {
+  // @ts-expect-error The events passed are bound to the input, so clicking the suffix icon failed to trigger the click event.
+  attrs.value.onClick?.(evt)
 }
 
 watch(

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -59,7 +59,7 @@
 
         <!-- suffix slot -->
         <span v-if="suffixVisible" :class="nsInput.e('suffix')">
-          <span :class="nsInput.e('suffix-inner')" @click.capture="handleClick">
+          <span :class="nsInput.e('suffix-inner')">
             <template
               v-if="!showClear || !showPwdVisible || !isWordLimitVisible"
             >
@@ -500,16 +500,11 @@ const select = () => {
   _ref.value?.select()
 }
 
-const clear = () => {
+const clear = (evt: MouseEvent) => {
   emit(UPDATE_MODEL_EVENT, '')
   emit(CHANGE_EVENT, '')
-  emit('clear')
+  emit('clear', evt)
   emit(INPUT_EVENT, '')
-}
-
-const handleClick = (evt: MouseEvent) => {
-  // @ts-expect-error The events passed are bound to the input, so clicking the suffix icon failed to trigger the click event.
-  attrs.value.onClick?.(evt)
 }
 
 watch(

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -500,7 +500,7 @@ const select = () => {
   _ref.value?.select()
 }
 
-const clear = (evt: MouseEvent) => {
+const clear = (evt?: MouseEvent) => {
   emit(UPDATE_MODEL_EVENT, '')
   emit(CHANGE_EVENT, '')
   emit('clear', evt)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing an input now forwards the originating click event to handlers so clear actions receive the MouseEvent and can respond appropriately.
  * Suffix elements on the input remain clickable and reliably trigger their handlers.

* **Tests**
  * Added a test to verify the clear action is invoked with the originating MouseEvent.

* **Documentation**
  * Updated event docs to describe the clear event's evt parameter and note availability since v2.13.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->