### PR TITLE
feat(components): [table] add table virtual scroll support

### DIFF
--- a/docs/en-US/component/table.md
+++ b/docs/en-US/component/table.md
@@ -255,6 +255,34 @@ table/tooltip-formatter
 
 :::
 
+## Virtual scrolling
+
+When dealing with large amounts of data, you can enable virtual scrolling to improve performance.
+
+### Basic virtual scrolling
+
+:::demo Enable virtual scrolling by setting `use-virtual` to `true`. You must also set `height` or `max-height`, and `row-height` to specify the height of each row. The `excess-rows` attribute controls how many extra rows are rendered outside the visible area to ensure smooth scrolling.
+
+table/virtual-scroll
+
+:::
+
+### Tree data virtual scrolling
+
+:::demo Virtual scrolling also supports tree data. When using virtual scrolling with tree data, you must set the `row-key` attribute. The table will automatically handle the virtual scrolling logic for expanded and collapsed nodes.
+
+table/virtual-scroll-tree
+
+:::
+
+### Lazy loading tree data with virtual scrolling
+
+:::demo Combine lazy loading with virtual scrolling for optimal performance with large tree datasets. Set `lazy` to `true` and provide a `load` function to load child nodes on demand. The `hasChildren` property determines whether a node can be expanded.
+
+table/virtual-scroll-tree-lazy
+
+:::
+
 ## Table API
 
 ### Table Attributes
@@ -306,6 +334,9 @@ table/tooltip-formatter
 | preserve-expanded-content ^(2.9.7) | whether to preserve expanded row content in DOM when collapsed                                                                                                                                                                                                             | ^[boolean]                                                                                                                                                           | false                                                                                                                   |
 | native-scrollbar ^(2.10.5)         | whether to use native scrollbars                                                                                                                                                                                                                                           | ^[boolean]                                                                                                                                                           | false                                                                                                                   |
 | row-expandable ^(2.13.2)           | enable expandable rows, works when the table has a column type="expand"                                                                                                                                                                                                    | ^[Function]`(row: any, index: number) => boolean`                                                                                                                    | —                                                                                                                       |
+| use-virtual                        | whether to enable virtual scrolling. When enabled, only visible rows are rendered, which significantly improves performance for large datasets. Must be used with `height` or `max-height` and `row-height`                                                                | ^[boolean]                                                                                                                                                           | false                                                                                                                   |
+| row-height                         | height of each row in pixels. Required when `use-virtual` is true. Must match the actual row height for accurate scrolling                                                                                                                                                 | ^[number]                                                                                                                                                            | 32                                                                                                                      |
+| excess-rows                        | number of extra rows to render outside the visible area when using virtual scrolling. Larger values provide smoother scrolling but increase memory usage. Recommended: 3-5 for normal scrolling, 5-10 for fast scrolling                                                   | ^[number]                                                                                                                                                            | 3                                                                                                                       |
 
 ### Table Events
 

--- a/docs/examples/table/virtual-scroll-tree-lazy.vue
+++ b/docs/examples/table/virtual-scroll-tree-lazy.vue
@@ -1,0 +1,78 @@
+<template>
+  <el-table
+    :data="treeData"
+    :use-virtual="true"
+    :row-height="50"
+    :height="500"
+    row-key="id"
+    lazy
+    :load="loadChildren"
+    :tree-props="{ children: 'children', hasChildren: 'hasChildren' }"
+    style="width: 100%"
+  >
+    <el-table-column prop="name" label="Name" width="300" />
+    <el-table-column prop="value" label="Value" width="200" />
+    <el-table-column prop="count" label="Count" width="120" />
+    <el-table-column prop="description" label="Description" />
+  </el-table>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+interface TreeNode {
+  id: string | number
+  name: string
+  value: string
+  count: number
+  description: string
+  hasChildren: boolean
+  children?: TreeNode[]
+}
+
+const treeData = ref<TreeNode[]>([
+  {
+    id: 1,
+    name: 'Root Node 1',
+    value: 'root-1',
+    count: 100,
+    description: 'First level node with lazy loading',
+    hasChildren: true,
+  },
+  {
+    id: 2,
+    name: 'Root Node 2',
+    value: 'root-2',
+    count: 200,
+    description: 'First level node with lazy loading',
+    hasChildren: true,
+  },
+  {
+    id: 3,
+    name: 'Root Node 3',
+    value: 'root-3',
+    count: 150,
+    description: 'First level node with lazy loading',
+    hasChildren: true,
+  },
+])
+
+// Simulate async loading of child nodes
+const loadChildren = (
+  row: TreeNode,
+  treeNode: any,
+  resolve: (data: TreeNode[]) => void
+) => {
+  setTimeout(() => {
+    const children: TreeNode[] = Array.from({ length: 10 }, (_, i) => ({
+      id: `${row.id}-${i}`,
+      name: `${row.name} - Child ${i}`,
+      value: `child-${row.id}-${i}`,
+      count: Math.floor(Math.random() * 100),
+      description: `Child node of ${row.name}`,
+      hasChildren: Math.random() > 0.5, // Randomly determine if node has children
+    }))
+    resolve(children)
+  }, 500)
+}
+</script>

--- a/docs/examples/table/virtual-scroll-tree.vue
+++ b/docs/examples/table/virtual-scroll-tree.vue
@@ -1,0 +1,104 @@
+<template>
+  <div>
+    <div style="margin-bottom: 20px">
+      <span style="margin-right: 20px"
+        >Total rows: {{ getTotalRows(tableData) }}</span
+      >
+      <el-button @click="loadTreeData(100)">Load 100 parent nodes</el-button>
+      <el-button @click="loadTreeData(500)">Load 500 parent nodes</el-button>
+      <el-button @click="loadTreeData(1000)">Load 1,000 parent nodes</el-button>
+    </div>
+    <el-table
+      :data="tableData"
+      :use-virtual="true"
+      :height="500"
+      :row-height="50"
+      :excess-rows="5"
+      row-key="id"
+      border
+      style="width: 100%"
+    >
+      <el-table-column type="selection" width="55" :selectable="selectable" />
+      <el-table-column prop="customIndex" width="80">
+        <template #default="scope">
+          {{ scope.treeNode.level ? scope.treeNode.childIndex + 1 : '' }}
+        </template>
+      </el-table-column>
+      <el-table-column prop="name" label="Name" width="300" />
+      <el-table-column prop="date" label="Date" width="200" />
+      <el-table-column prop="status" label="Status" width="150">
+        <template #default="scope">
+          <el-tag :type="scope.row.status === 'Active' ? 'success' : 'info'">
+            {{ scope.row.status }}
+          </el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column prop="description" label="Description" />
+    </el-table>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+interface TreeRow {
+  id: string
+  name: string
+  date: string
+  status: string
+  description: string
+  children?: TreeRow[]
+}
+
+const tableData = ref<TreeRow[]>([])
+
+const getTotalRows = (data: TreeRow[]): number => {
+  let count = data.length
+  data.forEach((item) => {
+    if (item.children && item.children.length > 0) {
+      count += getTotalRows(item.children)
+    }
+  })
+  return count
+}
+
+const loadTreeData = (parentCount: number) => {
+  const data: TreeRow[] = []
+  for (let i = 0; i < parentCount; i++) {
+    const parent: TreeRow = {
+      id: `${i + 1}`,
+      name: `Parent ${i + 1}`,
+      date: new Date(
+        Date.now() - Math.random() * 10000000000
+      ).toLocaleDateString(),
+      status: Math.random() > 0.5 ? 'Active' : 'Inactive',
+      description: `This is parent node ${i + 1}`,
+      children: [],
+    }
+
+    // Add 3-5 children for each parent
+    const childCount = Math.floor(Math.random() * 3) + 3
+    for (let j = 0; j < childCount; j++) {
+      parent.children!.push({
+        id: `${i + 1}-${j + 1}`,
+        name: `Child ${i + 1}-${j + 1}`,
+        date: new Date(
+          Date.now() - Math.random() * 10000000000
+        ).toLocaleDateString(),
+        status: Math.random() > 0.5 ? 'Active' : 'Inactive',
+        description: `This is child node ${i + 1}-${j + 1}`,
+      })
+    }
+
+    data.push(parent)
+  }
+  tableData.value = data
+}
+
+function selectable(row: TreeRow) {
+  return row.status === 'Active'
+}
+
+// Load initial data
+loadTreeData(100)
+</script>

