### PR TITLE
docs(components): [tabs] supplement the props exposed by tab-bar

### DIFF
--- a/docs/en-US/component/tabs.md
+++ b/docs/en-US/component/tabs.md
@@ -148,10 +148,10 @@ tabs/default-value
 
 ### Tab-bar Exposes
 
-| Name   | Description                             | Type                                        |
-| ------ | --------------------------------------- | ------------------------------------------- |
-| ref    | tab root html element                   | ^[object]`Ref<HTMLDivElement \| undefined>` |
-| update | method to manually update tab bar style | ^[Function]`() => void`                     |
+| Name   | Description                                                       | Type                                        |
+| ------ | ----------------------------------------------------------------- | ------------------------------------------- |
+| ref    | tab root html element                                             | ^[object]`Ref<HTMLDivElement \| undefined>` |
+| update | method to manually update tab bar style, return the updated style | ^[Function]`() => CSSProperties`            |
 
 ## Tab-pane API
 

--- a/docs/en-US/component/tabs.md
+++ b/docs/en-US/component/tabs.md
@@ -171,9 +171,9 @@ tabs/default-value
 ```ts
 type TabBarInstance = InstanceType<typeof TabBar> & {
   /** @description tab root html element */
-  ref: barRef
+  ref: Ref<HTMLDivElement | undefined>
   /** @description method to manually update tab bar style */
-  update
+  update: () => void
 }
 ```
 

--- a/docs/en-US/component/tabs.md
+++ b/docs/en-US/component/tabs.md
@@ -148,10 +148,10 @@ tabs/default-value
 
 ### Tab-bar Exposes
 
-| Name   | Description                                                       | Type                                        |
-| ------ | ----------------------------------------------------------------- | ------------------------------------------- |
-| ref    | tab root html element                                             | ^[object]`Ref<HTMLDivElement \| undefined>` |
-| update | method to manually update tab bar style, return the updated style | ^[Function]`() => CSSProperties`            |
+| Name             | Description                                                       | Type                                        |
+| ---------------- | ----------------------------------------------------------------- | ------------------------------------------- |
+| ref ^(2.9.10)    | tab root html element                                             | ^[object]`Ref<HTMLDivElement \| undefined>` |
+| update ^(2.9.10) | method to manually update tab bar style, return the updated style | ^[Function]`() => CSSProperties`            |
 
 ## Tab-pane API
 

--- a/docs/en-US/component/tabs.md
+++ b/docs/en-US/component/tabs.md
@@ -144,6 +144,15 @@ tabs/default-value
 | tabListRef ^(2.9.10) | el_tabs\_\_nav html element | ^[object]`Ref<HTMLDivElement \| undefined>` |
 | tabBarRef ^(2.9.10)  | el_tabs\_\_nav bar instance | ^[object]`Ref<TabBarInstance \| undefined>` |
 
+## Tab-bar API
+
+### Tab-bar Exposes
+
+| Name   | Description                             | Type                                        |
+| ------ | --------------------------------------- | ------------------------------------------- |
+| ref    | tab root html element                   | ^[object]`Ref<HTMLDivElement \| undefined>` |
+| update | method to manually update tab bar style | ^[Function]`() => void`                     |
+
 ## Tab-pane API
 
 ### Tab-pane Attributes
@@ -162,22 +171,6 @@ tabs/default-value
 | ------- | ------------------ |
 | default | Tab-pane's content |
 | label   | Tab-pane's label   |
-
-## Type Declarations
-
-<details>
-  <summary>Show declarations</summary>
-
-```ts
-type TabBarInstance = InstanceType<typeof TabBar> & {
-  /** @description tab root html element */
-  ref: Ref<HTMLDivElement | undefined>
-  /** @description method to manually update tab bar style */
-  update: () => void
-}
-```
-
-</details>
 
 ## FAQ
 

--- a/packages/components/tabs/src/tab-bar.vue
+++ b/packages/components/tabs/src/tab-bar.vue
@@ -84,7 +84,9 @@ const getBarStyle = (): CSSProperties => {
   }
 }
 
-const update = () => (barStyle.value = getBarStyle())
+const update = () => {
+  barStyle.value = getBarStyle()
+}
 
 const tabObservers = [] as ReturnType<typeof useResizeObserver>[]
 const observerTabs = () => {

--- a/packages/components/tabs/src/tab-bar.vue
+++ b/packages/components/tabs/src/tab-bar.vue
@@ -117,7 +117,7 @@ onBeforeUnmount(() => {
 defineExpose({
   /** @description tab root html element */
   ref: barRef,
-  /** @description method to manually update tab bar style */
+  /** @description method to manually update tab bar style, return the updated style */
   update,
 })
 </script>

--- a/packages/components/tabs/src/tab-bar.vue
+++ b/packages/components/tabs/src/tab-bar.vue
@@ -84,9 +84,7 @@ const getBarStyle = (): CSSProperties => {
   }
 }
 
-const update = () => {
-  barStyle.value = getBarStyle()
-}
+const update = () => (barStyle.value = getBarStyle())
 
 const tabObservers = [] as ReturnType<typeof useResizeObserver>[]
 const observerTabs = () => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Tab-bar Exposes" section in Tabs docs clarifying the exposed ref and describing that the update member returns the updated tab-bar style.
* **Refactor**
  * Adjusted exposure wording for the tab-bar's update member to clarify its return semantics; no change to runtime behavior or public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->