### PR TITLE
docs: add label for hiding source code

### DIFF
--- a/docs/.vitepress/vitepress/components/vp-demo.vue
+++ b/docs/.vitepress/vitepress/components/vp-demo.vue
@@ -32,6 +32,11 @@ const sourceCodeRef = ref<HTMLButtonElement>()
 
 const locale = computed(() => demoBlockLocale[lang.value])
 const decodedDescription = computed(() => decodeURIComponent(props.description))
+const sourceVisibilityLabel = computed(() =>
+  sourceVisible.value
+    ? locale.value['hide-source']
+    : locale.value['view-source']
+)
 
 const onSourceVisibleKeydown = (e: KeyboardEvent) => {
   if (
@@ -125,16 +130,14 @@ const copyCode = async () => {
         </ElIcon>
       </ElTooltip>
       <ElTooltip
-        :content="locale['view-source']"
+        :content="sourceVisibilityLabel"
         :show-arrow="false"
         :trigger="['hover', 'focus']"
         :trigger-keys="[]"
       >
         <button
           ref="sourceCodeRef"
-          :aria-label="
-            sourceVisible ? locale['hide-source'] : locale['view-source']
-          "
+          :aria-label="sourceVisibilityLabel"
           class="reset-btn el-icon op-btn"
           @click="toggleSourceVisible()"
         >


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

The label previously displayed as 'View source' when toggling between viewing and hiding the source code, so a 'Hide source' label has been added.

### Before

https://github.com/user-attachments/assets/8b95186c-ac59-4f3e-bdf2-b8686667807f

### After

https://github.com/user-attachments/assets/ebded86d-425f-4db5-b73a-838a974a6e11



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced accessibility and localization consistency for the source code visibility toggle in documentation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->