### PR TITLE
docs: migrate from presetUno to presetWind3

### DIFF
--- a/docs/unocss.config.ts
+++ b/docs/unocss.config.ts
@@ -1,7 +1,12 @@
-import { defineConfig, presetAttributify, presetIcons, presetUno } from 'unocss'
+import {
+  defineConfig,
+  presetAttributify,
+  presetIcons,
+  presetWind3,
+} from 'unocss'
 
 export default defineConfig({
-  presets: [presetUno(), presetAttributify(), presetIcons()],
+  presets: [presetWind3(), presetAttributify(), presetIcons()],
   content: {
     pipeline: {
       include: [`./**/*`],


### PR DESCRIPTION
The `presetUno` is Deprecated. Migrate to `presetWind3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the styling system configuration to switch to a newer preset framework for utility classes and icons. This adjusts how styles are generated and applied across the docs site without changing visual styles directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->