### PR TITLE
ci: bump node-version to 24

### DIFF
--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/lint-typecheck.yml
+++ b/.github/workflows/lint-typecheck.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/pr-docs-build.yml
+++ b/.github/workflows/pr-docs-build.yml
@@ -13,10 +13,10 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.19.0]
+        node-version: [24]
         os: [ubuntu-latest, windows-latest]
         include:
-          - node-version: 20.19.0
+          - node-version: 24
             node-name: LTS
 
       fail-fast: false

--- a/.github/workflows/publish-build-product.yml
+++ b/.github/workflows/publish-build-product.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/publish-docs-deploy-manual.yml
+++ b/.github/workflows/publish-docs-deploy-manual.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/publish-docs-deploy.yml
+++ b/.github/workflows/publish-docs-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/publish-npm-nightly.yml
+++ b/.github/workflows/publish-npm-nightly.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5

--- a/.github/workflows/publish-pr-commit-pkg.yml
+++ b/.github/workflows/publish-pr-commit-pkg.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/publish-size-report.yml
+++ b/.github/workflows/publish-size-report.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
           cache: 'pnpm'
 
       - uses: preactjs/compressed-size-action@v2

--- a/.github/workflows/staging-docs.yml
+++ b/.github/workflows/staging-docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/test-ssr.yml
+++ b/.github/workflows/test-ssr.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 20.19.0
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: [github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to use Node.js version 24 across all automated workflows, improving build environment compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->