### PR TITLE
test: [select/select-v2] incorrect trigger visible-change

### DIFF
--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -2964,4 +2964,77 @@ describe('Select', () => {
 
     parent.remove()
   })
+  // #23838
+  it('should keep dropdown visible during debouncing when options exist (remote)', async () => {
+    vi.useFakeTimers()
+
+    const options = ref([{ value: 'test', label: 'test' }])
+    const handleVisibleChange = vi.fn()
+    const remoteMethod = vi.fn((query: string) => {
+      if (query) {
+        options.value = [
+          { value: 'Alabama', label: 'Alabama' },
+          { value: 'Alaska', label: 'Alaska' },
+        ]
+      }
+    })
+
+    // Temporarily restore useDebounceFn to use real debounce with fake timers
+    const { useDebounceFn } = await vi.importActual('@vueuse/core')
+    vi.mocked(
+      vi.mocked(await import('@vueuse/core')).useDebounceFn
+    ).mockImplementation(useDebounceFn)
+
+    const wrapper = createSelect({
+      data() {
+        return {
+          filterable: true,
+          remote: true,
+          debounce: 300,
+          options,
+          value: '',
+        }
+      },
+      methods: {
+        remoteMethod,
+        onVisibleChange: handleVisibleChange,
+      },
+    })
+
+    const select = wrapper.findComponent(Select)
+    const vm = select.vm as any
+    const input = wrapper.find('input')
+
+    // Open dropdown first
+    await input.trigger('click')
+    await nextTick()
+    expect(vm.expanded).toBe(true)
+    expect(vm.dropdownMenuVisible).toBe(true)
+    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+    expect(handleVisibleChange).toHaveBeenLastCalledWith(true)
+
+    // Start typing to trigger remote search and debouncing
+    input.element.value = 'a'
+    await input.trigger('input')
+    await nextTick()
+    vi.advanceTimersByTime(50) // Advance time but don't complete debounce
+    await nextTick()
+
+    // During debouncing (before debounce completes), check dropdown and event count
+    // With the fix: dropdown stays visible, visible-change called only once
+    // Without the fix: dropdown becomes hidden then visible again, visible-change called 3 times
+    expect(vm.dropdownMenuVisible).toBe(true)
+    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+
+    // Complete the debounce
+    vi.advanceTimersByTime(300)
+    await nextTick()
+
+    expect(remoteMethod).toHaveBeenCalledWith('a')
+    expect(vm.dropdownMenuVisible).toBe(true)
+    // Should still only have been called once - dropdown never closed
+    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
+  })
 })

