### PR TITLE
style(components): [tag] fix icon in slot causing text wrap

### DIFF
--- a/packages/theme-chalk/src/tag.scss
+++ b/packages/theme-chalk/src/tag.scss
@@ -113,7 +113,6 @@ $tag-icon-span-gap: map.merge(
   $svg-margin-size: 1px;
 
   .#{$namespace}-icon {
-    display: flex;
     border-radius: 50%;
     cursor: pointer;
 

--- a/packages/theme-chalk/src/tag.scss
+++ b/packages/theme-chalk/src/tag.scss
@@ -133,6 +133,10 @@ $tag-icon-span-gap: map.merge(
       outline: 2px solid getCssVar('color-primary');
       outline-offset: 2px;
     }
+
+    .#{$namespace}-icon {
+      display: flex; // #22530
+    }
   }
 
   @include m(dark) {


### PR DESCRIPTION
现在的样式：
```css
.el-tag .el-icon {
    display: flex;
}
```
`el-icon`已经有了`display: inline-flex`，此处设置`display: flex;`会导致`el-icon`变成块布局，最终导致图标和文字换行。`el-tag`带图标的使用场景通常是图标和文字同一行。因此删掉`display: flex;`。

这个问题是最近大量使用`flex`后引起的，我原本使用的`2.11.9`版本没有这个问题。

<img width="192" height="99" alt="image" src="https://github.com/user-attachments/assets/f66146dd-4850-4318-acad-7dede380dadb" />


Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined tag component icon layout: adjusted how icon flex behavior is applied so icons inside closable tags align and render more consistently, improving tag close-button spacing and overall visual stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->