### PR TITLE
docs: correct `toc-content-mask` element z-index layering

### DIFF
--- a/docs/.vitepress/vitepress/styles/content/table-of-content.scss
+++ b/docs/.vitepress/vitepress/styles/content/table-of-content.scss
@@ -56,7 +56,7 @@
     bottom: 30px;
     height: 32px;
     width: 200px;
-    z-index: 10;
+    z-index: 4;
     background: linear-gradient(transparent, var(--bg-color) 70%);
   }
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

**Desc**
The BackTop component is being obscured at certain positions because the .toc-content-mask element has a higher z-index.

**Before**
<img width="1511" height="949" alt="before" src="https://github.com/user-attachments/assets/818f6ab7-de7c-4fa1-8b52-ce9d444e8af2" />
**After**
<img width="1511" height="949" alt="after" src="https://github.com/user-attachments/assets/eb1042d2-7418-4a8f-8cc3-11cc06b619ee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the visual layering of the table of contents element in documentation to improve positioning relative to other interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->