--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -2981,58 +2981,66 @@ describe('Select', () => {
 
     // Temporarily restore useDebounceFn to use real debounce with fake timers
     const { useDebounceFn } = await vi.importActual('@vueuse/core')
-    vi.mocked(
-      vi.mocked(await import('@vueuse/core')).useDebounceFn
-    ).mockImplementation(useDebounceFn)
+    const mockedUseDebounceFn = vi.mocked(
+      (await import('@vueuse/core')).useDebounceFn
+    )
+    const originalUseDebounceFnImpl =
+      mockedUseDebounceFn.getMockImplementation()
+    mockedUseDebounceFn.mockImplementation(useDebounceFn)
 
-    const wrapper = createSelect({
-      data() {
-        return {
-          filterable: true,
-          remote: true,
-          debounce: 300,
-          options,
-          value: '',
-        }
-      },
-      methods: {
-        remoteMethod,
-        onVisibleChange: handleVisibleChange,
-      },
-    })
+    try {
+      const wrapper = createSelect({
+        data() {
+          return {
+            filterable: true,
+            remote: true,
+            debounce: 300,
+            options,
+            value: '',
+          }
+        },
+        methods: {
+          remoteMethod,
+          onVisibleChange: handleVisibleChange,
+        },
+      })
 
-    const select = wrapper.findComponent(Select)
-    const vm = select.vm as any
-    const input = wrapper.find('input')
+      const select = wrapper.findComponent(Select)
+      const vm = select.vm as any
+      const input = wrapper.find('input')
 
-    // Open dropdown first
-    await input.trigger('click')
-    await nextTick()
-    expect(vm.expanded).toBe(true)
-    expect(vm.dropdownMenuVisible).toBe(true)
-    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
-    expect(handleVisibleChange).toHaveBeenLastCalledWith(true)
+      // Open dropdown first
+      await input.trigger('click')
+      await nextTick()
+      expect(vm.expanded).toBe(true)
+      expect(vm.dropdownMenuVisible).toBe(true)
+      expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+      expect(handleVisibleChange).toHaveBeenLastCalledWith(true)
 
-    // Start typing to trigger remote search and debouncing
-    input.element.value = 'a'
-    await input.trigger('input')
-    await nextTick()
-    vi.advanceTimersByTime(50) // Advance time but don't complete debounce
-    await nextTick()
+      // Start typing to trigger remote search and debouncing
+      input.element.value = 'a'
+      await input.trigger('input')
+      await nextTick()
+      vi.advanceTimersByTime(50) // Advance time but don't complete debounce
+      await nextTick()
 
-    // During debouncing (before debounce completes), check dropdown and event count
-    expect(vm.dropdownMenuVisible).toBe(true)
-    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+      // During debouncing (before debounce completes), check dropdown and event count
+      expect(vm.dropdownMenuVisible).toBe(true)
+      expect(handleVisibleChange).toHaveBeenCalledTimes(1)
 
-    // Complete the debounce
-    vi.advanceTimersByTime(300)
-    await nextTick()
+      // Complete the debounce
+      vi.advanceTimersByTime(300)
+      await nextTick()
 
-    expect(remoteMethod).toHaveBeenCalledWith('a')
-    expect(vm.dropdownMenuVisible).toBe(true)
-    // Should still only have been called once - dropdown never closed
-    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
-
-    vi.useRealTimers()
+      expect(remoteMethod).toHaveBeenCalledWith('a')
+      expect(vm.dropdownMenuVisible).toBe(true)
+      // Should still only have been called once - dropdown never closed
+      expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+    } finally {
+      mockedUseDebounceFn.mockImplementation(
+        originalUseDebounceFnImpl ?? ((fn: any) => fn)
+      )
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -3021,8 +3021,6 @@ describe('Select', () => {
     await nextTick()
 
     // During debouncing (before debounce completes), check dropdown and event count
-    // With the fix: dropdown stays visible, visible-change called only once
-    // Without the fix: dropdown becomes hidden then visible again, visible-change called 3 times
     expect(vm.dropdownMenuVisible).toBe(true)
     expect(handleVisibleChange).toHaveBeenCalledTimes(1)
 

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4476,78 +4476,86 @@ describe('Select', () => {
 
     // Temporarily restore useDebounceFn to use real debounce with fake timers
     const { useDebounceFn } = await vi.importActual('@vueuse/core')
-    vi.mocked(
-      vi.mocked(await import('@vueuse/core')).useDebounceFn
-    ).mockImplementation(useDebounceFn)
-
-    wrapper = mount(
-      {
-        components: {
-          'el-select': Select,
-          'el-option': Option,
-        },
-        template: `
-          <el-select
-            v-model="value"
-            filterable
-            remote
-            :debounce="300"
-            :remote-method="remoteMethod"
-            @visible-change="handleVisibleChange"
-          >
-            <el-option
-              v-for="item in options"
-              :key="item.value"
-              :label="item.label"
-              :value="item.value"
-            />
-          </el-select>
-        `,
-        setup() {
-          return {
-            value: ref(''),
-            options,
-            remoteMethod,
-            handleVisibleChange,
-          }
-        },
-      },
-      {
-        attachTo: 'body',
-      }
+    const mockedUseDebounceFn = vi.mocked(
+      (await import('@vueuse/core')).useDebounceFn
     )
+    const originalUseDebounceFnImpl =
+      mockedUseDebounceFn.getMockImplementation()
+    mockedUseDebounceFn.mockImplementation(useDebounceFn)
 
-    const select = wrapper.findComponent(Select)
-    const vm = select.vm as any
-    const input = wrapper.find('input')
+    try {
+      wrapper = mount(
+        {
+          components: {
+            'el-select': Select,
+            'el-option': Option,
+          },
+          template: `
+            <el-select
+              v-model="value"
+              filterable
+              remote
+              :debounce="300"
+              :remote-method="remoteMethod"
+              @visible-change="handleVisibleChange"
+            >
+              <el-option
+                v-for="item in options"
+                :key="item.value"
+                :label="item.label"
+                :value="item.value"
+              />
+            </el-select>
+          `,
+          setup() {
+            return {
+              value: ref(''),
+              options,
+              remoteMethod,
+              handleVisibleChange,
+            }
+          },
+        },
+        {
+          attachTo: 'body',
+        }
+      )
 
-    // Open dropdown first
-    await input.trigger('click')
-    await nextTick()
-    expect(vm.dropdownMenuVisible).toBe(true)
-    expect(vm.states.options.size).toBe(1) // initial option exists
-    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
-    expect(handleVisibleChange).toHaveBeenLastCalledWith(true)
+      const select = wrapper.findComponent(Select)
+      const vm = select.vm as any
+      const input = wrapper.find('input')
 
-    // Start typing to trigger remote search and debouncing
-    await input.setValue('a')
-    await nextTick()
-    vi.advanceTimersByTime(50) // Advance time but don't complete debounce
-    await nextTick()
+      // Open dropdown first
+      await input.trigger('click')
+      await nextTick()
+      expect(vm.dropdownMenuVisible).toBe(true)
+      expect(vm.states.options.size).toBe(1) // initial option exists
+      expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+      expect(handleVisibleChange).toHaveBeenLastCalledWith(true)
 
-    // During debouncing (before debounce completes), check dropdown and event count
-    expect(vm.dropdownMenuVisible).toBe(true)
-    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+      // Start typing to trigger remote search and debouncing
+      await input.setValue('a')
+      await nextTick()
+      vi.advanceTimersByTime(50) // Advance time but don't complete debounce
+      await nextTick()
 
-    // Complete the debounce
-    vi.advanceTimersByTime(300)
-    await nextTick()
+      // During debouncing (before debounce completes), check dropdown and event count
+      expect(vm.dropdownMenuVisible).toBe(true)
+      expect(handleVisibleChange).toHaveBeenCalledTimes(1)
 
-    expect(remoteMethod).toHaveBeenCalledWith('a')
-    expect(vm.dropdownMenuVisible).toBe(true)
-    // Should still only have been called once - dropdown never closed
-    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+      // Complete the debounce
+      vi.advanceTimersByTime(300)
+      await nextTick()
 
-    vi.useRealTimers()
+      expect(remoteMethod).toHaveBeenCalledWith('a')
+      expect(vm.dropdownMenuVisible).toBe(true)
+      // Should still only have been called once - dropdown never closed
+      expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+    } finally {
+      mockedUseDebounceFn.mockImplementation(
+        originalUseDebounceFnImpl ?? ((fn: any) => fn)
+      )
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4536,8 +4536,6 @@ describe('Select', () => {
     await nextTick()
 
     // During debouncing (before debounce completes), check dropdown and event count
-    // With the fix: dropdown stays visible, visible-change called only once
-    // Without the fix: dropdown becomes hidden then visible again, visible-change called 3 times
     expect(vm.dropdownMenuVisible).toBe(true)
     expect(handleVisibleChange).toHaveBeenCalledTimes(1)
 

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4459,4 +4459,97 @@ describe('Select', () => {
     await wrapper.find('input').trigger('change')
     expect(nativeChangeHandler).not.toHaveBeenCalled()
   })
+  // #23838
+  test('should keep dropdown visible during debouncing when options exist (remote)', async () => {
+    vi.useFakeTimers()
+
+    const options = ref([{ value: 'test', label: 'test' }])
+    const handleVisibleChange = vi.fn()
+    const remoteMethod = vi.fn((query: string) => {
+      if (query) {
+        options.value = [
+          { value: 'Alabama', label: 'Alabama' },
+          { value: 'Alaska', label: 'Alaska' },
+        ]
+      }
+    })
+
+    // Temporarily restore useDebounceFn to use real debounce with fake timers
+    const { useDebounceFn } = await vi.importActual('@vueuse/core')
+    vi.mocked(
+      vi.mocked(await import('@vueuse/core')).useDebounceFn
+    ).mockImplementation(useDebounceFn)
+
+    wrapper = mount(
+      {
+        components: {
+          'el-select': Select,
+          'el-option': Option,
+        },
+        template: `
+          <el-select
+            v-model="value"
+            filterable
+            remote
+            :debounce="300"
+            :remote-method="remoteMethod"
+            @visible-change="handleVisibleChange"
+          >
+            <el-option
+              v-for="item in options"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value"
+            />
+          </el-select>
+        `,
+        setup() {
+          return {
+            value: ref(''),
+            options,
+            remoteMethod,
+            handleVisibleChange,
+          }
+        },
+      },
+      {
+        attachTo: 'body',
+      }
+    )
+
+    const select = wrapper.findComponent(Select)
+    const vm = select.vm as any
+    const input = wrapper.find('input')
+
+    // Open dropdown first
+    await input.trigger('click')
+    await nextTick()
+    expect(vm.dropdownMenuVisible).toBe(true)
+    expect(vm.states.options.size).toBe(1) // initial option exists
+    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+    expect(handleVisibleChange).toHaveBeenLastCalledWith(true)
+
+    // Start typing to trigger remote search and debouncing
+    await input.setValue('a')
+    await nextTick()
+    vi.advanceTimersByTime(50) // Advance time but don't complete debounce
+    await nextTick()
+
+    // During debouncing (before debounce completes), check dropdown and event count
+    // With the fix: dropdown stays visible, visible-change called only once
+    // Without the fix: dropdown becomes hidden then visible again, visible-change called 3 times
+    expect(vm.dropdownMenuVisible).toBe(true)
+    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+
+    // Complete the debounce
+    vi.advanceTimersByTime(300)
+    await nextTick()
+
+    expect(remoteMethod).toHaveBeenCalledWith('a')
+    expect(vm.dropdownMenuVisible).toBe(true)
+    // Should still only have been called once - dropdown never closed
+    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
+  })
 })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

Supplement #23838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for remote-search debouncing in select components (standard and v2). They verify dropdown stays visible while typing, visibility-change emits only when opened, and the remote search is invoked after the debounce interval. Tests exercise timer-based debounce behavior and ensure stability of UI during delayed remote queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->