### PR TITLE
fix(components): [table] expanded rows cannot be updated using array methods

### DIFF
--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -2056,6 +2056,18 @@ describe('Table.vue', () => {
       childRows.forEach((item) => {
         expect(item.attributes('style')).toContain('')
       })
+
+      // #23759
+      wrapper.vm.expandRowKeys.splice(1, 1)
+      await doubleWait()
+      childRows = wrapper.findAll('.el-table__row--level-1')
+      childRows.forEach((item, index) => {
+        if (index < 2) {
+          expect(item.attributes('style')).toBe('')
+        } else {
+          expect(item.attributes('style')).toContain('display: none')
+        }
+      })
     })
 
     it('expand-row-keys & toggleRowExpansion', async () => {

--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -2063,10 +2063,17 @@ describe('Table.vue', () => {
       childRows = wrapper.findAll('.el-table__row--level-1')
       childRows.forEach((item, index) => {
         if (index < 2) {
-          expect(item.attributes('style')).toBe('')
+          expect(item.attributes('style')).not.toContain('display: none')
         } else {
           expect(item.attributes('style')).toContain('display: none')
         }
+      })
+
+      wrapper.vm.expandRowKeys.push('1999-3-31')
+      await doubleWait()
+      childRows = wrapper.findAll('.el-table__row--level-1')
+      childRows.forEach((item) => {
+        expect(item.attributes('style')).not.toContain('display: none')
       })
     })
 

--- a/packages/components/table/src/store/tree.ts
+++ b/packages/components/table/src/store/tree.ts
@@ -148,7 +148,8 @@ function useTree<T extends DefaultRow>(watcherData: WatcherPropsData<T>) {
     () => expandRowKeys.value,
     () => {
       updateTreeData(true)
-    }
+    },
+    { deep: true }
   )
 
   watch(


### PR DESCRIPTION
Fix the first case of #23759

[demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZGl2PlxuICAgIDxlbC1idXR0b24gQGNsaWNrPVwib25FeHBhbmQoJzMnKVwiPnVzaW5nIHNwbGljZSB0b2dnbGU8L2VsLWJ1dHRvbj5cbiAgICBleHBhbmQtcm93LWtleXM6IHt7IGtleXMgfX1cbiAgICA8ZWwtdGFibGUgOmRhdGE9XCJ0YWJsZURhdGFcIiBzdHlsZT1cIndpZHRoOiAxMDAlOyBtYXJnaW4tYm90dG9tOiAyMHB4XCIgcm93LWtleT1cImlkXCIgYm9yZGVyIDpleHBhbmQtcm93LWtleXM9XCJrZXlzXCI+XG4gICAgICA8ZWwtdGFibGUtY29sdW1uIHByb3A9XCJkYXRlXCIgbGFiZWw9XCJEYXRlXCIgc29ydGFibGUgLz5cbiAgICAgIDxlbC10YWJsZS1jb2x1bW4gcHJvcD1cIm5hbWVcIiBsYWJlbD1cIk5hbWVcIiBzb3J0YWJsZSAvPlxuICAgICAgPGVsLXRhYmxlLWNvbHVtbiBwcm9wPVwiYWRkcmVzc1wiIGxhYmVsPVwiQWRkcmVzc1wiIHNvcnRhYmxlIC8+XG4gICAgPC9lbC10YWJsZT5cbiAgPC9kaXY+XG48L3RlbXBsYXRlPlxuXG48c2NyaXB0IGxhbmc9XCJ0c1wiIHNldHVwPlxuaW1wb3J0IHsgcmVmIH0gZnJvbSAndnVlJ1xuaW50ZXJmYWNlIFVzZXIge1xuICBpZDogbnVtYmVyXG4gIGRhdGU6IHN0cmluZ1xuICBuYW1lOiBzdHJpbmdcbiAgYWRkcmVzczogc3RyaW5nXG4gIGhhc0NoaWxkcmVuPzogYm9vbGVhblxuICBjaGlsZHJlbj86IFVzZXJbXVxufVxuXG5jb25zdCBrZXlzID0gcmVmKFtdKVxuXG5jb25zdCBvbkV4cGFuZCA9ICh2YWx1ZTogc3RyaW5nKSA9PiB7XG4gIGNvbnN0IGluZGV4ID0ga2V5cy52YWx1ZS5maW5kSW5kZXgoaXRlbSA9PiBpdGVtID09PSB2YWx1ZSlcbiAgaWYgKGluZGV4ID49IDApIHtcbiAgICBrZXlzLnZhbHVlLnNwbGljZShpbmRleCwgMSlcbiAgfSBlbHNlIHtcbiAgICBrZXlzLnZhbHVlLnB1c2godmFsdWUpXG4gIH1cbn1cblxuY29uc3QgdGFibGVEYXRhOiBVc2VyW10gPSBbXG4gIHtcbiAgICBpZDogMSxcbiAgICBkYXRlOiAnMjAxNi0wNS0wMicsXG4gICAgbmFtZTogJ3dhbmd4aWFvaHUnLFxuICAgIGFkZHJlc3M6ICdOby4gMTg5LCBHcm92ZSBTdCwgTG9zIEFuZ2VsZXMnLFxuICB9LFxuICB7XG4gICAgaWQ6IDIsXG4gICAgZGF0ZTogJzIwMTYtMDUtMDQnLFxuICAgIG5hbWU6ICd3YW5neGlhb2h1JyxcbiAgICBhZGRyZXNzOiAnTm8uIDE4OSwgR3JvdmUgU3QsIExvcyBBbmdlbGVzJyxcbiAgfSxcbiAge1xuICAgIGlkOiAzLFxuICAgIGRhdGU6ICcyMDE2LTA1LTAxMTIzMTIzJyxcbiAgICBuYW1lOiAnd2FuZ3hpYW9odScsXG4gICAgYWRkcmVzczogJ05vLiAxODksIEdyb3ZlIFN0LCBMb3MgQW5nZWxlcycsXG4gICAgY2hpbGRyZW46IFtcbiAgICAgIHtcbiAgICAgICAgaWQ6IDMxLFxuICAgICAgICBkYXRlOiAnMjAxNi0wNS0wMScsXG4gICAgICAgIG5hbWU6ICd3YW5neGlhb2h1JyxcbiAgICAgICAgYWRkcmVzczogJ05vLiAxODksIEdyb3ZlIFN0LCBMb3MgQW5nZWxlcycsXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICBpZDogMzIsXG4gICAgICAgIGRhdGU6ICcyMDE2LTA1LTAxJyxcbiAgICAgICAgbmFtZTogJ3dhbmd4aWFvaHUnLFxuICAgICAgICBhZGRyZXNzOiAnTm8uIDE4OSwgR3JvdmUgU3QsIExvcyBBbmdlbGVzJyxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGlkOiAzMyxcbiAgICAgICAgZGF0ZTogJzIwMTYtMDUtMDEnLFxuICAgICAgICBuYW1lOiAnd2FuZ3hpYW9odScsXG4gICAgICAgIGFkZHJlc3M6ICdOby4gMTg5LCBHcm92ZSBTdCwgTG9zIEFuZ2VsZXMnLFxuICAgICAgfSxcbiAgICBdLFxuICB9LFxuICB7XG4gICAgaWQ6IDQsXG4gICAgZGF0ZTogJzIwMTYtMDUtMDMnLFxuICAgIG5hbWU6ICd3YW5neGlhb2h1JyxcbiAgICBhZGRyZXNzOiAnTm8uIDE4OSwgR3JvdmUgU3QsIExvcyBBbmdlbGVzJyxcbiAgfSxcbl1cbjwvc2NyaXB0PlxuIiwiZWxlbWVudC1wbHVzLmpzIjoiaW1wb3J0IEVsZW1lbnRQbHVzIGZyb20gJ2VsZW1lbnQtcGx1cydcbmltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcblxubGV0IGluc3RhbGxlZCA9IGZhbHNlXG5hd2FpdCBsb2FkU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gc2V0dXBFbGVtZW50UGx1cygpIHtcbiAgaWYgKGluc3RhbGxlZCkgcmV0dXJuXG4gIGNvbnN0IGluc3RhbmNlID0gZ2V0Q3VycmVudEluc3RhbmNlKClcbiAgaW5zdGFuY2UuYXBwQ29udGV4dC5hcHAudXNlKEVsZW1lbnRQbHVzKVxuICBpbnN0YWxsZWQgPSB0cnVlXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkU3R5bGUoKSB7XG4gIGNvbnN0IHN0eWxlcyA9IFsnaHR0cHM6Ly9yYXcuZXNtLnNoL3ByL2VsZW1lbnQtcGx1c0AyMzc2MS9kaXN0L2luZGV4LmNzcycsICdodHRwczovL3Jhdy5lc20uc2gvcHIvZWxlbWVudC1wbHVzQDIzNzYxL3RoZW1lLWNoYWxrL2RhcmsvY3NzLXZhcnMuY3NzJ10ubWFwKChzdHlsZSkgPT4ge1xuICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgICAgbGluay5ocmVmID0gc3R5bGVcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgICB9KVxuICB9KVxuICByZXR1cm4gUHJvbWlzZS5hbGxTZXR0bGVkKHN0eWxlcylcbn1cbiIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3VucGtnLmNvbS9AdnVlL3J1bnRpbWUtZG9tQGxhdGVzdC9kaXN0L3J1bnRpbWUtZG9tLmVzbS1icm93c2VyLmpzXCIsXG4gICAgXCJAdnVlL3NoYXJlZFwiOiBcImh0dHBzOi8vdW5wa2cuY29tL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9yYXcuZXNtLnNoL3ByL2VsZW1lbnQtcGx1c0AyMzc2MS9kaXN0L2luZGV4LmZ1bGwubWluLm1qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzL1wiOiBcImh0dHBzOi8vcmF3LmVzbS5zaC9wci9lbGVtZW50LXBsdXNAMjM3NjEvXCIsXG4gICAgXCJAZWxlbWVudC1wbHVzL2ljb25zLXZ1ZVwiOiBcImh0dHBzOi8vdW5wa2cuY29tL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsIl9vIjp7InNob3dIaWRkZW4iOnRydWUsInN0eWxlU291cmNlIjoiaHR0cHM6Ly9yYXcuZXNtLnNoL3ByL2VsZW1lbnQtcGx1c0AyMzc2MS9kaXN0L2luZGV4LmNzcyJ9fQ==)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table row expansion reactivity so nested or runtime changes to expanded rows are reliably detected and reflected in the UI.

* **Tests**
  * Added a runtime test that mutates expanded rows and verifies dynamic show/hide behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->