### PR TITLE
feat(components): [scrollbar] expose scrollable state

### DIFF
--- a/docs/en-US/component/scrollbar.md
+++ b/docs/en-US/component/scrollbar.md
@@ -47,6 +47,14 @@ scrollbar/infinite-scroll
 
 :::
 
+## Scrollable State ^(2.13.7)
+
+:::demo Use `scrollable` to get the current scrollable state. The state can be `true` (both directions scrollable), `'vertical'`, `'horizontal'`, or `false`.
+
+scrollbar/scrollable-state
+
+:::
+
 ## API
 
 ### Attributes
@@ -86,11 +94,12 @@ scrollbar/infinite-scroll
 
 ### Exposes
 
-| Name          | Description                                | Type                                                                       |
-| ------------- | ------------------------------------------ | -------------------------------------------------------------------------- |
-| handleScroll  | handle scroll event                        | ^[Function]`() => void`                                                    |
-| scrollTo      | scrolls to a particular set of coordinates | ^[Function]`(options: ScrollToOptions \| number, yCoord?: number) => void` |
-| setScrollTop  | Set distance to scroll top                 | ^[Function]`(scrollTop: number) => void`                                   |
-| setScrollLeft | Set distance to scroll left                | ^[Function]`(scrollLeft: number) => void`                                  |
-| update        | update scrollbar state manually            | ^[Function]`() => void`                                                    |
-| wrapRef       | scrollbar wrap ref                         | ^[object]`Ref<HTMLDivElement>`                                             |
+| Name                 | Description                                | Type                                                                       |
+| -------------------- | ------------------------------------------ | -------------------------------------------------------------------------- |
+| handleScroll         | handle scroll event                        | ^[Function]`() => void`                                                    |
+| scrollTo             | scrolls to a particular set of coordinates | ^[Function]`(options: ScrollToOptions \| number, yCoord?: number) => void` |
+| setScrollTop         | Set distance to scroll top                 | ^[Function]`(scrollTop: number) => void`                                   |
+| setScrollLeft        | Set distance to scroll left                | ^[Function]`(scrollLeft: number) => void`                                  |
+| update               | update scrollbar state manually            | ^[Function]`() => void`                                                    |
+| wrapRef              | scrollbar wrap ref                         | ^[object]`Ref<HTMLDivElement>`                                             |
+| scrollable ^(2.13.7) | current scrollable state                   | ^[ref]`true \| 'vertical' \| 'horizontal' \| false`                        |

--- a/docs/en-US/component/scrollbar.md
+++ b/docs/en-US/component/scrollbar.md
@@ -102,4 +102,4 @@ scrollbar/scrollable-state
 | setScrollLeft        | Set distance to scroll left                | ^[Function]`(scrollLeft: number) => void`                                  |
 | update               | update scrollbar state manually            | ^[Function]`() => void`                                                    |
 | wrapRef              | scrollbar wrap ref                         | ^[object]`Ref<HTMLDivElement>`                                             |
-| scrollable ^(2.13.7) | current scrollable state                   | ^[ref]`true \| 'vertical' \| 'horizontal' \| false`                        |
+| scrollable ^(2.13.7) | current scrollable state                   | ^[object]`Ref<boolean \| 'vertical' \| 'horizontal'>`                      |

--- a/docs/examples/scrollbar/scrollable-state.vue
+++ b/docs/examples/scrollbar/scrollable-state.vue
@@ -1,0 +1,60 @@
+<template>
+  <el-radio-group v-model="direction" style="margin-bottom: 10px">
+    <el-radio-button value="vertical">Vertical</el-radio-button>
+    <el-radio-button value="horizontal">Horizontal</el-radio-button>
+    <el-radio-button value="both">Both</el-radio-button>
+    <el-radio-button value="unscrollable">Unscrollable</el-radio-button>
+  </el-radio-group>
+  <el-scrollbar ref="scrollbarRef" height="200px">
+    <div :style="contentStyle">
+      <p v-for="item in count" :key="item" class="scrollbar-demo-item">
+        {{ item }}
+      </p>
+    </div>
+  </el-scrollbar>
+  <div style="margin-top: 10px">
+    scrollable: <el-tag :type="tagType">{{ scrollable }}</el-tag>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from 'vue'
+
+import type { ScrollbarInstance } from 'element-plus'
+
+const scrollbarRef = ref<ScrollbarInstance>()
+const direction = ref('vertical')
+
+const scrollable = computed(() => scrollbarRef.value?.scrollable ?? false)
+const tagType = computed(() => {
+  if (scrollable.value === true) return 'success'
+  if (scrollable.value === 'vertical' || scrollable.value === 'horizontal')
+    return 'primary'
+  return 'info'
+})
+const count = computed(() => {
+  if (direction.value === 'horizontal' || direction.value === 'unscrollable')
+    return 3
+  return 5
+})
+const contentStyle = computed(() => {
+  if (direction.value === 'horizontal' || direction.value === 'both') {
+    return 'width: 110%'
+  }
+  return ''
+})
+</script>
+
+<style scoped>
+.scrollbar-demo-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 50px;
+  margin: 10px;
+  text-align: center;
+  border-radius: 4px;
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary);
+}
+</style>

