### PR TITLE
fix(components): [input-tag] Add tags twice when entering Korean

### DIFF
--- a/packages/components/input-tag/src/composables/use-input-tag.ts
+++ b/packages/components/input-tag/src/composables/use-input-tag.ts
@@ -33,6 +33,7 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
   const inputRef = shallowRef<HTMLInputElement>()
   const inputValue = ref<string>()
   const tagTooltipRef = ref<TooltipInstance>()
+  const pendingAddTag = ref(false)
 
   const tagSize = computed(() => {
     return ['small'].includes(size.value) ? 'small' : 'default'
@@ -114,8 +115,13 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
   }
 
   const handleKeydown = (event: KeyboardEvent) => {
-    if (isComposing.value) return
     const code = getEventCode(event)
+    if (isComposing.value || event.isComposing) {
+      if (code === props.trigger && props.trigger === EVENT_CODE.space) {
+        pendingAddTag.value = true
+      }
+      return
+    }
 
     switch (code) {
       case props.trigger:
@@ -141,7 +147,7 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
   }
 
   const handleKeyup = (event: KeyboardEvent) => {
-    if (isComposing.value || !isAndroid()) return
+    if (isComposing.value || event.isComposing || !isAndroid()) return
     const code = getEventCode(event)
 
     switch (code) {
@@ -227,8 +233,16 @@ export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
     isComposing,
     handleCompositionStart,
     handleCompositionUpdate,
-    handleCompositionEnd,
+    handleCompositionEnd: onCompositionEnd,
   } = useComposition({ afterComposition: handleInput })
+
+  const handleCompositionEnd = (event: CompositionEvent) => {
+    onCompositionEnd(event)
+    if (pendingAddTag.value) {
+      pendingAddTag.value = false
+      handleAddTag()
+    }
+  }
 
   watch(
     () => props.modelValue,


### PR DESCRIPTION
- The issue of accidentally triggering tag addition when processing Korean input
- Adding pendingAddTag status control trigger to space causes an exception when adding Korean tags

fix [#23788](https://github.com/element-plus/element-plus/issues/23788)

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the tag input component's handling of composition-based input methods, including Asian language systems. Tags now automatically add when completing composition input with a space trigger, removing the need for extra steps and providing a more seamless experience for users relying on these input methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->