### PR TITLE
fix(components): [time-picker] allow clearing time via keyboard when using `is-range`

### DIFF
--- a/packages/components/time-picker/__tests__/time-picker.test.tsx
+++ b/packages/components/time-picker/__tests__/time-picker.test.tsx
@@ -736,6 +736,50 @@ describe('TimePicker(range)', () => {
     expect(findPicker().exists()).toBe(false)
   })
 
+  it('clearing only one side of timerange should not clear the whole model', async () => {
+    const changeHandler = vi.fn()
+    const value = ref<[Date, Date]>([
+      new Date(2025, 0, 1, 9, 0, 0),
+      new Date(2025, 0, 1, 17, 0, 0),
+    ])
+    const wrapper = mount(() => (
+      <TimePicker v-model={value.value} is-range onChange={changeHandler} />
+    ))
+
+    const [startInput] = wrapper.findAll('input')
+
+    await startInput.setValue('')
+    expect(startInput.element.value).toBe('')
+
+    await startInput.trigger('blur')
+    await nextTick()
+    expect(value.value).not.toBeNull()
+  })
+
+  it('manually clear timerange via keyboard', async () => {
+    const changeHandler = vi.fn()
+    const value = ref<[Date, Date]>([
+      new Date(2025, 0, 1, 9, 0, 0),
+      new Date(2025, 0, 1, 17, 0, 0),
+    ])
+    const wrapper = mount(() => (
+      <TimePicker v-model={value.value} is-range onChange={changeHandler} />
+    ))
+
+    const [startInput, endInput] = wrapper.findAll('input')
+
+    await startInput.setValue('')
+    expect(startInput.element.value).toBe('')
+
+    await endInput.setValue('')
+    expect(endInput.element.value).toBe('')
+
+    await startInput.trigger('blur')
+    await nextTick()
+    expect(changeHandler).toHaveBeenCalledTimes(1)
+    expect(value.value).toBeNull()
+  })
+
   it('selectableRange ', async () => {
     // left ['08:00:00 - 12:59:59'] right ['11:00:00 - 16:59:59']
     const value = ref([

--- a/packages/components/time-picker/__tests__/time-picker.test.tsx
+++ b/packages/components/time-picker/__tests__/time-picker.test.tsx
@@ -753,6 +753,7 @@ describe('TimePicker(range)', () => {
 
     await startInput.trigger('blur')
     await nextTick()
+    expect(changeHandler).not.toHaveBeenCalled()
     expect(value.value).not.toBeNull()
   })
 

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -407,8 +407,8 @@ const displayValue = computed<UserInput>(() => {
   const formattedValue = formatToString(parsedValue.value)
   if (isArray(userInput.value)) {
     return [
-      userInput.value[0] || (formattedValue && formattedValue[0]) || '',
-      userInput.value[1] || (formattedValue && formattedValue[1]) || '',
+      userInput.value[0] ?? (formattedValue && formattedValue[0]) ?? '',
+      userInput.value[1] ?? (formattedValue && formattedValue[1]) ?? '',
     ]
   } else if (userInput.value !== null) {
     return userInput.value
@@ -527,7 +527,10 @@ onBeforeUnmount(() => {
 const handleChange = () => {
   if (isTimePicker.value && !props.saveOnBlur) return
 
-  if (userInput.value) {
+  const isRangeEmpty =
+    isArray(userInput.value) && userInput.value.every((v) => v === '')
+
+  if (userInput.value && !isRangeEmpty) {
     const value = parseUserInputToDayjs(displayValue.value)
     if (value) {
       if (isValidValue(value)) {
@@ -536,7 +539,7 @@ const handleChange = () => {
       userInput.value = null
     }
   }
-  if (userInput.value === '') {
+  if (userInput.value === '' || isRangeEmpty) {
     emitInput(emptyValues.valueOnClear.value)
     emitChange(emptyValues.valueOnClear.value, true)
     userInput.value = null


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fixed #23865 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Range time-picker preserves intentionally empty values (e.g., empty strings) and only treats a range as cleared when all parts are empty; single-value clearing behavior unchanged.

* **Tests**
  * Added a test confirming keyboard/manual clearing of a date-range emits a single change and resets the model to null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->