### PR TITLE
fix(components): [input-tag] Prevent duplicate tags when using Korean IME with Enter key

### DIFF
--- a/packages/components/input-tag/src/composables/use-input-tag.ts
+++ b/packages/components/input-tag/src/composables/use-input-tag.ts
@@ -121,13 +121,21 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
       case props.trigger:
         event.preventDefault()
         event.stopPropagation()
-        handleAddTag()
+        Promise.resolve().then(() => {
+          if (!isComposing.value) {
+            handleAddTag()
+          }
+        })
         break
       case EVENT_CODE.numpadEnter:
         if (props.trigger === EVENT_CODE.enter) {
           event.preventDefault()
           event.stopPropagation()
-          handleAddTag()
+          Promise.resolve().then(() => {
+            if (!isComposing.value) {
+              handleAddTag()
+            }
+          })
         }
         break
       case EVENT_CODE.backspace:


### PR DESCRIPTION
## Description

This PR fixes the issue where pressing Enter key with Korean IME (Input Method Editor) creates duplicate tags in the InputTag component.

## Related Issue

Fixes #23788

## Root Cause

The `handleCompositionEnd` function uses `nextTick` to call `afterComposition` (which is `handleInput`). This causes a timing issue:
1. `compositionend` event fires, `isComposing` is set to `false`
2. `nextTick` schedules `handleInput` for later execution
3. Meanwhile, Enter key triggers `handleKeydown`
4. At this point, `isComposing` is already `false`, so `handleAddTag()` is called
5. This results in duplicate tag creation

## Solution

Add a microtask delay in `handleKeydown` with a double-check for `isComposing` state:
- Use `Promise.resolve().then()` to ensure `compositionend` has been fully processed
- Add secondary check for `isComposing.value` before calling `handleAddTag()`

## Changes

- Modified `handleKeydown` function in `packages/components/input-tag/src/composables/use-input-tag.ts`
- Added microtask delay for Enter key handling
- Added double-check for IME composition state

## Testing

Please test with:
- [x] Korean IME + Enter key
- [x] Chinese IME + Enter key
- [x] Japanese IME + Enter key
- [x] English keyboard + Enter key
- [x] Rapid Enter key presses

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code compiles without errors
- [x] Follows the contribution guidelines
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag addition timing when using input method editors (IME) or composing text, ensuring tags are added reliably at the appropriate moment without interference from composition state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->