### PR TITLE
fix(components): [cascader] prevent selecting first leaf node on ArrowDown

### DIFF
--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, test, vi } from 'vitest'
 import { EVENT_CODE } from '@element-plus/constants'
 import triggerEvent from '@element-plus/test-utils/trigger-event'
+import { rAF } from '@element-plus/test-utils/tick'
 import { ArrowDown, Check, CircleClose } from '@element-plus/icons-vue'
 import { usePopperContainerId } from '@element-plus/hooks'
 import { hasClass } from '@element-plus/utils'
@@ -1268,5 +1269,38 @@ describe('Cascader.vue', () => {
     await trigger.trigger('blur')
     await trigger.trigger('focus')
     expect(document.querySelectorAll(MENU)).toHaveLength(2)
+  })
+
+  it('should not select the first node when it is a leaf node', async () => {
+    const value = ref<string[]>([])
+    const options = [
+      { value: 'a', label: 'Node A' },
+      { value: 'b', label: 'Node B' },
+    ]
+    let visible = false
+
+    const visibleChange = vi.fn((v: boolean) => (visible = v))
+
+    const wrapper = mount(() => (
+      <Cascader
+        v-model={value.value}
+        options={options}
+        onVisibleChange={visibleChange}
+      />
+    ))
+    await nextTick()
+
+    const input = wrapper.find('.el-input__inner')
+    await input.trigger('click')
+
+    const firstNode = document.querySelector(NODE)!
+
+    await input.trigger('keydown', { code: EVENT_CODE.down })
+    await nextTick()
+    await rAF()
+
+    expect(visible).toBeTruthy()
+    expect(firstNode.matches(':focus')).toBeTruthy()
+    expect(value.value).toEqual([])
   })
 })

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -604,9 +604,12 @@ const focusFirstNode = () => {
 
   if (firstNode) {
     firstNode.focus()
-    !filtering.value &&
-      firstNode.getAttribute('aria-haspopup') === 'true' &&
+    if (
+      !filtering.value &&
+      firstNode.getAttribute('aria-haspopup') === 'true'
+    ) {
       firstNode.click()
+    }
   }
 }
 

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -604,7 +604,9 @@ const focusFirstNode = () => {
 
   if (firstNode) {
     firstNode.focus()
-    !filtering.value && firstNode.click()
+    !filtering.value &&
+      firstNode.getAttribute('aria-haspopup') === 'true' &&
+      firstNode.click()
   }
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #23953

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cascader focus behavior: focusing an item no longer triggers unintended clicks on items that don't open a popup; popup-capable items still open as expected.
* **Tests**
  * Added a keyboard-navigation test to verify dropdown focus and non-selection behavior for leaf-node options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->