### PR TITLE
fix(components): [button] color prop not working with link/text mode

### DIFF
--- a/packages/components/button/src/button-custom.ts
+++ b/packages/components/button/src/button-custom.ts
@@ -90,6 +90,13 @@ export function useButtonCustomStyle(props: ButtonProps) {
             disabledButtonColor
         }
       }
+      if (props.link || props.text) {
+        styles = ns.cssVarBlock({
+          'text-color': buttonColor,
+          'hover-text-color': buttonColor,
+          'active-text-color': buttonColor,
+        })
+      }
     }
 
     return styles


### PR DESCRIPTION
closed #23994

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
## Summary by CodeRabbit
* **Bug Fixes**
  * The `color` property does not take effect on `el-button` when `link` or `text` is set.