### PR TITLE
ci: check build fail

### DIFF
--- a/.github/workflows/publish-docs-deploy-manual.yml
+++ b/.github/workflows/publish-docs-deploy-manual.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.19.0
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
@@ -51,7 +51,7 @@ jobs:
         run: pnpm docs:build
         env:
           DOC_ENV: production
-          NODE_OPTIONS: --max-old-space-size=6144
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.4.1

--- a/.github/workflows/publish-docs-deploy-manual.yml
+++ b/.github/workflows/publish-docs-deploy-manual.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.19.0
-          cache: "pnpm"
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/publish-docs-deploy.yml
+++ b/.github/workflows/publish-docs-deploy.yml
@@ -2,7 +2,7 @@ name: Publish Docs Deploy
 
 on:
   workflow_run:
-    workflows: ['Publish to NPM registry']
+    workflows: ["Publish to NPM registry"]
     types: [completed]
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.19.0
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
@@ -58,7 +58,7 @@ jobs:
         run: pnpm docs:build
         env:
           DOC_ENV: production
-          NODE_OPTIONS: --max-old-space-size=6144
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.4.1

--- a/.github/workflows/publish-docs-deploy.yml
+++ b/.github/workflows/publish-docs-deploy.yml
@@ -2,7 +2,7 @@ name: Publish Docs Deploy
 
 on:
   workflow_run:
-    workflows: ["Publish to NPM registry"]
+    workflows: ['Publish to NPM registry']
     types: [completed]
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.19.0
-          cache: "pnpm"
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/staging-docs.yml
+++ b/.github/workflows/staging-docs.yml
@@ -3,10 +3,10 @@ name: Staging Docs
 on:
   push:
     branches:
-      - "dev"
+      - 'dev'
   pull_request:
     branches:
-      - "dev"
+      - 'dev'
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.19.0
-          cache: "pnpm"
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/staging-docs.yml
+++ b/.github/workflows/staging-docs.yml
@@ -3,8 +3,10 @@ name: Staging Docs
 on:
   push:
     branches:
-      - 'dev'
-
+      - "dev"
+  pull_request:
+    branches:
+      - "dev"
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
@@ -26,7 +28,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.19.0
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
@@ -71,7 +73,7 @@ jobs:
         run: pnpm docs:build
         env:
           DOC_ENV: staging
-          NODE_OPTIONS: --max-old-space-size=6144
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Deploy staging website
         uses: JamesIves/github-pages-deploy-action@v4.4.1

--- a/.github/workflows/staging-docs.yml
+++ b/.github/workflows/staging-docs.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - 'dev'
-  pull_request:
-    branches:
-      - 'dev'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

#23829 After merging, an out-of-memory error occurs when executing `pnpm docs:build`. Currently, increasing the `max-old-space-size` parameter can resolve the issue (it's likely that Prettier is using too much memory when formatting files).

https://github.com/element-plus/element-plus/actions/runs/23277552864/job/67683639032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for documentation builds to improve build stability and prevent memory-related failures.
  * Clarified build configuration for documentation pipelines; no functional changes to deployment or build flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->