### PR TITLE
fix(hooks): [use-composition] abnormal state in Korean input composition

### DIFF
--- a/packages/hooks/use-composition/index.ts
+++ b/packages/hooks/use-composition/index.ts
@@ -1,5 +1,4 @@
 import { nextTick, ref } from 'vue'
-import { isKorean } from '@element-plus/utils'
 
 interface UseCompositionOptions {
   afterComposition: (event: CompositionEvent) => void
@@ -21,9 +20,6 @@ export function useComposition({
 
   const handleCompositionUpdate = (event: CompositionEvent) => {
     emit?.('compositionupdate', event)
-    const text = (event.target as HTMLInputElement)?.value
-    const lastCharacter = text[text.length - 1] || ''
-    isComposing.value = !isKorean(lastCharacter)
   }
 
   const handleCompositionEnd = (event: CompositionEvent) => {

--- a/packages/hooks/use-composition/index.ts
+++ b/packages/hooks/use-composition/index.ts
@@ -20,6 +20,7 @@ export function useComposition({
 
   const handleCompositionUpdate = (event: CompositionEvent) => {
     emit?.('compositionupdate', event)
+    isComposing.value = true
   }
 
   const handleCompositionEnd = (event: CompositionEvent) => {

--- a/packages/utils/i18n.ts
+++ b/packages/utils/i18n.ts
@@ -1,2 +1,5 @@
+/**
+ * @deprecated This function is deprecated and will be removed in future versions.
+ */
 export const isKorean = (text: string) =>
   /([\uAC00-\uD7AF\u3130-\u318F])+/gi.test(text)


### PR DESCRIPTION
I looked into why `isKorean` was originally introduced and found that the affected users were all on IE11. 
Since we no longer support IE, this hack can be removed. 
I’ve tested issues [#11665](https://github.com/ElemeFE/element/issues/11665) and [#10611](https://github.com/ElemeFE/element/issues/10611) in Edge, Chrome, and Firefox, and everything looks fine now.

resolves #23788

Original issues:
 - https://github.com/ElemeFE/element/issues/10611
 - https://github.com/ElemeFE/element/issues/11665 

Introducing `isKorean` PR:
 - https://github.com/ElemeFE/element/pull/15069
 - https://github.com/ElemeFE/element/pull/10648


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified composition state handling for text input so composition updates no longer trigger intermediate value checks; input composition behavior remains correct and more consistent.

* **Chores**
  * Marked the language-detection utility as deprecated via documentation notes to indicate it will be phased out in future releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->