### PR TITLE
docs: preview page show pr number link

### DIFF
--- a/docs/.vitepress/vitepress/components/vp-navbar.vue
+++ b/docs/.vitepress/vitepress/components/vp-navbar.vue
@@ -61,6 +61,7 @@ onMounted(() => {
             :href="`https://github.com/element-plus/element-plus/pull/${showPrNumber}`"
             target="_blank"
             rel="noopener noreferrer"
+            type="primary"
           >
             {{ showVersion }}
           </el-link>

--- a/docs/.vitepress/vitepress/components/vp-navbar.vue
+++ b/docs/.vitepress/vitepress/components/vp-navbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { inBrowser, useData, withBase } from 'vitepress'
 import { version as epVersion } from 'element-plus'
 import VPNavbarSearch from './navbar/vp-search.vue'
@@ -27,6 +27,20 @@ const currentLink = computed(() => {
 
   return existLangIndex === -1 ? '/' : `/${theme.value.langs[existLangIndex]}/`
 })
+
+const showVersion = ref(epVersion.replace('0.0.0-staging.', ''))
+const showPrNumber = ref('')
+
+onMounted(() => {
+  const isPreview = window.location?.host.startsWith('preview-')
+  if (isPreview) {
+    const prNumber = window.location?.host.split('-', 2)[1]
+    if (prNumber) {
+      showPrNumber.value = prNumber
+      showVersion.value = `PR ${prNumber}`
+    }
+  }
+})
 </script>
 
 <template>
@@ -40,9 +54,20 @@ const currentLink = computed(() => {
             alt="Element Plus Logo"
           />
         </a>
-        <el-tag round size="small" title="latest version">{{
-          epVersion.replace('0.0.0-staging.', '')
-        }}</el-tag>
+
+        <el-tag round size="small" title="latest version">
+          <el-link
+            v-if="showPrNumber"
+            :href="`https://github.com/element-plus/element-plus/pull/${showPrNumber}`"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ showVersion }}
+          </el-link>
+          <span v-else>
+            {{ showVersion }}
+          </span>
+        </el-tag>
       </div>
       <div class="content">
         <VPNavbarSearch class="search" :options="theme.agolia" multilang />


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

<img width="508" height="166" alt="image" src="https://github.com/user-attachments/assets/83580a39-d89a-40a9-b6ba-40bf9dc2a3a6" />

It makes it easy to distinguish tags and quickly jump back to GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navbar version tag now updates dynamically: preview deployments show the PR number as a linked label to the corresponding GitHub pull request; non-preview deployments display the version as plain text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->