### PR TITLE
fix(components): [tree] reconcile parent states in setCheckedKeys

### DIFF
--- a/packages/components/tree/__tests__/tree.test.ts
+++ b/packages/components/tree/__tests__/tree.test.ts
@@ -805,8 +805,22 @@ describe('Tree.vue', () => {
     const tree = treeWrapper.vm as InstanceType<typeof Tree>
 
     tree.setCheckedKeys([2], true)
-    expect(tree.getCheckedNodes().length).toEqual(2)
-    expect(tree.getCheckedKeys().length).toEqual(2)
+    expect(tree.getCheckedNodes().length).toEqual(3)
+    expect(tree.getCheckedKeys().length).toEqual(3)
+  })
+
+  test('setCheckedKeys with leafOnly=true produces consistent parent states', async () => {
+    const { wrapper } = getTreeVm(
+      `:props="defaultProps" show-checkbox node-key="id"`
+    )
+    const treeWrapper = wrapper.findComponent(Tree)
+    const tree = treeWrapper.vm as InstanceType<typeof Tree>
+
+    tree.setCheckedKeys([1], true)
+
+    expect(tree.getCheckedKeys().sort()).toEqual([1, 11, 111])
+    expect(tree.getHalfCheckedNodes()).toEqual([])
+    expect(tree.getHalfCheckedKeys()).toEqual([])
   })
 
   test('setCurrentKey', async () => {

--- a/packages/components/tree/src/model/tree-store.ts
+++ b/packages/components/tree/src/model/tree-store.ts
@@ -340,15 +340,16 @@ export default class TreeStore {
       node.setChecked(true, true)
 
       if (leafOnly) {
-        node.setChecked(false, false)
+        node.setChecked(false, false, true)
         const traverse = function (node: Node): void {
           const childNodes = node.childNodes
           childNodes.forEach((child) => {
             if (!child.isLeaf) {
-              child.setChecked(false, false)
+              child.setChecked(false, false, true)
             }
             traverse(child)
           })
+          node.reInitChecked()
         }
         traverse(node)
       }


### PR DESCRIPTION
closed #22032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tree component's leaf-only selection logic to ensure proper propagation and reinitialization of checked states, resulting in consistent parent node behavior.

* **Tests**
  * Updated test cases to reflect new expected behavior and added comprehensive test to verify consistency of parent node states when using leaf-only selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->