### PR TITLE
docs: standardize API description formatting

### DIFF
--- a/docs/en-US/component/divider.md
+++ b/docs/en-US/component/divider.md
@@ -53,10 +53,10 @@ divider/vertical-divider
 | ---------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
 | direction        | Set divider's direction                                    | ^[enum]`'horizontal' \| 'vertical'`                                                                                                         | horizontal |
 | border-style     | Set the style of divider                                   | ^[enum]`'none' \| 'solid' \| 'hidden' \| 'dashed' \| ...` [css/border-style](https://developer.mozilla.org/zh-CN/docs/Web/CSS/border-style) | solid      |
-| content-position | the position of the customized content on the divider line | ^[enum]`'left' \| 'right' \| 'center' `                                                                                                     | center     |
+| content-position | The position of the customized content on the divider line | ^[enum]`'left' \| 'right' \| 'center' `                                                                                                     | center     |
 
 ### Slots
 
 | Name    | Description                            |
 | ------- | -------------------------------------- |
-| default | customized content on the divider line |
+| default | Customized content on the divider line |

--- a/docs/en-US/component/divider.md
+++ b/docs/en-US/component/divider.md
@@ -53,7 +53,7 @@ divider/vertical-divider
 | ---------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
 | direction        | Set divider's direction                                    | ^[enum]`'horizontal' \| 'vertical'`                                                                                                         | horizontal |
 | border-style     | Set the style of divider                                   | ^[enum]`'none' \| 'solid' \| 'hidden' \| 'dashed' \| ...` [css/border-style](https://developer.mozilla.org/zh-CN/docs/Web/CSS/border-style) | solid      |
-| content-position | The position of the customized content on the divider line | ^[enum]`'left' \| 'right' \| 'center' `                                                                                                     | center     |
+| content-position | The position of the customized content on the divider line | ^[enum]`'left' \| 'right' \| 'center'`                                                                                                      | center     |
 
 ### Slots
 

--- a/docs/en-US/component/icon.md
+++ b/docs/en-US/component/icon.md
@@ -232,4 +232,4 @@ import { Edit, Share, Delete, Search, Loading } from '@element-plus/icons-vue'
 
 | Name    | Description               |
 | ------- | ------------------------- |
-| default | customize default content |
+| default | Customize default content |

--- a/docs/en-US/component/splitter.md
+++ b/docs/en-US/component/splitter.md
@@ -113,6 +113,6 @@ splitter/lazy
 
 ### SplitterPanel Exposes
 
-| Name                       | Description                 | Type                           |
-| -------------------------- | --------------------------- | ------------------------------ |
-| splitterPanelRef ^(2.11.9) | Splitter-panel html element | ^[object]`Ref<HTMLDivElement>` |
+| Name                       | Description                | Type                           |
+| -------------------------- | -------------------------- | ------------------------------ |
+| splitterPanelRef ^(2.11.9) | SplitterPanel html element | ^[object]`Ref<HTMLDivElement>` |

--- a/docs/en-US/component/splitter.md
+++ b/docs/en-US/component/splitter.md
@@ -115,4 +115,4 @@ splitter/lazy
 
 | Name                       | Description                 | Type                           |
 | -------------------------- | --------------------------- | ------------------------------ |
-| splitterPanelRef ^(2.11.9) | splitter-panel html element | ^[object]`Ref<HTMLDivElement>` |
+| splitterPanelRef ^(2.11.9) | Splitter-panel html element | ^[object]`Ref<HTMLDivElement>` |


### PR DESCRIPTION
## Summary

Fix inconsistent capitalization in API table descriptions for 3 components. Descriptions that start with a lowercase English letter are updated to start with an uppercase letter. Descriptions starting with a backtick are left unchanged.

- `icon.md`: 1 fix
- `splitter.md`: 1 fix
- `divider.md`: 2 fixes

## Related Issue

Related #23692

## Test Plan

- [ ] Verify all changed descriptions now start with an uppercase letter
- [ ] Verify no descriptions starting with `` ` `` were modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized capitalization and minor formatting in API docs for Divider, Icon, and Splitter components: slot and attribute descriptions updated for consistency and clarity. No behavioral or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->