### PR TITLE
docs: add component changelog drawer and open issues button

### DIFF
--- a/docs/.vitepress/config/vite.ts
+++ b/docs/.vitepress/config/vite.ts
@@ -16,6 +16,7 @@ import {
   projRoot,
 } from '@element-plus/build-utils'
 import { MarkdownTransform } from '../plugins/markdown-transform'
+import { ComponentChangelogPlugin } from '../plugins/component-changelog'
 
 import type { Plugin, UserConfig } from 'vitepress'
 
@@ -107,6 +108,7 @@ export const getViteConfig = ({ mode }: { mode: string }) => {
       }),
 
       MarkdownTransform() as Plugin,
+      ComponentChangelogPlugin() as Plugin,
       Inspect(),
       groupIconVitePlugin() as Plugin,
       env.HTTPS ? (mkcert() as Plugin) : undefined,

--- a/docs/.vitepress/crowdin/en-US/component/component-meta.json
+++ b/docs/.vitepress/crowdin/en-US/component/component-meta.json
@@ -1,6 +1,5 @@
 {
-  "title": "Changelog",
+  "changelog": "Changelog",
   "view-full-changelog": "View full changelog",
-  "no-changelog": "No changelog available",
   "open-issues": "Open issues"
 }

--- a/docs/.vitepress/crowdin/en-US/component/component-meta.json
+++ b/docs/.vitepress/crowdin/en-US/component/component-meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Changelog",
+  "view-full-changelog": "View full changelog",
+  "no-changelog": "No changelog available",
+  "open-issues": "Open issues"
+}

--- a/docs/.vitepress/env.d.ts
+++ b/docs/.vitepress/env.d.ts
@@ -1,10 +1,6 @@
 /// <reference types="vite/client" />
 
 declare module 'virtual:component-changelog-data' {
-  import type { ComponentChangelogs } from './utils/changelog-parser'
-
-  const data: ComponentChangelogs
+  const data: import('./utils/changelog-parser').ComponentChangelogs
   export default data
 }
-
-export {}

--- a/docs/.vitepress/env.d.ts
+++ b/docs/.vitepress/env.d.ts
@@ -1,3 +1,10 @@
 /// <reference types="vite/client" />
 
+declare module 'virtual:component-changelog-data' {
+  import type { ComponentChangelogs } from './utils/changelog-parser'
+
+  const data: ComponentChangelogs
+  export default data
+}
+
 export {}

--- a/docs/.vitepress/plugins/component-changelog.ts
+++ b/docs/.vitepress/plugins/component-changelog.ts
@@ -1,0 +1,31 @@
+import { loadChangelog } from '../utils/changelog-parser'
+
+import type { Plugin } from 'vite'
+
+const VIRTUAL_MODULE_ID = 'virtual:component-changelog-data'
+const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`
+
+export function ComponentChangelogPlugin(): Plugin {
+  let changelogData: string
+
+  return {
+    name: 'element-plus-component-changelog',
+
+    async buildStart() {
+      const data = await loadChangelog()
+      changelogData = JSON.stringify(data)
+    },
+
+    resolveId(id) {
+      if (id === VIRTUAL_MODULE_ID) {
+        return RESOLVED_VIRTUAL_MODULE_ID
+      }
+    },
+
+    load(id) {
+      if (id === RESOLVED_VIRTUAL_MODULE_ID) {
+        return `export default ${changelogData}`
+      }
+    },
+  }
+}

--- a/docs/.vitepress/plugins/markdown-transform.ts
+++ b/docs/.vitepress/plugins/markdown-transform.ts
@@ -94,6 +94,9 @@ const transformVpScriptSetup = (code: string, append: Append) => {
 
 const GITHUB_BLOB_URL = `https://github.com/${REPO_PATH}/blob/${REPO_BRANCH}`
 const GITHUB_TREE_URL = `https://github.com/${REPO_PATH}/tree/${REPO_BRANCH}`