--- a/docs/examples/table/virtual-scroll.vue
+++ b/docs/examples/table/virtual-scroll.vue
@@ -1,0 +1,59 @@
+<template>
+  <div>
+    <div style="margin-bottom: 20px">
+      <span style="margin-right: 20px">Total rows: {{ tableData.length }}</span>
+      <el-button @click="loadData(10000)">Load 10,000 rows</el-button>
+      <el-button @click="loadData(50000)">Load 50,000 rows</el-button>
+      <el-button @click="loadData(100000)">Load 100,000 rows</el-button>
+    </div>
+    <el-table
+      :data="tableData"
+      :use-virtual="true"
+      :height="500"
+      :row-height="50"
+      :excess-rows="5"
+      border
+      style="width: 100%"
+    >
+      <el-table-column type="selection" width="55" />
+      <el-table-column prop="id" label="ID" width="100" />
+      <el-table-column prop="name" label="Name" width="200" />
+      <el-table-column prop="age" label="Age" width="100" />
+      <el-table-column prop="email" label="Email" width="250" />
+      <el-table-column prop="address" label="Address" />
+    </el-table>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+interface TableRow {
+  id: number
+  name: string
+  age: number
+  email: string
+  address: string
+}
+
+const tableData = ref<TableRow[]>([])
+
+const loadData = (count: number) => {
+  const data: TableRow[] = []
+  for (let i = 0; i < count; i++) {
+    data.push({
+      id: i + 1,
+      name: `User ${i + 1}`,
+      age: Math.floor(Math.random() * 50) + 18,
+      email: `user${i + 1}@example.com`,
+      address: `${Math.floor(Math.random() * 1000)} Main Street, City ${
+        Math.floor(Math.random() * 100) + 1
+      }`,
+    })
+  }
+  tableData.value = data
+}
+
+// Load initial data
+loadData(10000)
+</script>

