### PR TITLE
fix(components): [form] reset stale props on dynamic fields

### DIFF
--- a/packages/components/form/__tests__/form.test.tsx
+++ b/packages/components/form/__tests__/form.test.tsx
@@ -371,7 +371,7 @@ describe('Form', () => {
     vi.useRealTimers()
   })
 
-  it('reset the dynamic fields', async () => {
+  it('reset dynamic fields after prop switch', async () => {
     const form = reactive({
       prop: 'name' as 'name' | 'name2',
       name: 'jerry',
@@ -382,7 +382,7 @@ describe('Form', () => {
       setup() {
         return () => (
           <Form ref="form" model={form}>
-            <FormItem ref="field" label={form.prop} prop={form.prop}>
+            <FormItem ref="field" prop={form.prop}>
               <Input v-model={form[form.prop]} />
             </FormItem>
           </Form>
@@ -390,80 +390,23 @@ describe('Form', () => {
       },
     })
 
-    // Modify the value of the initial bound field (name)
     form.name = 'tom'
-
-    // Switch the dynamic prop to name2 and set its value
     form.prop = 'name2'
+    await nextTick()
     form.name2 = 'jack'
 
-    // Wait for reactivity system to update the DOM and component state
-    await nextTick()
-
+    const formRef = wrapper.findComponent({ ref: 'form' }).vm as FormInstance
     const fieldRef = wrapper.findComponent({ ref: 'field' })
       .vm as FormItemInstance
+
     fieldRef.resetField()
-
-    expect(fieldRef.prop).toBe('name2')
-    expect(form.name).toBe('tom')
-    expect(form.name2).toBe('jerry')
-
-    const formRef = wrapper.findComponent({ ref: 'form' }).vm as FormInstance
-    formRef.resetFields()
-
-    expect(form.name).toBe('tom')
-    expect(form.name2).toBe('jerry')
-  })
-
-  it('reset the re-mounted dynamic fields', async () => {
-    const form = reactive({
-      fieldKey: 0,
-      prop: 'name' as 'name' | 'name2',
-      name: 'jerry',
-      name2: '',
-    })
-
-    const wrapper = mount({
-      setup() {
-        return () => (
-          <Form ref="form" model={form}>
-            <FormItem
-              ref="field"
-              key={form.fieldKey}
-              label={form.prop}
-              prop={form.prop}
-            >
-              <Input v-model={form[form.prop]} />
-            </FormItem>
-          </Form>
-        )
-      },
-    })
-
-    // Modify the value of the initial bound field (name)
-    form.name = 'tom'
-
-    const fieldRef = wrapper.findComponent({ ref: 'field' })
-      .vm as FormItemInstance
-    // Override the initial value of the current field (name) to 'jack'
-    fieldRef.setInitialValue('jack')
-
-    // Switch dynamic prop to name2 and increment key to trigger FormItem re-mount,
-    // at this time, resetting name2 should reset it to `''`
-    form.prop = 'name2'
-    form.fieldKey++
-
-    // Wait for reactivity system to update the DOM and component state
-    await nextTick()
-
-    // Modify the value of the newly bound field (name2)
-    form.name2 = 'judy'
-
-    const formRef = wrapper.findComponent({ ref: 'form' }).vm as FormInstance
-    formRef.resetFields()
-
-    expect(form.name).toBe('jack')
     expect(form.name2).toBe('')
+    expect(form.name).toBe('tom')
+
+    form.name2 = 'jack'
+    formRef.resetFields()
+    expect(form.name2).toBe('')
+    expect(form.name).toBe('tom')
   })
 
   it('clear validate', async () => {

--- a/packages/components/form/__tests__/form.test.tsx
+++ b/packages/components/form/__tests__/form.test.tsx
@@ -371,6 +371,101 @@ describe('Form', () => {
     vi.useRealTimers()
   })
 
+  it('reset the dynamic fields', async () => {
+    const form = reactive({
+      prop: 'name' as 'name' | 'name2',
+      name: 'jerry',
+      name2: '',
+    })
+
+    const wrapper = mount({
+      setup() {
+        return () => (
+          <Form ref="form" model={form}>
+            <FormItem ref="field" label={form.prop} prop={form.prop}>
+              <Input v-model={form[form.prop]} />
+            </FormItem>
+          </Form>
+        )
+      },
+    })
+
+    // Modify the value of the initial bound field (name)
+    form.name = 'tom'
+
+    // Switch the dynamic prop to name2 and set its value
+    form.prop = 'name2'
+    form.name2 = 'jack'
+
+    // Wait for reactivity system to update the DOM and component state
+    await nextTick()
+
+    const fieldRef = wrapper.findComponent({ ref: 'field' })
+      .vm as FormItemInstance
+    fieldRef.resetField()
+
+    expect(fieldRef.prop).toBe('name2')
+    expect(form.name).toBe('tom')
+    expect(form.name2).toBe('jerry')
+
+    const formRef = wrapper.findComponent({ ref: 'form' }).vm as FormInstance
+    formRef.resetFields()
+
+    expect(form.name).toBe('tom')
+    expect(form.name2).toBe('jerry')
+  })
+
+  it('reset the re-mounted dynamic fields', async () => {
+    const form = reactive({
+      fieldKey: 0,
+      prop: 'name' as 'name' | 'name2',
+      name: 'jerry',
+      name2: '',
+    })
+
+    const wrapper = mount({
+      setup() {
+        return () => (
+          <Form ref="form" model={form}>
+            <FormItem
+              ref="field"
+              key={form.fieldKey}
+              label={form.prop}
+              prop={form.prop}
+            >
+              <Input v-model={form[form.prop]} />
+            </FormItem>
+          </Form>
+        )
+      },
+    })
+
+    // Modify the value of the initial bound field (name)
+    form.name = 'tom'
+
+    const fieldRef = wrapper.findComponent({ ref: 'field' })
+      .vm as FormItemInstance
+    // Override the initial value of the current field (name) to 'jack'
+    fieldRef.setInitialValue('jack')
+
+    // Switch dynamic prop to name2 and increment key to trigger FormItem re-mount,
+    // at this time, resetting name2 should reset it to `''`
+    form.prop = 'name2'
+    form.fieldKey++
+
+    // Wait for reactivity system to update the DOM and component state
+    await nextTick()
+
+    // Modify the value of the newly bound field (name2)
+    form.name2 = 'judy'
+
+    const formRef = wrapper.findComponent({ ref: 'form' }).vm as FormInstance
+    formRef.resetFields()
+
+    expect(form.name).toBe('jack')
+    expect(form.name2).toBe('')
+  })
+
   it('clear validate', async () => {
     const wrapper = mount({
       setup() {

--- a/packages/components/form/src/form-item.vue
+++ b/packages/components/form/src/form-item.vue
@@ -370,6 +370,8 @@ const setInitialValue: FormItemContext['setInitialValue'] = (value: any) => {
   initialValue = cloneDeep(value)
 }
 
+const getInitialValue: FormItemContext['getInitialValue'] = () => initialValue
+
 watch(
   () => props.error,
   (val) => {
@@ -402,9 +404,19 @@ const context: FormItemContext = reactive({
   validate,
   propString,
   setInitialValue,
+  getInitialValue,
 })
 
 provide(formItemContextKey, context)
+
+watch(propString, (newPropString, oldPropString) => {
+  if (!formContext || !oldPropString) return
+  formContext.removeField(context, oldPropString)
+  if (newPropString) {
+    setInitialValue(fieldValue.value)
+    formContext.addField(context)
+  }
+})
 
 onMounted(() => {
   if (props.prop) {

--- a/packages/components/form/src/form.vue
+++ b/packages/components/form/src/form.vue
@@ -6,7 +6,6 @@
 
 <script lang="ts" setup>
 import { computed, provide, reactive, ref, toRefs, watch } from 'vue'
-import { cloneDeep } from 'lodash-unified'
 import {
   debugWarn,
   ensureArray,
@@ -48,7 +47,7 @@ const emit = defineEmits(formEmits)
 
 const formRef = ref<HTMLElement>()
 const fields = reactive<FormItemContext[]>([])
-const initialValues = new Map<string, any>()
+const removedFields = new Map<string, FormItemContext>()
 
 const formSize = useFormSize()
 const ns = useNamespace('form')
@@ -70,18 +69,13 @@ const getField: FormContext['getField'] = (prop) => {
 
 const addField: FormContext['addField'] = (field) => {
   fields.push(field)
-  if (field.propString) {
-    if (initialValues.has(field.propString)) {
-      field.setInitialValue(initialValues.get(field.propString))
-    } else {
-      initialValues.set(field.propString, cloneDeep(field.fieldValue))
-    }
-  }
 }
 
 const removeField: FormContext['removeField'] = (field) => {
   if (field.prop) {
     fields.splice(fields.indexOf(field), 1)
+    // When field unmounts, propString remains unchanged, so it can be used as the key
+    removedFields.set(field.propString, field)
   }
 }
 
@@ -98,14 +92,14 @@ const setInitialValues: FormContext['setInitialValues'] = (initModel) => {
     return
   }
 
-  for (const key of initialValues.keys()) {
-    initialValues.set(key, cloneDeep(getProp(initModel, key).value))
-  }
-  fields.forEach((field) => {
+  const eachCallback = (field: FormItemContext) => {
     if (field.prop) {
+      // getProp will return undefined if the prop is not found
       field.setInitialValue(getProp(initModel, field.prop).value)
     }
-  })
+  }
+  removedFields.forEach(eachCallback)
+  fields.forEach(eachCallback)
 }
 
 const resetFields: FormContext['resetFields'] = (properties = []) => {
@@ -114,22 +108,39 @@ const resetFields: FormContext['resetFields'] = (properties = []) => {
     return
   }
 
-  filterFields(fields, properties).forEach((field) => field.resetField())
-
-  const activePropStrings = new Set(
-    fields.map((f) => f.propString).filter(Boolean)
+  const isSpecificProps = properties.length > 0
+  const propStrings = ensureArray(properties).map((prop) =>
+    isArray(prop) ? prop.join('.') : prop
   )
-  const propsToCheck =
-    properties.length > 0
-      ? ensureArray(properties).map((p) => (isArray(p) ? p.join('.') : p))
-      : [...initialValues.keys()]
 
-  for (const propString of propsToCheck) {
-    if (!activePropStrings.has(propString) && initialValues.has(propString)) {
-      getProp(props.model, propString).value = cloneDeep(
-        initialValues.get(propString)
+  // First reset the existing or specified fields
+  filterFields(fields, propStrings, true).forEach((field) => {
+    field.resetField()
+
+    // The key in removedFields is fixed at unmount time, so if the same propString exists in fields,
+    // it means the field is duplicated and we need to remove the cache from removedFields
+    removedFields.delete(field.propString)
+
+    // If propStrings are provided, remove the already reset field from propStrings
+    if (isSpecificProps) {
+      const index = propStrings.indexOf(field.propString)
+      if (index > -1) {
+        propStrings.splice(index, 1)
+      }
+    }
+  })
+
+  // If propStrings are provided, search for fields not yet reset in removedFields,
+  // otherwise reset all removedFields
+  if (isSpecificProps) {
+    // propStrings.length > 0 means there are fields not yet reset, otherwise all fields have been reset
+    if (propStrings.length > 0) {
+      filterFields([...removedFields.values()], propStrings, true).forEach(
+        (field) => field.resetField()
       )
     }
+  } else {
+    removedFields.forEach((field) => field.resetField())
   }
 }
 

--- a/packages/components/form/src/form.vue
+++ b/packages/components/form/src/form.vue
@@ -6,6 +6,7 @@
 
 <script lang="ts" setup>
 import { computed, provide, reactive, ref, toRefs, watch } from 'vue'
+import { cloneDeep } from 'lodash-unified'
 import {
   debugWarn,
   ensureArray,
@@ -47,7 +48,7 @@ const emit = defineEmits(formEmits)
 
 const formRef = ref<HTMLElement>()
 const fields = reactive<FormItemContext[]>([])
-const removedFields = new Map<string, FormItemContext>()
+const initialValues = new Map<string, any>()
 
 const formSize = useFormSize()
 const ns = useNamespace('form')
@@ -68,14 +69,31 @@ const getField: FormContext['getField'] = (prop) => {
 }
 
 const addField: FormContext['addField'] = (field) => {
-  fields.push(field)
+  if (!fields.includes(field)) {
+    fields.push(field)
+  }
+  if (field.propString) {
+    if (initialValues.has(field.propString)) {
+      field.setInitialValue(initialValues.get(field.propString))
+    } else {
+      initialValues.set(field.propString, cloneDeep(field.fieldValue))
+    }
+  }
 }
 
-const removeField: FormContext['removeField'] = (field) => {
-  if (field.prop) {
-    fields.splice(fields.indexOf(field), 1)
-    // When field unmounts, propString remains unchanged, so it can be used as the key
-    removedFields.set(field.propString, field)
+const removeField: FormContext['removeField'] = (field, oldPropString?) => {
+  if (oldPropString) {
+    // Prop changed on a live field: delete stale key, field stays in fields[]
+    initialValues.delete(oldPropString)
+    return
+  }
+  // Unmount: splice from array, cache initialValue for potential remount
+  const idx = fields.indexOf(field)
+  if (idx > -1) {
+    fields.splice(idx, 1)
+    if (field.propString) {
+      initialValues.set(field.propString, cloneDeep(field.getInitialValue()))
+    }
   }
 }
 
@@ -92,14 +110,14 @@ const setInitialValues: FormContext['setInitialValues'] = (initModel) => {
     return
   }
 
-  const eachCallback = (field: FormItemContext) => {
+  for (const key of initialValues.keys()) {
+    initialValues.set(key, cloneDeep(getProp(initModel, key).value))
+  }
+  fields.forEach((field) => {
     if (field.prop) {
-      // getProp will return undefined if the prop is not found
       field.setInitialValue(getProp(initModel, field.prop).value)
     }
-  }
-  removedFields.forEach(eachCallback)
-  fields.forEach(eachCallback)
+  })
 }
 
 const resetFields: FormContext['resetFields'] = (properties = []) => {
@@ -108,39 +126,22 @@ const resetFields: FormContext['resetFields'] = (properties = []) => {
     return
   }
 
-  const isSpecificProps = properties.length > 0
-  const propStrings = ensureArray(properties).map((prop) =>
-    isArray(prop) ? prop.join('.') : prop
+  filterFields(fields, properties).forEach((field) => field.resetField())
+
+  const activePropStrings = new Set(
+    fields.map((f) => f.propString).filter(Boolean)
   )
+  const propsToCheck =
+    properties.length > 0
+      ? ensureArray(properties).map((p) => (isArray(p) ? p.join('.') : p))
+      : [...initialValues.keys()]
 
-  // First reset the existing or specified fields
-  filterFields(fields, propStrings, true).forEach((field) => {
-    field.resetField()
-
-    // The key in removedFields is fixed at unmount time, so if the same propString exists in fields,
-    // it means the field is duplicated and we need to remove the cache from removedFields
-    removedFields.delete(field.propString)
-
-    // If propStrings are provided, remove the already reset field from propStrings
-    if (isSpecificProps) {
-      const index = propStrings.indexOf(field.propString)
-      if (index > -1) {
-        propStrings.splice(index, 1)
-      }
-    }
-  })
-
-  // If propStrings are provided, search for fields not yet reset in removedFields,
-  // otherwise reset all removedFields
-  if (isSpecificProps) {
-    // propStrings.length > 0 means there are fields not yet reset, otherwise all fields have been reset
-    if (propStrings.length > 0) {
-      filterFields([...removedFields.values()], propStrings, true).forEach(
-        (field) => field.resetField()
+  for (const propString of propsToCheck) {
+    if (!activePropStrings.has(propString) && initialValues.has(propString)) {
+      getProp(props.model, propString).value = cloneDeep(
+        initialValues.get(propString)
       )
     }
-  } else {
-    removedFields.forEach((field) => field.resetField())
   }
 }
 

--- a/packages/components/form/src/types.ts
+++ b/packages/components/form/src/types.ts
@@ -52,7 +52,7 @@ export type FormContext = FormProps &
     emit: SetupContext<FormEmits>['emit']
     getField: (prop: FormItemProp) => FormItemContext | undefined
     addField: (field: FormItemContext) => void
-    removeField: (field: FormItemContext) => void
+    removeField: (field: FormItemContext, oldPropString?: string) => void
     resetFields: (props?: Arrayable<FormItemProp>) => void
     setInitialValues: (initModel: Record<string, any>) => void
     clearValidate: (props?: Arrayable<FormItemProp>) => void
@@ -82,4 +82,5 @@ export interface FormItemContext extends FormItemProps {
   resetField(): void
   clearValidate(): void
   setInitialValue: (value: any) => void
+  getInitialValue: () => any
 }

--- a/packages/components/form/src/utils.ts
+++ b/packages/components/form/src/utils.ts
@@ -49,12 +49,11 @@ export function useFormLabelWidth() {
 
 export const filterFields = (
   fields: FormItemContext[],
-  props: Arrayable<FormItemProp>,
-  skipNormalize?: boolean
+  props: Arrayable<FormItemProp>
 ) => {
-  const normalized = skipNormalize
-    ? (props as string[])
-    : ensureArray(props).map((prop) => (isArray(prop) ? prop.join('.') : prop))
+  const normalized = ensureArray(props).map((prop) =>
+    isArray(prop) ? prop.join('.') : prop
+  )
   return normalized.length > 0
     ? fields.filter(
         (field) => field.propString && normalized.includes(field.propString)

--- a/packages/components/form/src/utils.ts
+++ b/packages/components/form/src/utils.ts
@@ -49,11 +49,12 @@ export function useFormLabelWidth() {
 
 export const filterFields = (
   fields: FormItemContext[],
-  props: Arrayable<FormItemProp>
+  props: Arrayable<FormItemProp>,
+  skipNormalize?: boolean
 ) => {
-  const normalized = ensureArray(props).map((prop) =>
-    isArray(prop) ? prop.join('.') : prop
-  )
+  const normalized = skipNormalize
+    ? (props as string[])
+    : ensureArray(props).map((prop) => (isArray(prop) ? prop.join('.') : prop))
   return normalized.length > 0
     ? fields.filter(
         (field) => field.propString && normalized.includes(field.propString)


### PR DESCRIPTION
closed #23705

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevents duplicate field registration in forms.
  * Fixed reset behavior for dynamic fields—resetting individual or all fields now correctly handles fields with changing properties without affecting other fields.

* **Tests**
  * Added test coverage for dynamic field reset scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->