### PR TITLE
chore(components): [dialog] ensure the transtition name type is correct

### DIFF
--- a/packages/components/dialog/src/use-dialog.ts
+++ b/packages/components/dialog/src/use-dialog.ts
@@ -102,7 +102,7 @@ export const useDialog = (
       globalConfig.value?.transition ??
       DEFAULT_DIALOG_TRANSITION
     const baseConfig = {
-      name: transition,
+      name: transition as string,
       onAfterEnter: afterEnter,
       onBeforeLeave: beforeLeave,
       onAfterLeave: afterLeave,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


I'm not sure whether this type error only occurs in my VSCode, but from both the type definition and the actual logic, `TransitionProps['name']` can only be `string`.


<img width="636" height="165" alt="image" src="https://github.com/user-attachments/assets/814153d1-f7bb-4db3-be4d-0ad499fbcb8f" />

<img width="697" height="68" alt="image" src="https://github.com/user-attachments/assets/b998eebb-a2cc-4f37-bc1c-66b04c314f8f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog transition value handling to ensure proper type coercion in transition configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->