### PR TITLE
fix(components): [time-picker] clearing input with keyboard in range

### DIFF
--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -407,8 +407,8 @@ const displayValue = computed<UserInput>(() => {
   const formattedValue = formatToString(parsedValue.value)
   if (isArray(userInput.value)) {
     return [
-      userInput.value[0] || (formattedValue && formattedValue[0]) || '',
-      userInput.value[1] || (formattedValue && formattedValue[1]) || '',
+      userInput.value[0] ?? (formattedValue && formattedValue[0]) ?? '',
+      userInput.value[1] ?? (formattedValue && formattedValue[1]) ?? '',
     ]
   } else if (userInput.value !== null) {
     return userInput.value
@@ -526,6 +526,18 @@ onBeforeUnmount(() => {
 
 const handleChange = () => {
   if (isTimePicker.value && !props.saveOnBlur) return
+
+  if (isArray(userInput.value)) {
+    const [startRaw, endRaw] = userInput.value
+    const startEmpty = startRaw === ''
+    const endEmpty = endRaw === ''
+    if (startEmpty && endEmpty) {
+      emitInput(emptyValues.valueOnClear.value)
+      emitChange(emptyValues.valueOnClear.value, true)
+      userInput.value = null
+      return
+    }
+  }
 
   if (userInput.value) {
     const value = parseUserInputToDayjs(displayValue.value)


### PR DESCRIPTION
This update resolves the issue where the input value could not be cleared using the keyboard in the 'range' mode of the time-picker and date-picker components.(#23865)

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fixed [#23865]
This update resolves the issue where the input value could not be cleared
using the keyboard in the 'range' mode of the time-picker and
date-picker components.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Time picker range display now preserves explicit zero and empty-string inputs instead of replacing them with fallback values.
  * Time picker range clearing now detects fully empty start/end entries, emits the cleared value and change event immediately, sets the input to empty, and avoids running further parsing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->