### PR TITLE
fix(components): [table-v2] add slot typings

### DIFF
--- a/packages/components/table-v2/src/components/index.ts
+++ b/packages/components/table-v2/src/components/index.ts
@@ -11,7 +11,7 @@ export type {
   TableV2HeaderRowRendererParams,
 } from './header-row'
 
-export type { TableV2RowCellRenderParam } from './row'
+export type { TableV2RowCellRenderParam, TableV2RowSlotProps } from './row'
 export type {
   TableV2HeaderRendererParams,
   TableV2HeaderInstance,

--- a/packages/components/table-v2/src/components/row.tsx
+++ b/packages/components/table-v2/src/components/row.tsx
@@ -252,3 +252,13 @@ export type TableV2RowCellRenderParam = {
     onExpand: (expand: boolean) => void
   }
 }
+
+export type TableV2RowSlotProps = {
+  cells: VNode[]
+  columns: TableV2RowProps['columns']
+  depth: number
+  style: TableV2RowProps['style']
+  rowData: any
+  rowIndex: number
+  isScrolling: boolean
+}

--- a/packages/components/table-v2/src/table-v2.tsx
+++ b/packages/components/table-v2/src/table-v2.tsx
@@ -15,21 +15,33 @@ import Footer from './renderers/footer'
 import Empty from './renderers/empty'
 import Overlay from './renderers/overlay'
 
-import type { CSSProperties } from 'vue'
+import type { CSSProperties, SlotsType } from 'vue'
 import type { TableGridRowSlotParams } from './table-grid'
 import type { ScrollStrategy } from './composables/use-scrollbar'
 import type {
   TableV2HeaderRendererParams,
   TableV2HeaderRowCellRendererParams,
   TableV2RowCellRenderParam,
+  TableV2RowSlotProps,
 } from './components'
-import type { KeyType } from './types'
+import type { KeyType, TableV2CustomizedHeaderSlotParam } from './types'
+
+type TableV2Slots = {
+  row: TableV2RowSlotProps
+  cell: TableV2RowCellRenderParam
+  header: TableV2CustomizedHeaderSlotParam
+  'header-cell': TableV2HeaderRowCellRendererParams
+  footer: undefined
+  empty: undefined
+  overlay: undefined
+}
 
 const COMPONENT_NAME = 'ElTableV2'
 
 const TableV2 = defineComponent({
   name: COMPONENT_NAME,
   props: tableV2Props,
+  slots: Object as SlotsType<TableV2Slots>,
   setup(props, { slots, expose }) {
     const ns = useNamespace('table-v2')
     const { t } = useLocale()

--- a/packages/components/table-v2/src/table-v2.tsx
+++ b/packages/components/table-v2/src/table-v2.tsx
@@ -27,13 +27,13 @@ import type {
 import type { KeyType, TableV2CustomizedHeaderSlotParam } from './types'
 
 type TableV2Slots = {
-  row: TableV2RowSlotProps
-  cell: TableV2RowCellRenderParam
-  header: TableV2CustomizedHeaderSlotParam
-  'header-cell': TableV2HeaderRowCellRendererParams
-  footer: undefined
-  empty: undefined
-  overlay: undefined
+  row?: (props: TableV2RowSlotProps) => any
+  cell?: (props: TableV2RowCellRenderParam) => any
+  header?: (props: TableV2CustomizedHeaderSlotParam) => any
+  'header-cell'?: (props: TableV2HeaderRowCellRendererParams) => any
+  footer?: () => any
+  empty?: () => any
+  overlay?: () => any
 }
 
 const COMPONENT_NAME = 'ElTableV2'


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

### Description

Add missing slot typings for `table-v2`.

This PR adds `SlotsType` definitions to `table-v2` and exports the corresponding slot prop types, so built-in slots such as `row`, `cell`, `header`, `header-cell`, `footer`, `empty`, and `overlay` can provide better TypeScript inference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal type additions for Table V2 slots and row slot props; no runtime, UI, or behavior changes visible to end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->