### PR TITLE
fix(components): [color-picker-panel] set showAlpha default to false

### DIFF
--- a/packages/components/color-picker-panel/src/color-picker-panel.vue
+++ b/packages/components/color-picker-panel/src/color-picker-panel.vue
@@ -69,6 +69,7 @@ const props = withDefaults(defineProps<ColorPickerPanelProps>(), {
   modelValue: undefined,
   border: true,
   validateEvent: true,
+  showAlpha: false,
 })
 const emit = defineEmits(colorPickerPanelEmits)
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
Before:

<img width="1970" height="546" alt="image" src="https://github.com/user-attachments/assets/26a07cfb-ea14-4114-ac75-f35bc9cbf0ca" />

After:

<img width="1446" height="398" alt="image" src="https://github.com/user-attachments/assets/38fc6a98-3b20-411a-a7b7-91c76c57b9c4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable alpha channel control to the color picker panel. Users can now optionally display or hide the opacity slider in the color selection interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->