--- a/packages/components/scrollbar/src/scrollbar.ts
+++ b/packages/components/scrollbar/src/scrollbar.ts
@@ -4,6 +4,12 @@ import { useAriaProps } from '@element-plus/hooks'
 import type { ExtractPublicPropTypes, StyleValue } from 'vue'
 import type Scrollbar from './scrollbar.vue'
 
+/**
+ * @description
+ * If `true`, the scrollbar is scrollable in both directions.
+ */
+export type Scrollable = true | 'vertical' | 'horizontal' | false
+
 export interface ScrollbarProps {
   /**
    * @description trigger distance(px)

--- a/packages/components/scrollbar/src/scrollbar.ts
+++ b/packages/components/scrollbar/src/scrollbar.ts
@@ -8,7 +8,7 @@ import type Scrollbar from './scrollbar.vue'
  * @description
  * If `true`, the scrollbar is scrollable in both directions.
  */
-export type Scrollable = true | 'vertical' | 'horizontal' | false
+export type Scrollable = boolean | 'vertical' | 'horizontal'
 
 export interface ScrollbarProps {
   /**

--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -45,7 +45,11 @@ import Bar from './bar.vue'
 import { scrollbarContextKey } from './constants'
 import { scrollbarEmits } from './scrollbar'
 
-import type { ScrollbarDirection, ScrollbarProps } from './scrollbar'
+import type {
+  Scrollable,
+  ScrollbarDirection,
+  ScrollbarProps,
+} from './scrollbar'
 import type { BarInstance } from './bar'
 import type { CSSProperties, StyleValue } from 'vue'
 
@@ -88,6 +92,7 @@ const scrollbarRef = ref<HTMLDivElement>()
 const wrapRef = ref<HTMLDivElement>()
 const resizeRef = ref<HTMLElement>()
 const barRef = ref<BarInstance>()
+const scrollable = ref<Scrollable>(false)
 
 const wrapStyle = computed<StyleValue>(() => {
   const style: CSSProperties = {}
@@ -203,7 +208,24 @@ const setScrollLeft = (value: number) => {
   wrapRef.value!.scrollLeft = value
 }
 
+const calcScrollable = () => {
+  const wrap = wrapRef.value
+  if (!wrap) return
+  const _vertical = wrap.scrollHeight > wrap.clientHeight
+  const _horizontal = wrap.scrollWidth > wrap.clientWidth
+  let _scrollable: Scrollable = false
+  if (_vertical && _horizontal) {
+    _scrollable = true
+  } else if (_horizontal) {
+    _scrollable = 'horizontal'
+  } else if (_vertical) {
+    _scrollable = 'vertical'
+  }
+  scrollable.value = _scrollable
+}
+
 const update = () => {
+  calcScrollable()
   barRef.value?.update()
   distanceScrollState[direction] = false
 }
@@ -263,6 +285,8 @@ onUpdated(() => update())
 defineExpose({
   /** @description scrollbar wrap ref */
   wrapRef,
+  /** @description scrollbar is scrollable */
+  scrollable,
   /** @description update scrollbar state manually */
   update,
   /** @description scrolls to a particular set of coordinates */


### PR DESCRIPTION
closed #23847

[Example](https://preview-23908-element-plus.surge.sh/en-US/component/scrollbar#scrollable-state)

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scrollbar now exposes a `scrollable` state: `true`, `'vertical'`, `'horizontal'`, or `false` (available in v2.13.7+).
* **Documentation**
  * Updated docs to document the new `scrollable` entry and adjusted the exposes table layout.
* **Examples**
  * Added a demo showing how to view and control the scrollbar's `scrollable` state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->