+
+const EXCLUDE_CHANGELOG_COMPONENTS = new Set(['overview'])
+
 const transformComponentMarkdown = (
   id: string,
   componentId: string,
@@ -116,6 +119,16 @@ const transformComponentMarkdown = (
 
   const isComponent = fs.existsSync(componentPath)
   const isHaveComponentStyle = fs.existsSync(stylePath)
+
+  // Inject changelog component after H1 title
+  if (!EXCLUDE_CHANGELOG_COMPONENTS.has(componentId)) {
+    const h1Match = code.match(/^#\s+.+$/m)
+    if (h1Match) {
+      const h1End = code.indexOf(h1Match[0]) + h1Match[0].length
+      const changelogTag = `\n\n<VpComponentChangelog component="${componentId}" />\n`
+      code = code.slice(0, h1End) + changelogTag + code.slice(h1End)
+    }
+  }
 
   const links = [[footerLocale[lang].docs, docUrl]]
 

--- a/docs/.vitepress/plugins/markdown-transform.ts
+++ b/docs/.vitepress/plugins/markdown-transform.ts
@@ -125,8 +125,8 @@ const transformComponentMarkdown = (
     const h1Match = code.match(/^#\s+.+$/m)
     if (h1Match) {
       const h1End = code.indexOf(h1Match[0]) + h1Match[0].length
-      const changelogTag = `\n\n<VpComponentChangelog component="${componentId}" />\n`
-      code = code.slice(0, h1End) + changelogTag + code.slice(h1End)
+      const componentMetaTag = `\n\n<VpComponentMeta component="${componentId}" />\n`
+      code = code.slice(0, h1End) + componentMetaTag + code.slice(h1End)
     }
   }
 

--- a/docs/.vitepress/utils/changelog-parser.ts
+++ b/docs/.vitepress/utils/changelog-parser.ts
@@ -28,8 +28,13 @@ const TYPE_MAP: Record<string, ChangelogEntry['type']> = {
 }
 
 function normalizeComponentNames(raw: string): string[] {
-  const parts = Array.from(new Set([...raw.split('/'), ...raw.split(',')])).map(
-    (s) => s.trim().toLowerCase()
+  const parts = Array.from(
+    new Set(
+      raw
+        .split(/[/,]/)
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean)
+    )
   )
 
   const result: string[] = []

--- a/docs/.vitepress/utils/changelog-parser.ts
+++ b/docs/.vitepress/utils/changelog-parser.ts
@@ -217,9 +217,9 @@ export function parseChangelog(content: string): ComponentChangelogs {
     }
   }
 
-  // Limit to most recent 10 versions per component
+  // Limit to most recent 20 versions per component
   for (const key of Object.keys(componentMap)) {
-    componentMap[key] = componentMap[key].slice(0, 10)
+    componentMap[key] = componentMap[key].slice(0, 20)
   }
 
   return componentMap

--- a/docs/.vitepress/utils/changelog-parser.ts
+++ b/docs/.vitepress/utils/changelog-parser.ts
@@ -18,7 +18,7 @@ export interface VersionChangelog {
 export type ComponentChangelogs = Record<string, VersionChangelog[]>
 
 const COMPONENT_ENTRY_RE =
-  /^-\s+(?:Components?\s*)?\[([^\]]+)\]\s+(.+?)(?:\s*\(#(\d+)(?:\s+by\s+@(\S+))?\))?$/
+  /^-\s+(?:[^[]*?\s?)?\[([^\]]+)\]:?\s+(.+?)(?:\s*\(#(\d+)(?:\s+by\s+@(\S+))?\))?$/
 
 const TYPE_MAP: Record<string, ChangelogEntry['type']> = {
   Features: 'feature',
@@ -27,45 +27,119 @@ const TYPE_MAP: Record<string, ChangelogEntry['type']> = {
   'Breaking Changes': 'breaking',
 }
 
+// Alias map for sub-components or shorthand references
+const ALIAS_MAP: Record<string, string> = {
+  // Sub-components → parent
+  textarea: 'input',
+  'breadcrumb-item': 'breadcrumb',
+  'button-group': 'button',
+  'carousel-item': 'carousel',
+  'checkbox-button': 'checkbox',
+  'checkbox-group': 'checkbox',
+  'collapse-item': 'collapse',
+  'collapse-transition': 'collapse',
+  'descriptions-item': 'descriptions',
+  'dropdown-item': 'dropdown',
+  'dropdown-menu': 'dropdown',
+  'form-item': 'form',
+  'form-label-wrap': 'form',
+  'label-wrap': 'form',
+  'menu-item': 'menu',
+  'menu-item-group': 'menu',
+  'sub-menu': 'menu',
+  option: 'select',
+  'option-group': 'select',
+  'radio-button': 'radio',
+  'radio-group': 'radio',
+  'skeleton-item': 'skeleton',
+  'splitter-panel': 'splitter',
+  step: 'steps',
+  'tab-pane': 'tabs',
+  'tab-bar': 'tabs',
+  tab: 'tabs',
+  bar: 'tabs',
+  'table-column': 'table',
+  'table-body': 'table',
+  'table-header': 'table',
+  'table-footer': 'table',
+  'timeline-item': 'timeline',
+  'tour-step': 'tour',
+  'anchor-link': 'anchor',
+  'avatar-group': 'avatar',
+
+  // Container sub-components
+  aside: 'container',
+  footer: 'container',
+  header: 'container',
+  main: 'container',
+
+  // Layout
+  col: 'layout',
+  row: 'layout',
+
+  // Standalone → canonical parent
+  'virtual-table': 'table-v2',
+  'image-viewer': 'image',
+  'cascader-panel': 'cascader',
+  'check-tag': 'tag',
+  'upload-dragger': 'upload',
+
+  // Internal sub-components
+  'popper-trigger': 'popper',
+  'popper-container': 'popper',
+  'tree-node-content': 'tree',
+
+  // Changelog typos & alternate names
+  description: 'descriptions',
+  'description-item': 'descriptions',
+  'descriptions-cell': 'descriptions',
+  'data-picker': 'date-picker',
+  'date-time-picker': 'datetime-picker',
+  timepicker: 'time-picker',
+  calender: 'calendar',
+  'number-input': 'input-number',
+  checkout: 'checkbox',
+  opover: 'popover',
+  'pop-confirm': 'popconfirm',
+}
+
 function normalizeComponentNames(raw: string): string[] {
   const parts = Array.from(
     new Set(
       raw
-        .split(/[/,]/)
-        .map((s) => s.trim().toLowerCase())
+        .split(/[/,&]/)
+        .map((s) => s.trim())
         .filter(Boolean)
     )
   )
 
   const result: string[] = []
 
-  // Alias map for sub-components or shorthand references
-  const aliasMap: Record<string, string> = {
-    textarea: 'input',
-    'collapse-item': 'collapse',
-    'menu-item': 'menu',
-    'dropdown-item': 'dropdown',
-    'tab-pane': 'tabs',
-    'tab-bar': 'tabs',
-    'timeline-item': 'timeline',
-    'form-item': 'form',
-    'virtual-table': 'table-v2',
-  }
-
   for (let i = 0; i < parts.length; i++) {
     let name = parts[i]
 
-    // Handle shorthand like [select/v2] → ['select', 'select-v2']
-    if (i > 0 && !name.includes('-') && name.length <= 3) {
-      const combined = `${parts[0]}-${name}`
-      result.push(parts[0])
+    // Strip 'el-' / 'El' prefix
+    name = name.replace(/^[Ee]l-?/, '')
+
+    // Convert camelCase / PascalCase → kebab-case:
+    //   timelineItem → timeline-item, DatePickerPanel → date-picker-panel
+    name = name
+      .replace(/([a-z])([A-Z])/g, '$1-$2')
+      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+      .toLowerCase()
+
+    // Handle version shorthand like [select/v2] → ['select', 'select-v2']
+    if (i > 0 && /^v\d+$/.test(name)) {
+      const base = normalizeComponentNames(parts[0])[0]
+      const combined = `${base}-${name}`
+      result.push(base)
       result.push(combined)
       continue
     }
 
     // Apply alias mapping
-    if (aliasMap[name]) {
-      name = aliasMap[name]
+    if (ALIAS_MAP[name]) {
+      name = ALIAS_MAP[name]
     }
 
     result.push(name)
@@ -75,7 +149,7 @@ function normalizeComponentNames(raw: string): string[] {
 }
 
 export function parseChangelog(content: string): ComponentChangelogs {
-  const lines = content.split('\n')
+  const lines = content.replace(/\r\n?/g, '\n').split('\n')
   const componentMap: ComponentChangelogs = {}
 
   let currentVersion = ''

--- a/docs/.vitepress/utils/changelog-parser.ts
+++ b/docs/.vitepress/utils/changelog-parser.ts
@@ -1,0 +1,153 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { projRoot } from '@element-plus/build-utils'
+
+export interface ChangelogEntry {
+  type: 'feature' | 'bugfix' | 'refactor' | 'breaking'
+  description: string
+  pr?: string
+  author?: string
+}
+
+export interface VersionChangelog {
+  version: string
+  date: string
+  entries: ChangelogEntry[]
+}
+
+export type ComponentChangelogs = Record<string, VersionChangelog[]>
+
+const COMPONENT_ENTRY_RE =
+  /^-\s+(?:Components?\s*)?\[([^\]]+)\]\s+(.+?)(?:\s*\(#(\d+)(?:\s+by\s+@(\S+))?\))?$/
+
+const TYPE_MAP: Record<string, ChangelogEntry['type']> = {
+  Features: 'feature',
+  'Bug fixes': 'bugfix',
+  Refactors: 'refactor',
+  'Breaking Changes': 'breaking',
+}
+
+function normalizeComponentNames(raw: string): string[] {
+  const parts = Array.from(new Set([...raw.split('/'), ...raw.split(',')])).map(
+    (s) => s.trim().toLowerCase()
+  )
+
+  const result: string[] = []
+
+  // Alias map for sub-components or shorthand references
+  const aliasMap: Record<string, string> = {
+    textarea: 'input',
+    'collapse-item': 'collapse',
+    'menu-item': 'menu',
+    'dropdown-item': 'dropdown',
+    'tab-pane': 'tabs',
+    'tab-bar': 'tabs',
+    'timeline-item': 'timeline',
+    'form-item': 'form',
+    'virtual-table': 'table-v2',
+  }
+
+  for (let i = 0; i < parts.length; i++) {
+    let name = parts[i]
+
+    // Handle shorthand like [select/v2] → ['select', 'select-v2']
+    if (i > 0 && !name.includes('-') && name.length <= 3) {
+      const combined = `${parts[0]}-${name}`
+      result.push(parts[0])
+      result.push(combined)
+      continue
+    }
+
+    // Apply alias mapping
+    if (aliasMap[name]) {
+      name = aliasMap[name]
+    }
+
+    result.push(name)
+  }
+
+  return [...new Set(result)]
+}
+
+export function parseChangelog(content: string): ComponentChangelogs {
+  const lines = content.split('\n')
+  const componentMap: ComponentChangelogs = {}
+
+  let currentVersion = ''
+  let currentDate = ''
+  let currentType: ChangelogEntry['type'] = 'feature'
+
+  for (const line of lines) {
+    // Match version: ### 2.13.3
+    const versionMatch = line.match(/^###\s+(\d+\.\d+\.\d+.*)$/)
+    if (versionMatch) {
+      currentVersion = versionMatch[1].trim()
+      currentDate = ''
+      continue
+    }
+
+    // Match date: _2026-02-28_
+    const dateMatch = line.match(/^_(.+)_$/)
+    if (dateMatch) {
+      currentDate = dateMatch[1].trim()
+      continue
+    }
+
+    // Match section type: #### Features
+    const typeMatch = line.match(/^####\s+(.+)$/)
+    if (typeMatch) {
+      const typeKey = typeMatch[1].trim()
+      currentType = TYPE_MAP[typeKey] || 'refactor'
+      continue
+    }
+
+    // Match component entries
+    if (!currentVersion) continue
+
+    const entryMatch = line.match(COMPONENT_ENTRY_RE)
+    if (!entryMatch) continue
+
+    const [, rawComponents, description, pr, author] = entryMatch
+    const componentNames = normalizeComponentNames(rawComponents)
+
+    const entry: ChangelogEntry = {
+      type: currentType,
+      description: description.trim(),
+      ...(pr && { pr }),
+      ...(author && { author }),
+    }
+
+    for (const compName of componentNames) {
+      if (!componentMap[compName]) {
+        componentMap[compName] = []
+      }
+
+      let versionEntry = componentMap[compName].find(
+        (v) => v.version === currentVersion
+      )
+      if (!versionEntry) {
+        versionEntry = {
+          version: currentVersion,
+          date: currentDate,
+          entries: [],
+        }
+        componentMap[compName].push(versionEntry)
+      }
+
+      versionEntry.entries.push(entry)
+    }
+  }
+
+  // Limit to most recent 10 versions per component
+  for (const key of Object.keys(componentMap)) {
+    componentMap[key] = componentMap[key].slice(0, 10)
+  }
+
+  return componentMap
+}
+
+export async function loadChangelog(): Promise<ComponentChangelogs> {
+  const changelogPath = path.resolve(projRoot, 'CHANGELOG.en-US.md')
+  const content = await fs.readFile(changelogPath, 'utf-8')
+  return parseChangelog(content)
+}

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { Clock, Loading, Warning } from '@element-plus/icons-vue'
 import { useWindowSize } from '@vueuse/core'
 import { useLocale } from '../../composables/locale'

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -42,7 +42,7 @@ const issuesUrl = computed(() => {
 })
 
 const { width: windowWidth } = useWindowSize()
-const drawerSize = computed(() => (windowWidth.value < 768 ? '100%' : '40%'))
+const drawerSize = computed(() => (windowWidth.value < 768 ? '100%' : '700px'))
 
 const getTypeIcon = (type: string) => {
   return TYPE_ICONS[type] || TYPE_ICONS['refactor']
@@ -87,22 +87,21 @@ const openIssues = () => {
 
 <template>
   <ClientOnly>
-    <div class="vp-component-changelog">
+    <div v-if="hasChangelog" class="vp-component-changelog">
       <el-button-group class="component-meta-card" size="small">
-        <el-button v-if="hasChangelog" :icon="Clock" @click="openDrawer">
+        <el-button :icon="Clock" @click="openDrawer">
           {{ locale['changelog'] }}
         </el-button>
         <el-button :icon="Warning" @click="openIssues">
           {{ locale['open-issues'] }}
           <div class="issue-count">
             <span v-if="!issueLoading">{{ issueCount ?? 0 }}</span>
-            <el-icon v-else><Loading /></el-icon>
+            <el-icon v-else class="is-loading"><Loading /></el-icon>
           </div>
         </el-button>
       </el-button-group>
 
       <el-drawer
-        v-if="hasChangelog"
         v-model="drawerVisible"
         class="changelog-drawer"
         :size="drawerSize"

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -55,9 +55,20 @@ const getTimelineItemType = (
   return 'info'
 }
 
+const HTML_ESCAPE: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+}
+
+const escapeHtml = (text: string) =>
+  text.replace(/[&<>"']/g, (ch) => HTML_ESCAPE[ch])
+
 const renderDescription = (desc: string) => {
   // Convert `code` to <code> tags
-  let html = desc.replace(/`([^`]+)`/g, '<code>$1</code>')
+  let html = escapeHtml(desc).replace(/`([^`]+)`/g, '<code>$1</code>')
   // Convert #PR to links
   html = html
     .replace(
@@ -81,7 +92,11 @@ const fetchIssueCount = async () => {
     if (res.ok) {
       const data = await res.json()
       issueCount.value = data.total_count ?? 0
+    } else {
+      issueCount.value = 0
     }
+  } catch {
+    issueCount.value = 0
   } finally {
     issueLoading.value = false
   }
@@ -100,9 +115,9 @@ fetchIssueCount()
 
 <template>
   <ClientOnly>
-    <div v-if="hasChangelog" class="vp-component-changelog">
+    <div class="vp-component-changelog">
       <el-button-group class="component-meta-card">
-        <el-button :icon="Clock" @click="openDrawer">
+        <el-button v-if="hasChangelog" :icon="Clock" @click="openDrawer">
           {{ locale['title'] }}
         </el-button>
         <el-button :icon="Warning" @click="openIssues">
@@ -115,6 +130,7 @@ fetchIssueCount()
       </el-button-group>
 
       <el-drawer
+        v-if="hasChangelog"
         v-model="drawerVisible"
         class="changelog-drawer"
         :size="drawerSize"

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -110,7 +110,9 @@ const openIssues = () => {
   window.open(issuesUrl.value, '_blank')
 }
 
-fetchIssueCount()
+onMounted(() => {
+  fetchIssueCount()
+})
 </script>
 
 <template>

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -79,8 +79,18 @@ const renderDescription = (desc: string) => {
   return html
 }
 
+const issueCountCache = new Map<string, { count: number; timestamp: number }>()
+const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
 const fetchIssueCount = async () => {
   const { component } = props
+
+  const cached = issueCountCache.get(component)
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+    issueCount.value = cached.count
+    return
+  }
+
   issueLoading.value = true
   try {
     const q = encodeURIComponent(
@@ -91,7 +101,9 @@ const fetchIssueCount = async () => {
     )
     if (res.ok) {
       const data = await res.json()
-      issueCount.value = data.total_count ?? 0
+      const count = data.total_count ?? 0
+      issueCount.value = count
+      issueCountCache.set(component, { count, timestamp: Date.now() })
     } else {
       issueCount.value = 0
     }
@@ -118,7 +130,7 @@ onMounted(() => {
 <template>
   <ClientOnly>
     <div class="vp-component-changelog">
-      <el-button-group class="component-meta-card">
+      <el-button-group class="component-meta-card" size="small">
         <el-button v-if="hasChangelog" :icon="Clock" @click="openDrawer">
           {{ locale['title'] }}
         </el-button>

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue'
 import { Clock, Loading, Warning } from '@element-plus/icons-vue'
 import { useLocale } from '../../composables/locale'
-import changelogLocale from '../../../i18n/component/component-changelog.json'
+import changelogLocale from '../../../i18n/component/component-meta.json'
 import allChangelogs from 'virtual:component-changelog-data'
 import { useWindowSize } from '@vueuse/core'
 

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -73,7 +73,7 @@ const renderDescription = (desc: string) => {
   html = html
     .replace(
       /#(\d+)/g,
-      '<a href="https://github.com/element-plus/element-plus/pull/$1" target="_blank">#$1</a>'
+      '<a href="https://github.com/element-plus/element-plus/pull/$1" target="_blank" rel="noopener noreferrer" >#$1</a>'
     )
     .replace(/([^.]$)/, '$1.')
   return html
@@ -107,7 +107,7 @@ const openDrawer = () => {
 }
 
 const openIssues = () => {
-  window.open(issuesUrl.value, '_blank')
+  window.open(issuesUrl.value, '_blank', 'noopener,noreferrer')
 }
 
 onMounted(() => {
@@ -145,6 +145,7 @@ onMounted(() => {
               type="primary"
               href="https://github.com/element-plus/element-plus/releases"
               target="_blank"
+              rel="noopener noreferrer"
             >
               {{ locale['view-full-changelog'] }}
             </el-link>
@@ -167,8 +168,8 @@ onMounted(() => {
             </div>
             <ul class="changelog-entries">
               <li
-                v-for="{ type, description, pr, author } in entries"
-                :key="pr || description"
+                v-for="({ type, description, pr, author }, idx) in entries"
+                :key="idx"
                 class="changelog-entry"
               >
                 <span class="changelog-entry-icon">
@@ -184,6 +185,7 @@ onMounted(() => {
                   :href="`https://github.com/element-plus/element-plus/pull/${pr}`"
                   underline="always"
                   target="_blank"
+                  rel="noopener noreferrer"
                 >
                   #{{ pr }}
                 </el-link>
@@ -192,6 +194,7 @@ onMounted(() => {
                   :href="`https://github.com/${author}`"
                   underline="always"
                   target="_blank"
+                  rel="noopener noreferrer"
                 >
                   @{{ author }}
                 </el-link>

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -226,7 +226,6 @@ const openIssues = () => {
   .changelog-version {
     font-size: 16px;
     font-weight: 600;
-    color: var(--el-text-color-primary);
   }
 
   .changelog-entries {

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { Clock, Loading, Warning } from '@element-plus/icons-vue'
 import { useWindowSize } from '@vueuse/core'
+import { useIssueCount } from '../../composables/use-issue-count'
 import { useLocale } from '../../composables/locale'
 import changelogLocale from '../../../i18n/component/component-meta.json'
 import allChangelogs from 'virtual:component-changelog-data'
@@ -26,8 +27,9 @@ const TYPE_ICONS: Record<string, string> = {
 const locale = useLocale(changelogLocale)
 const drawerVisible = ref(false)
 
-const issueCount = ref<number | null>(null)
-const issueLoading = ref(false)
+const { count: issueCount, loading: issueLoading } = useIssueCount(
+  props.component
+)
 
 const hasChangelog = computed(() => changelogs.value.length > 0)
 
@@ -40,7 +42,7 @@ const issuesUrl = computed(() => {
 })
 
 const { width: windowWidth } = useWindowSize()
-const drawerSize = computed(() => (windowWidth.value < 768 ? '100%' : '60%'))
+const drawerSize = computed(() => (windowWidth.value < 768 ? '100%' : '40%'))
 
 const getTypeIcon = (type: string) => {
   return TYPE_ICONS[type] || TYPE_ICONS['refactor']
@@ -69,49 +71,9 @@ const escapeHtml = (text: string) =>
 const renderDescription = (desc: string) => {
   // Convert `code` to <code> tags
   let html = escapeHtml(desc).replace(/`([^`]+)`/g, '<code>$1</code>')
-  // Convert #PR to links
-  html = html
-    .replace(
-      /#(\d+)/g,
-      '<a href="https://github.com/element-plus/element-plus/pull/$1" target="_blank" rel="noopener noreferrer" >#$1</a>'
-    )
-    .replace(/([^.]$)/, '$1.')
+  // Ensure description ends with a period
+  html = html.replace(/([^.]$)/, '$1.')
   return html
-}
-
-const issueCountCache = new Map<string, { count: number; timestamp: number }>()
-const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
-
-const fetchIssueCount = async () => {
-  const { component } = props
-
-  const cached = issueCountCache.get(component)
-  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-    issueCount.value = cached.count
-    return
-  }
-
-  issueLoading.value = true
-  try {
-    const q = encodeURIComponent(
-      `repo:element-plus/element-plus is:open is:issue in:title [${component}]`
-    )
-    const res = await fetch(
-      `https://api.github.com/search/issues?q=${q}&per_page=1`
-    )
-    if (res.ok) {
-      const data = await res.json()
-      const count = data.total_count ?? 0
-      issueCount.value = count
-      issueCountCache.set(component, { count, timestamp: Date.now() })
-    } else {
-      issueCount.value = 0
-    }
-  } catch {
-    issueCount.value = 0
-  } finally {
-    issueLoading.value = false
-  }
 }
 
 const openDrawer = () => {
@@ -121,10 +83,6 @@ const openDrawer = () => {
 const openIssues = () => {
   window.open(issuesUrl.value, '_blank', 'noopener,noreferrer')
 }
-
-onMounted(() => {
-  fetchIssueCount()
-})
 </script>
 
 <template>
@@ -132,13 +90,13 @@ onMounted(() => {
     <div class="vp-component-changelog">
       <el-button-group class="component-meta-card" size="small">
         <el-button v-if="hasChangelog" :icon="Clock" @click="openDrawer">
-          {{ locale['title'] }}
+          {{ locale['changelog'] }}
         </el-button>
         <el-button :icon="Warning" @click="openIssues">
           {{ locale['open-issues'] }}
           <div class="issue-count">
             <span v-if="!issueLoading">{{ issueCount ?? 0 }}</span>
-            <el-icon v-else class="is-loading"><Loading /></el-icon>
+            <el-icon v-else><Loading /></el-icon>
           </div>
         </el-button>
       </el-button-group>
@@ -148,11 +106,14 @@ onMounted(() => {
         v-model="drawerVisible"
         class="changelog-drawer"
         :size="drawerSize"
+        resizable
         append-to-body
       >
         <template #header>
           <div class="changelog-drawer-header">
-            <span class="changelog-drawer-title">{{ locale['title'] }}</span>
+            <span class="changelog-drawer-title">
+              {{ locale['changelog'] }}
+            </span>
             <el-link
               type="primary"
               href="https://github.com/element-plus/element-plus/releases"
@@ -173,7 +134,14 @@ onMounted(() => {
             size="large"
           >
             <div class="changelog-version-header">
-              <span class="changelog-version">{{ version }}</span>
+              <el-link
+                :href="`https://github.com/element-plus/element-plus/releases/tag/${version}`"
+                class="changelog-version"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {{ version }}
+              </el-link>
               <el-tag size="small" round effect="plain">
                 {{ date }}
               </el-tag>
@@ -252,6 +220,7 @@ onMounted(() => {
     align-items: center;
     gap: 8px;
     margin-bottom: 8px;
+    line-height: 1;
   }
 
   .changelog-version {
@@ -263,24 +232,23 @@ onMounted(() => {
   .changelog-entries {
     margin: 0;
     padding: 0;
-    list-style: circle;
+    list-style: none;
   }
 
   .changelog-entry {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: 4px;
     margin-bottom: 6px;
     font-size: 14px;
     line-height: 1.6;
     color: var(--el-text-color-regular);
+
+    & > span,
+    & > a {
+      margin-right: 6px;
+    }
   }
 
   .changelog-entry-icon {
-    flex-shrink: 0;
     width: 20px;
-    text-align: center;
   }
 
   .changelog-entry-desc {

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -169,7 +169,7 @@ onMounted(() => {
             v-for="{ version, date, entries } in changelogs"
             :key="version"
             :type="getTimelineItemType(entries)"
-            :hollow="true"
+            hollow
             size="large"
           >
             <div class="changelog-version-header">

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -1,0 +1,279 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Clock, Loading, Warning } from '@element-plus/icons-vue'
+import { useLocale } from '../../composables/locale'
+import changelogLocale from '../../../i18n/component/component-changelog.json'
+import allChangelogs from 'virtual:component-changelog-data'
+import { useWindowSize } from '@vueuse/core'
+
+import type { TimelineItemProps } from 'element-plus'
+import type { VersionChangelog } from '../../../utils/changelog-parser'
+
+const props = defineProps({
+  component: {
+    type: String,
+    required: true,
+  },
+})
+
+const TYPE_ICONS: Record<string, string> = {
+  feature: '✨',
+  bugfix: '🐛',
+  refactor: '🔨',
+  breaking: '⚠️',
+}
+
+const locale = useLocale(changelogLocale)
+const drawerVisible = ref(false)
+
+const issueCount = ref<number | null>(null)
+const issueLoading = ref(false)
+
+const hasChangelog = computed(() => changelogs.value.length > 0)
+
+const changelogs = computed<VersionChangelog[]>(
+  () => allChangelogs[props.component] || []
+)
+const issuesUrl = computed(() => {
+  const q = encodeURIComponent(`is:open is:issue in:title [${props.component}]`)
+  return `https://github.com/element-plus/element-plus/issues?q=${q}`
+})
+
+const { width: windowWidth } = useWindowSize()
+const drawerSize = computed(() => (windowWidth.value < 768 ? '100%' : '60%'))
+
+const getTypeIcon = (type: string) => {
+  return TYPE_ICONS[type] || TYPE_ICONS['refactor']
+}
+
+const getTimelineItemType = (
+  entries: VersionChangelog['entries']
+): TimelineItemProps['type'] => {
+  if (entries.some((e) => e.type === 'breaking')) return 'danger'
+  if (entries.some((e) => e.type === 'feature')) return 'success'
+  if (entries.some((e) => e.type === 'bugfix')) return 'primary'
+  return 'info'
+}
+
+const renderDescription = (desc: string) => {
+  // Convert `code` to <code> tags
+  let html = desc.replace(/`([^`]+)`/g, '<code>$1</code>')
+  // Convert #PR to links
+  html = html
+    .replace(
+      /#(\d+)/g,
+      '<a href="https://github.com/element-plus/element-plus/pull/$1" target="_blank">#$1</a>'
+    )
+    .replace(/([^.]$)/, '$1.')
+  return html
+}
+
+const fetchIssueCount = async () => {
+  const { component } = props
+  issueLoading.value = true
+  try {
+    const q = encodeURIComponent(
+      `repo:element-plus/element-plus is:open is:issue in:title [${component}]`
+    )
+    const res = await fetch(
+      `https://api.github.com/search/issues?q=${q}&per_page=1`
+    )
+    if (res.ok) {
+      const data = await res.json()
+      issueCount.value = data.total_count ?? 0
+    }
+  } finally {
+    issueLoading.value = false
+  }
+}
+
+const openDrawer = () => {
+  drawerVisible.value = true
+}
+
+const openIssues = () => {
+  window.open(issuesUrl.value, '_blank')
+}
+
+fetchIssueCount()
+</script>
+
+<template>
+  <ClientOnly>
+    <div v-if="hasChangelog" class="vp-component-changelog">
+      <el-button-group class="component-meta-card">
+        <el-button :icon="Clock" @click="openDrawer">
+          {{ locale['title'] }}
+        </el-button>
+        <el-button :icon="Warning" @click="openIssues">
+          {{ locale['open-issues'] }}
+          <div class="issue-count">
+            <span v-if="!issueLoading">{{ issueCount ?? 0 }}</span>
+            <el-icon v-else class="is-loading"><Loading /></el-icon>
+          </div>
+        </el-button>
+      </el-button-group>
+
+      <el-drawer
+        v-model="drawerVisible"
+        class="changelog-drawer"
+        :size="drawerSize"
+        append-to-body
+      >
+        <template #header>
+          <div class="changelog-drawer-header">
+            <span class="changelog-drawer-title">{{ locale['title'] }}</span>
+            <el-link
+              type="primary"
+              href="https://github.com/element-plus/element-plus/releases"
+              target="_blank"
+            >
+              {{ locale['view-full-changelog'] }}
+            </el-link>
+          </div>
+        </template>
+
+        <el-timeline class="changelog-timeline">
+          <el-timeline-item
+            v-for="item in changelogs"
+            :key="item.version"
+            :type="getTimelineItemType(item.entries)"
+            :hollow="true"
+            size="large"
+          >
+            <div class="changelog-version-header">
+              <span class="changelog-version">{{ item.version }}</span>
+              <el-tag size="small" round effect="plain">
+                {{ item.date }}
+              </el-tag>
+            </div>
+            <ul class="changelog-entries">
+              <li
+                v-for="({ type, description, pr, author }, idx) in item.entries"
+                :key="idx"
+                class="changelog-entry"
+              >
+                <span class="changelog-entry-icon">
+                  {{ getTypeIcon(type) }}
+                </span>
+                <span
+                  class="changelog-entry-desc"
+                  v-html="renderDescription(description)"
+                />
+                <el-link
+                  v-if="pr"
+                  type="primary"
+                  :href="`https://github.com/element-plus/element-plus/pull/${pr}`"
+                  underline="always"
+                  target="_blank"
+                >
+                  #{{ pr }}
+                </el-link>
+                <el-link
+                  v-if="author"
+                  :href="`https://github.com/${author}`"
+                  underline="always"
+                  target="_blank"
+                >
+                  @{{ author }}
+                </el-link>
+              </li>
+            </ul>
+          </el-timeline-item>
+        </el-timeline>
+      </el-drawer>
+    </div>
+  </ClientOnly>
+</template>
+
+<style lang="scss" scoped>
+.vp-component-changelog {
+  margin-top: 12px;
+  margin-bottom: 16px;
+
+  .component-meta-card {
+    .issue-count {
+      margin-left: 6px;
+      min-width: 14px;
+    }
+  }
+}
+
+.changelog-drawer {
+  .changelog-drawer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding-right: 16px;
+  }
+
+  .changelog-drawer-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--el-text-color-primary);
+  }
+
+  .changelog-version-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+
+  .changelog-version {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--el-text-color-primary);
+  }
+
+  .changelog-entries {
+    margin: 0;
+    padding: 0;
+    list-style: circle;
+  }
+
+  .changelog-entry {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 4px;
+    margin-bottom: 6px;
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--el-text-color-regular);
+  }
+
+  .changelog-entry-icon {
+    flex-shrink: 0;
+    width: 20px;
+    text-align: center;
+  }
+
+  .changelog-entry-desc {
+    margin-right: 6px;
+    min-width: 0;
+    word-break: break-word;
+
+    :deep(code) {
+      padding: 2px 6px;
+      color: var(--el-color-primary);
+      background-color: var(--el-color-primary-light-9);
+      border-radius: 4px;
+    }
+
+    :deep(a) {
+      color: var(--el-color-primary);
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
+.changelog-timeline {
+  padding-left: 16px;
+}
+</style>

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { Clock, Loading, Warning } from '@element-plus/icons-vue'
+import { useWindowSize } from '@vueuse/core'
 import { useLocale } from '../../composables/locale'
 import changelogLocale from '../../../i18n/component/component-meta.json'
 import allChangelogs from 'virtual:component-changelog-data'
-import { useWindowSize } from '@vueuse/core'
 
 import type { TimelineItemProps } from 'element-plus'
 import type { VersionChangelog } from '../../../utils/changelog-parser'
@@ -135,22 +135,22 @@ fetchIssueCount()
 
         <el-timeline class="changelog-timeline">
           <el-timeline-item
-            v-for="item in changelogs"
-            :key="item.version"
-            :type="getTimelineItemType(item.entries)"
+            v-for="{ version, date, entries } in changelogs"
+            :key="version"
+            :type="getTimelineItemType(entries)"
             :hollow="true"
             size="large"
           >
             <div class="changelog-version-header">
-              <span class="changelog-version">{{ item.version }}</span>
+              <span class="changelog-version">{{ version }}</span>
               <el-tag size="small" round effect="plain">
-                {{ item.date }}
+                {{ date }}
               </el-tag>
             </div>
             <ul class="changelog-entries">
               <li
-                v-for="({ type, description, pr, author }, idx) in item.entries"
-                :key="idx"
+                v-for="{ type, description, pr, author } in entries"
+                :key="pr || description"
                 class="changelog-entry"
               >
                 <span class="changelog-entry-icon">

--- a/docs/.vitepress/vitepress/composables/use-issue-count.ts
+++ b/docs/.vitepress/vitepress/composables/use-issue-count.ts
@@ -1,0 +1,45 @@
+import { onMounted, ref } from 'vue'
+
+const cache = new Map<string, { count: number; timestamp: number }>()
+const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+export const useIssueCount = (component: string) => {
+  const count = ref<number | null>(null)
+  const loading = ref(false)
+
+  const fetchCount = async () => {
+    const cached = cache.get(component)
+    if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+      count.value = cached.count
+      return
+    }
+
+    loading.value = true
+    try {
+      const q = encodeURIComponent(
+        `repo:element-plus/element-plus is:open is:issue in:title [${component}]`
+      )
+      const res = await fetch(
+        `https://api.github.com/search/issues?q=${q}&per_page=1`
+      )
+      if (res.ok) {
+        const data = await res.json()
+        const total = data.total_count ?? 0
+        count.value = total
+        cache.set(component, { count: total, timestamp: Date.now() })
+      } else {
+        count.value = 0
+      }
+    } catch {
+      count.value = 0
+    } finally {
+      loading.value = false
+    }
+  }
+
+  onMounted(() => {
+    fetchCount()
+  })
+
+  return { count, loading }
+}

--- a/docs/components.d.ts
+++ b/docs/components.d.ts
@@ -155,6 +155,7 @@ declare module 'vue' {
     VpApiTyping: typeof import('./.vitepress/vitepress/components/globals/vp-api-typing.vue')['default']
     VpApp: typeof import('./.vitepress/vitepress/components/vp-app.vue')['default']
     VpChangelog: typeof import('./.vitepress/vitepress/components/globals/vp-changelog.vue')['default']
+    VpComponentMeta: typeof import('./.vitepress/vitepress/components/globals/vp-component-meta.vue')['default']
     VpContent: typeof import('./.vitepress/vitepress/components/vp-content.vue')['default']
     VpDemo: typeof import('./.vitepress/vitepress/components/vp-demo.vue')['default']
     VpDocContent: typeof import('./.vitepress/vitepress/components/vp-doc-content.vue')['default']


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

I think being able to view the current component’s changelog and open issues directly on the component page would be very helpful for developers.

PS: Most of the code was generated by GitHub Copilot and Claude Opus 4.6. I made some adjustments and conducted a thorough review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Component changelog UI in docs: versioned timelines with descriptions, PRs, and authors.
  * GitHub open-issues counter per component with caching.
  * Automatic insertion of the changelog meta block into component pages after the title.
  * Integration that loads and exposes changelog data to the docs.
  * Localized labels for the changelog UI (title, view full, no changelog, open issues).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->