### PR TITLE
fix(components): fix el-tabs overflow mode abnormal

### DIFF
--- a/packages/components/tabs/src/tab-nav.tsx
+++ b/packages/components/tabs/src/tab-nav.tsx
@@ -341,6 +341,26 @@ const TabNav = defineComponent({
     })
 
     onMounted(() => setTimeout(() => scrollToActiveTab(), 0))
+
+    watch(
+      () => props.currentName,
+      (_, oldName) => {
+        const prevTab = tabRefsMap.value[oldName]
+        if (!prevTab) return
+
+        const closeIcon = prevTab.querySelector<HTMLElement>('.is-icon-close')
+        if (!closeIcon) return
+        if (closeIcon.getBoundingClientRect().width === 0) return
+
+        const handler = (event: TransitionEvent) => {
+          if (event.propertyName !== 'width') return
+          rAF(update)
+          closeIcon.removeEventListener('transitionend', handler)
+        }
+        closeIcon.addEventListener('transitionend', handler)
+      }
+    )
+
     onUpdated(() => update())
 
     expose({


### PR DESCRIPTION
when tabs overflow, clicking the "Add Tab" button results in an abnormal spacing between the last tab and the el-tabs__nav-next icon.

closed #23794

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab switching behavior to ensure proper updates when transitioning between tabs with close icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->