### PR TITLE
fix: using csstype type ts error

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@vue/shared": "catalog:",
     "@vue/test-utils": "catalog:",
     "consola": "^2.15.3",
+    "csstype": "^3.2.3",
     "cz-git": "^1.11.1",
     "czg": "^1.11.1",
     "eslint": "^9.37.0",

--- a/packages/components/message-box/src/message-box.type.ts
+++ b/packages/components/message-box/src/message-box.type.ts
@@ -1,8 +1,9 @@
 import { buttonTypes } from '@element-plus/components/button'
 
-import type { AppContext, CSSProperties, Component, VNode } from 'vue'
+import type { AppContext, Component, VNode } from 'vue'
 import type { ComponentSize } from '@element-plus/constants'
 import type { InputType } from '@element-plus/components/input/src/input'
+import type { CSSProperties } from '@element-plus/utils'
 
 type MessageType = '' | 'primary' | 'success' | 'warning' | 'info' | 'error'
 type MessageBoxButtonType = (typeof buttonTypes)[number]

--- a/packages/utils/typescript.ts
+++ b/packages/utils/typescript.ts
@@ -1,3 +1,5 @@
+import type * as CSS from 'csstype'
+
 export const mutable = <T extends readonly any[] | Record<string, unknown>>(
   val: T
 ) => val as Mutable<typeof val>
@@ -93,32 +95,28 @@ type Path<T> =
  */
 export type FieldPath<T> = T extends object ? Path<T> : never
 
-type Globals = 'inherit' | 'initial' | 'revert' | 'unset' | 'revert-layer'
+/**
+ * csstype 是 vue的依赖，因此，直接从vue中导入CSSProperties会导致ts类型解析错误，参考 https://github.com/pnpm/pnpm/issues/7453，因此，我们直接安装csstype，并从csstype中导入CSSProperties
+ *
+ * csstype is a dependency of vue, so importing CSSProperties directly from vue will cause ts type parsing errors, see https://github.com/pnpm/pnpm/issues/7453. Therefore, we directly install csstype and import CSSProperties from csstype.
+ */
+export interface CSSProperties
+  extends
+    CSS.Properties<string | number>,
+    CSS.PropertiesHyphen<string | number> {
+  /**
+   * The index signature was removed to enable closed typing for style
+   * using CSSType. You're able to use type assertion or module augmentation
+   * to add properties or an index signature of your own.
+   *
+   * For examples and more information, visit:
+   * https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+   */
+  [v: `--${string}`]: string | number | undefined
+}
 
-export type ObjectFit =
-  | 'fill'
-  | 'contain'
-  | 'cover'
-  | 'none'
-  | 'scale-down'
-  | Globals
+export type ObjectFit = CSSProperties['objectFit']
 
-export type ZIndexType = Globals | 'auto' | number
+export type ZIndexType = CSSProperties['zIndex']
 
-export type AlignItems =
-  | 'normal'
-  | 'stretch'
-  | 'center'
-  | 'start'
-  | 'end'
-  | 'flex-start'
-  | 'flex-end'
-  | 'self-start'
-  | 'self-end'
-  | 'anchor-center'
-  | 'baseline'
-  | 'first baseline'
-  | 'last baseline'
-  | 'safe center'
-  | 'unsafe center'
-  | Globals
+export type AlignItems = CSSProperties['alignItems']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       consola:
         specifier: ^2.15.3
         version: 2.15.3
+      csstype:
+        specifier: ^3.2.3
+        version: 3.2.3
       cz-git:
         specifier: ^1.11.1
         version: 1.12.0
@@ -263,7 +266,7 @@ importers:
         version: 4.0.1
       element-plus:
         specifier: npm:element-plus@latest
-        version: 2.13.5(typescript@5.5.4)(vue@3.5.25(typescript@5.5.4))
+        version: 2.13.6(typescript@5.5.4)(vue@3.5.25(typescript@5.5.4))
       markdown-it:
         specifier: ^14.1.0
         version: 14.1.0
@@ -4300,8 +4303,8 @@ packages:
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
-  element-plus@2.13.5:
-    resolution: {integrity: sha512-dmY24fhSREfZN/PuUt0YZigMso7wWzl+B5o+YKNN15kQIn/0hzamsPU+ebj9SES0IbUqsLX1wkrzYmzU8VrVOQ==}
+  element-plus@2.13.6:
+    resolution: {integrity: sha512-XHgwXr8Fjz6i+6BaqFhAbae/dJbG7bBAAlHrY3pWL7dpj+JcqcOyKYt4Oy5KP86FQwS1k4uIZDjCx2FyUR5lDg==}
     peerDependencies:
       vue: ^3.3.0
 
@@ -12452,7 +12455,7 @@ snapshots:
 
   electron-to-chromium@1.5.267: {}
 
-  element-plus@2.13.5(typescript@5.5.4)(vue@3.5.25(typescript@5.5.4)):
+  element-plus@2.13.6(typescript@5.5.4)(vue@3.5.25(typescript@5.5.4)):
     dependencies:
       '@ctrl/tinycolor': 4.2.0
       '@element-plus/icons-vue': 2.3.2(vue@3.5.25(typescript@5.5.4))
@@ -12469,6 +12472,7 @@ snapshots:
       memoize-one: 6.0.0
       normalize-wheel-es: 1.2.0
       vue: 3.5.25(typescript@5.5.4)
+      vue-component-type-helpers: 3.2.4
     transitivePeerDependencies:
       - typescript
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `csstype` package as a development dependency for improved CSS type definitions.

* **Refactor**
  * Updated CSS property type definitions to use `csstype` package types for enhanced TypeScript support and broader CSS property coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->