### PR TITLE
fix(components): [tabs] incorrect boundary detection when container size is a float number

### DIFF
--- a/packages/components/tabs/src/tab-nav.tsx
+++ b/packages/components/tabs/src/tab-nav.tsx
@@ -236,9 +236,9 @@ const TabNav = defineComponent({
 
       props.stretch && tabBarRef.value?.update()
 
-      const navSize = nav$.value[`offset${capitalize(sizeName.value)}`]
+      const navSize = nav$.value.getBoundingClientRect()[sizeName.value]
       const containerSize =
-        navScroll$.value[`offset${capitalize(sizeName.value)}`]
+        navScroll$.value.getBoundingClientRect()[sizeName.value]
       const currentOffset = navOffset.value
 
       if (containerSize < navSize) {


### PR DESCRIPTION
fix #23773

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling detection in tabs navigation by using more accurate size measurements. This ensures scroll controls appear correctly when tab content exceeds available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->