### PR TITLE
fix(components): [input-number] handle IME period and trailing decimal #23563

### DIFF
--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -725,3 +725,109 @@ describe('InputNumber.vue', () => {
     expect(input.element.value).toBe('10')
   })
 })
+
+describe('filterNumberInput', () => {
+  const triggerInput = async (
+    wrapper: ReturnType<typeof mount>,
+    value: string
+  ) => {
+    const input = wrapper.find('input')
+    input.element.value = value
+    await input.trigger('input')
+  }
+
+  test('converts Chinese full-width period (。) to decimal point', async () => {
+    const handleInput = vi.fn()
+    const num = ref(0)
+    const wrapper = mount(() => (
+      <InputNumber v-model={num.value} onInput={handleInput} />
+    ))
+    await triggerInput(wrapper, '1。5')
+    expect(handleInput).toHaveBeenCalledWith(1.5)
+  })
+
+  test('strips non-numeric characters', async () => {
+    const handleInput = vi.fn()
+    const num = ref(0)
+    const wrapper = mount(() => (
+      <InputNumber v-model={num.value} onInput={handleInput} />
+    ))
+    await triggerInput(wrapper, 'abc')
+    expect(handleInput).toHaveBeenCalledWith(null)
+  })
+
+  test('allows intermediate trailing decimal point in display', async () => {
+    const handleInput = vi.fn()
+    const num = ref(0)
+    const wrapper = mount(() => (
+      <InputNumber v-model={num.value} onInput={handleInput} />
+    ))
+    await triggerInput(wrapper, '1.')
+    // numeric value is 1, but display keeps '1.' for continued typing
+    expect(handleInput).toHaveBeenCalledWith(1)
+    expect(wrapper.find('input').element.value).toBe('1.')
+  })
+
+  test('allows negative numbers', async () => {
+    const handleInput = vi.fn()
+    const num = ref(0)
+    const wrapper = mount(() => (
+      <InputNumber v-model={num.value} onInput={handleInput} />
+    ))
+    await triggerInput(wrapper, '-1.5')
+    expect(handleInput).toHaveBeenCalledWith(-1.5)
+  })
+
+  test('strips extra decimal points, keeping only the first', async () => {
+    const handleInput = vi.fn()
+    const num = ref(0)
+    const wrapper = mount(() => (
+      <InputNumber v-model={num.value} onInput={handleInput} />
+    ))
+    await triggerInput(wrapper, '1.2.3')
+    expect(handleInput).toHaveBeenCalledWith(1.23)
+  })
+
+  test('allows scientific notation by default', async () => {
+    const handleInput = vi.fn()
+    const num = ref(0)
+    const wrapper = mount(() => (
+      <InputNumber v-model={num.value} onInput={handleInput} />
+    ))
+    await triggerInput(wrapper, '1e5')
+    expect(handleInput).toHaveBeenCalledWith(100000)
+  })
+
+  test('strips scientific notation when disabledScientific is set', async () => {
+    const handleInput = vi.fn()
+    const num = ref(0)
+    const wrapper = mount(() => (
+      <InputNumber
+        v-model={num.value}
+        onInput={handleInput}
+        disabledScientific
+      />
+    ))
+    await triggerInput(wrapper, '1e5')
+    // 'e' is stripped, result is '15'
+    expect(handleInput).toHaveBeenCalledWith(15)
+  })
+
+  test('default inputmode attribute is decimal', () => {
+    const num = ref(0)
+    const wrapper = mount(() => <InputNumber v-model={num.value} />)
+    expect(wrapper.find('input').element.getAttribute('inputmode')).toBe(
+      'decimal'
+    )
+  })
+
+  test('inputmode prop overrides the default', () => {
+    const num = ref(0)
+    const wrapper = mount(() => (
+      <InputNumber v-model={num.value} inputmode="numeric" />
+    ))
+    expect(wrapper.find('input').element.getAttribute('inputmode')).toBe(
+      'numeric'
+    )
+  })
+})

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -308,6 +308,7 @@ const setCurrentValue = (
   data.currentValue = newVal
 }
 const handleInput = (value: string) => {
+  value = value.replace(/。/g, '.')
   data.userInput = value
   const newVal = value === '' ? null : Number(value)
   emit(INPUT_EVENT, newVal)
@@ -335,6 +336,9 @@ const handleFocus = (event: MouseEvent | FocusEvent) => {
 }
 
 const handleBlur = (event: MouseEvent | FocusEvent) => {
+  if (typeof data.userInput === 'string' && data.userInput.endsWith('.')) {
+    data.userInput = data.userInput.slice(0, -1)
+  }
   data.userInput = null
   // When non-numeric content is entered into a numeric input box,
   // the content displayed on the page is not cleared after the value is cleared. #18533

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -43,19 +43,16 @@
     <el-input
       :id="id"
       ref="input"
-      type="number"
-      :step="step"
+      type="text"
       :model-value="displayValue"
       :placeholder="placeholder"
       :readonly="readonly"
       :disabled="inputNumberDisabled"
       :size="inputNumberSize"
-      :max="max"
-      :min="min"
       :name="name"
       :aria-label="ariaLabel"
       :validate-event="false"
-      :inputmode="inputmode"
+      :inputmode="inputmode ?? 'decimal'"
       @keydown="handleKeydown"
       @blur="handleBlur"
       @focus="handleFocus"
@@ -307,10 +304,41 @@ const setCurrentValue = (
   }
   data.currentValue = newVal
 }
-const handleInput = (value: string) => {
+const filterNumberInput = (value: string): string => {
+  // Convert full-width period to half-width
   value = value.replace(/。/g, '.')
-  data.userInput = value
-  const newVal = value === '' ? null : Number(value)
+  const allowScientific = !props.disabledScientific
+  let result = ''
+  let hasDot = false
+  let hasExp = false
+  for (const ch of value) {
+    if (ch >= '0' && ch <= '9') {
+      result += ch
+    } else if (ch === '-' || ch === '+') {
+      // Sign allowed at start, or immediately after e/E
+      if (result === '' || /[eE]$/.test(result)) {
+        result += ch
+      }
+    } else if (ch === '.') {
+      // At most one dot, not after exponent
+      if (!hasDot && !hasExp) {
+        hasDot = true
+        result += ch
+      }
+    } else if ((ch === 'e' || ch === 'E') && allowScientific) {
+      // At most one exponent, must follow a digit
+      if (!hasExp && /\d$/.test(result)) {
+        hasExp = true
+        result += ch
+      }
+    }
+  }
+  return result
+}
+const handleInput = (value: string) => {
+  const filtered = filterNumberInput(value)
+  data.userInput = filtered
+  const newVal = filtered === '' ? null : Number(filtered)
   emit(INPUT_EVENT, newVal)
   setCurrentValue(newVal, false)
 }


### PR DESCRIPTION
## Summary

Switch from `type="number"` to `type="text" inputmode="decimal"` to fundamentally fix IME input issues on Chinese input methods.

- Add `filterNumberInput()` for single-pass normalization: converts full-width period (`。` → `.`), enforces one decimal point, one exponent (after a digit), sign only at start or after `e/E`, strips everything else
- Change `type="number"` to `type="text"` with `inputmode="decimal"` as default (maintains numeric keyboard on mobile; can be overridden via the existing `inputmode` prop)
- Remove `:min` / `:max` / `:step` from template (no effect on `type="text"`; range validation is handled by `verifyValue()`, stepping by `increase()` / `decrease()`)
- Add 9 unit tests covering the filtering logic and `inputmode` default

## Related Issue

Closes #23563

## Test Plan

- [ ] Type a decimal number using Chinese IME — decimal point should work correctly
- [ ] Type Chinese period `。` — should be converted to `.`
- [ ] Type `1.` and continue typing — trailing dot preserved during input, cleaned on blur
- [ ] Negative numbers, scientific notation (`1e5`) work as expected
- [ ] Run `pnpm test`