### PR TITLE
refactor(components): refs to useTemplateRef

### DIFF
--- a/internal/build/package.json
+++ b/internal/build/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "@pnpm/types": "^8.4.0",
     "jiti": "^2.6.1",
-    "unbuild": "^3.0.0",
-    "vue-tsc": "^3.2.3"
+    "unbuild": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "vitest": "^4.0.16",
     "vue": "catalog:",
     "vue-router": "^4.0.16",
-    "vue-tsc": "=3.1.5"
+    "vue-tsc": "^3.2.4"
   },
   "engines": {
     "node": ">= 20.19.0"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "vitest": "^4.0.16",
     "vue": "catalog:",
     "vue-router": "^4.0.16",
-    "vue-tsc": "^3.2.4"
+    "vue-tsc": "^3.2.5"
   },
   "engines": {
     "node": ">= 20.19.0"

--- a/packages/components/carousel/src/carousel-item.vue
+++ b/packages/components/carousel/src/carousel-item.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, unref } from 'vue'
+import { computed, unref, useTemplateRef } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { useCarouselItem } from './use-carousel-item'
 import { CAROUSEL_ITEM_NAME } from './constants'
@@ -30,9 +30,10 @@ const props = withDefaults(defineProps<CarouselItemProps>(), {
 })
 const ns = useNamespace('carousel')
 
