### PR TITLE
feat(components): [input] add `password-icon` slot

### DIFF
--- a/docs/en-US/component/input.md
+++ b/docs/en-US/component/input.md
@@ -51,7 +51,7 @@ input/formatter
 
 ## Password box
 
-:::demo Make a toggle-able password Input with the `show-password` attribute. Since ^(2.13.6) , the `password-icon` slot is supported to override the default icon.
+:::demo Make a toggle-able password Input with the `show-password` attribute. Since ^(2.13.6), the `password-icon` slot is supported to override the default icon.
 
 input/password
 

--- a/docs/en-US/component/input.md
+++ b/docs/en-US/component/input.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Input
 lang: en-US
 ---
@@ -51,7 +51,7 @@ input/formatter
 
 ## Password box
 
-:::demo Make a toggle-able password Input with the `show-password` attribute.
+:::demo Make a toggle-able password Input with the `show-password` attribute. Since ^(2.13.6) , the `password-icon` slot is supported to override the default icon.
 
 input/password
 
@@ -172,12 +172,13 @@ input/length-limiting
 
 ### Slots
 
-| Name    | Description                                                               |
-| ------- | ------------------------------------------------------------------------- |
-| prefix  | content as Input prefix, only works when `type` is not 'textarea'         |
-| suffix  | content as Input suffix, only works when `type` is not 'textarea'         |
-| prepend | content to prepend before Input, only works when `type` is not 'textarea' |
-| append  | content to append after Input, only works when `type` is not 'textarea'   |
+| Name                    | Description                                                                                                           |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| prefix                  | content as Input prefix, only works when `type` is not 'textarea'                                                     |
+| suffix                  | content as Input suffix, only works when `type` is not 'textarea'                                                     |
+| prepend                 | content to prepend before Input, only works when `type` is not 'textarea'                                             |
+| append                  | content to append after Input, only works when `type` is not 'textarea'                                               |
+| password-icon ^(2.13.6) | content as Input password icon, only works when `show-password` is true. The scope variable is `{ visible: boolean }` |
 
 ### Exposes
 

--- a/docs/examples/input/password.vue
+++ b/docs/examples/input/password.vue
@@ -1,11 +1,45 @@
 <template>
-  <el-input
-    v-model="input"
-    style="width: 240px"
-    type="password"
-    placeholder="Please input password"
-    show-password
-  />
+  <div class="flex flex-col gap-2">
+    <el-input
+      v-model="input"
+      style="width: 240px"
+      type="password"
+      placeholder="Please input password"
+      show-password
+    />
+    <el-input
+      v-model="input"
+      style="width: 240px"
+      type="password"
+      placeholder="Please input password"
+      show-password
+    >
+      <template #password-icon="{ visible }">
+        <el-icon :size="16">
+          <svg
+            v-if="visible"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+          >
+            <path
+              fill="currentColor"
+              d="M16 20H8v-2h8zm-8-2H4v-2h4zm12 0h-4v-2h4zM4 16H2v-2h2zm10-6h-2v2h2zh2v4h-2v2h-4v-2H8v-4h2V8h4zm8 6h-2v-2h2zM2 14H0v-4h2zm22 0h-2v-4h2zM4 10H2V8h2zm18 0h-2V8h2zM8 8H4V6h4zm12 0h-4V6h4zm-4-2H8V4h8z"
+            />
+          </svg>
+          <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <g fill="currentColor">
+              <path
+                d="M0 10h2v4H0zm24 0h-2v4h2zm-8 0h-2v2h2zm-6 0H8v4h2zM2 8h2v2H2zm0 8h2v-2H2zm20-8h-2v2h2zm0 8h-2v-2h2zM4 6h4v2H4zm0 12h4v-2H4zM20 6h-4v2h4zM10 4h6v2h-6zM8 20h8v-2H8zm4-12h2v2h-2zm-2 6h4v2h-4zM8 8h2v2H8zm2 2h2v4h-2zm2 2h2v2h-2z"
+              />
+              <path
+                d="M6 6h2v2H6zM4 4h2v2H4zM2 2h2v2H2zm12 12h2v2h-2zm2 2h2v2h-2zm2 2h2v2h-2zm2 2h2v2h-2z"
+              />
+            </g>
+          </svg>
+        </el-icon>
+      </template>
+    </el-input>
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/docs/examples/input/password.vue
+++ b/docs/examples/input/password.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-2">
+  <div class="input-group">
     <el-input
       v-model="input"
       style="width: 240px"
