### PR TITLE
fix(components): [dialog] fix body height not filling fullscreen dialog

### DIFF
--- a/packages/components/dialog/__tests__/dialog.test.tsx
+++ b/packages/components/dialog/__tests__/dialog.test.tsx
@@ -573,6 +573,7 @@ describe('Dialog.vue', () => {
       expect(wrapper.find('.el-dialog.is-fullscreen').exists()).toBe(true)
       expect(wrapper.find('.el-dialog__body').exists()).toBe(true)
       expect(wrapper.find('.el-dialog__footer').exists()).toBe(true)
+      expect(wrapper.find('.el-dialog__footer').text()).toContain('OK')
       expect(wrapper.find('.el-dialog__body').text()).toEqual(AXIOM)
     })
   })

--- a/packages/components/dialog/__tests__/dialog.test.tsx
+++ b/packages/components/dialog/__tests__/dialog.test.tsx
@@ -539,6 +539,44 @@ describe('Dialog.vue', () => {
     })
   })
 
+  describe('fullscreen', () => {
+    test('should apply fullscreen class when fullscreen is true', async () => {
+      const wrapper = mount(
+        <Dialog modelValue={true} fullscreen>
+          {AXIOM}
+        </Dialog>
+      )
+
+      await nextTick()
+      await rAF()
+      await nextTick()
+      expect(wrapper.find('.el-dialog').classes()).toContain('is-fullscreen')
+    })
+
+    test('fullscreen dialog should render body and footer', async () => {
+      const wrapper = mount(
+        <Dialog
+          modelValue={true}
+          fullscreen
+          v-slots={{
+            footer: () => <button>OK</button>,
+          }}
+        >
+          {AXIOM}
+        </Dialog>
+      )
+
+      await nextTick()
+      await rAF()
+      await nextTick()
+
+      expect(wrapper.find('.el-dialog.is-fullscreen').exists()).toBe(true)
+      expect(wrapper.find('.el-dialog__body').exists()).toBe(true)
+      expect(wrapper.find('.el-dialog__footer').exists()).toBe(true)
+      expect(wrapper.find('.el-dialog__body').text()).toEqual(AXIOM)
+    })
+  })
+
   describe('transition', () => {
     test('dialog supports transition as string', async () => {
       const wrapper = mount(

--- a/packages/components/dialog/__tests__/dialog.test.tsx
+++ b/packages/components/dialog/__tests__/dialog.test.tsx
@@ -552,30 +552,6 @@ describe('Dialog.vue', () => {
       await nextTick()
       expect(wrapper.find('.el-dialog').classes()).toContain('is-fullscreen')
     })
-
-    test('fullscreen dialog should render body and footer', async () => {
-      const wrapper = mount(
-        <Dialog
-          modelValue={true}
-          fullscreen
-          v-slots={{
-            footer: () => <button>OK</button>,
-          }}
-        >
-          {AXIOM}
-        </Dialog>
-      )
-
-      await nextTick()
-      await rAF()
-      await nextTick()
-
-      expect(wrapper.find('.el-dialog.is-fullscreen').exists()).toBe(true)
-      expect(wrapper.find('.el-dialog__body').exists()).toBe(true)
-      expect(wrapper.find('.el-dialog__footer').exists()).toBe(true)
-      expect(wrapper.find('.el-dialog__footer').text()).toContain('OK')
-      expect(wrapper.find('.el-dialog__body').text()).toEqual(AXIOM)
-    })
   })
 
   describe('transition', () => {

--- a/packages/theme-chalk/src/dialog.scss
+++ b/packages/theme-chalk/src/dialog.scss
@@ -30,10 +30,17 @@
     @include set-css-var-value('dialog-width', 100%);
     @include set-css-var-value('dialog-margin-top', 0);
 
+    display: flex;
+    flex-direction: column;
     margin-bottom: 0;
     height: 100%;
-    overflow: auto;
+    overflow: hidden;
     border-radius: 0px;
+
+    @include e(body) {
+      flex: 1;
+      overflow: auto;
+    }
   }
 
   @include e(wrapper) {

--- a/packages/theme-chalk/src/dialog.scss
+++ b/packages/theme-chalk/src/dialog.scss
@@ -37,9 +37,18 @@
     overflow: hidden;
     border-radius: 0px;
 
+    @include e(header) {
+      flex-shrink: 0;
+    }
+
     @include e(body) {
-      flex: 1;
+      flex: 1 1 0;
+      min-height: 0;
       overflow: auto;
+    }
+
+    @include e(footer) {
+      flex-shrink: 0;
     }
   }
 


### PR DESCRIPTION
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## 🐛 Bug Fixes

Fixes #23902

### Problem

When `el-dialog` is set to `fullscreen`, the body does not stretch to fill the remaining height. The footer immediately follows the body content instead of anchoring to the bottom.

### Root Cause

The fullscreen dialog lacked a flex layout, so the body had no mechanism to grow and fill available space.

### Solution

- Add `display: flex; flex-direction: column` to the fullscreen dialog container
- Change `overflow: auto` from the container to the body only (so header/footer don't scroll away)
- Add `flex: 1 1 0; min-height: 0` to body so it fills remaining space correctly in all browsers (the `min-height: 0` prevents Safari/older Chrome flex shrink issues)
- Add `flex-shrink: 0` to header and footer to prevent them from being compressed

### Changes

- `packages/theme-chalk/src/dialog.scss` — fullscreen layout fix
- `packages/components/dialog/__tests__/dialog.test.tsx` — add fullscreen mode tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated fullscreen Dialog layout so the header and footer remain fixed while the body provides the scrollable content area.
  * Improved fullscreen Dialog behavior by preventing the overall dialog container from scrolling independently.

* **Tests**
  * Adjusted fullscreen Dialog test coverage to reflect the updated layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->