### PR TITLE
refactor(components): [mention/autocomplete] remove references marked as deprecated

### DIFF
--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -171,10 +171,9 @@ const props = withDefaults(defineProps<AutocompleteProps<T>>(), {
 })
 const emit = defineEmits(autocompleteEmits)
 const passInputProps = computed(() => {
-  const inputProps = ElInput.props ?? {}
-  const inputPropsKeys =
-    Object[isArray(inputProps) ? 'values' : 'keys'](inputProps)
-  return pick(props, inputPropsKeys)
+  const inputProps = ElInput.props ?? []
+  const keys = isArray(inputProps) ? inputProps : Object.keys(inputProps)
+  return pick(props, keys)
 })
 
 const rawAttrs = useRawAttrs()

--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -170,9 +170,12 @@ const props = withDefaults(defineProps<AutocompleteProps<T>>(), {
   teleported: true,
 })
 const emit = defineEmits(autocompleteEmits)
-const passInputProps = computed(() =>
-  pick(props, Object.keys(ElInput.props ?? {}))
-)
+const passInputProps = computed(() => {
+  const inputProps = ElInput.props ?? {}
+  const inputPropsKeys =
+    Object[isArray(inputProps) ? 'values' : 'keys'](inputProps)
+  return pick(props, inputPropsKeys)
+})
 
 const rawAttrs = useRawAttrs()
 const disabled = useFormDisabled()

--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -136,10 +136,7 @@ import {
   INPUT_EVENT,
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
-import ElInput, {
-  inputProps,
-  inputPropsDefaults,
-} from '@element-plus/components/input'
+import ElInput, { inputPropsDefaults } from '@element-plus/components/input'
 import ElScrollbar from '@element-plus/components/scrollbar'
 import ElTooltip from '@element-plus/components/tooltip'
 import ElIcon from '@element-plus/components/icon'
@@ -173,7 +170,9 @@ const props = withDefaults(defineProps<AutocompleteProps<T>>(), {
   teleported: true,
 })
 const emit = defineEmits(autocompleteEmits)
-const passInputProps = computed(() => pick(props, Object.keys(inputProps)))
+const passInputProps = computed(() =>
+  pick(props, Object.keys(ElInput.props ?? {}))
+)
 
 const rawAttrs = useRawAttrs()
 const disabled = useFormDisabled()

--- a/packages/components/mention/src/mention.vue
+++ b/packages/components/mention/src/mention.vue
@@ -60,10 +60,7 @@
 import { computed, mergeProps, nextTick, ref } from 'vue'
 import { pick } from 'lodash-unified'
 import { useFocusController, useId, useNamespace } from '@element-plus/hooks'
-import ElInput, {
-  inputProps,
-  inputPropsDefaults,
-} from '@element-plus/components/input'
+import ElInput, { inputPropsDefaults } from '@element-plus/components/input'
 import ElTooltip from '@element-plus/components/tooltip'
 import {
   EVENT_CODE,
@@ -109,7 +106,9 @@ defineSlots<
   }
 >()
 
-const passInputProps = computed(() => pick(props, Object.keys(inputProps)))
+const passInputProps = computed(() =>
+  pick(props, Object.keys(ElInput.props ?? {}))
+)
 
 const ns = useNamespace('mention')
 const disabled = useFormDisabled()

--- a/packages/components/mention/src/mention.vue
+++ b/packages/components/mention/src/mention.vue
@@ -68,7 +68,7 @@ import {
   UPDATE_MODEL_EVENT,
 } from '@element-plus/constants'
 import { useFormDisabled } from '@element-plus/components/form'
-import { getEventCode, isFunction } from '@element-plus/utils'
+import { getEventCode, isArray, isFunction } from '@element-plus/utils'
 import { mentionDefaultProps, mentionEmits } from './mention'
 import { filterOption, getCursorPosition, getMentionCtx } from './helper'
 import ElMentionDropdown from './mention-dropdown.vue'
@@ -106,9 +106,12 @@ defineSlots<
   }
 >()
 
-const passInputProps = computed(() =>
-  pick(props, Object.keys(ElInput.props ?? {}))
-)
+const passInputProps = computed(() => {
+  const inputProps = ElInput.props ?? {}
+  const inputPropsKeys =
+    Object[isArray(inputProps) ? 'values' : 'keys'](inputProps)
+  return pick(props, inputPropsKeys)
+})
 
 const ns = useNamespace('mention')
 const disabled = useFormDisabled()

--- a/packages/components/mention/src/mention.vue
+++ b/packages/components/mention/src/mention.vue
@@ -107,10 +107,9 @@ defineSlots<
 >()
 
 const passInputProps = computed(() => {
-  const inputProps = ElInput.props ?? {}
-  const inputPropsKeys =
-    Object[isArray(inputProps) ? 'values' : 'keys'](inputProps)
-  return pick(props, inputPropsKeys)
+  const inputProps = ElInput.props ?? []
+  const keys = isArray(inputProps) ? inputProps : Object.keys(inputProps)
+  return pick(props, keys)
 })
 
 const ns = useNamespace('mention')


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

test:
```ts
test('inputProps keys === Input.props keys', () => {
  expect(Object.keys(Input.props).sort()).toEqual(
    Object.keys(inputProps).sort()
  )
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved prop-forwarding for autocomplete and mention inputs to be more robust and compatible with varying input component definitions, simplifying imports and reducing fragile coupling—resulting in more reliable input behavior across edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->