### PR TITLE
fix(components): [scrollbar] show scrollbar during scrolling

### DIFF
--- a/packages/components/scrollbar/__tests__/scrollbar.test.tsx
+++ b/packages/components/scrollbar/__tests__/scrollbar.test.tsx
@@ -1,10 +1,10 @@
 import { nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vitest'
-import makeScroll from '@element-plus/test-utils/make-scroll'
-import defineGetter from '@element-plus/test-utils/define-getter'
 import Scrollbar from '../src/scrollbar.vue'
 import Thumb from '../src/thumb.vue'
+import { defineGetter, makeScroll, sleep } from '@element-plus/test-utils'
+import { SCROLLING_KEEP_ALIVE_TIME } from '../src/constants'
 
 describe('ScrollBar', () => {
   test('vertical', async () => {
@@ -390,5 +390,46 @@ describe('ScrollBar', () => {
     scrollHeightRestore()
     offsetWidthRestore()
     scrollWidthRestore()
+  })
+
+  test('should show scrollbar during scrolling', async () => {
+    const outerHeight = 204
+    const innerHeight = 500
+    const transitionDuration = 120
+    const wrapper = mount(() => (
+      <Scrollbar style={`height: ${outerHeight}px;`}>
+        <div style={`height: ${innerHeight}px;`}></div>
+      </Scrollbar>
+    ))
+
+    const scrollDom = wrapper.find('.el-scrollbar__wrap').element
+    const offsetHeightRestore = defineGetter(
+      scrollDom,
+      'offsetHeight',
+      outerHeight
+    )
+    const scrollHeightRestore = defineGetter(
+      scrollDom,
+      'scrollHeight',
+      innerHeight
+    )
+
+    const thumbBar = wrapper.find('.is-vertical')
+    expect(thumbBar.attributes('style')).toMatchInlineSnapshot(
+      `"display: none;"`
+    )
+    await makeScroll(scrollDom, 'scrollTop', 100)
+    expect(thumbBar.attributes('style')).toMatchInlineSnapshot(`""`)
+    await makeScroll(scrollDom, 'scrollTop', 0)
+    expect(thumbBar.attributes('style')).toMatchInlineSnapshot(`""`)
+    await sleep(SCROLLING_KEEP_ALIVE_TIME / 2)
+    expect(thumbBar.attributes('style')).toMatchInlineSnapshot(`""`)
+    await sleep(SCROLLING_KEEP_ALIVE_TIME / 2 + transitionDuration)
+    expect(thumbBar.attributes('style')).toMatchInlineSnapshot(
+      `"display: none;"`
+    )
+
+    offsetHeightRestore()
+    scrollHeightRestore()
   })
 })

--- a/packages/components/scrollbar/src/constants.ts
+++ b/packages/components/scrollbar/src/constants.ts
@@ -8,3 +8,5 @@ export interface ScrollbarContext {
 export const scrollbarContextKey: InjectionKey<ScrollbarContext> = Symbol(
   'scrollbarContextKey'
 )
+
+export const SCROLLING_KEEP_ALIVE_TIME = 300

--- a/packages/components/scrollbar/src/thumb.vue
+++ b/packages/components/scrollbar/src/thumb.vue
@@ -1,7 +1,7 @@
 <template>
   <transition :name="ns.b('fade')">
     <div
-      v-show="always || visible"
+      v-show="always || visible || isScrolling"
       ref="instance"
       :class="[ns.e('bar'), ns.is(bar.key)]"
       @mousedown="clickTrackHandler"
@@ -18,12 +18,13 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, onBeforeUnmount, ref, toRef } from 'vue'
+import { computed, inject, onBeforeUnmount, ref, toRef, watch } from 'vue'
 import { useEventListener } from '@vueuse/core'
 import { isClient, throwError } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
-import { scrollbarContextKey } from './constants'
+import { SCROLLING_KEEP_ALIVE_TIME, scrollbarContextKey } from './constants'
 import { BAR_MAP, renderThumbStyle } from './util'
+import { debounce } from 'lodash-unified'
 
 import type { ThumbProps } from './thumb'
 
@@ -40,6 +41,7 @@ const thumb = ref<HTMLDivElement>()
 
 const thumbState = ref<Partial<Record<'X' | 'Y', number>>>({})
 const visible = ref(false)
+const isScrolling = ref(false)
 
 let cursorDown = false
 let cursorLeave = false
@@ -156,6 +158,25 @@ const mouseLeaveScrollbarHandler = () => {
   cursorLeave = true
   visible.value = cursorDown
 }
+
+const setIsScrollingDebounce = debounce(
+  (val: boolean) => {
+    isScrolling.value = val
+  },
+  SCROLLING_KEEP_ALIVE_TIME,
+  {
+    leading: false,
+    trailing: true,
+  }
+)
+
+watch(
+  () => props.move,
+  () => {
+    isScrolling.value = true
+    setIsScrollingDebounce(false)
+  }
+)
 
 onBeforeUnmount(() => {
   restoreOnselectstart()


### PR DESCRIPTION
### Desc

Fix scrollbar is hidden when browser is inactive.

### Before

https://github.com/user-attachments/assets/9be4d153-f2c9-4839-ab5a-0be5a9321ec0

### After

https://github.com/user-attachments/assets/448f05d6-1d1b-4d4b-a2b4-ad02e4eee87f


- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scrollbar behavior: the scrollbar thumb now remains visible while you're actively scrolling and automatically hides after 300 milliseconds of inactivity, providing a cleaner and less visually obstructive user experience during and after scrolling.

* **Tests**
  * Added comprehensive test coverage for scrollbar visibility behavior during scrolling and automatic hide functionality after scrolling stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->