### PR TITLE
fix: build compatible with generic components

### DIFF
--- a/internal/build/src/plugins/supply-validator.ts
+++ b/internal/build/src/plugins/supply-validator.ts
@@ -96,7 +96,7 @@ export function SupplyValidator(): Plugin {
         if (propsIndexes.length !== 2) return
 
         const scriptContent = rawContent.split(
-          /<script lang="ts" setup(?: generic=".+")?>|<\/script>/g
+          /<script\s+lang="ts"\s+setup(?:\s+generic=".+")?\s*>|<\/script>/g
         )[1]
         if (!scriptContent) return
 

--- a/internal/build/src/plugins/supply-validator.ts
+++ b/internal/build/src/plugins/supply-validator.ts
@@ -88,7 +88,7 @@ export function SupplyValidator(): Plugin {
       handler(code, id) {
         const vueFilePath = id.slice(0, id.indexOf('?'))
         const rawContent = fs.readFileSync(vueFilePath, 'utf-8')
-        const propsType = rawContent.match(/defineProps<(\w+)>/)?.[1]
+        const propsType = rawContent.match(/defineProps<(\w+)(?:<\w+>)?>/)?.[1]
         if (!propsType) return
 
         const { propsIndexes, mergePropsIndexes } =
@@ -96,8 +96,10 @@ export function SupplyValidator(): Plugin {
         if (propsIndexes.length !== 2) return
 
         const scriptContent = rawContent.split(
-          /<script lang="ts" setup>|<\/script>/g
+          /<script lang="ts" setup(?: generic=".+")?>|<\/script>/g
         )[1]
+        if (!scriptContent) return
+
         const extractImportFile = extractImportPropsStatements(
           vueFilePath,
           scriptContent,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

The `supply-validator-plugin` plugin is built to be compatible with the generic component format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for Vue setup scripts using generic type parameters so component props are recognized more reliably.
  * Enhanced parsing of component script blocks to accept additional attributes and varied formatting.
  * Added a safety check to skip processing when script content is missing, preventing failures during validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->