### PR TITLE
fix(components): [select] selection requires double tap on mobile

### DIFF
--- a/packages/components/select/src/option.vue
+++ b/packages/components/select/src/option.vue
@@ -8,6 +8,7 @@
     :aria-selected="itemSelected"
     @mousemove="hoverItem"
     @click.stop="selectOptionClick"
+    @touchend.prevent="selectOptionClick"
   >
     <slot>
       <span>{{ currentLabel }}</span>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

related to element-plus/issues/23486

Actually, in most cases before, I had to click the option twice: the first click focused it, and the second click actually selected it.

**Before:**

https://github.com/user-attachments/assets/84366a42-fc32-4156-a450-c3a497052fbc

**After**

https://github.com/user-attachments/assets/26ae5e26-2f11-4cdf-af0d-ca17914f9517





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch interaction handling for select options on touch-enabled devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->