### PR TITLE
fix(hooks): [use-timeout] avoid window usage in SSR

### DIFF
--- a/packages/hooks/__tests__/use-timeout.ssr.test.ts
+++ b/packages/hooks/__tests__/use-timeout.ssr.test.ts
@@ -23,5 +23,6 @@ describe('use-timeout (SSR)', () => {
     })
 
     await expect(renderToString(createSSRApp(App))).resolves.toContain('ssr')
+    expect(fn).not.toHaveBeenCalled()
   })
 })

--- a/packages/hooks/__tests__/use-timeout.ssr.test.ts
+++ b/packages/hooks/__tests__/use-timeout.ssr.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @vitest-environment node
+ */
+
+import { createSSRApp, defineComponent, h } from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import { describe, expect, it, vi } from 'vitest'
+import { useTimeout } from '../use-timeout'
+
+describe('use-timeout (SSR)', () => {
+  it('should render without window in SSR environment', async () => {
+    const fn = vi.fn()
+
+    expect('window' in globalThis).toBe(false)
+
+    const App = defineComponent({
+      setup() {
+        const { registerTimeout } = useTimeout()
+        registerTimeout(fn, 0)
+
+        return () => h('div', 'ssr')
+      },
+    })
+
+    await expect(renderToString(createSSRApp(App))).resolves.toContain('ssr')
+  })
+})

--- a/packages/hooks/__tests__/use-timeout.test.ts
+++ b/packages/hooks/__tests__/use-timeout.test.ts
@@ -1,4 +1,4 @@
-import { defineComponent } from 'vue'
+import { defineComponent, effectScope } from 'vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useTimeout } from '../use-timeout'
@@ -52,5 +52,28 @@ describe('use-timeout', () => {
     vi.runOnlyPendingTimers()
 
     expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('should work when window is undefined (SSR-like environment)', () => {
+    const fn = vi.fn()
+
+    vi.stubGlobal('window', undefined)
+
+    try {
+      const scope = effectScope()
+      expect(() => {
+        scope.run(() => {
+          const { registerTimeout } = useTimeout()
+          registerTimeout(fn, 0)
+        })
+
+        scope.stop()
+        vi.runOnlyPendingTimers()
+      }).not.toThrow()
+
+      expect(fn).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })

--- a/packages/hooks/__tests__/use-timeout.test.ts
+++ b/packages/hooks/__tests__/use-timeout.test.ts
@@ -55,6 +55,7 @@ describe('use-timeout', () => {
   })
 
   it('should work when window is undefined (SSR-like environment)', () => {
+    wrapper.unmount()
     const fn = vi.fn()
 
     vi.stubGlobal('window', undefined)
@@ -73,6 +74,7 @@ describe('use-timeout', () => {
 
       expect(fn).not.toHaveBeenCalled()
     } finally {
+      vi.clearAllTimers()
       vi.unstubAllGlobals()
     }
   })

--- a/packages/hooks/use-timeout/index.ts
+++ b/packages/hooks/use-timeout/index.ts
@@ -1,13 +1,18 @@
 import { tryOnScopeDispose } from '@vueuse/core'
 
 export function useTimeout() {
-  let timeoutHandle: number
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined
 
   const registerTimeout = (fn: (...args: any[]) => any, delay: number) => {
     cancelTimeout()
-    timeoutHandle = window.setTimeout(fn, delay)
+    timeoutHandle = setTimeout(fn, delay)
   }
-  const cancelTimeout = () => window.clearTimeout(timeoutHandle)
+  const cancelTimeout = () => {
+    if (timeoutHandle === undefined) return
+
+    clearTimeout(timeoutHandle)
+    timeoutHandle = undefined
+  }
 
   tryOnScopeDispose(() => cancelTimeout())
 

--- a/packages/hooks/use-timeout/index.ts
+++ b/packages/hooks/use-timeout/index.ts
@@ -1,16 +1,16 @@
 import { tryOnScopeDispose } from '@vueuse/core'
 
 export function useTimeout() {
-  let timeoutHandle: ReturnType<typeof globalThis.setTimeout> | undefined
+  let timeoutHandle: number | undefined
 
   const registerTimeout = (fn: (...args: any[]) => any, delay: number) => {
     cancelTimeout()
-    timeoutHandle = setTimeout(fn, delay)
+    timeoutHandle = globalThis.setTimeout(fn, delay)
   }
   const cancelTimeout = () => {
     if (timeoutHandle === undefined) return
 
-    clearTimeout(timeoutHandle)
+    globalThis.clearTimeout(timeoutHandle)
     timeoutHandle = undefined
   }
 

--- a/packages/hooks/use-timeout/index.ts
+++ b/packages/hooks/use-timeout/index.ts
@@ -1,7 +1,7 @@
 import { tryOnScopeDispose } from '@vueuse/core'
 
 export function useTimeout() {
-  let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+  let timeoutHandle: ReturnType<typeof globalThis.setTimeout> | undefined
 
   const registerTimeout = (fn: (...args: any[]) => any, delay: number) => {
     cancelTimeout()


### PR DESCRIPTION
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## 🐛 Bug Fixes

Fixes #23903

### Problem

`use-timeout` used `window.setTimeout` and `window.clearTimeout`. In SSR (Node) environment, `window` may be undefined, which can throw during scope dispose and break server rendering.

### Solution

- Replace `window.setTimeout` / `window.clearTimeout` with global `setTimeout` / `clearTimeout`
- Use `ReturnType<typeof setTimeout>` for cross-environment timer handle typing
- Add `undefined` guard in `cancelTimeout` and reset handle after cancel

### Tests

- Add SSR-like test case where `window` is stubbed as `undefined`
- Ensure cleanup in test always restores globals via `try/finally`
- Verified:
  - `pnpm vitest run packages/hooks/__tests__/use-timeout.test.ts`
  - `pnpm vitest run packages/hooks/__tests__`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering Node/SSR and no-browser-global scenarios to ensure timeouts are not invoked during server rendering and are properly cleaned up.

* **Bug Fixes**
  * Made timeout registration and cancellation more robust so cancellations safely no-op when no timer exists and callbacks are prevented after scope teardown, including in non-browser environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->