### PR TITLE
refactor(components): cleanup `defineProps` types

### DIFF
--- a/packages/components/anchor/src/anchor-link.vue
+++ b/packages/components/anchor/src/anchor-link.vue
@@ -30,9 +30,7 @@ defineOptions({
   name: 'ElAnchorLink',
 })
 
-const props = withDefaults(defineProps<AnchorLinkProps>(), {
-  href: undefined,
-})
+const props = defineProps<AnchorLinkProps>()
 
 const linkRef = ref<HTMLElement | null>(null)
 

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -57,7 +57,6 @@ import type {
   CascaderNode,
   CascaderNodeValue,
   CascaderOption,
-  CascaderProps,
   CascaderValue,
   ElCascaderPanelContext,
 } from './types'
@@ -69,8 +68,8 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<CascaderPanelProps>(), {
-  options: () => [] as CascaderOption[],
-  props: () => ({}) as CascaderProps,
+  options: () => [],
+  props: () => ({}),
   border: true,
 })
 const emit = defineEmits(cascaderPanelEmits)

--- a/packages/components/color-picker-panel/src/composables/use-predefine.ts
+++ b/packages/components/color-picker-panel/src/composables/use-predefine.ts
@@ -1,10 +1,10 @@
 import { computed, inject, ref, watch, watchEffect } from 'vue'
 import { useNamespace } from '@element-plus/hooks'
-import { PredefineProps } from '../props/predefine'
 import { colorPickerPanelContextKey } from '../color-picker-panel'
 import Color from '../utils/color'
 
 import type { Ref } from 'vue'
+import type { PredefineProps } from '../props/predefine'
 
 export const usePredefine = (props: PredefineProps) => {
   const { currentColor } = inject(colorPickerPanelContextKey)!

--- a/packages/components/descriptions/src/description.ts
+++ b/packages/components/descriptions/src/description.ts
@@ -1,8 +1,8 @@
 import { buildProps } from '@element-plus/utils'
 import { useSizeProp } from '@element-plus/hooks'
-import { ComponentSize } from '@element-plus/constants'
 
 import type { ExtractPublicPropTypes } from 'vue'
+import type { ComponentSize } from '@element-plus/constants'
 import type Description from './description.vue'
 
 export interface DescriptionProps {

--- a/packages/components/icon/src/icon.vue
+++ b/packages/components/icon/src/icon.vue
@@ -16,9 +16,7 @@ defineOptions({
   name: 'ElIcon',
   inheritAttrs: false,
 })
-const props = withDefaults(defineProps<IconProps>(), {
-  size: undefined,
-})
+const props = defineProps<IconProps>()
 const ns = useNamespace('icon')
 
 const style = computed<CSSProperties>(() => {

--- a/packages/components/popper/src/trigger.vue
+++ b/packages/components/popper/src/trigger.vue
@@ -28,7 +28,7 @@ defineOptions({
   inheritAttrs: false,
 })
 
-const props = withDefaults(defineProps<PopperTriggerProps>(), {})
+const props = defineProps<PopperTriggerProps>()
 
 const { role, triggerRef } = inject(POPPER_INJECTION_KEY, undefined)!
 

--- a/packages/components/upload/src/upload-content.ts
+++ b/packages/components/upload/src/upload-content.ts
@@ -1,12 +1,9 @@
 import { NOOP, buildProps, definePropType } from '@element-plus/utils'
-import {
-  UploadBaseProps,
-  uploadBaseProps,
-  uploadBasePropsDefaults,
-} from './upload'
+import { uploadBaseProps, uploadBasePropsDefaults } from './upload'
 
 import type { ExtractPublicPropTypes } from 'vue'
 import type {
+  UploadBaseProps,
   UploadFile,
   UploadHooks,
   UploadProgressEvent,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

Cleanup some workarounds left behind by the type-only props migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of component property definitions and import structures across the component library to improve code efficiency and reduce runtime dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->