+const carouselItemRef = useTemplateRef<HTMLElement>('carouselItemRef')
+
 // inject
 const {
-  carouselItemRef,
   active,
   animating,
   hover,
@@ -43,7 +44,7 @@ const {
   scale,
   ready,
   handleItemClick,
-} = useCarouselItem(props)
+} = useCarouselItem(props, carouselItemRef)
 
 const itemKls = computed(() => [
   ns.e('item'),

--- a/packages/components/carousel/src/carousel-item.vue
+++ b/packages/components/carousel/src/carousel-item.vue
@@ -30,7 +30,7 @@ const props = withDefaults(defineProps<CarouselItemProps>(), {
 })
 const ns = useNamespace('carousel')
 
-const carouselItemRef = useTemplateRef<HTMLElement>('carouselItemRef')
+const carouselItemRef = useTemplateRef('carouselItemRef')
 
 // inject
 const {

--- a/packages/components/carousel/src/carousel.vue
+++ b/packages/components/carousel/src/carousel.vue
@@ -118,7 +118,7 @@ const props = withDefaults(defineProps<CarouselProps>(), {
   pauseOnHover: true,
 })
 const emit = defineEmits(carouselEmits)
-const root = useTemplateRef<HTMLDivElement>('root')
+const root = useTemplateRef('root')
 const {
   activeIndex,
   exposeActiveIndex,

--- a/packages/components/carousel/src/carousel.vue
+++ b/packages/components/carousel/src/carousel.vue
@@ -89,7 +89,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, unref } from 'vue'
+import { computed, unref, useTemplateRef } from 'vue'
 import { ElIcon } from '@element-plus/components/icon'
 import { ArrowLeft, ArrowRight } from '@element-plus/icons-vue'
 import { useLocale, useNamespace } from '@element-plus/hooks'
@@ -118,8 +118,8 @@ const props = withDefaults(defineProps<CarouselProps>(), {
   pauseOnHover: true,
 })
 const emit = defineEmits(carouselEmits)
+const root = useTemplateRef<HTMLDivElement>('root')
 const {
-  root,
   activeIndex,
   exposeActiveIndex,
   arrowDisplay,
@@ -142,7 +142,7 @@ const {
   ItemsSorter,
   throttledArrowClick,
   throttledIndicatorHover,
-} = useCarousel(props, emit, COMPONENT_NAME)
+} = useCarousel(props, emit, COMPONENT_NAME, root)
 const ns = useNamespace('carousel')
 
 const { t } = useLocale()

--- a/packages/components/carousel/src/constants.ts
+++ b/packages/components/carousel/src/constants.ts
@@ -1,4 +1,4 @@
-import type { InjectionKey, Ref, VNode } from 'vue'
+import type { InjectionKey, Ref, TemplateRef, VNode } from 'vue'
 import type { CarouselItemProps } from './carousel-item'
 
 export type CarouselItemStates = {
@@ -20,7 +20,7 @@ export type CarouselItemContext = {
 }
 
 export type CarouselContext = {
-  root: Readonly<Ref<HTMLElement | null>>
+  root: TemplateRef<HTMLElement>
   items: Ref<CarouselItemContext[]>
   isCardType: Ref<boolean>
   isVertical: Ref<boolean>

--- a/packages/components/carousel/src/constants.ts
+++ b/packages/components/carousel/src/constants.ts
@@ -20,7 +20,7 @@ export type CarouselItemContext = {
 }
 
 export type CarouselContext = {
-  root: Ref<HTMLElement | undefined>
+  root: Readonly<Ref<HTMLElement | null>>
   items: Ref<CarouselItemContext[]>
   isCardType: Ref<boolean>
   isVertical: Ref<boolean>

--- a/packages/components/carousel/src/use-carousel-item.ts
+++ b/packages/components/carousel/src/use-carousel-item.ts
@@ -9,9 +9,13 @@ import {
 import { debugWarn, isUndefined } from '@element-plus/utils'
 import { CAROUSEL_ITEM_NAME, carouselContextKey } from './constants'
 
+import type { Ref } from 'vue'
 import type { CarouselItemProps } from './carousel-item'
 
-export const useCarouselItem = (props: Required<CarouselItemProps>) => {
+export const useCarouselItem = (
+  props: Required<CarouselItemProps>,
+  carouselItemRef: Readonly<Ref<HTMLElement | null>>
+) => {
   const carouselContext = inject(carouselContextKey)!
   // instance
   const instance = getCurrentInstance()!
@@ -29,7 +33,6 @@ export const useCarouselItem = (props: Required<CarouselItemProps>) => {
     )
   }
 
-  const carouselItemRef = ref<HTMLElement>()
   const hover = ref(false)
   const translate = ref(0)
   const scale = ref(1)

--- a/packages/components/carousel/src/use-carousel-item.ts
+++ b/packages/components/carousel/src/use-carousel-item.ts
@@ -9,12 +9,12 @@ import {
 import { debugWarn, isUndefined } from '@element-plus/utils'
 import { CAROUSEL_ITEM_NAME, carouselContextKey } from './constants'
 
-import type { Ref } from 'vue'
+import type { TemplateRef } from 'vue'
 import type { CarouselItemProps } from './carousel-item'
 
 export const useCarouselItem = (
   props: Required<CarouselItemProps>,
-  carouselItemRef: Readonly<Ref<HTMLElement | null>>
+  carouselItemRef: TemplateRef<HTMLElement>
 ) => {
   const carouselContext = inject(carouselContextKey)!
   // instance

--- a/packages/components/carousel/src/use-carousel.ts
+++ b/packages/components/carousel/src/use-carousel.ts
@@ -18,7 +18,7 @@ import { useOrderedChildren } from '@element-plus/hooks'
 import { CHANGE_EVENT } from '@element-plus/constants'
 import { CAROUSEL_ITEM_NAME, carouselContextKey } from './constants'
 
-import type { SetupContext } from 'vue'
+import type { Ref, SetupContext } from 'vue'
 import type { CarouselItemContext } from './constants'
 import type { CarouselEmits, CarouselProps } from './carousel'
 
@@ -27,7 +27,8 @@ const THROTTLE_TIME = 300
 export const useCarousel = (
   props: Required<CarouselProps>,
   emit: SetupContext<CarouselEmits>['emit'],
-  componentName: string
+  componentName: string,
+  root: Readonly<Ref<HTMLDivElement | null>>
 ) => {
   const {
     children: items,
@@ -45,7 +46,6 @@ export const useCarousel = (
   const activeIndex = ref(-1)
   const timer = ref<ReturnType<typeof setInterval> | null>(null)
   const hover = ref(false)
-  const root = ref<HTMLDivElement>()
   const containerHeight = ref<number>(0)
   const isItemsTwoLength = ref(true)
 

--- a/packages/components/carousel/src/use-carousel.ts
+++ b/packages/components/carousel/src/use-carousel.ts
@@ -18,7 +18,7 @@ import { useOrderedChildren } from '@element-plus/hooks'
 import { CHANGE_EVENT } from '@element-plus/constants'
 import { CAROUSEL_ITEM_NAME, carouselContextKey } from './constants'
 
-import type { Ref, SetupContext } from 'vue'
+import type { SetupContext, TemplateRef } from 'vue'
 import type { CarouselItemContext } from './constants'
 import type { CarouselEmits, CarouselProps } from './carousel'
 
@@ -28,7 +28,7 @@ export const useCarousel = (
   props: Required<CarouselProps>,
   emit: SetupContext<CarouselEmits>['emit'],
   componentName: string,
-  root: Readonly<Ref<HTMLDivElement | null>>
+  root: TemplateRef<HTMLDivElement>
 ) => {
   const {
     children: items,

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -355,7 +355,7 @@ const { isComposing, handleComposition } = useComposition({
   },
 })
 
-const wrapperRef = useTemplateRef<HTMLElement>('wrapperRef')
+const wrapperRef = useTemplateRef('wrapperRef')
 
 const tooltipRef = ref<TooltipInstance>()
 const tagTooltipRef = ref<TooltipInstance>()

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -223,6 +223,7 @@ import {
   onMounted,
   ref,
   useAttrs,
+  useTemplateRef,
   watch,
 } from 'vue'
 import { cloneDeep } from 'lodash-unified'
@@ -354,6 +355,8 @@ const { isComposing, handleComposition } = useComposition({
   },
 })
 
+const wrapperRef = useTemplateRef<HTMLElement>('wrapperRef')
+
 const tooltipRef = ref<TooltipInstance>()
 const tagTooltipRef = ref<TooltipInstance>()
 const inputRef = ref<InputInstance>()
@@ -409,8 +412,9 @@ const checkedNodes: ComputedRef<CascaderNode[]> = computed(
   () => cascaderPanelRef.value?.checkedNodes || []
 )
 
-const { wrapperRef, isFocused, handleBlur } = useFocusController(inputRef, {
+const { isFocused, handleBlur } = useFocusController(inputRef, {
   disabled: isDisabled,
+  wrapperRef,
   beforeBlur(event) {
     return (
       tooltipRef.value?.isFocusInsideContent(event) ||

--- a/packages/components/color-picker-panel/src/color-picker-panel.vue
+++ b/packages/components/color-picker-panel/src/color-picker-panel.vue
@@ -43,7 +43,16 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, nextTick, onMounted, provide, ref, watch } from 'vue'
+import {
+  computed,
+  inject,
+  nextTick,
+  onMounted,
+  provide,
+  ref,
+  useTemplateRef,
+  watch,
+} from 'vue'
 import { ElInput } from '@element-plus/components/input'
 import { useFormDisabled, useFormItem } from '@element-plus/components/form'
 import { useNamespace } from '@element-plus/hooks'
@@ -77,10 +86,10 @@ const emit = defineEmits(colorPickerPanelEmits)
 const ns = useNamespace('color-picker-panel')
 const { formItem } = useFormItem()
 const disabled = useFormDisabled()
-const hueRef = ref<InstanceType<typeof HueSlider>>()
-const svRef = ref<InstanceType<typeof SvPanel>>()
-const alphaRef = ref<InstanceType<typeof AlphaSlider>>()
-const inputRef = ref<InputInstance>()
+const hueRef = useTemplateRef<InstanceType<typeof HueSlider>>('hueRef')
+const svRef = useTemplateRef<InstanceType<typeof SvPanel>>('svRef')
+const alphaRef = useTemplateRef<InstanceType<typeof AlphaSlider>>('alphaRef')
+const inputRef = useTemplateRef<InputInstance>('inputRef')
 const customInput = ref('')
 
 const { color } = inject(

--- a/packages/components/color-picker-panel/src/color-picker-panel.vue
+++ b/packages/components/color-picker-panel/src/color-picker-panel.vue
@@ -70,7 +70,6 @@ import {
 import { useCommonColor } from './composables/use-common-color'
 
 import type { ColorPickerPanelProps } from './color-picker-panel'
-import type { InputInstance } from '@element-plus/components/input'
 
 defineOptions({
   name: 'ElColorPickerPanel',
@@ -86,10 +85,10 @@ const emit = defineEmits(colorPickerPanelEmits)
 const ns = useNamespace('color-picker-panel')
 const { formItem } = useFormItem()
 const disabled = useFormDisabled()
-const hueRef = useTemplateRef<InstanceType<typeof HueSlider>>('hueRef')
-const svRef = useTemplateRef<InstanceType<typeof SvPanel>>('svRef')
-const alphaRef = useTemplateRef<InstanceType<typeof AlphaSlider>>('alphaRef')
-const inputRef = useTemplateRef<InputInstance>('inputRef')
+const hueRef = useTemplateRef('hueRef')
+const svRef = useTemplateRef('svRef')
+const alphaRef = useTemplateRef('alphaRef')
+const inputRef = useTemplateRef('inputRef')
 const customInput = ref('')
 
 const { color } = inject(

--- a/packages/components/color-picker-panel/src/components/sv-panel.vue
+++ b/packages/components/color-picker-panel/src/components/sv-panel.vue
@@ -30,7 +30,7 @@ defineOptions({
 
 const props = defineProps<SvPanelProps>()
 
-const cursorRef = useTemplateRef<HTMLElement>('cursorRef')
+const cursorRef = useTemplateRef('cursorRef')
 
 const {
   cursorTop,

--- a/packages/components/color-picker-panel/src/components/sv-panel.vue
+++ b/packages/components/color-picker-panel/src/components/sv-panel.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { useLocale } from '@element-plus/hooks/use-locale'
 import { useSvPanel, useSvPanelDOM } from '../composables/use-sv-panel'
 
@@ -30,8 +30,9 @@ defineOptions({
 
 const props = defineProps<SvPanelProps>()
 
+const cursorRef = useTemplateRef<HTMLElement>('cursorRef')
+
 const {
-  cursorRef,
   cursorTop,
   cursorLeft,
   background,
@@ -40,7 +41,7 @@ const {
   handleClick,
   handleDrag,
   handleKeydown,
-} = useSvPanel(props)
+} = useSvPanel(props, cursorRef)
 
 const { rootKls, cursorKls, rootStyle, cursorStyle, update } = useSvPanelDOM(
   props,

--- a/packages/components/color-picker-panel/src/composables/use-sv-panel.ts
+++ b/packages/components/color-picker-panel/src/composables/use-sv-panel.ts
@@ -4,12 +4,12 @@ import { useNamespace } from '@element-plus/hooks'
 import { addUnit, getClientXY, getEventCode } from '@element-plus/utils'
 import { draggable } from '../utils/draggable'
 
-import type { Ref } from 'vue'
+import type { TemplateRef } from 'vue'
 import type { SvPanelProps } from '../props/sv-panel'
 
 export const useSvPanel = (
   props: SvPanelProps,
-  cursorRef: Readonly<Ref<HTMLElement | null>>
+  cursorRef: TemplateRef<HTMLElement>
 ) => {
   const instance = getCurrentInstance()!
   const cursorTop = ref(0)

--- a/packages/components/color-picker-panel/src/composables/use-sv-panel.ts
+++ b/packages/components/color-picker-panel/src/composables/use-sv-panel.ts
@@ -4,12 +4,14 @@ import { useNamespace } from '@element-plus/hooks'
 import { addUnit, getClientXY, getEventCode } from '@element-plus/utils'
 import { draggable } from '../utils/draggable'
 
+import type { Ref } from 'vue'
 import type { SvPanelProps } from '../props/sv-panel'
 
-export const useSvPanel = (props: SvPanelProps) => {
+export const useSvPanel = (
+  props: SvPanelProps,
+  cursorRef: Readonly<Ref<HTMLElement | null>>
+) => {
   const instance = getCurrentInstance()!
-
-  const cursorRef = ref<HTMLElement>()
   const cursorTop = ref(0)
   const cursorLeft = ref(0)
   const background = ref('hsl(0, 100%, 50%)')

--- a/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
+++ b/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
@@ -5,7 +5,7 @@ import { useLocale, useNamespace } from '@element-plus/hooks'
 import { castArray, isArray } from '@element-plus/utils'
 import { buildPickerTable } from '../utils'
 
-import type { Ref, SetupContext } from 'vue'
+import type { SetupContext, TemplateRef } from 'vue'
 import type { Dayjs } from 'dayjs'
 import type { DateCell } from '../types'
 import type {
@@ -20,7 +20,7 @@ const isNormalDay = (type = '') => {
 export const useBasicDateTable = (
   props: BasicDateTableProps,
   emit: SetupContext<BasicDateTableEmits>['emit'],
-  tbodyRef: Readonly<Ref<HTMLElement | null | undefined>>
+  tbodyRef: TemplateRef<HTMLElement>
 ) => {
   const { lang } = useLocale()
   const currentCellRef = ref<HTMLElement>()

--- a/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
+++ b/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
@@ -5,7 +5,7 @@ import { useLocale, useNamespace } from '@element-plus/hooks'
 import { castArray, isArray } from '@element-plus/utils'
 import { buildPickerTable } from '../utils'
 
-import type { SetupContext } from 'vue'
+import type { Ref, SetupContext } from 'vue'
 import type { Dayjs } from 'dayjs'
 import type { DateCell } from '../types'
 import type {
@@ -19,10 +19,10 @@ const isNormalDay = (type = '') => {
 
 export const useBasicDateTable = (
   props: BasicDateTableProps,
-  emit: SetupContext<BasicDateTableEmits>['emit']
+  emit: SetupContext<BasicDateTableEmits>['emit'],
+  tbodyRef: Readonly<Ref<HTMLElement | null | undefined>>
 ) => {
   const { lang } = useLocale()
-  const tbodyRef = ref<HTMLElement>()
   const currentCellRef = ref<HTMLElement>()
   // data
   const lastRow = ref<number>()

--- a/packages/components/date-picker-panel/src/composables/use-panel-date-range.ts
+++ b/packages/components/date-picker-panel/src/composables/use-panel-date-range.ts
@@ -19,12 +19,12 @@ export const usePanelDateRange = (
   props: PanelDateRangeProps,
   emit: Emits,
   leftDate: Ref<Dayjs>,
-  rightDate: Ref<Dayjs>
+  rightDate: Ref<Dayjs>,
+  leftCurrentViewRef: Ref<CurrentViewRef | null>,
+  rightCurrentViewRef: Ref<CurrentViewRef | null>
 ) => {
   const leftCurrentView = ref<CurrentView>('date')
-  const leftCurrentViewRef = ref<CurrentViewRef>()
   const rightCurrentView = ref<CurrentView>('date')
-  const rightCurrentViewRef = ref<CurrentViewRef>()
   const pickerBase = inject(PICKER_BASE_INJECTION_KEY) as any
   const { disabledDate } = pickerBase.props
   const { t, lang } = useLocale()
@@ -59,7 +59,7 @@ export const usePanelDateRange = (
     return `${yearValue.value} ${yearTranslation}`
   }
 
-  function focusPicker(currentViewRef?: CurrentViewRef) {
+  function focusPicker(currentViewRef?: CurrentViewRef | null) {
     currentViewRef?.focus()
   }
 

--- a/packages/components/date-picker-panel/src/date-picker-com/basic-date-table.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/basic-date-table.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onBeforeUnmount } from 'vue'
+import { onBeforeUnmount, useTemplateRef } from 'vue'
 import {
   basicDateTableEmits,
   basicDateTableProps,
@@ -65,10 +65,11 @@ import ElDatePickerCell from './basic-cell-render'
 const props = defineProps(basicDateTableProps)
 const emit = defineEmits(basicDateTableEmits)
 
+const tbodyRef = useTemplateRef<HTMLElement>('tbodyRef')
+
 const {
   WEEKS,
   rows,
-  tbodyRef,
   currentCellRef,
 
   focus,
@@ -81,7 +82,7 @@ const {
   handleMouseDown,
   handleMouseMove,
   handleFocus,
-} = useBasicDateTable(props, emit)
+} = useBasicDateTable(props, emit, tbodyRef)
 const { tableLabel, tableKls, getCellClasses, getRowKls, weekHeaderClass, t } =
   useBasicDateTableDOM(props, {
     isCurrent,

--- a/packages/components/date-picker-panel/src/date-picker-com/basic-date-table.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/basic-date-table.vue
@@ -65,7 +65,7 @@ import ElDatePickerCell from './basic-cell-render'
 const props = defineProps(basicDateTableProps)
 const emit = defineEmits(basicDateTableEmits)
 
-const tbodyRef = useTemplateRef<HTMLElement>('tbodyRef')
+const tbodyRef = useTemplateRef('tbodyRef')
 
 const {
   WEEKS,

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
@@ -405,7 +405,16 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, nextTick, ref, toRef, unref, watch } from 'vue'
+import {
+  computed,
+  inject,
+  nextTick,
+  ref,
+  toRef,
+  unref,
+  useTemplateRef,
+  watch,
+} from 'vue'
 import dayjs from 'dayjs'
 import { ClickOutside as vClickoutside } from '@element-plus/directives'
 import { useLocale } from '@element-plus/hooks'
@@ -470,6 +479,13 @@ const format: Ref<string | undefined> = toRef(pickerBase.props, 'format')
 const shortcuts = toRef(pickerBase.props, 'shortcuts')
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 const { lang } = useLocale()
+const leftCurrentViewRef = useTemplateRef<{ focus: () => void }>(
+  'leftCurrentViewRef'
+)
+const rightCurrentViewRef = useTemplateRef<{ focus: () => void }>(
+  'rightCurrentViewRef'
+)
+
 const leftDate = ref<Dayjs>(dayjs().locale(lang.value))
 const rightDate = ref<Dayjs>(dayjs().locale(lang.value).add(1, unit))
 
@@ -517,8 +533,6 @@ const timeUserInput = ref<UserInput>({
 const {
   leftCurrentView,
   rightCurrentView,
-  leftCurrentViewRef,
-  rightCurrentViewRef,
   leftYear,
   rightYear,
   leftMonth,
@@ -533,7 +547,14 @@ const {
   handleRightMonthPick,
   handlePanelChange,
   adjustDateByView,
-} = usePanelDateRange(props, emit, leftDate, rightDate)
+} = usePanelDateRange(
+  props,
+  emit,
+  leftDate,
+  rightDate,
+  leftCurrentViewRef,
+  rightCurrentViewRef
+)
 
 const hasShortcuts = computed(() => !!shortcuts.value.length)
 

--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-range.vue
@@ -479,12 +479,8 @@ const format: Ref<string | undefined> = toRef(pickerBase.props, 'format')
 const shortcuts = toRef(pickerBase.props, 'shortcuts')
 const defaultValue = toRef(pickerBase.props, 'defaultValue')
 const { lang } = useLocale()
-const leftCurrentViewRef = useTemplateRef<{ focus: () => void }>(
-  'leftCurrentViewRef'
-)
-const rightCurrentViewRef = useTemplateRef<{ focus: () => void }>(
-  'rightCurrentViewRef'
-)
+const leftCurrentViewRef = useTemplateRef('leftCurrentViewRef')
+const rightCurrentViewRef = useTemplateRef('rightCurrentViewRef')
 
 const leftDate = ref<Dayjs>(dayjs().locale(lang.value))
 const rightDate = ref<Dayjs>(dayjs().locale(lang.value).add(1, unit))

--- a/packages/components/dialog/src/use-dialog.ts
+++ b/packages/components/dialog/src/use-dialog.ts
@@ -101,12 +101,7 @@ export const useDialog = (
       props.transition ??
       globalConfig.value?.transition ??
       DEFAULT_DIALOG_TRANSITION
-    const baseConfig = {
-      name: transition,
-      onAfterEnter: afterEnter,
-      onBeforeLeave: beforeLeave,
-      onAfterLeave: afterLeave,
-    }
+
     if (isObject(transition)) {
       const config = { ...transition } as TransitionProps
       const _mergeHook = (
@@ -137,7 +132,12 @@ export const useDialog = (
       return config
     }
 
-    return baseConfig
+    return {
+      name: transition,
+      onAfterEnter: afterEnter,
+      onBeforeLeave: beforeLeave,
+      onAfterLeave: afterLeave,
+    }
   })
 
   function afterEnter() {

--- a/packages/components/input-tag/src/composables/use-drag-tag.ts
+++ b/packages/components/input-tag/src/composables/use-drag-tag.ts
@@ -2,13 +2,13 @@ import { ref } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { getStyle, isUndefined, setStyle } from '@element-plus/utils'
 
-import type { Ref, ShallowRef } from 'vue'
+import type { TemplateRef } from 'vue'
 
 type DropType = 'before' | 'after'
 
 interface UseDragTagOptions {
-  wrapperRef: Readonly<ShallowRef<HTMLElement | null>>
-  dropIndicatorRef: Readonly<Ref<HTMLElement | null>>
+  wrapperRef: TemplateRef<HTMLElement>
+  dropIndicatorRef: TemplateRef<HTMLElement>
   handleDragged: (
     draggingIndex: number,
     dropIndex: number,

--- a/packages/components/input-tag/src/composables/use-drag-tag.ts
+++ b/packages/components/input-tag/src/composables/use-drag-tag.ts
@@ -1,13 +1,14 @@
-import { ref, shallowRef } from 'vue'
+import { ref } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { getStyle, isUndefined, setStyle } from '@element-plus/utils'
 
-import type { ShallowRef } from 'vue'
+import type { Ref, ShallowRef } from 'vue'
 
 type DropType = 'before' | 'after'
 
 interface UseDragTagOptions {
-  wrapperRef: ShallowRef<HTMLElement | undefined>
+  wrapperRef: Readonly<ShallowRef<HTMLElement | null>>
+  dropIndicatorRef: Readonly<Ref<HTMLElement | null>>
   handleDragged: (
     draggingIndex: number,
     dropIndex: number,
@@ -18,11 +19,11 @@ interface UseDragTagOptions {
 
 export function useDragTag({
   wrapperRef,
+  dropIndicatorRef,
   handleDragged,
   afterDragged,
 }: UseDragTagOptions) {
   const ns = useNamespace('input-tag')
-  const dropIndicatorRef = shallowRef<HTMLElement>()
   const showDropIndicator = ref(false)
 
   let draggingIndex: number | undefined

--- a/packages/components/input-tag/src/composables/use-input-tag-dom.ts
+++ b/packages/components/input-tag/src/composables/use-input-tag-dom.ts
@@ -3,7 +3,7 @@ import { useNamespace } from '@element-plus/hooks'
 import { MINIMUM_INPUT_WIDTH } from '@element-plus/constants'
 import { useResizeObserver } from '@vueuse/core'
 
-import type { ComputedRef, Ref, StyleValue } from 'vue'
+import type { ComputedRef, Ref, StyleValue, TemplateRef } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
 import type { IconComponent } from '@element-plus/utils'
 import type { InputTagProps } from '../input-tag'
@@ -18,8 +18,8 @@ interface UseInputTagDomOptions {
   validateState: ComputedRef<string>
   validateIcon: ComputedRef<'' | IconComponent>
   needStatusIcon: ComputedRef<boolean>
-  collapseItemRef: Readonly<Ref<HTMLElement | null>>
-  innerRef: Readonly<Ref<HTMLElement | null>>
+  collapseItemRef: TemplateRef<HTMLElement>
+  innerRef: TemplateRef<HTMLElement>
 }
 
 export function useInputTagDom({

--- a/packages/components/input-tag/src/composables/use-input-tag-dom.ts
+++ b/packages/components/input-tag/src/composables/use-input-tag-dom.ts
@@ -1,4 +1,4 @@
-import { computed, reactive, ref, useAttrs, useSlots } from 'vue'
+import { computed, reactive, useAttrs, useSlots } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { MINIMUM_INPUT_WIDTH } from '@element-plus/constants'
 import { useResizeObserver } from '@vueuse/core'
@@ -18,6 +18,8 @@ interface UseInputTagDomOptions {
   validateState: ComputedRef<string>
   validateIcon: ComputedRef<'' | IconComponent>
   needStatusIcon: ComputedRef<boolean>
+  collapseItemRef: Readonly<Ref<HTMLElement | null>>
+  innerRef: Readonly<Ref<HTMLElement | null>>
 }
 
 export function useInputTagDom({
@@ -30,14 +32,13 @@ export function useInputTagDom({
   validateState,
   validateIcon,
   needStatusIcon,
+  collapseItemRef,
+  innerRef,
 }: UseInputTagDomOptions) {
   const attrs = useAttrs()
   const slots = useSlots()
   const ns = useNamespace('input-tag')
   const nsInput = useNamespace('input')
-
-  const collapseItemRef = ref<HTMLElement>()
-  const innerRef = ref<HTMLElement>()
 
   const containerKls = computed(() => [
     ns.b(),

--- a/packages/components/input-tag/src/composables/use-input-tag.ts
+++ b/packages/components/input-tag/src/composables/use-input-tag.ts
@@ -1,4 +1,4 @@
-import { computed, ref, shallowRef, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import {
   CHANGE_EVENT,
   EVENT_CODE,
@@ -15,6 +15,7 @@ import {
 import { useComposition, useFocusController } from '@element-plus/hooks'
 import { useFormDisabled, useFormSize } from '@element-plus/components/form'
 
+import type { Ref, ShallowRef } from 'vue'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
 import type { EmitFn } from '@element-plus/utils'
 import type { FormItemContext } from '@element-plus/components/form'
@@ -24,15 +25,23 @@ interface UseInputTagOptions {
   props: InputTagProps
   emit: EmitFn<InputTagEmits>
   formItem?: FormItemContext
+  inputRef: Readonly<ShallowRef<HTMLInputElement | null>>
+  wrapperRef: Readonly<ShallowRef<HTMLElement | null>>
+  tagTooltipRef: Readonly<Ref<TooltipInstance | null>>
 }
 
-export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
+export function useInputTag({
+  props,
+  emit,
+  formItem,
+  inputRef,
+  wrapperRef: externalWrapperRef,
+  tagTooltipRef,
+}: UseInputTagOptions) {
   const disabled = useFormDisabled()
   const size = useFormSize()
 
-  const inputRef = shallowRef<HTMLInputElement>()
   const inputValue = ref<string>()
-  const tagTooltipRef = ref<TooltipInstance>()
 
   const tagSize = computed(() => {
     return ['small'].includes(size.value) ? 'small' : 'default'
@@ -205,8 +214,9 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
     inputRef.value?.blur()
   }
 
-  const { wrapperRef, isFocused } = useFocusController(inputRef, {
+  const { isFocused } = useFocusController(inputRef, {
     disabled,
+    wrapperRef: externalWrapperRef,
     beforeBlur(event) {
       return tagTooltipRef.value?.isFocusInsideContent(event)
     },
@@ -240,9 +250,6 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
   )
 
   return {
-    inputRef,
-    wrapperRef,
-    tagTooltipRef,
     isFocused,
     isComposing,
     inputValue,

--- a/packages/components/input-tag/src/composables/use-input-tag.ts
+++ b/packages/components/input-tag/src/composables/use-input-tag.ts
@@ -15,7 +15,7 @@ import {
 import { useComposition, useFocusController } from '@element-plus/hooks'
 import { useFormDisabled, useFormSize } from '@element-plus/components/form'
 
-import type { Ref, ShallowRef } from 'vue'
+import type { TemplateRef } from 'vue'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
 import type { EmitFn } from '@element-plus/utils'
 import type { FormItemContext } from '@element-plus/components/form'
@@ -25,9 +25,9 @@ interface UseInputTagOptions {
   props: InputTagProps
   emit: EmitFn<InputTagEmits>
   formItem?: FormItemContext
-  inputRef: Readonly<ShallowRef<HTMLInputElement | null>>
-  wrapperRef: Readonly<ShallowRef<HTMLElement | null>>
-  tagTooltipRef: Readonly<Ref<TooltipInstance | null>>
+  inputRef: TemplateRef<HTMLInputElement>
+  wrapperRef: TemplateRef<HTMLElement>
+  tagTooltipRef: TemplateRef<TooltipInstance>
 }
 
 export function useInputTag({

--- a/packages/components/input-tag/src/input-tag.vue
+++ b/packages/components/input-tag/src/input-tag.vue
@@ -185,14 +185,13 @@ const validateIcon = computed(() => {
   return validateState.value && ValidateComponentsMap[validateState.value]
 })
 
-const inputRef = useTemplateRef<HTMLInputElement>('inputRef')
-const wrapperRef = useTemplateRef<HTMLElement>('wrapperRef')
-const tagTooltipRef =
-  useTemplateRef<InstanceType<typeof ElTooltip>>('tagTooltipRef')
-const calculatorRef = useTemplateRef<HTMLElement>('calculatorRef')
-const dropIndicatorRef = useTemplateRef<HTMLElement>('dropIndicatorRef')
-const collapseItemRef = useTemplateRef<HTMLElement>('collapseItemRef')
-const innerRef = useTemplateRef<HTMLElement>('innerRef')
+const inputRef = useTemplateRef('inputRef')
+const wrapperRef = useTemplateRef('wrapperRef')
+const tagTooltipRef = useTemplateRef('tagTooltipRef')
+const calculatorRef = useTemplateRef('calculatorRef')
+const dropIndicatorRef = useTemplateRef('dropIndicatorRef')
+const collapseItemRef = useTemplateRef('collapseItemRef')
+const innerRef = useTemplateRef('innerRef')
 
 const {
   isFocused,

--- a/packages/components/input-tag/src/input-tag.vue
+++ b/packages/components/input-tag/src/input-tag.vue
@@ -134,7 +134,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, markRaw, useSlots } from 'vue'
+import { computed, markRaw, useSlots, useTemplateRef } from 'vue'
 import { useAttrs, useCalcInputWidth } from '@element-plus/hooks'
 import { NOOP, ValidateComponentsMap } from '@element-plus/utils'
 import { CircleClose } from '@element-plus/icons-vue'
@@ -185,10 +185,16 @@ const validateIcon = computed(() => {
   return validateState.value && ValidateComponentsMap[validateState.value]
 })
 
+const inputRef = useTemplateRef<HTMLInputElement>('inputRef')
+const wrapperRef = useTemplateRef<HTMLElement>('wrapperRef')
+const tagTooltipRef =
+  useTemplateRef<InstanceType<typeof ElTooltip>>('tagTooltipRef')
+const calculatorRef = useTemplateRef<HTMLElement>('calculatorRef')
+const dropIndicatorRef = useTemplateRef<HTMLElement>('dropIndicatorRef')
+const collapseItemRef = useTemplateRef<HTMLElement>('collapseItemRef')
+const innerRef = useTemplateRef<HTMLElement>('innerRef')
+
 const {
-  inputRef,
-  wrapperRef,
-  tagTooltipRef,
   isFocused,
   inputValue,
   size,
@@ -210,16 +216,16 @@ const {
   handleCompositionEnd,
   focus,
   blur,
-} = useInputTag({ props, emit, formItem })
+} = useInputTag({ props, emit, formItem, inputRef, wrapperRef, tagTooltipRef })
 const { hovering, handleMouseEnter, handleMouseLeave } = useHovering()
-const { calculatorRef, inputStyle } = useCalcInputWidth()
-const {
-  dropIndicatorRef,
-  showDropIndicator,
-  handleDragStart,
-  handleDragOver,
-  handleDragEnd,
-} = useDragTag({ wrapperRef, handleDragged, afterDragged: focus })
+const { inputStyle } = useCalcInputWidth(calculatorRef)
+const { showDropIndicator, handleDragStart, handleDragOver, handleDragEnd } =
+  useDragTag({
+    wrapperRef,
+    dropIndicatorRef,
+    handleDragged,
+    afterDragged: focus,
+  })
 const {
   ns,
   nsInput,
@@ -229,8 +235,6 @@ const {
   showClear,
   showSuffix,
   tagStyle,
-  collapseItemRef,
-  innerRef,
 } = useInputTagDom({
   props,
   hovering,
@@ -241,6 +245,8 @@ const {
   validateState,
   validateIcon,
   needStatusIcon,
+  collapseItemRef,
+  innerRef,
 })
 
 defineExpose({

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -185,6 +185,7 @@ import {
   toRef,
   useAttrs as useRawAttrs,
   useSlots,
+  useTemplateRef,
   watch,
 } from 'vue'
 import { useResizeObserver } from '@vueuse/core'
@@ -269,6 +270,8 @@ const inputDisabled = useFormDisabled()
 const nsInput = useNamespace('input')
 const nsTextarea = useNamespace('textarea')
 
+const wrapperRef = useTemplateRef<HTMLElement>('wrapperRef')
+
 const input = shallowRef<HTMLInputElement>()
 const textarea = shallowRef<HTMLTextAreaElement>()
 
@@ -281,18 +284,15 @@ const saveValue = ref('')
 const _ref = computed(() => input.value || textarea.value)
 
 // wrapperRef for type="text", handleFocus and handleBlur for type="textarea"
-// @ts-ignore - used in template ref binding, TS cannot detect template usage
-const { wrapperRef, isFocused, handleFocus, handleBlur } = useFocusController(
-  _ref,
-  {
-    disabled: inputDisabled,
-    afterBlur() {
-      if (props.validateEvent) {
-        elFormItem?.validate?.('blur').catch((err) => debugWarn(err))
-      }
-    },
-  }
-)
+const { isFocused, handleFocus, handleBlur } = useFocusController(_ref, {
+  disabled: inputDisabled,
+  wrapperRef,
+  afterBlur() {
+    if (props.validateEvent) {
+      elFormItem?.validate?.('blur').catch((err) => debugWarn(err))
+    }
+  },
+})
 
 const needStatusIcon = computed(() => elForm?.statusIcon ?? false)
 const validateState = computed(() => elFormItem?.validateState || '')

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -270,7 +270,7 @@ const inputDisabled = useFormDisabled()
 const nsInput = useNamespace('input')
 const nsTextarea = useNamespace('textarea')
 
-const wrapperRef = useTemplateRef<HTMLElement>('wrapperRef')
+const wrapperRef = useTemplateRef('wrapperRef')
 
 const input = shallowRef<HTMLInputElement>()
 const textarea = shallowRef<HTMLTextAreaElement>()

--- a/packages/components/mention/src/mention-dropdown.vue
+++ b/packages/components/mention/src/mention-dropdown.vue
@@ -63,10 +63,9 @@ const ns = useNamespace('mention')
 const { t } = useLocale()
 const hoveringIndex = ref(-1)
 
-const scrollbarRef =
-  useTemplateRef<InstanceType<typeof ElScrollbar>>('scrollbarRef')
-const optionRefs = useTemplateRef<HTMLElement[]>('optionRefs')
-const dropdownRef = useTemplateRef<HTMLElement>('dropdownRef')
+const scrollbarRef = useTemplateRef('scrollbarRef')
+const optionRefs = useTemplateRef('optionRefs')
+const dropdownRef = useTemplateRef('dropdownRef')
 
 const optionkls = (item: MentionOption, index: number) => [
   ns.be('dropdown', 'item'),

--- a/packages/components/mention/src/mention-dropdown.vue
+++ b/packages/components/mention/src/mention-dropdown.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, ref, watch } from 'vue'
+import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { scrollIntoView } from '@element-plus/utils'
 import ElScrollbar from '@element-plus/components/scrollbar'
@@ -63,9 +63,10 @@ const ns = useNamespace('mention')
 const { t } = useLocale()
 const hoveringIndex = ref(-1)
 
-const scrollbarRef = ref<InstanceType<typeof ElScrollbar>>()
-const optionRefs = ref<HTMLElement[]>()
-const dropdownRef = ref<HTMLElement>()
+const scrollbarRef =
+  useTemplateRef<InstanceType<typeof ElScrollbar>>('scrollbarRef')
+const optionRefs = useTemplateRef<HTMLElement[]>('optionRefs')
+const dropdownRef = useTemplateRef<HTMLElement>('dropdownRef')
 
 const optionkls = (item: MentionOption, index: number) => [
   ns.be('dropdown', 'item'),

--- a/packages/components/mention/src/mention.vue
+++ b/packages/components/mention/src/mention.vue
@@ -117,8 +117,7 @@ const contentId = useId()
 
 const elInputRef = useTemplateRef<InputInstance>('elInputRef')
 const tooltipRef = useTemplateRef<TooltipInstance>('tooltipRef')
-const dropdownRef =
-  useTemplateRef<InstanceType<typeof ElMentionDropdown>>('dropdownRef')
+const dropdownRef = useTemplateRef('dropdownRef')
 
 const visible = ref(false)
 const cursorStyle = ref<CSSProperties>()

--- a/packages/components/mention/src/mention.vue
+++ b/packages/components/mention/src/mention.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script lang="ts" setup generic="T extends MentionOption = MentionOption">
-import { computed, mergeProps, nextTick, ref } from 'vue'
+import { computed, mergeProps, nextTick, ref, useTemplateRef } from 'vue'
 import { pick } from 'lodash-unified'
 import { useFocusController, useId, useNamespace } from '@element-plus/hooks'
 import ElInput, {
@@ -115,9 +115,10 @@ const ns = useNamespace('mention')
 const disabled = useFormDisabled()
 const contentId = useId()
 
-const elInputRef = ref<InputInstance>()
-const tooltipRef = ref<TooltipInstance>()
-const dropdownRef = ref<InstanceType<typeof ElMentionDropdown>>()
+const elInputRef = useTemplateRef<InputInstance>('elInputRef')
+const tooltipRef = useTemplateRef<TooltipInstance>('tooltipRef')
+const dropdownRef =
+  useTemplateRef<InstanceType<typeof ElMentionDropdown>>('dropdownRef')
 
 const visible = ref(false)
 const cursorStyle = ref<CSSProperties>()

--- a/packages/components/radio/src/radio-button.vue
+++ b/packages/components/radio/src/radio-button.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { useRadio } from './use-radio'
 import { radioButtonPropsDefaults } from './radio-button'
@@ -51,8 +51,11 @@ const props = withDefaults(
 )
 
 const ns = useNamespace('radio')
-const { radioRef, focus, size, disabled, modelValue, radioGroup, actualValue } =
-  useRadio(props)
+const radioRef = useTemplateRef<HTMLInputElement>('radioRef')
+const { focus, size, disabled, modelValue, radioGroup, actualValue } = useRadio(
+  props,
+  radioRef
+)
 
 const activeStyle = computed<CSSProperties>(() => {
   return {

--- a/packages/components/radio/src/radio-button.vue
+++ b/packages/components/radio/src/radio-button.vue
@@ -51,7 +51,7 @@ const props = withDefaults(
 )
 
 const ns = useNamespace('radio')
-const radioRef = useTemplateRef<HTMLInputElement>('radioRef')
+const radioRef = useTemplateRef('radioRef')
 const { focus, size, disabled, modelValue, radioGroup, actualValue } = useRadio(
   props,
   radioRef

--- a/packages/components/radio/src/radio.vue
+++ b/packages/components/radio/src/radio.vue
@@ -55,7 +55,7 @@ const props = withDefaults(defineProps<RadioProps>(), radioPropsDefaults)
 const emit = defineEmits(radioEmits)
 
 const ns = useNamespace('radio')
-const radioRef = useTemplateRef<HTMLInputElement>('radioRef')
+const radioRef = useTemplateRef('radioRef')
 const { radioGroup, focus, size, disabled, modelValue, actualValue } = useRadio(
   props,
   radioRef,

--- a/packages/components/radio/src/radio.vue
+++ b/packages/components/radio/src/radio.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script lang="ts" setup>
-import { nextTick } from 'vue'
+import { nextTick, useTemplateRef } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
 import { CHANGE_EVENT } from '@element-plus/constants'
 import { type RadioProps, radioEmits, radioPropsDefaults } from './radio'
@@ -55,8 +55,12 @@ const props = withDefaults(defineProps<RadioProps>(), radioPropsDefaults)
 const emit = defineEmits(radioEmits)
 
 const ns = useNamespace('radio')
-const { radioRef, radioGroup, focus, size, disabled, modelValue, actualValue } =
-  useRadio(props, emit)
+const radioRef = useTemplateRef<HTMLInputElement>('radioRef')
+const { radioGroup, focus, size, disabled, modelValue, actualValue } = useRadio(
+  props,
+  radioRef,
+  emit
+)
 
 function handleChange() {
   nextTick(() => emit(CHANGE_EVENT, modelValue.value))

--- a/packages/components/radio/src/use-radio.ts
+++ b/packages/components/radio/src/use-radio.ts
@@ -5,15 +5,16 @@ import { useDeprecated } from '@element-plus/hooks'
 import { isPropAbsent } from '@element-plus/utils'
 import { radioGroupKey } from './constants'
 
+import type { Ref, SetupContext } from 'vue'
 import type { RadioButtonProps } from './radio-button'
-import type { SetupContext } from 'vue'
 import type { RadioEmits, RadioProps } from './radio'
 
 export const useRadio = (
   props: RadioProps | RadioButtonProps,
+  radioRef?: Readonly<Ref<HTMLInputElement | null | undefined>>,
   emit?: SetupContext<RadioEmits>['emit']
 ) => {
-  const radioRef = ref<HTMLInputElement>()
+  const _radioRef = radioRef ?? ref<HTMLInputElement>()
   const radioGroup = inject(radioGroupKey, undefined)
   const isGroup = computed(() => !!radioGroup)
   const actualValue = computed(() => {
@@ -34,7 +35,7 @@ export const useRadio = (
       } else {
         emit && emit(UPDATE_MODEL_EVENT, val)
       }
-      radioRef.value!.checked = props.modelValue === actualValue.value
+      _radioRef.value!.checked = props.modelValue === actualValue.value
     },
   })
 
@@ -60,7 +61,7 @@ export const useRadio = (
   )
 
   return {
-    radioRef,
+    radioRef: _radioRef,
     isGroup,
     radioGroup,
     focus,

--- a/packages/components/radio/src/use-radio.ts
+++ b/packages/components/radio/src/use-radio.ts
@@ -5,13 +5,13 @@ import { useDeprecated } from '@element-plus/hooks'
 import { isPropAbsent } from '@element-plus/utils'
 import { radioGroupKey } from './constants'
 
-import type { Ref, SetupContext } from 'vue'
+import type { SetupContext, TemplateRef } from 'vue'
 import type { RadioButtonProps } from './radio-button'
 import type { RadioEmits, RadioProps } from './radio'
 
 export const useRadio = (
   props: RadioProps | RadioButtonProps,
-  radioRef?: Readonly<Ref<HTMLInputElement | null | undefined>>,
+  radioRef?: TemplateRef<HTMLInputElement>,
   emit?: SetupContext<RadioEmits>['emit']
 ) => {
   const _radioRef = radioRef ?? ref<HTMLInputElement>()

--- a/packages/components/slider/src/button.ts
+++ b/packages/components/slider/src/button.ts
@@ -37,7 +37,7 @@ export type SliderButtonInstance = ComponentPublicInstance<typeof Button>
 
 export type ButtonRefs = Record<
   'firstButton' | 'secondButton',
-  Ref<SliderButtonInstance | null>
+  Readonly<Ref<SliderButtonInstance | null>>
 >
 
 export interface SliderButtonInitData {

--- a/packages/components/slider/src/button.ts
+++ b/packages/components/slider/src/button.ts
@@ -6,7 +6,7 @@ import type {
   ComponentPublicInstance,
   ExtractPropTypes,
   ExtractPublicPropTypes,
-  Ref,
+  TemplateRef,
 } from 'vue'
 import type Button from './button.vue'
 
@@ -37,7 +37,7 @@ export type SliderButtonInstance = ComponentPublicInstance<typeof Button>
 
 export type ButtonRefs = Record<
   'firstButton' | 'secondButton',
-  Readonly<Ref<SliderButtonInstance | null>>
+  TemplateRef<SliderButtonInstance>
 >
 
 export interface SliderButtonInitData {

--- a/packages/components/slider/src/button.ts
+++ b/packages/components/slider/src/button.ts
@@ -37,7 +37,7 @@ export type SliderButtonInstance = ComponentPublicInstance<typeof Button>
 
 export type ButtonRefs = Record<
   'firstButton' | 'secondButton',
-  Ref<SliderButtonInstance | undefined>
+  Ref<SliderButtonInstance | null>
 >
 
 export interface SliderButtonInitData {

--- a/packages/components/slider/src/button.vue
+++ b/packages/components/slider/src/button.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    ref="button"
+    ref="buttonRef"
     :class="[ns.e('button-wrapper'), { hover: hovering, dragging }]"
     :style="wrapperStyle"
     :tabindex="disabled ? undefined : 0"
@@ -12,7 +12,7 @@
     @keydown="onKeyDown"
   >
     <el-tooltip
-      ref="tooltip"
+      ref="tooltipRef"
       :visible="tooltipVisible"
       :placement="placement"
       :fallback-placements="['top', 'bottom', 'right', 'left']"
@@ -30,7 +30,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, reactive, toRefs } from 'vue'
+import { computed, reactive, toRefs, useTemplateRef } from 'vue'
 import { ElTooltip } from '@element-plus/components/tooltip'
 import { useNamespace } from '@element-plus/hooks'
 import { useSliderButton } from './composables'
@@ -46,6 +46,9 @@ const props = defineProps(sliderButtonProps)
 const emit = defineEmits(sliderButtonEmits)
 
 const ns = useNamespace('slider')
+
+const buttonRef = useTemplateRef<HTMLDivElement>('buttonRef')
+const tooltipRef = useTemplateRef<InstanceType<typeof ElTooltip>>('tooltipRef')
 
 const initData = reactive<SliderButtonInitData>({
   hovering: false,
@@ -66,8 +69,6 @@ const tooltipPersistent = computed(() =>
 
 const {
   disabled,
-  button,
-  tooltip,
   showTooltip,
   persistent,
   tooltipVisible,
@@ -78,7 +79,7 @@ const {
   onButtonDown,
   onKeyDown,
   setPosition,
-} = useSliderButton(props, initData, emit)
+} = useSliderButton(props, initData, emit, buttonRef, tooltipRef)
 
 const { hovering, dragging } = toRefs(initData)
 

--- a/packages/components/slider/src/button.vue
+++ b/packages/components/slider/src/button.vue
@@ -47,8 +47,8 @@ const emit = defineEmits(sliderButtonEmits)
 
 const ns = useNamespace('slider')
 
-const buttonRef = useTemplateRef<HTMLDivElement>('buttonRef')
-const tooltipRef = useTemplateRef<InstanceType<typeof ElTooltip>>('tooltipRef')
+const buttonRef = useTemplateRef('buttonRef')
+const tooltipRef = useTemplateRef('tooltipRef')
 
 const initData = reactive<SliderButtonInitData>({
   hovering: false,

--- a/packages/components/slider/src/composables/use-slide.ts
+++ b/packages/components/slider/src/composables/use-slide.ts
@@ -70,7 +70,7 @@ export const useSlide = (
 
   const resetSize = () => {
     if (slider.value) {
-      const rect = slider.value!.getBoundingClientRect()
+      const rect = slider.value.getBoundingClientRect()
       initData.sliderSize = rect[props.vertical ? 'height' : 'width']
     }
   }

--- a/packages/components/slider/src/composables/use-slide.ts
+++ b/packages/components/slider/src/composables/use-slide.ts
@@ -6,7 +6,7 @@ import {
 } from '@element-plus/constants'
 import { useFormDisabled, useFormItem } from '@element-plus/components/form'
 
-import type { CSSProperties, Ref, SetupContext, ShallowRef } from 'vue'
+import type { CSSProperties, SetupContext, TemplateRef } from 'vue'
 import type { Arrayable } from '@element-plus/utils'
 import type { SliderEmits, SliderInitData, SliderProps } from '../slider'
 import type { ButtonRefs, SliderButtonInstance } from '../button'
@@ -15,9 +15,9 @@ export const useSlide = (
   props: SliderProps,
   initData: SliderInitData,
   emit: SetupContext<SliderEmits>['emit'],
-  slider: Readonly<ShallowRef<HTMLElement | null>>,
-  firstButton: Readonly<Ref<SliderButtonInstance | null>>,
-  secondButton: Readonly<Ref<SliderButtonInstance | null>>
+  slider: TemplateRef<HTMLElement>,
+  firstButton: TemplateRef<SliderButtonInstance>,
+  secondButton: TemplateRef<SliderButtonInstance>
 ) => {
   const { formItem: elFormItem } = useFormItem()
 
@@ -77,7 +77,7 @@ export const useSlide = (
 
   const getButtonRefByPercent = (
     percent: number
-  ): Readonly<Ref<SliderButtonInstance | null>> => {
+  ): TemplateRef<SliderButtonInstance> => {
     const targetValue = props.min + (percent * (props.max - props.min)) / 100
     if (!props.range) {
       return firstButton
@@ -100,9 +100,7 @@ export const useSlide = (
     return buttonRefs[buttonRefName]
   }
 
-  const setPosition = (
-    percent: number
-  ): Readonly<Ref<SliderButtonInstance | null>> => {
+  const setPosition = (percent: number): TemplateRef<SliderButtonInstance> => {
     const buttonRef = getButtonRefByPercent(percent)
     buttonRef.value!.setPosition(percent)
     return buttonRef
@@ -138,7 +136,7 @@ export const useSlide = (
 
   const handleSliderPointerEvent = (
     event: MouseEvent | TouchEvent
-  ): Readonly<Ref<SliderButtonInstance | null>> | undefined => {
+  ): TemplateRef<SliderButtonInstance> | undefined => {
     if (sliderDisabled.value || initData.dragging) return
     resetSize()
     let newPercent = 0

--- a/packages/components/slider/src/composables/use-slide.ts
+++ b/packages/components/slider/src/composables/use-slide.ts
@@ -16,8 +16,8 @@ export const useSlide = (
   initData: SliderInitData,
   emit: SetupContext<SliderEmits>['emit'],
   slider: Readonly<ShallowRef<HTMLElement | null>>,
-  firstButton: Ref<SliderButtonInstance | null>,
-  secondButton: Ref<SliderButtonInstance | null>
+  firstButton: Readonly<Ref<SliderButtonInstance | null>>,
+  secondButton: Readonly<Ref<SliderButtonInstance | null>>
 ) => {
   const { formItem: elFormItem } = useFormItem()
 
@@ -77,7 +77,7 @@ export const useSlide = (
 
   const getButtonRefByPercent = (
     percent: number
-  ): Ref<SliderButtonInstance | null> => {
+  ): Readonly<Ref<SliderButtonInstance | null>> => {
     const targetValue = props.min + (percent * (props.max - props.min)) / 100
     if (!props.range) {
       return firstButton
@@ -100,7 +100,9 @@ export const useSlide = (
     return buttonRefs[buttonRefName]
   }
 
-  const setPosition = (percent: number): Ref<SliderButtonInstance | null> => {
+  const setPosition = (
+    percent: number
+  ): Readonly<Ref<SliderButtonInstance | null>> => {
     const buttonRef = getButtonRefByPercent(percent)
     buttonRef.value!.setPosition(percent)
     return buttonRef
@@ -136,7 +138,7 @@ export const useSlide = (
 
   const handleSliderPointerEvent = (
     event: MouseEvent | TouchEvent
-  ): Ref<SliderButtonInstance | null> | undefined => {
+  ): Readonly<Ref<SliderButtonInstance | null>> | undefined => {
     if (sliderDisabled.value || initData.dragging) return
     resetSize()
     let newPercent = 0

--- a/packages/components/slider/src/composables/use-slide.ts
+++ b/packages/components/slider/src/composables/use-slide.ts
@@ -1,4 +1,4 @@
-import { computed, nextTick, ref, shallowRef } from 'vue'
+import { computed, nextTick } from 'vue'
 import {
   CHANGE_EVENT,
   INPUT_EVENT,
@@ -6,7 +6,7 @@ import {
 } from '@element-plus/constants'
 import { useFormDisabled, useFormItem } from '@element-plus/components/form'
 
-import type { CSSProperties, Ref, SetupContext } from 'vue'
+import type { CSSProperties, Ref, SetupContext, ShallowRef } from 'vue'
 import type { Arrayable } from '@element-plus/utils'
 import type { SliderEmits, SliderInitData, SliderProps } from '../slider'
 import type { ButtonRefs, SliderButtonInstance } from '../button'
@@ -14,15 +14,12 @@ import type { ButtonRefs, SliderButtonInstance } from '../button'
 export const useSlide = (
   props: SliderProps,
   initData: SliderInitData,
-  emit: SetupContext<SliderEmits>['emit']
+  emit: SetupContext<SliderEmits>['emit'],
+  slider: Readonly<ShallowRef<HTMLElement | null>>,
+  firstButton: Ref<SliderButtonInstance | null>,
+  secondButton: Ref<SliderButtonInstance | null>
 ) => {
   const { formItem: elFormItem } = useFormItem()
-
-  const slider = shallowRef<HTMLElement>()
-
-  const firstButton = ref<SliderButtonInstance>()
-
-  const secondButton = ref<SliderButtonInstance>()
 
   const buttonRefs: ButtonRefs = {
     firstButton,
@@ -73,14 +70,14 @@ export const useSlide = (
 
   const resetSize = () => {
     if (slider.value) {
-      const rect = slider.value.getBoundingClientRect()
+      const rect = slider.value!.getBoundingClientRect()
       initData.sliderSize = rect[props.vertical ? 'height' : 'width']
     }
   }
 
   const getButtonRefByPercent = (
     percent: number
-  ): Ref<SliderButtonInstance | undefined> => {
+  ): Ref<SliderButtonInstance | null> => {
     const targetValue = props.min + (percent * (props.max - props.min)) / 100
     if (!props.range) {
       return firstButton
@@ -103,9 +100,7 @@ export const useSlide = (
     return buttonRefs[buttonRefName]
   }
 
-  const setPosition = (
-    percent: number
-  ): Ref<SliderButtonInstance | undefined> => {
+  const setPosition = (percent: number): Ref<SliderButtonInstance | null> => {
     const buttonRef = getButtonRefByPercent(percent)
     buttonRef.value!.setPosition(percent)
     return buttonRef
@@ -141,7 +136,7 @@ export const useSlide = (
 
   const handleSliderPointerEvent = (
     event: MouseEvent | TouchEvent
-  ): Ref<SliderButtonInstance | undefined> | undefined => {
+  ): Ref<SliderButtonInstance | null> | undefined => {
     if (sliderDisabled.value || initData.dragging) return
     resetSize()
     let newPercent = 0

--- a/packages/components/slider/src/composables/use-slider-button.ts
+++ b/packages/components/slider/src/composables/use-slider-button.ts
@@ -17,10 +17,9 @@ import type { TooltipInstance } from '@element-plus/components/tooltip'
 const useTooltip = (
   props: SliderButtonProps,
   formatTooltip: Ref<SliderProps['formatTooltip']>,
-  showTooltip: Ref<SliderProps['showTooltip']>
+  showTooltip: Ref<SliderProps['showTooltip']>,
+  tooltip: Ref<TooltipInstance | null>
 ) => {
-  const tooltip = ref<TooltipInstance>()
-
   const tooltipVisible = ref(false)
 
   const enableFormat = computed(() => {
@@ -54,7 +53,9 @@ const useTooltip = (
 export const useSliderButton = (
   props: SliderButtonProps,
   initData: SliderButtonInitData,
-  emit: SetupContext<SliderButtonEmits>['emit']
+  emit: SetupContext<SliderButtonEmits>['emit'],
+  buttonRef: Ref<HTMLDivElement | null>,
+  tooltipRef: Ref<TooltipInstance | null>
 ) => {
   const {
     disabled,
@@ -72,10 +73,8 @@ export const useSliderButton = (
     markList,
   } = inject(sliderContextKey)!
 
-  const { tooltip, tooltipVisible, formatValue, displayTooltip, hideTooltip } =
-    useTooltip(props, formatTooltip!, showTooltip)
-
-  const button = ref<HTMLDivElement>()
+  const { tooltipVisible, formatValue, displayTooltip, hideTooltip } =
+    useTooltip(props, formatTooltip!, showTooltip, tooltipRef)
 
   const currentPosition = computed(() => {
     return `${
@@ -114,7 +113,7 @@ export const useSliderButton = (
     window.addEventListener('mouseup', onDragEnd)
     window.addEventListener('touchend', onDragEnd)
     window.addEventListener('contextmenu', onDragEnd)
-    button.value!.focus()
+    buttonRef.value!.focus()
   }
 
   const incrementPosition = (amount: number) => {
@@ -361,7 +360,7 @@ export const useSliderButton = (
 
     await nextTick()
     initData.dragging && displayTooltip()
-    tooltip.value!.updatePopper()
+    tooltipRef.value!.updatePopper()
   }
 
   watch(
@@ -371,12 +370,10 @@ export const useSliderButton = (
     }
   )
 
-  useEventListener(button, 'touchstart', onButtonDown, { passive: false })
+  useEventListener(buttonRef, 'touchstart', onButtonDown, { passive: false })
 
   return {
     disabled,
-    button,
-    tooltip,
     tooltipVisible,
     showTooltip,
     persistent,

--- a/packages/components/slider/src/composables/use-slider-button.ts
+++ b/packages/components/slider/src/composables/use-slider-button.ts
@@ -5,7 +5,13 @@ import { EVENT_CODE, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { getEventCode, isNumber } from '@element-plus/utils'
 import { sliderContextKey } from '../constants'
 
-import type { CSSProperties, ComputedRef, Ref, SetupContext } from 'vue'
+import type {
+  CSSProperties,
+  ComputedRef,
+  Ref,
+  SetupContext,
+  TemplateRef,
+} from 'vue'
 import type { SliderProps } from '../slider'
 import type {
   SliderButtonEmits,
@@ -18,7 +24,7 @@ const useTooltip = (
   props: SliderButtonProps,
   formatTooltip: Ref<SliderProps['formatTooltip']>,
   showTooltip: Ref<SliderProps['showTooltip']>,
-  tooltip: Readonly<Ref<TooltipInstance | null>>
+  tooltip: TemplateRef<TooltipInstance>
 ) => {
   const tooltipVisible = ref(false)
 
@@ -54,8 +60,8 @@ export const useSliderButton = (
   props: SliderButtonProps,
   initData: SliderButtonInitData,
   emit: SetupContext<SliderButtonEmits>['emit'],
-  buttonRef: Readonly<Ref<HTMLDivElement | null>>,
-  tooltipRef: Readonly<Ref<TooltipInstance | null>>
+  buttonRef: TemplateRef<HTMLDivElement>,
+  tooltipRef: TemplateRef<TooltipInstance>
 ) => {
   const {
     disabled,

--- a/packages/components/slider/src/composables/use-slider-button.ts
+++ b/packages/components/slider/src/composables/use-slider-button.ts
@@ -18,7 +18,7 @@ const useTooltip = (
   props: SliderButtonProps,
   formatTooltip: Ref<SliderProps['formatTooltip']>,
   showTooltip: Ref<SliderProps['showTooltip']>,
-  tooltip: Ref<TooltipInstance | null>
+  tooltip: Readonly<Ref<TooltipInstance | null>>
 ) => {
   const tooltipVisible = ref(false)
 
@@ -54,8 +54,8 @@ export const useSliderButton = (
   props: SliderButtonProps,
   initData: SliderButtonInitData,
   emit: SetupContext<SliderButtonEmits>['emit'],
-  buttonRef: Ref<HTMLDivElement | null>,
-  tooltipRef: Ref<TooltipInstance | null>
+  buttonRef: Readonly<Ref<HTMLDivElement | null>>,
+  tooltipRef: Readonly<Ref<TooltipInstance | null>>
 ) => {
   const {
     disabled,

--- a/packages/components/slider/src/composables/use-slider-button.ts
+++ b/packages/components/slider/src/composables/use-slider-button.ts
@@ -360,7 +360,7 @@ export const useSliderButton = (
 
     await nextTick()
     initData.dragging && displayTooltip()
-    tooltipRef.value!.updatePopper()
+    tooltipRef.value?.updatePopper()
   }
 
   watch(

--- a/packages/components/slider/src/slider.vue
+++ b/packages/components/slider/src/slider.vue
@@ -138,7 +138,7 @@ const emit = defineEmits(sliderEmits)
 const ns = useNamespace('slider')
 const { t } = useLocale()
 
-const slider = useTemplateRef<HTMLElement>('slider')
+const slider = useTemplateRef('slider')
 const firstButton = useTemplateRef<SliderButtonInstance>('firstButton')
 const secondButton = useTemplateRef<SliderButtonInstance>('secondButton')
 

--- a/packages/components/slider/src/slider.vue
+++ b/packages/components/slider/src/slider.vue
@@ -107,7 +107,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, provide, reactive, toRefs } from 'vue'
+import { computed, provide, reactive, toRefs, useTemplateRef } from 'vue'
 import { useEventListener } from '@vueuse/core'
 import ElInputNumber from '@element-plus/components/input-number'
 import { useFormItemInputId, useFormSize } from '@element-plus/components/form'
@@ -125,6 +125,7 @@ import {
 } from './composables'
 import { isNumber } from '@element-plus/utils'
 
+import type { SliderButtonInstance } from './button'
 import type { SliderInitData } from './slider'
 
 defineOptions({
@@ -137,6 +138,10 @@ const emit = defineEmits(sliderEmits)
 const ns = useNamespace('slider')
 const { t } = useLocale()
 
+const slider = useTemplateRef<HTMLElement>('slider')
+const firstButton = useTemplateRef<SliderButtonInstance>('firstButton')
+const secondButton = useTemplateRef<SliderButtonInstance>('secondButton')
+
 const initData = reactive<SliderInitData>({
   firstValue: 0,
   secondValue: 0,
@@ -147,9 +152,6 @@ const initData = reactive<SliderInitData>({
 
 const {
   elFormItem,
-  slider,
-  firstButton,
-  secondButton,
   sliderDisabled,
   minValue,
   maxValue,
@@ -163,7 +165,7 @@ const {
   onSliderMarkerDown,
   setFirstValue,
   setSecondValue,
-} = useSlide(props, initData, emit)
+} = useSlide(props, initData, emit, slider, firstButton, secondButton)
 
 const { stops, getStopStyle } = useStops(props, initData, minValue, maxValue)
 

--- a/packages/components/splitter/src/hooks/useContainer.ts
+++ b/packages/components/splitter/src/hooks/useContainer.ts
@@ -1,15 +1,17 @@
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useElementSize } from '@vueuse/core'
 
 import type { Ref } from 'vue'
 
-export function useContainer(layout: Ref<'horizontal' | 'vertical'>) {
-  const containerEl = ref<HTMLDivElement>()
+export function useContainer(
+  layout: Ref<'horizontal' | 'vertical'>,
+  containerEl: Readonly<Ref<HTMLDivElement | null>>
+) {
   const { width, height } = useElementSize(containerEl)
 
   const containerSize = computed(() => {
     return layout.value === 'horizontal' ? width.value : height.value
   })
 
-  return { containerEl, containerSize }
+  return { containerSize }
 }

--- a/packages/components/splitter/src/hooks/useContainer.ts
+++ b/packages/components/splitter/src/hooks/useContainer.ts
@@ -1,11 +1,11 @@
 import { computed } from 'vue'
 import { useElementSize } from '@vueuse/core'
 
-import type { Ref } from 'vue'
+import type { Ref, TemplateRef } from 'vue'
 
 export function useContainer(
   layout: Ref<'horizontal' | 'vertical'>,
-  containerEl: Readonly<Ref<HTMLDivElement | null>>
+  containerEl: TemplateRef<HTMLDivElement>
 ) {
   const { width, height } = useElementSize(containerEl)
 

--- a/packages/components/splitter/src/splitter.vue
+++ b/packages/components/splitter/src/splitter.vue
@@ -6,6 +6,7 @@ import {
   provide,
   reactive,
   toRef,
+  useTemplateRef,
   watch,
 } from 'vue'
 import { useNamespace, useOrderedChildren } from '@element-plus/hooks'
@@ -30,7 +31,8 @@ const props = withDefaults(defineProps<SplitterProps>(), {
 const layout = toRef(props, 'layout')
 const lazy = toRef(props, 'lazy')
 
-const { containerEl, containerSize } = useContainer(layout)
+const containerEl = useTemplateRef<HTMLDivElement>('containerEl')
+const { containerSize } = useContainer(layout, containerEl)
 
 const {
   removeChild: unregisterPanel,

--- a/packages/components/splitter/src/splitter.vue
+++ b/packages/components/splitter/src/splitter.vue
@@ -31,7 +31,7 @@ const props = withDefaults(defineProps<SplitterProps>(), {
 const layout = toRef(props, 'layout')
 const lazy = toRef(props, 'lazy')
 
-const containerEl = useTemplateRef<HTMLDivElement>('containerEl')
+const containerEl = useTemplateRef('containerEl')
 const { containerSize } = useContainer(layout, containerEl)
 
 const {

--- a/packages/components/time-picker/src/common/picker-range-trigger.vue
+++ b/packages/components/time-picker/src/common/picker-range-trigger.vue
@@ -80,7 +80,7 @@ const attrs = useAttrs()
 const nsDate = useNamespace('date')
 const nsRange = useNamespace('range')
 
-const wrapperRef = useTemplateRef<HTMLElement>('wrapperRef')
+const wrapperRef = useTemplateRef('wrapperRef')
 
 const inputRef = ref<HTMLInputElement>()
 const endInputRef = ref<HTMLInputElement>()

--- a/packages/components/time-picker/src/common/picker-range-trigger.vue
+++ b/packages/components/time-picker/src/common/picker-range-trigger.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, reactive, ref } from 'vue'
+import { computed, reactive, ref, useTemplateRef } from 'vue'
 import { useAttrs, useFocusController, useNamespace } from '@element-plus/hooks'
 import { timePickerRangeTriggerProps } from './props'
 import { useFormItem, useFormItemInputId } from '@element-plus/components/form'
@@ -80,11 +80,13 @@ const attrs = useAttrs()
 const nsDate = useNamespace('date')
 const nsRange = useNamespace('range')
 
+const wrapperRef = useTemplateRef<HTMLElement>('wrapperRef')
+
 const inputRef = ref<HTMLInputElement>()
 const endInputRef = ref<HTMLInputElement>()
-
-const { wrapperRef, isFocused } = useFocusController(inputRef, {
+const { isFocused } = useFocusController(inputRef, {
   disabled: computed(() => props.disabled),
+  wrapperRef,
 })
 
 const handleClick = (evt: MouseEvent) => {

--- a/packages/components/time-select/src/time-select.vue
+++ b/packages/components/time-select/src/time-select.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat.js'
 import ElSelect from '@element-plus/components/select'
@@ -79,7 +79,7 @@ const props = withDefaults(defineProps<TimeSelectProps>(), {
 })
 
 const nsInput = useNamespace('input')
-const select = ref<typeof ElSelect>()
+const select = useTemplateRef<InstanceType<typeof ElSelect>>('select')
 
 const _disabled = useFormDisabled()
 const { lang } = useLocale()

--- a/packages/components/time-select/src/time-select.vue
+++ b/packages/components/time-select/src/time-select.vue
@@ -79,7 +79,7 @@ const props = withDefaults(defineProps<TimeSelectProps>(), {
 })
 
 const nsInput = useNamespace('input')
-const select = useTemplateRef<InstanceType<typeof ElSelect>>('select')
+const select = useTemplateRef('select')
 
 const _disabled = useFormDisabled()
 const { lang } = useLocale()

--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -15,7 +15,7 @@ import type {
   FixedSizeList,
   Alignment as ScrollStrategy,
 } from '@element-plus/components/virtual-list'
-import type { SetupContext } from 'vue'
+import type { Ref, SetupContext } from 'vue'
 import type { treeEmits } from '../virtual-tree'
 import type { CheckboxValueType } from '@element-plus/components/checkbox'
 import type {
@@ -29,12 +29,12 @@ import type {
 
 export function useTree(
   props: TreeProps,
-  emit: SetupContext<typeof treeEmits>['emit']
+  emit: SetupContext<typeof treeEmits>['emit'],
+  listRef: Readonly<Ref<InstanceType<typeof FixedSizeList> | null>>
 ) {
   const expandedKeySet = ref<Set<TreeKey>>(new Set())
   const currentKey = ref<TreeKey | undefined>()
   const tree = shallowRef<Tree | undefined>()
-  const listRef = ref<typeof FixedSizeList | undefined>()
 
   const {
     isIndeterminate,

--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -15,7 +15,7 @@ import type {
   FixedSizeList,
   Alignment as ScrollStrategy,
 } from '@element-plus/components/virtual-list'
-import type { Ref, SetupContext } from 'vue'
+import type { SetupContext, TemplateRef } from 'vue'
 import type { treeEmits } from '../virtual-tree'
 import type { CheckboxValueType } from '@element-plus/components/checkbox'
 import type {
@@ -30,7 +30,7 @@ import type {
 export function useTree(
   props: TreeProps,
   emit: SetupContext<typeof treeEmits>['emit'],
-  listRef: Readonly<Ref<InstanceType<typeof FixedSizeList> | null>>
+  listRef: TemplateRef<InstanceType<typeof FixedSizeList>>
 ) {
   const expandedKeySet = ref<Set<TreeKey>>(new Set())
   const currentKey = ref<TreeKey | undefined>()

--- a/packages/components/tree-v2/src/tree.vue
+++ b/packages/components/tree-v2/src/tree.vue
@@ -106,7 +106,7 @@ provide(ROOT_TREE_INJECTION_KEY, {
 provide(formItemContextKey, undefined)
 const { t } = useLocale()
 const ns = useNamespace('tree')
-const listRef = useTemplateRef<InstanceType<typeof FixedSizeList>>('listRef')
+const listRef = useTemplateRef('listRef')
 
 const {
   flattenTree,

--- a/packages/components/tree-v2/src/tree.vue
+++ b/packages/components/tree-v2/src/tree.vue
@@ -45,7 +45,13 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, getCurrentInstance, provide, useSlots } from 'vue'
+import {
+  computed,
+  getCurrentInstance,
+  provide,
+  useSlots,
+  useTemplateRef,
+} from 'vue'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { formItemContextKey } from '@element-plus/components/form'
 import { FixedSizeList } from '@element-plus/components/virtual-list'
@@ -100,10 +106,11 @@ provide(ROOT_TREE_INJECTION_KEY, {
 provide(formItemContextKey, undefined)
 const { t } = useLocale()
 const ns = useNamespace('tree')
+const listRef = useTemplateRef<InstanceType<typeof FixedSizeList>>('listRef')
+
 const {
   flattenTree,
   isNotEmpty,
-  listRef,
   toggleExpand,
   isIndeterminate,
   isChecked,
@@ -132,7 +139,7 @@ const {
   setExpandedKeys,
   scrollToNode,
   scrollTo,
-} = useTree(props, emit)
+} = useTree(props, emit, listRef)
 
 defineExpose({
   toggleCheckbox,

--- a/packages/element-plus/package.json
+++ b/packages/element-plus/package.json
@@ -77,7 +77,7 @@
     "lib/components/*/style/*"
   ],
   "peerDependencies": {
-    "vue": "^3.3.0"
+    "vue": "^3.5.0"
   },
   "dependencies": {
     "@ctrl/tinycolor": "catalog:",

--- a/packages/hooks/use-calc-input-width/index.ts
+++ b/packages/hooks/use-calc-input-width/index.ts
@@ -2,8 +2,12 @@ import { computed, ref, shallowRef } from 'vue'
 import { useResizeObserver } from '@vueuse/core'
 import { MINIMUM_INPUT_WIDTH } from '@element-plus/constants'
 
-export function useCalcInputWidth() {
-  const calculatorRef = shallowRef<HTMLElement>()
+import type { ShallowRef } from 'vue'
+
+export function useCalcInputWidth(
+  calculatorRef?: Readonly<ShallowRef<HTMLElement | null | undefined>>
+) {
+  const _calculatorRef = calculatorRef ?? shallowRef<HTMLElement>()
   const calculatorWidth = ref(0)
 
   const inputStyle = computed(() => ({
@@ -12,13 +16,13 @@ export function useCalcInputWidth() {
 
   const resetCalculatorWidth = () => {
     calculatorWidth.value =
-      calculatorRef.value?.getBoundingClientRect().width ?? 0
+      _calculatorRef.value?.getBoundingClientRect().width ?? 0
   }
 
-  useResizeObserver(calculatorRef, resetCalculatorWidth)
+  useResizeObserver(_calculatorRef, resetCalculatorWidth)
 
   return {
-    calculatorRef,
+    calculatorRef: _calculatorRef,
     calculatorWidth,
     inputStyle,
   }

--- a/packages/hooks/use-focus-controller/index.ts
+++ b/packages/hooks/use-focus-controller/index.ts
@@ -26,21 +26,23 @@ interface UseFocusControllerOptions {
    */
   beforeBlur?: (event: FocusEvent) => boolean | undefined
   afterBlur?: () => void
+  wrapperRef?: Readonly<ShallowRef<HTMLElement | undefined | null>>
 }
 
 export function useFocusController<T extends { focus: () => void }>(
-  target: ShallowRef<T | undefined>,
+  target: Readonly<ShallowRef<T | undefined | null>>,
   {
     disabled,
     beforeFocus,
     afterFocus,
     beforeBlur,
     afterBlur,
+    wrapperRef,
   }: UseFocusControllerOptions = {}
 ) {
   const instance = getCurrentInstance()!
   const { emit } = instance
-  const wrapperRef = shallowRef<HTMLElement>()
+  const _wrapperRef = wrapperRef ?? shallowRef<HTMLElement>()
   const isFocused = ref(false)
 
   const handleFocus = (event: FocusEvent) => {
@@ -57,7 +59,7 @@ export function useFocusController<T extends { focus: () => void }>(
     if (
       unref(disabled) ||
       (event.relatedTarget &&
-        wrapperRef.value?.contains(event.relatedTarget as Node)) ||
+        _wrapperRef.value?.contains(event.relatedTarget as Node)) ||
       cancelBlur
     )
       return
@@ -71,15 +73,15 @@ export function useFocusController<T extends { focus: () => void }>(
     if (
       unref(disabled) ||
       isFocusable(event.target as HTMLElement) ||
-      (wrapperRef.value?.contains(document.activeElement) &&
-        wrapperRef.value !== document.activeElement)
+      (_wrapperRef.value?.contains(document.activeElement) &&
+        _wrapperRef.value !== document.activeElement)
     )
       return
 
     target.value?.focus()
   }
 
-  watch([wrapperRef, () => unref(disabled)], ([el, disabled]) => {
+  watch([_wrapperRef, () => unref(disabled)], ([el, disabled]) => {
     if (!el) return
     if (disabled) {
       el.removeAttribute('tabindex')
@@ -88,9 +90,9 @@ export function useFocusController<T extends { focus: () => void }>(
     }
   })
 
-  useEventListener(wrapperRef, 'focus', handleFocus, true)
-  useEventListener(wrapperRef, 'blur', handleBlur, true)
-  useEventListener(wrapperRef, 'click', handleClick, true)
+  useEventListener(_wrapperRef, 'focus', handleFocus, true)
+  useEventListener(_wrapperRef, 'blur', handleBlur, true)
+  useEventListener(_wrapperRef, 'click', handleClick, true)
 
   // only for test
   if (process.env.NODE_ENV === 'test') {
@@ -109,7 +111,7 @@ export function useFocusController<T extends { focus: () => void }>(
   return {
     isFocused,
     /** Avoid using wrapperRef and handleFocus/handleBlur together */
-    wrapperRef,
+    wrapperRef: _wrapperRef,
     handleFocus,
     handleBlur,
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,7 +591,7 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       vue:
-        specifier: ^3.3.0
+        specifier: ^3.5.0
         version: 3.5.25(typescript@5.5.4)
       vue-component-type-helpers:
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,8 +238,8 @@ importers:
         specifier: ^4.0.16
         version: 4.6.4(vue@3.5.25(typescript@5.5.4))
       vue-tsc:
-        specifier: '=3.1.5'
-        version: 3.1.5(typescript@5.5.4)
+        specifier: ^3.2.5
+        version: 3.2.5(typescript@5.5.4)
 
   docs:
     dependencies:
@@ -372,7 +372,7 @@ importers:
         version: 1.0.0-rc.6
       rolldown-plugin-dts:
         specifier: ^0.22.2
-        version: 0.22.2(rolldown@1.0.0-rc.6)(typescript@5.5.4)(vue-tsc@3.2.3(typescript@5.5.4))
+        version: 0.22.2(rolldown@1.0.0-rc.6)(typescript@5.5.4)(vue-tsc@3.2.5(typescript@5.5.4))
       tinyglobby:
         specifier: ^0.2.15
         version: 0.2.15
@@ -385,16 +385,13 @@ importers:
         version: 2.6.1
       unbuild:
         specifier: ^3.0.0
-        version: 3.6.1(sass@1.97.3)(typescript@5.5.4)(vue-tsc@3.2.3(typescript@5.5.4))(vue@3.5.25(typescript@5.5.4))
-      vue-tsc:
-        specifier: ^3.2.3
-        version: 3.2.3(typescript@5.5.4)
+        version: 3.6.1(sass@1.97.3)(typescript@5.5.4)(vue-tsc@3.2.5(typescript@5.5.4))(vue@3.5.25(typescript@5.5.4))
 
   internal/build-constants:
     devDependencies:
       unbuild:
         specifier: ^3.0.0
-        version: 3.6.1(sass@1.97.3)(typescript@5.5.4)(vue-tsc@3.2.3(typescript@5.5.4))(vue@3.5.25(typescript@5.5.4))
+        version: 3.6.1(sass@1.97.3)(typescript@5.5.4)(vue-tsc@3.2.5(typescript@5.5.4))(vue@3.5.25(typescript@5.5.4))
 
   internal/build-utils:
     dependencies:
@@ -410,7 +407,7 @@ importers:
     devDependencies:
       unbuild:
         specifier: ^3.0.0
-        version: 3.6.1(sass@1.97.3)(typescript@5.5.4)(vue-tsc@3.2.3(typescript@5.5.4))(vue@3.5.25(typescript@5.5.4))
+        version: 3.6.1(sass@1.97.3)(typescript@5.5.4)(vue-tsc@3.2.5(typescript@5.5.4))(vue@3.5.25(typescript@5.5.4))
 
   internal/eslint-config:
     dependencies:
@@ -3076,23 +3073,14 @@ packages:
   '@vitest/utils@4.0.16':
     resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
 
-  '@volar/language-core@2.4.23':
-    resolution: {integrity: sha512-hEEd5ET/oSmBC6pi1j6NaNYRWoAiDhINbT8rmwtINugR39loROSlufGdYMF9TaKGfz+ViGs1Idi3mAhnuPcoGQ==}
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
-  '@volar/language-core@2.4.27':
-    resolution: {integrity: sha512-DjmjBWZ4tJKxfNC1F6HyYERNHPYS7L7OPFyCrestykNdUZMFYzI9WTyvwPcaNaHlrEUwESHYsfEw3isInncZxQ==}
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
 
-  '@volar/source-map@2.4.23':
-    resolution: {integrity: sha512-Z1Uc8IB57Lm6k7q6KIDu/p+JWtf3xsXJqAX/5r18hYOTpJyBn0KXUR8oTJ4WFYOcDzWC9n3IflGgHowx6U6z9Q==}
-
-  '@volar/source-map@2.4.27':
-    resolution: {integrity: sha512-ynlcBReMgOZj2i6po+qVswtDUeeBRCTgDurjMGShbm8WYZgJ0PA4RmtebBJ0BCYol1qPv3GQF6jK7C9qoVc7lg==}
-
-  '@volar/typescript@2.4.23':
-    resolution: {integrity: sha512-lAB5zJghWxVPqfcStmAP1ZqQacMpe90UrP5RJ3arDyrhy4aCUQqmxPPLB2PWDKugvylmO41ljK7vZ+t6INMTag==}
-
-  '@volar/typescript@2.4.27':
-    resolution: {integrity: sha512-eWaYCcl/uAPInSK2Lze6IqVWaBu/itVqR5InXcHXFyles4zO++Mglt3oxdgj75BDcv1Knr9Y93nowS8U3wqhxg==}
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
 
   '@vue/babel-helper-vue-transform-on@1.5.0':
     resolution: {integrity: sha512-0dAYkerNhhHutHZ34JtTl2czVQHUNWv6xEbkdF5W+Yrv5pCWsqjeORdOgbtW2I9gWlt+wBmVn+ttqN9ZxR5tzA==}
@@ -3134,16 +3122,8 @@ packages:
   '@vue/devtools-shared@7.7.9':
     resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
 
-  '@vue/language-core@3.1.5':
-    resolution: {integrity: sha512-FMcqyzWN+sYBeqRMWPGT2QY0mUasZMVIuHvmb5NT3eeqPrbHBYtCP8JWEUCDCgM+Zr62uuWY/qoeBrPrzfa78w==}
-    peerDependencies:
-      typescript: ~5.5.4
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@vue/language-core@3.2.3':
-    resolution: {integrity: sha512-VpN/GnYDzGLh44AI6i1OB/WsLXo6vwnl0EWHBelGc4TyC0yEq6azwNaed/+Tgr8anFlSdWYnMEkyHJDPe7ii7A==}
+  '@vue/language-core@3.2.5':
+    resolution: {integrity: sha512-d3OIxN/+KRedeM5wQ6H6NIpwS3P5gC9nmyaHgBk+rO6dIsjY+tOh4UlPpiZbAh3YtLdCGEX4M16RmsBqPmJV+g==}
 
   '@vue/reactivity@3.5.25':
     resolution: {integrity: sha512-5xfAypCQepv4Jog1U4zn8cZIcbKKFka3AgWHEFQeK65OW+Ys4XybP6z2kKgws4YB43KGpqp5D/K3go2UPPunLA==}
@@ -8037,14 +8017,8 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
-  vue-tsc@3.1.5:
-    resolution: {integrity: sha512-L/G9IUjOWhBU0yun89rv8fKqmKC+T0HfhrFjlIml71WpfBv9eb4E9Bev8FMbyueBIU9vxQqbd+oOsVcDa5amGw==}
-    hasBin: true
-    peerDependencies:
-      typescript: ~5.5.4
-
-  vue-tsc@3.2.3:
-    resolution: {integrity: sha512-1RdRB7rQXGFMdpo0aXf9spVzWEPGAk7PEb/ejHQwVrcuQA/HsGiixIc3uBQeqY2YjeEEgvr2ShQewBgcN4c1Cw==}
+  vue-tsc@3.2.5:
+    resolution: {integrity: sha512-/htfTCMluQ+P2FISGAooul8kO4JMheOTCbCy4M6dYnYYjqLe3BExZudAua6MSIKSFYQtFOYAll7XobYwcpokGA==}
     hasBin: true
     peerDependencies:
       typescript: ~5.5.4
@@ -11068,27 +11042,15 @@ snapshots:
       '@vitest/pretty-format': 4.0.16
       tinyrainbow: 3.0.3
 
-  '@volar/language-core@2.4.23':
+  '@volar/language-core@2.4.28':
     dependencies:
-      '@volar/source-map': 2.4.23
+      '@volar/source-map': 2.4.28
 
-  '@volar/language-core@2.4.27':
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
     dependencies:
-      '@volar/source-map': 2.4.27
-
-  '@volar/source-map@2.4.23': {}
-
-  '@volar/source-map@2.4.27': {}
-
-  '@volar/typescript@2.4.23':
-    dependencies:
-      '@volar/language-core': 2.4.23
-      path-browserify: 1.0.1
-      vscode-uri: 3.1.0
-
-  '@volar/typescript@2.4.27':
-    dependencies:
-      '@volar/language-core': 2.4.27
+      '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
@@ -11171,21 +11133,9 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/language-core@3.1.5(typescript@5.5.4)':
+  '@vue/language-core@3.2.5':
     dependencies:
-      '@volar/language-core': 2.4.23
-      '@vue/compiler-dom': 3.5.25
-      '@vue/shared': 3.5.27
-      alien-signals: 3.1.1
-      muggle-string: 0.4.1
-      path-browserify: 1.0.1
-      picomatch: 4.0.3
-    optionalDependencies:
-      typescript: 5.5.4
-
-  '@vue/language-core@3.2.3':
-    dependencies:
-      '@volar/language-core': 2.4.27
+      '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.25
       '@vue/shared': 3.5.27
       alien-signals: 3.1.1
@@ -14595,7 +14545,7 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
-  mkdist@2.4.1(sass@1.97.3)(typescript@5.5.4)(vue-tsc@3.2.3(typescript@5.5.4))(vue@3.5.25(typescript@5.5.4)):
+  mkdist@2.4.1(sass@1.97.3)(typescript@5.5.4)(vue-tsc@3.2.5(typescript@5.5.4))(vue@3.5.25(typescript@5.5.4)):
     dependencies:
       autoprefixer: 10.4.23(postcss@8.5.6)
       citty: 0.1.6
@@ -14614,7 +14564,7 @@ snapshots:
       sass: 1.97.3
       typescript: 5.5.4
       vue: 3.5.25(typescript@5.5.4)
-      vue-tsc: 3.2.3(typescript@5.5.4)
+      vue-tsc: 3.2.5(typescript@5.5.4)
 
   mlly@1.8.0:
     dependencies:
@@ -15552,7 +15502,7 @@ snapshots:
     dependencies:
       glob: 9.3.5
 
-  rolldown-plugin-dts@0.22.2(rolldown@1.0.0-rc.6)(typescript@5.5.4)(vue-tsc@3.2.3(typescript@5.5.4)):
+  rolldown-plugin-dts@0.22.2(rolldown@1.0.0-rc.6)(typescript@5.5.4)(vue-tsc@3.2.5(typescript@5.5.4)):
     dependencies:
       '@babel/generator': 8.0.0-rc.1
       '@babel/helper-validator-identifier': 8.0.0-rc.1
@@ -15566,7 +15516,7 @@ snapshots:
       rolldown: 1.0.0-rc.6
     optionalDependencies:
       typescript: 5.5.4
-      vue-tsc: 3.2.3(typescript@5.5.4)
+      vue-tsc: 3.2.5(typescript@5.5.4)
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -16382,7 +16332,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  unbuild@3.6.1(sass@1.97.3)(typescript@5.5.4)(vue-tsc@3.2.3(typescript@5.5.4))(vue@3.5.25(typescript@5.5.4)):
+  unbuild@3.6.1(sass@1.97.3)(typescript@5.5.4)(vue-tsc@3.2.5(typescript@5.5.4))(vue@3.5.25(typescript@5.5.4)):
     dependencies:
       '@rollup/plugin-alias': 5.1.1(rollup@4.55.1)
       '@rollup/plugin-commonjs': 28.0.9(rollup@4.55.1)
@@ -16398,7 +16348,7 @@ snapshots:
       hookable: 5.5.3
       jiti: 2.6.1
       magic-string: 0.30.21
-      mkdist: 2.4.1(sass@1.97.3)(typescript@5.5.4)(vue-tsc@3.2.3(typescript@5.5.4))(vue@3.5.25(typescript@5.5.4))
+      mkdist: 2.4.1(sass@1.97.3)(typescript@5.5.4)(vue-tsc@3.2.5(typescript@5.5.4))(vue@3.5.25(typescript@5.5.4))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -16809,16 +16759,10 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.25(typescript@5.5.4)
 
-  vue-tsc@3.1.5(typescript@5.5.4):
+  vue-tsc@3.2.5(typescript@5.5.4):
     dependencies:
-      '@volar/typescript': 2.4.23
-      '@vue/language-core': 3.1.5(typescript@5.5.4)
-      typescript: 5.5.4
-
-  vue-tsc@3.2.3(typescript@5.5.4):
-    dependencies:
-      '@volar/typescript': 2.4.27
-      '@vue/language-core': 3.2.3
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.2.5
       typescript: 5.5.4
 
   vue@3.5.25(typescript@5.5.4):


### PR DESCRIPTION
https://github.com/vuejs/language-tools/issues/5815#issuecomment-3622337201


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized template-ref usage across components and hooks, moving ownership of DOM/component refs into templates and passing them into composables to simplify ref management, focus/interaction, and sizing logic.

* **Chores**
  * Removed/relaxed vue-tsc dev dependency and updated package Vue peer requirement to a newer minor range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->