@@ -30,3 +30,11 @@ import { Lock, Unlock } from '@element-plus/icons-vue'
 
 const input = ref('')
 </script>
+
+<style scoped>
+.input-group {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+}
+</style>

--- a/docs/examples/input/password.vue
+++ b/docs/examples/input/password.vue
@@ -16,26 +16,8 @@
     >
       <template #password-icon="{ visible }">
         <el-icon :size="16">
-          <svg
-            v-if="visible"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-          >
-            <path
-              fill="currentColor"
-              d="M16 20H8v-2h8zm-8-2H4v-2h4zm12 0h-4v-2h4zM4 16H2v-2h2zm10-6h-2v2h2zh2v4h-2v2h-4v-2H8v-4h2V8h4zm8 6h-2v-2h2zM2 14H0v-4h2zm22 0h-2v-4h2zM4 10H2V8h2zm18 0h-2V8h2zM8 8H4V6h4zm12 0h-4V6h4zm-4-2H8V4h8z"
-            />
-          </svg>
-          <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <g fill="currentColor">
-              <path
-                d="M0 10h2v4H0zm24 0h-2v4h2zm-8 0h-2v2h2zm-6 0H8v4h2zM2 8h2v2H2zm0 8h2v-2H2zm20-8h-2v2h2zm0 8h-2v-2h2zM4 6h4v2H4zm0 12h4v-2H4zM20 6h-4v2h4zM10 4h6v2h-6zM8 20h8v-2H8zm4-12h2v2h-2zm-2 6h4v2h-4zM8 8h2v2H8zm2 2h2v4h-2zm2 2h2v2h-2z"
-              />
-              <path
-                d="M6 6h2v2H6zM4 4h2v2H4zM2 2h2v2H2zm12 12h2v2h-2zm2 2h2v2h-2zm2 2h2v2h-2zm2 2h2v2h-2z"
-              />
-            </g>
-          </svg>
+          <Unlock v-if="visible" />
+          <Lock v-else />
         </el-icon>
       </template>
     </el-input>
@@ -44,6 +26,7 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
+import { Lock, Unlock } from '@element-plus/icons-vue'
 
 const input = ref('')
 </script>

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -614,6 +614,36 @@ describe('Input.vue', () => {
     expect(input.element.selectionEnd).toBe(4)
   })
 
+  test('password-icon slot', async () => {
+    const wrapper = mount(() => (
+      <Input
+        modelValue="123"
+        showPassword
+        v-slots={{
+          'password-icon': ({ visible }: { visible: boolean }) => (
+            <span class="custom-password-icon">
+              {visible ? 'Hide' : 'Show'}
+            </span>
+          ),
+        }}
+      />
+    ))
+
+    const icon = wrapper.find('.el-input__password')
+    expect(icon.exists()).toBe(true)
+
+    // Initial state: password hidden
+    expect(wrapper.find('.custom-password-icon').text()).toBe('Show')
+
+    // Click to toggle
+    await icon.trigger('click')
+    expect(wrapper.find('.custom-password-icon').text()).toBe('Hide')
+
+    // Click again
+    await icon.trigger('click')
+    expect(wrapper.find('.custom-password-icon').text()).toBe('Show')
+  })
+
   describe('form item accessibility integration', () => {
     test('automatic id attachment', async () => {
       const wrapper = mount(() => (

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -83,7 +83,9 @@
               @mousedown.prevent="NOOP"
               @mouseup.prevent="NOOP"
             >
-              <component :is="passwordIcon" />
+              <slot name="password-icon" :visible="passwordVisible">
+                <component :is="passwordIcon" />
+              </slot>
             </el-icon>
             <span
               v-if="isWordLimitVisible"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

rel: #23768

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a customizable password-icon slot to the input component so consumers can provide custom content for the password visibility toggle.

* **Documentation**
  * Updated docs and example to demonstrate the password-icon slot and clarified the Slots table and related headings.

* **Tests**
  * Added tests verifying the slot renders correctly and that the visibility toggle updates the slot content as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->