--- a/packages/components/table/__tests__/table-virtual.test.ts
+++ b/packages/components/table/__tests__/table-virtual.test.ts
@@ -1,0 +1,1167 @@
+// @ts-nocheck
+import { nextTick } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import ElTable from '../src/table.vue'
+import ElTableColumn from '../src/table-column'
+import { doubleWait, mount } from './table-test-common'
+
+vi.mock('lodash-unified', async () => {
+  return {
+    ...((await vi.importActual('lodash-unified')) as Record<string, any>),
+    debounce: vi.fn((fn) => {
+      fn.cancel = vi.fn()
+      fn.flush = vi.fn()
+      return fn
+    }),
+  }
+})
+
+Range.prototype.getBoundingClientRect = () => ({
+  bottom: 0,
+  height: 0,
+  left: 0,
+  right: 0,
+  top: 0,
+  width: 0,
+})
+
+function generateLargeData(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    name: `Row ${i + 1}`,
+    value: `Value ${i + 1}`,
+  }))
+}
+
+function generateTreeData(parentCount: number, childCount: number) {
+  return Array.from({ length: parentCount }, (_, i) => ({
+    id: i + 1,
+    name: `Parent ${i + 1}`,
+    value: `Value ${i + 1}`,
+    children: Array.from({ length: childCount }, (_, j) => ({
+      id: parentCount + i * childCount + j + 1,
+      name: `Child ${i + 1}-${j + 1}`,
+      value: `ChildValue ${i + 1}-${j + 1}`,
+    })),
+  }))
+}
+
+describe('Table Virtual Scroll', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  describe('basic virtual scroll', () => {
+    it('should render only visible rows when use-virtual is enabled', async () => {
+      const data = generateLargeData(100)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+          >
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      const rows = wrapper.findAll('.el-table__body-wrapper tbody tr')
+      // With height=200, rowHeight=32, visibleCount=ceil(200/32)=7, plus excessRows(3)+1=11
+      // Should render far fewer than 100 rows
+      expect(rows.length).toBeLessThan(100)
+      expect(rows.length).toBeGreaterThan(0)
+
+      wrapper.unmount()
+    })
+
+    it('should set virtual body height based on total row count', async () => {
+      const data = generateLargeData(50)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="40"
+            row-key="id"
+          >
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      // virtualBodyHeight = data.length * rowHeight = 50 * 40 = 2000
+      const virtualContainer = wrapper.find(
+        '.el-table__body-wrapper .el-scrollbar__view > div'
+      )
+      expect(virtualContainer.attributes('style')).toContain('height: 2000px')
+
+      wrapper.unmount()
+    })
+
+    it('should set fixed row height on each tr', async () => {
+      const data = generateLargeData(20)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="50"
+            row-key="id"
+          >
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      const rows = wrapper.findAll('.el-table__body-wrapper tbody tr')
+      for (const row of rows) {
+        expect(row.attributes('style')).toContain('height: 50px')
+      }
+
+      wrapper.unmount()
+    })
+
+    it('should render all rows when use-virtual is false', async () => {
+      const data = generateLargeData(20)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="200"
+            :use-virtual="false"
+            row-key="id"
+          >
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      const rows = wrapper.findAll('.el-table__body-wrapper tbody tr')
+      expect(rows.length).toEqual(20)
+
+      wrapper.unmount()
+    })
+
+    it('should update visible rows when data changes', async () => {
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+          >
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return { data: generateLargeData(100) }
+        },
+      })
+
+      await doubleWait()
+
+      const rowsBefore = wrapper.findAll('.el-table__body-wrapper tbody tr')
+      const countBefore = rowsBefore.length
+
+      await wrapper.setData({ data: generateLargeData(5) })
+      await doubleWait()
+
+      const rowsAfter = wrapper.findAll('.el-table__body-wrapper tbody tr')
+      expect(rowsAfter.length).toBeLessThanOrEqual(5)
+      expect(rowsAfter.length).toBeLessThan(countBefore)
+
+      wrapper.unmount()
+    })
+
+    it('should respect excess-rows prop', async () => {
+      const data = generateLargeData(100)
+      const wrapperSmall = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            :excess-rows="1"
+            row-key="id"
+          >
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      const wrapperLarge = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            :excess-rows="10"
+            row-key="id"
+          >
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      const rowsSmall = wrapperSmall.findAll('.el-table__body-wrapper tbody tr')
+      const rowsLarge = wrapperLarge.findAll('.el-table__body-wrapper tbody tr')
+      // Larger excessRows should render more rows
+      expect(rowsLarge.length).toBeGreaterThan(rowsSmall.length)
+
+      wrapperSmall.unmount()
+      wrapperLarge.unmount()
+    })
+
+    it('should work with max-height', async () => {
+      const data = generateLargeData(100)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            max-height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+          >
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      const rows = wrapper.findAll('.el-table__body-wrapper tbody tr')
+      expect(rows.length).toBeLessThan(100)
+      expect(rows.length).toBeGreaterThan(0)
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('virtual scroll with tree data', () => {
+    it('should render tree rows correctly with virtual scroll', async () => {
+      const data = generateTreeData(10, 3)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="300"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+            default-expand-all
+          >
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+      await nextTick()
+
+      const rows = wrapper.findAll('.el-table__body-wrapper tbody tr')
+      // Total rows = 10 parents + 10*3 children = 40, but virtual scroll should render fewer
+      expect(rows.length).toBeGreaterThan(0)
+      expect(rows.length).toBeLessThan(40)
+
+      wrapper.unmount()
+    })
+
+    it('should update virtual body height when tree nodes are expanded', async () => {
+      const data = generateTreeData(5, 4)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="300"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+          >
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      // Initially only 5 top-level rows, height = 5 * 32 = 160
+      const virtualContainer = wrapper.find(
+        '.el-table__body-wrapper .el-scrollbar__view > div'
+      )
+      expect(virtualContainer.attributes('style')).toContain('height: 160px')
+
+      // Click to expand the first row
+      const expandIcon = wrapper.find(
+        '.el-table__body-wrapper .el-table__expand-icon'
+      )
+      if (expandIcon.exists()) {
+        await expandIcon.trigger('click')
+        await doubleWait()
+        await nextTick()
+
+        // After expanding first parent (4 children), height = (5 + 4) * 32 = 288
+        expect(virtualContainer.attributes('style')).toContain('height: 288px')
+      }
+
+      wrapper.unmount()
+    })
+
+    it('should calculate tree start and end correctly', async () => {
+      const data = generateTreeData(20, 5)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="300"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+            default-expand-all
+          >
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+      await nextTick()
+
+      // Total = 20 parents + 20*5 children = 120 rows
+      // virtualBodyHeight = 120 * 32 = 3840
+      const virtualContainer = wrapper.find(
+        '.el-table__body-wrapper .el-scrollbar__view > div'
+      )
+      expect(virtualContainer.attributes('style')).toContain('height: 3840px')
+
+      // Rendered rows should be much less than total
+      const rows = wrapper.findAll('.el-table__body-wrapper tbody tr')
+      expect(rows.length).toBeLessThan(120)
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('virtual scroll with lazy tree', () => {
+    it('should render lazy tree table with virtual scroll', async () => {
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="300"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+            lazy
+            :load="loadChildren"
+            :tree-props="{ children: 'children', hasChildren: 'hasChildren' }"
+          >
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return {
+            data: Array.from({ length: 20 }, (_, i) => ({
+              id: i + 1,
+              name: `Parent ${i + 1}`,
+              hasChildren: true,
+            })),
+          }
+        },
+        methods: {
+          loadChildren(row, _treeNode, resolve) {
+            setTimeout(() => {
+              resolve(
+                Array.from({ length: 3 }, (_, i) => ({
+                  id: row.id * 1000 + i + 1,
+                  name: `Child ${row.id}-${i + 1}`,
+                }))
+              )
+            }, 0)
+          },
+        },
+      })
+
+      await doubleWait()
+
+      // Initially only top-level rows rendered
+      const rows = wrapper.findAll('.el-table__body-wrapper tbody tr')
+      expect(rows.length).toBeGreaterThan(0)
+      expect(rows.length).toBeLessThanOrEqual(20)
+
+      wrapper.unmount()
+    })
+
+    it('should update height after lazy children are loaded', async () => {
+      let resolveLoad: ((data: any[]) => void) | null = null
+
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="300"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+            lazy
+            :load="loadChildren"
+            :tree-props="{ children: 'children', hasChildren: 'hasChildren' }"
+          >
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return {
+            data: Array.from({ length: 5 }, (_, i) => ({
+              id: i + 1,
+              name: `Parent ${i + 1}`,
+              hasChildren: true,
+            })),
+          }
+        },
+        methods: {
+          loadChildren(_row, _treeNode, resolve) {
+            resolveLoad = resolve
+          },
+        },
+      })
+
+      await doubleWait()
+
+      // Initial height = 5 * 32 = 160
+      const virtualContainer = wrapper.find(
+        '.el-table__body-wrapper .el-scrollbar__view > div'
+      )
+      expect(virtualContainer.attributes('style')).toContain('height: 160px')
+
+      // Click expand icon on first row
+      const expandIcon = wrapper.find(
+        '.el-table__body-wrapper .el-table__expand-icon'
+      )
+      if (expandIcon.exists()) {
+        await expandIcon.trigger('click')
+        await doubleWait()
+
+        // Height should still be 160 while loading (loaded=false)
+        expect(virtualContainer.attributes('style')).toContain('height: 160px')
+
+        // Resolve the lazy load with 3 children
+        if (resolveLoad) {
+          resolveLoad(
+            Array.from({ length: 3 }, (_, i) => ({
+              id: 1000 + i + 1,
+              name: `Child 1-${i + 1}`,
+            }))
+          )
+        }
+
+        await doubleWait()
+        await nextTick()
+
+        // After loading: height = (5 + 3) * 32 = 256
+        expect(virtualContainer.attributes('style')).toContain('height: 256px')
+      }
+
+      wrapper.unmount()
+    })
+
+    it('should not include loading nodes in expandedKeysCache', async () => {
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="300"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+            lazy
+            :load="loadChildren"
+            :tree-props="{ children: 'children', hasChildren: 'hasChildren' }"
+          >
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return {
+            data: Array.from({ length: 3 }, (_, i) => ({
+              id: i + 1,
+              name: `Parent ${i + 1}`,
+              hasChildren: true,
+            })),
+          }
+        },
+        methods: {
+          loadChildren() {
+            // intentionally not resolving to keep the node in loading state
+          },
+        },
+      })
+
+      await doubleWait()
+
+      const virtualContainer = wrapper.find(
+        '.el-table__body-wrapper .el-scrollbar__view > div'
+      )
+
+      // Before expanding: height = 3 * 32 = 96
+      expect(virtualContainer.attributes('style')).toContain('height: 96px')
+
+      const expandIcon = wrapper.find(
+        '.el-table__body-wrapper .el-table__expand-icon'
+      )
+      if (expandIcon.exists()) {
+        await expandIcon.trigger('click')
+        await doubleWait()
+
+        // During loading, node is expanded but not loaded
+        // expandedKeysCache should NOT include it, so height stays the same
+        expect(virtualContainer.attributes('style')).toContain('height: 96px')
+      }
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('virtual scroll events', () => {
+    it('should emit scroll event', async () => {
+      const data = generateLargeData(100)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+            @scroll="onScroll"
+          >
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data, scrolled: false }
+        },
+        methods: {
+          onScroll() {
+            this.scrolled = true
+          },
+        },
+      })
+
+      await doubleWait()
+
+      const scrollWrapper = wrapper.find(
+        '.el-table__body-wrapper .el-scrollbar__wrap'
+      )
+      if (scrollWrapper.exists()) {
+        await scrollWrapper.trigger('scroll')
+        await doubleWait()
+      }
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('virtual scroll with selection', () => {
+    it('should support row selection with virtual scroll', async () => {
+      const data = generateLargeData(50)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            ref="table"
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+          >
+            <el-table-column type="selection" />
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      // Selection column should be rendered
+      const checkboxes = wrapper.findAll('.el-table__body-wrapper .el-checkbox')
+      expect(checkboxes.length).toBeGreaterThan(0)
+
+      // Select-all checkbox should exist in header
+      const headerCheckbox = wrapper.find(
+        '.el-table__header-wrapper .el-checkbox'
+      )
+      expect(headerCheckbox.exists()).toBe(true)
+
+      wrapper.unmount()
+    })
+
+    it('toggleAllSelection should select all rows', async () => {
+      const data = generateLargeData(200)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            ref="table"
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+            @selection-change="handleSelectionChange"
+          >
+            <el-table-column type="selection" />
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return { data, selection: [] }
+        },
+        methods: {
+          handleSelectionChange(val) {
+            this.selection = val
+          },
+        },
+      })
+
+      await doubleWait()
+
+      const vm = wrapper.vm
+      // Select all
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+      expect(vm.selection.length).toEqual(200)
+
+      // Deselect all
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+      expect(vm.selection.length).toEqual(0)
+
+      wrapper.unmount()
+    })
+
+    it('toggleAllSelection should emit select-all event', async () => {
+      const data = generateLargeData(50)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            ref="table"
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+            @select-all="handleSelectAll"
+          >
+            <el-table-column type="selection" />
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data, selectAllResult: null }
+        },
+        methods: {
+          handleSelectAll(selection) {
+            this.selectAllResult = selection
+          },
+        },
+      })
+
+      await doubleWait()
+
+      const vm = wrapper.vm
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+      expect(vm.selectAllResult).not.toBeNull()
+      expect(vm.selectAllResult.length).toEqual(50)
+
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+      expect(vm.selectAllResult.length).toEqual(0)
+
+      wrapper.unmount()
+    })
+
+    it('toggleAllSelection should respect selectable', async () => {
+      const data = generateLargeData(100)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            ref="table"
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+            @selection-change="handleSelectionChange"
+          >
+            <el-table-column type="selection" :selectable="isSelectable" />
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data, selection: [] }
+        },
+        methods: {
+          handleSelectionChange(val) {
+            this.selection = val
+          },
+          isSelectable(row) {
+            // Only even id rows are selectable
+            return row.id % 2 === 0
+          },
+        },
+      })
+
+      await doubleWait()
+
+      const vm = wrapper.vm
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+
+      // Only 50 even-id rows should be selected
+      expect(vm.selection.length).toEqual(50)
+      expect(vm.selection.every((row) => row.id % 2 === 0)).toBe(true)
+
+      wrapper.unmount()
+    })
+
+    it('toggleAllSelection should select tree children rows', async () => {
+      const data = generateTreeData(10, 5)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            ref="table"
+            :data="data"
+            height="300"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+            default-expand-all
+            @selection-change="handleSelectionChange"
+          >
+            <el-table-column type="selection" />
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return { data, selection: [] }
+        },
+        methods: {
+          handleSelectionChange(val) {
+            this.selection = val
+          },
+        },
+      })
+
+      await doubleWait()
+      await nextTick()
+
+      const vm = wrapper.vm
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+
+      // 10 parents + 10*5 children = 60 total rows
+      expect(vm.selection.length).toEqual(60)
+
+      // Deselect all
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+      expect(vm.selection.length).toEqual(0)
+
+      wrapper.unmount()
+    })
+
+    it('toggleAllSelection should update header checkbox state', async () => {
+      const data = generateLargeData(50)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            ref="table"
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+          >
+            <el-table-column type="selection" />
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      const vm = wrapper.vm
+      const headerCheckbox = wrapper.find(
+        '.el-table__header-wrapper .el-checkbox'
+      )
+
+      // Initially unchecked
+      expect(headerCheckbox.classes()).not.toContain('is-checked')
+
+      // Select all
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+
+      expect(headerCheckbox.classes()).toContain('is-checked')
+
+      // Deselect all
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+
+      expect(headerCheckbox.classes()).not.toContain('is-checked')
+
+      wrapper.unmount()
+    })
+
+    it('toggleAllSelection should update visible row checkboxes', async () => {
+      const data = generateLargeData(50)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            ref="table"
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+          >
+            <el-table-column type="selection" />
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      const vm = wrapper.vm
+
+      // Select all
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+
+      // All visible row checkboxes should be checked
+      const bodyCheckboxes = wrapper.findAll(
+        '.el-table__body-wrapper .el-checkbox'
+      )
+      bodyCheckboxes.forEach((checkbox) => {
+        expect(checkbox.classes()).toContain('is-checked')
+      })
+
+      wrapper.unmount()
+    })
+
+    it('getSelectionRows should return correct rows after toggleAllSelection', async () => {
+      const data = generateLargeData(100)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            ref="table"
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+          >
+            <el-table-column type="selection" />
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      const vm = wrapper.vm
+
+      // Select all
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+
+      const selectedRows = vm.$refs.table.getSelectionRows()
+      expect(selectedRows.length).toEqual(100)
+
+      // Deselect all
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+
+      const emptyRows = vm.$refs.table.getSelectionRows()
+      expect(emptyRows.length).toEqual(0)
+
+      wrapper.unmount()
+    })
+
+    it('clearSelection should work after toggleAllSelection', async () => {
+      const data = generateLargeData(100)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            ref="table"
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+            @selection-change="handleSelectionChange"
+          >
+            <el-table-column type="selection" />
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data, selection: [] }
+        },
+        methods: {
+          handleSelectionChange(val) {
+            this.selection = val
+          },
+        },
+      })
+
+      await doubleWait()
+
+      const vm = wrapper.vm
+
+      // Select all
+      vm.$refs.table.toggleAllSelection()
+      await doubleWait()
+      expect(vm.selection.length).toEqual(100)
+
+      // Clear selection
+      vm.$refs.table.clearSelection()
+      await doubleWait()
+      expect(vm.selection.length).toEqual(0)
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('virtual scroll with index column', () => {
+    it('should display correct index in virtual scroll mode', async () => {
+      const data = generateLargeData(100)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+          >
+            <el-table-column type="index" label="#" />
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      // First visible row should have index starting from 1
+      const firstIndexCell = wrapper.find('.el-table__body-wrapper td .cell')
+      if (firstIndexCell.exists()) {
+        expect(firstIndexCell.text()).toBe('1')
+      }
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('virtual scroll edge cases', () => {
+    it('should handle empty data', async () => {
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+          >
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data: [] }
+        },
+      })
+
+      await doubleWait()
+
+      const rows = wrapper.findAll('.el-table__body-wrapper tbody tr')
+      expect(rows.length).toEqual(0)
+
+      wrapper.unmount()
+    })
+
+    it('should handle data smaller than viewport', async () => {
+      const data = generateLargeData(3)
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="500"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+          >
+            <el-table-column prop="id" label="ID" />
+          </el-table>
+        `,
+        data() {
+          return { data }
+        },
+      })
+
+      await doubleWait()
+
+      const rows = wrapper.findAll('.el-table__body-wrapper tbody tr')
+      // All 3 rows should be rendered since they fit in viewport
+      expect(rows.length).toEqual(3)
+
+      wrapper.unmount()
+    })
+
+    it('should handle dynamic data replacement', async () => {
+      const wrapper = mount({
+        components: { ElTable, ElTableColumn },
+        template: `
+          <el-table
+            :data="data"
+            height="200"
+            :use-virtual="true"
+            :row-height="32"
+            row-key="id"
+          >
+            <el-table-column prop="id" label="ID" />
+            <el-table-column prop="name" label="Name" />
+          </el-table>
+        `,
+        data() {
+          return { data: generateLargeData(100) }
+        },
+      })
+
+      await doubleWait()
+
+      // Replace with completely different data
+      await wrapper.setData({
+        data: Array.from({ length: 50 }, (_, i) => ({
+          id: i + 200,
+          name: `New Row ${i + 1}`,
+        })),
+      })
+      await doubleWait()
+
+      const virtualContainer = wrapper.find(
+        '.el-table__body-wrapper .el-scrollbar__view > div'
+      )
+      // New height = 50 * 32 = 1600
+      expect(virtualContainer.attributes('style')).toContain('height: 1600px')
+
+      wrapper.unmount()
+    })
+  })
+})

--- a/packages/components/table/src/store/helper.ts
+++ b/packages/components/table/src/store/helper.ts
@@ -38,7 +38,64 @@ export function createStore<T extends DefaultRow>(
   const store = useStore<T>()
   // fix https://github.com/ElemeFE/element/issues/14075
   // related pr https://github.com/ElemeFE/element/pull/14146
-  store.toggleAllSelection = debounce(store._toggleAllSelection, 10)
+  // 修复在虚拟滚动下，取消全选/全选时卡顿的问题
+  store.toggleAllSelection = debounce(() => {
+    if (props.useVirtual) {
+      const { selectOnIndeterminate, isAllSelected, selection, selectable } =
+        store.states
+      const value = selectOnIndeterminate.value
+        ? !isAllSelected.value
+        : !(isAllSelected.value || selection.value.length)
+      isAllSelected.value = value
+
+      const allRows: any[] = []
+      const collectRows = (rows: any[]) => {
+        rows.forEach((row) => {
+          allRows.push(row)
+          // 收集树形子节点
+          const children = row[store.states.childrenColumnName.value]
+          if (children && children.length) {
+            collectRows(children)
+          }
+        })
+      }
+      collectRows(store.states.data.value || [])
+
+      // 收集懒加载子节点
+      const lazyTreeNodeMap = store.states.lazyTreeNodeMap?.value
+      if (lazyTreeNodeMap) {
+        Object.values(lazyTreeNodeMap).forEach((children: any) => {
+          if (children && children.length) {
+            collectRows(children)
+          }
+        })
+      }
+
+      if (value) {
+        // 全选：添加所有可选行
+        const newSelection: any[] = []
+        let rowIndex = 0
+        allRows.forEach((row) => {
+          if (!selectable.value || selectable.value.call(null, row, rowIndex)) {
+            newSelection.push(row)
+          }
+          rowIndex++
+        })
+        selection.value = newSelection
+      } else {
+        // 取消全选
+        selection.value = []
+      }
+
+      table.emit(
+        'selection-change',
+        selection.value ? selection.value.slice() : []
+      )
+      table.emit('select-all', (selection.value || []).slice())
+    } else {
+      store._toggleAllSelection()
+    }
+  }, 10)
   Object.keys(InitialStateMap).forEach((key) => {
     handleValue(getArrKeysValue(props, key), key, store)
   })

--- a/packages/components/table/src/store/watcher.ts
+++ b/packages/components/table/src/store/watcher.ts
@@ -1,4 +1,12 @@
-import { computed, getCurrentInstance, ref, toRefs, unref, watch } from 'vue'
+import {
+  computed,
+  getCurrentInstance,
+  ref,
+  toRaw,
+  toRefs,
+  unref,
+  watch,
+} from 'vue'
 import { ensureArray, hasOwn, isArray, isString } from '@element-plus/utils'
 import {
   getColumnById,
@@ -93,6 +101,14 @@ function useWatcher<T extends DefaultRow>() {
 
   const selectedMap = computed(() => {
     return rowKey.value ? getKeysMap(selection.value, rowKey.value) : undefined
+  })
+
+  // 无 rowKey 时用 WeakSet 做 O(1) 查找，避免 includes() 的 O(n) 开销
+  const selectionSet = computed(() => {
+    if (rowKey.value) return undefined
+    const sel = selection.value
+    const _len = sel.length // eslint-disable-line @typescript-eslint/no-unused-vars
+    return new WeakSet(toRaw(sel))
   })
 
   watch(
@@ -193,6 +209,8 @@ function useWatcher<T extends DefaultRow>() {
   const isSelected = (row: T) => {
     if (selectedMap.value) {
       return !!selectedMap.value[getRowIdentity(row, rowKey.value)]
+    } else if (selectionSet.value) {
+      return selectionSet.value.has(row)
     } else {
       return selection.value.includes(row)
     }

--- a/packages/components/table/src/table-body/index.ts
+++ b/packages/components/table/src/table-body/index.ts
@@ -79,8 +79,18 @@ export default defineComponent({
 
       rAF(() => {
         // just get first level children; fix #9723
-        const oldRow = rows[oldVal]
-        const newRow = rows[newVal]
+        const oldRow =
+          rows[
+            props.context.useVirtual
+              ? oldVal - props.context.start.value
+              : oldVal
+          ]
+        const newRow =
+          rows[
+            props.context.useVirtual
+              ? newVal - props.context.start.value
+              : newVal
+          ]
         // when there is fixed row, hover on rowSpan > 1 should not clear the class
         if (oldRow && !oldRow.classList.contains('hover-fixed-row')) {
           removeClass(oldRow, 'hover-row')
@@ -105,17 +115,38 @@ export default defineComponent({
     }
   },
   render() {
-    const { wrappedRowRender, store } = this
-    const data = store?.states.data.value || []
-    // Why do we need tabIndex: -1 ?
-    // If you set the tabindex attribute on an element ,
-    // then its child content cannot be scrolled with the arrow keys,
-    // unless you set tabindex on the content too
-    // See https://github.com/facebook/react/issues/25462#issuecomment-1274775248 or https://developer.mozilla.org/zh-CN/docs/Web/HTML/Global_attributes/tabindex
-    return h('tbody', { tabIndex: -1 }, [
-      data.reduce((acc: VNode[], row) => {
-        return acc.concat(wrappedRowRender(row, acc.length) as VNode[])
-      }, []),
-    ])
+    if (this.context.props.useVirtual) {
+      const { wrappedRowRender } = this
+      const body = h('tbody', { tabIndex: -1 }, [
+        this.context.virtualData.value.reduce((acc: VNode[], row) => {
+          if (Object.keys(this.context.store.states.treeData.value).length) {
+            return acc.concat(
+              wrappedRowRender(
+                row,
+                acc.length + this.context.treeStart.value
+              ) as VNode[]
+            )
+          } else {
+            const index = acc.length + this.context.start.value
+            const tr = wrappedRowRender(row, index) as VNode[]
+            return acc.concat(tr)
+          }
+        }, []),
+      ])
+      return body
+    } else {
+      const { wrappedRowRender, store } = this
+      const data = store?.states.data.value || []
+      // Why do we need tabIndex: -1 ?
+      // If you set the tabindex attribute on an element ,
+      // then its child content cannot be scrolled with the arrow keys,
+      // unless you set tabindex on the content too
+      // See https://github.com/facebook/react/issues/25462#issuecomment-1274775248 or https://developer.mozilla.org/zh-CN/docs/Web/HTML/Global_attributes/tabindex
+      return h('tbody', { tabIndex: -1 }, [
+        data.reduce((acc: VNode[], row) => {
+          return acc.concat(wrappedRowRender(row, acc.length) as VNode[])
+        }, []),
+      ])
+    }
   },
 })

--- a/packages/components/table/src/table-body/render-helper.ts
+++ b/packages/components/table/src/table-body/render-helper.ts
@@ -63,6 +63,13 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
     treeRowData?: TreeNode,
     expanded = false
   ) => {
+    if (
+      props.context?.useVirtual &&
+      ($index < (props.context?.start.value as number) ||
+        $index > (props.context?.end.value as number))
+    ) {
+      return ''
+    }
     const { tooltipEffect, tooltipOptions, store } = props
     const { indent, columns } = store!.states
     const rowClasses = []
@@ -82,7 +89,15 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
     return h(
       'tr',
       {
-        style: [displayStyle, getRowStyle(row, $index)],
+        style: [
+          {
+            height: props.context?.useVirtual
+              ? `${props.context?.rowHeight}px`
+              : undefined,
+          },
+          displayStyle,
+          getRowStyle(row, $index),
+        ],
         class: rowClasses,
         key: getKeyOfRow(row, $index),
         onDblclick: ($event: Event) => handleDoubleClick($event, row),
@@ -114,6 +129,7 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
         if (cellIndex === firstDefaultColumnIndex.value && treeRowData) {
           data.treeNode = {
             indent: treeRowData.level && treeRowData.level * indent.value,
+            childIndex: treeRowData.childIndex, // 记录子节点序号, 用于自定义行号渲染
             level: treeRowData.level,
           }
           if (isBoolean(treeRowData.expanded)) {
@@ -192,25 +208,28 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
 
       // 仅在需要时创建展开行（保留模式或展开状态）
       if (parent.props.preserveExpandedContent || expanded) {
-        rows[0].push(
-          h(
-            'tr',
-            {
-              key: `expanded-row__${tr.key as string}`,
-              style: { display: expanded ? '' : 'none' },
-            },
-            [
-              h(
-                'td',
-                {
-                  colspan: columns.length,
-                  class: `${ns.e('cell')} ${ns.e('expanded-cell')}`,
-                },
-                [renderExpanded({ row, $index, store, expanded })]
-              ),
-            ]
+        // 确保 tr 不是空字符串
+        if (tr) {
+          rows[0].push(
+            h(
+              'tr',
+              {
+                key: `expanded-row__${tr.key as string}`,
+                style: { display: expanded ? '' : 'none' },
+              },
+              [
+                h(
+                  'td',
+                  {
+                    colspan: columns.length,
+                    class: `${ns.e('cell')} ${ns.e('expanded-cell')}`,
+                  },
+                  [renderExpanded({ row, $index, store, expanded })]
+                ),
+              ]
+            )
           )
-        )
+        }
       }
 
       return rows
@@ -239,15 +258,19 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
       const tmp = [rowRender(row, $index, treeRowData ?? undefined)]
       // 渲染嵌套数据
       if (cur) {
+        if (props.context?.useVirtual && !cur.expanded) {
+          return tmp
+        }
         // currentRow 记录的是 index，所以还需主动增加 TreeTable 的 index
         let i = 0
         const traverse = (children: T[], parent: TreeData) => {
           if (!(children && children.length && parent)) return
-          children.forEach((node) => {
+          children.forEach((node, childIndex) => {
             // 父节点的 display 状态影响子节点的显示状态
             const innerTreeRowData: Partial<Record<string, any>> = {
               display: parent.display && parent.expanded,
               level: parent.level! + 1,
+              childIndex,
               expanded: false,
               noLazyChildren: false,
               loading: false,
@@ -277,10 +300,12 @@ function useRender<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
             i++
             tmp.push(rowRender(node, $index + i, innerTreeRowData))
             if (cur) {
-              const nodes =
-                lazyTreeNodeMap.value[childKey] ||
-                node[childrenColumnName.value]
-              traverse(nodes, cur)
+              if (!(props.context?.useVirtual && !cur.expanded)) {
+                const nodes =
+                  lazyTreeNodeMap.value[childKey] ||
+                  node[childrenColumnName.value]
+                traverse(nodes, cur)
+              }
             }
           })
         }

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -67,53 +67,64 @@
           :always="scrollbarAlwaysOn"
           :tabindex="scrollbarTabindex"
           :native="nativeScrollbar"
-          @scroll="$emit('scroll', $event)"
+          @scroll="
+            ($event) => {
+              handleScroll($event)
+              $emit('scroll', $event)
+            }
+          "
         >
-          <table
-            ref="tableBody"
-            :class="ns.e('body')"
-            cellspacing="0"
-            cellpadding="0"
-            border="0"
-            :style="{
-              width: bodyWidth,
-              tableLayout,
-            }"
-          >
-            <hColgroup
-              :columns="store.states.columns.value"
-              :table-layout="tableLayout"
-            />
-            <table-header
-              v-if="showHeader && tableLayout === 'auto'"
-              ref="tableHeaderRef"
-              :class="ns.e('body-header')"
-              :border="border"
-              :default-sort="defaultSort"
-              :store="store"
-              :append-filter-panel-to="appendFilterPanelTo"
-              @set-drag-visible="setDragVisible"
-            />
-            <table-body
-              :context="context"
-              :highlight="highlightCurrentRow"
-              :row-class-name="rowClassName"
-              :tooltip-effect="computedTooltipEffect"
-              :tooltip-options="computedTooltipOptions"
-              :row-style="rowStyle"
-              :store="store"
-              :stripe="stripe"
-            />
-            <table-footer
-              v-if="showSummary && tableLayout === 'auto'"
-              :class="ns.e('body-footer')"
-              :border="border"
-              :default-sort="defaultSort"
-              :store="store"
-              :sum-text="computedSumText"
-              :summary-method="summaryMethod"
-            />
-          </table>
+          <div :style="useVirtual ? `height: ${virtualBodyHeight}px;` : ''">
+            <div
+              :style="useVirtual ? `position: sticky; top: ${innerTop}px;` : ''"
+            >
+              <table
+                ref="tableBody"
+                :class="ns.e('body')"
+                cellspacing="0"
+                cellpadding="0"
+                border="0"
+                :style="{
+                  width: bodyWidth,
+                  tableLayout,
+                }"
+              >
+                <hColgroup
+                  :columns="store.states.columns.value"
+                  :table-layout="tableLayout"
+                />
+                <table-header
+                  v-if="showHeader && tableLayout === 'auto'"
+                  ref="tableHeaderRef"
+                  :class="ns.e('body-header')"
+                  :border="border"
+                  :default-sort="defaultSort"
+                  :store="store"
+                  :append-filter-panel-to="appendFilterPanelTo"
+                  @set-drag-visible="setDragVisible"
+                />
+                <table-body
+                  :context="context"
+                  :highlight="highlightCurrentRow"
+                  :row-class-name="rowClassName"
+                  :tooltip-effect="computedTooltipEffect"
+                  :tooltip-options="computedTooltipOptions"
+                  :row-style="rowStyle"
+                  :store="store"
+                  :stripe="stripe"
+                />
+                <table-footer
+                  v-if="showSummary && tableLayout === 'auto'"
+                  :class="ns.e('body-footer')"
+                  :border="border"
+                  :default-sort="defaultSort"
+                  :store="store"
+                  :sum-text="computedSumText"
+                  :summary-method="summaryMethod"
+                />
+              </table>
+            </div>
+          </div>
           <div
             v-if="isEmpty"
             ref="emptyBlock"
@@ -175,10 +186,14 @@ import {
   computed,
   defineComponent,
   getCurrentInstance,
+  nextTick,
   onBeforeUnmount,
   provide,
+  ref,
+  shallowRef,
+  watch,
 } from 'vue'
-import { debounce } from 'lodash-unified'
+import { debounce, throttle } from 'lodash-unified'
 import { Mousewheel } from '@element-plus/directives'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { useGlobalConfig } from '@element-plus/components/config-provider'
@@ -195,6 +210,7 @@ import useKeyRender from './table/key-render-helper'
 import defaultProps from './table/defaults'
 import { TABLE_INJECTION_KEY } from './tokens'
 import { hColgroup } from './h-helper'
+import { getRowIdentity } from './util'
 import { useScrollbar } from './composables/use-scrollbar'
 
 import type { Table } from './table/defaults'
@@ -287,8 +303,26 @@ export default defineComponent({
       scrollbarStyle,
     } = useStyle<Row>(props, layout, store, table)
 
-    const { scrollBarRef, scrollTo, setScrollLeft, setScrollTop } =
-      useScrollbar()
+    const {
+      scrollBarRef,
+      scrollTo: scrollToOld,
+      setScrollLeft,
+      setScrollTop: setScrollTopOld,
+    } = useScrollbar()
+    const scrollTo = function (
+      options: number | ScrollToOptions,
+      yCoord?: number | undefined
+    ) {
+      scrollToOld(options, yCoord)
+      handleScroll({
+        scrollTop:
+          (typeof options === 'number' ? options : options.top) || yCoord,
+      })
+    }
+    const setScrollTop = function (value: number | undefined) {
+      setScrollTopOld(value)
+      handleScroll({ scrollTop: value })
+    }
 
     const debouncedUpdateLayout = debounce(doLayout, 50)
 
@@ -325,8 +359,236 @@ export default defineComponent({
     onBeforeUnmount(() => {
       debouncedUpdateLayout.cancel()
     })
+    const { data, treeData } = store.states
+    const start = ref(0)
+    const end = ref(25)
+    const treeStart = ref(0)
+    const realTreeStart = ref(0)
+    const realTreeEnd = ref(25)
+    table.useVirtual = props.useVirtual
+    table.rowHeight = props.rowHeight
+    table.start = start
+    table.end = end
+    table.treeStart = treeStart
+    const innerTop = ref(0)
+    const scrollTop = ref(0)
+
+    // 性能优化：使用 Set 存储展开节点缓存，查找性能 O(1)
+    const expandedKeysCache = shallowRef<Set<string>>(new Set())
+
+    const visibleCount = computed(() =>
+      Math.ceil(
+        Number.parseFloat((props.height || props.maxHeight || 0).toString()) /
+          props.rowHeight
+      )
+    )
+    const handleScroll = function (event: { scrollTop: number | undefined }) {
+      if (props.useVirtual) {
+        const top = event.scrollTop || 0
+        scrollTop.value = top
+        const expectIdx = Math.floor(top / props.rowHeight)
+        innerTop.value = expectIdx * props.rowHeight - top
+        setVirtualParams(expectIdx)
+      }
+    }
+    const setVirtualParams = throttle(
+      (expectIdx) => {
+        const newStart = expectIdx
+        const newEnd = expectIdx + visibleCount.value + props.excessRows + 1
+
+        // 只有当范围真正改变时才更新
+        if (start.value !== newStart || end.value !== newEnd) {
+          start.value = newStart
+          end.value = newEnd
+          // 计算 treeStart 和 realTreeEnd
+          calculateTreeStart()
+          calculateTreeEnd()
+        }
+
+        // 使用 requestAnimationFrame 优化滚动条更新
+        requestAnimationFrame(() => {
+          scrollBarRef.value?.update()
+        })
+      },
+      16, // 优化为60fps
+      {
+        leading: true,
+        trailing: true, // 确保最后一次滚动也被处理
+      }
+    )
+    // 递归计算某个展开节点的所有可见后代数量
+    const getVisibleDescendantCount = (rowKey: string): number => {
+      if (!expandedKeysCache.value.has(rowKey)) return 0
+      const children = treeData.value[rowKey]?.children
+      if (!children || !children.length) return 0
+      let count = children.length
+      for (const childKey of children) {
+        count += getVisibleDescendantCount(childKey)
+      }
+      return count
+    }
+
+    // 更新展开节点缓存
+    const updateExpandedKeysCache = () => {
+      if (!props.useVirtual || !Object.keys(treeData.value).length) {
+        expandedKeysCache.value = new Set()
+        return
+      }
+
+      const expandedKeys = Object.keys(treeData.value).filter(
+        (key) =>
+          treeData.value[key].expanded &&
+          (!props.lazy || treeData.value[key].loaded)
+      )
+      expandedKeysCache.value = new Set(expandedKeys)
+    }
+    const virtualBodyHeight = computed(() => {
+      if (!props.useVirtual || !data.value) {
+        return 0
+      }
+
+      if (expandedKeysCache.value.size) {
+        let totalDescendants = 0
+        for (let i = 0; i < data.value.length; i++) {
+          const rowKey = getRowIdentity(data.value[i], props.rowKey || null)
+          totalDescendants += getVisibleDescendantCount(rowKey)
+        }
+        return (data.value.length + totalDescendants) * props.rowHeight
+      } else {
+        return data.value.length * props.rowHeight
+      }
+    })
+    watch(virtualBodyHeight, () => {
+      nextTick(() => {
+        // fix scrollbar's position
+        scrollBarRef.value.update()
+      })
+    })
+    // 计算 treeStart 的函数
+    const calculateTreeStart = () => {
+      const expandedKeys = expandedKeysCache.value
+      if (
+        !data.value ||
+        !Object.keys(treeData.value).length ||
+        !expandedKeys.size
+      ) {
+        treeStart.value = start.value
+        realTreeStart.value = start.value
+        return
+      }
+
+      let ci = -1
+      for (let i = 0; i < data.value.length; i++) {
+        ci++
+        const rowKey = getRowIdentity(data.value[i], props.rowKey || null)
+        const descendantCount = getVisibleDescendantCount(rowKey)
+        ci += descendantCount
+        if (ci >= start.value) {
+          realTreeStart.value = i
+          treeStart.value = ci - descendantCount
+          return
+        }
+      }
+
+      // 兜底：start 超出数据范围时，定位到最后一条数据
+      realTreeStart.value = data.value.length - 1
+      treeStart.value = ci
+    }
+
+    // 计算 realTreeEnd 的函数
+    const calculateTreeEnd = () => {
+      const expandedKeys = expandedKeysCache.value
+      if (
+        !data.value ||
+        !Object.keys(treeData.value).length ||
+        !expandedKeys.size
+      ) {
+        return
+      }
+
+      let ci = treeStart.value - 1
+      for (let i = realTreeStart.value; i < data.value.length; i++) {
+        ci++
+        const rowKey = getRowIdentity(data.value[i], props.rowKey || null)
+        ci += getVisibleDescendantCount(rowKey)
+        if (ci >= end.value) {
+          realTreeEnd.value = i
+          return
+        }
+      }
+
+      // 如果没有找到,说明 end 超出了数据范围
+      realTreeEnd.value = data.value.length - 1
+    }
+
+    const virtualData = computed(() => {
+      if (!data.value) {
+        return []
+      }
+
+      if (expandedKeysCache.value.size) {
+        return data.value.slice(realTreeStart.value, realTreeEnd.value + 1)
+      } else {
+        return data.value.slice(start.value, end.value)
+      }
+    })
+
+    table.virtualData = virtualData
+
+    // 优化监听器
+    watch(
+      () => props.data,
+      () => {
+        handleScroll({ scrollTop: 0 })
+      },
+      { flush: 'post', immediate: true }
+    )
+
+    watch(
+      () => props.height,
+      () => handleScroll({ scrollTop: scrollTop.value })
+    )
+
+    watch(
+      () => props.maxHeight,
+      () => handleScroll({ scrollTop: scrollTop.value })
+    )
+
+    // 监听 treeData 变化,更新展开节点缓存并重新计算
+    watch(
+      () => treeData.value,
+      () => {
+        if (props.useVirtual) {
+          updateExpandedKeysCache()
+          calculateTreeStart()
+          calculateTreeEnd()
+        }
+      },
+      { deep: true, immediate: true }
+    )
+
+    // 监听 data 变化,重新计算
+    watch(
+      () => data.value,
+      () => {
+        if (props.useVirtual) {
+          updateExpandedKeysCache()
+          calculateTreeStart()
+          calculateTreeEnd()
+        }
+      },
+      { immediate: true }
+    )
 
     return {
+      start,
+      end,
+      rowHeight: props.rowHeight,
+      treeStart,
+      scrollTop,
+      handleScroll,
+      virtualBodyHeight,
+      innerTop,
       ns,
       layout,
       store,

--- a/packages/components/table/src/table/defaults.ts
+++ b/packages/components/table/src/table/defaults.ts
@@ -81,6 +81,12 @@ interface Table<T extends DefaultRow = any> extends ComponentInternalInstance {
   refs: TableRefs
   tableId: string
   state: TableState
+  useVirtual: boolean
+  rowHeight: number
+  start: Ref<number>
+  end: Ref<number>
+  treeStart: Ref<number>
+  virtualData: Ref<T[]>
 }
 
 type ColumnCls<T> = string | ((data: { row: T; rowIndex: number }) => string)
@@ -105,6 +111,9 @@ type CellStyle<T extends DefaultRow> =
     }) => CSSProperties)
 type Layout = 'fixed' | 'auto'
 interface TableProps<T extends DefaultRow> {
+  useVirtual?: boolean
+  rowHeight?: number
+  excessRows?: number
   data: T[]
   size?: ComponentSize
   width?: string | number
@@ -190,6 +199,7 @@ interface TreeNode {
   indent?: number
   level?: number
   display?: boolean
+  childIndex?: number
 }
 
 interface RenderRowData<T extends DefaultRow> {
@@ -211,6 +221,15 @@ interface TableConfigContext {
 }
 
 export default {
+  useVirtual: Boolean,
+  rowHeight: {
+    type: Number,
+    default: 32,
+  },
+  excessRows: {
+    type: Number,
+    default: 3,
+  },
   /**
    * @description table data
    */


### PR DESCRIPTION
Add virtual scroll for large datasets:
Basic virtual scroll
Tree data support
Lazy-loaded tree support
Optimized selection performance
Documentation and tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added virtual scrolling support for tables to efficiently render large datasets. New properties enable virtual scrolling (`use-virtual`), control row height (`row-height`), and adjust rendering buffer (`excess-rows`).
  * Comprehensive documentation with examples for basic virtual scrolling, hierarchical data, and lazy-loaded tree structures now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->