### PR TITLE
feat(components): [button] support custom color with link/text

### DIFF
--- a/docs/en-US/component/button.md
+++ b/docs/en-US/component/button.md
@@ -129,6 +129,8 @@ You can custom button color.
 
 We will calculate hover color & active color automatically.
 
+The `color` prop also works with `link` and `text` buttons since ^(2.13.7).
+
 :::demo
 
 button/custom
@@ -156,7 +158,7 @@ button/custom
 | autofocus         | same as native button's `autofocus`                                                                                                                  | ^[boolean]                                                                                                   | false   |
 | native-type       | same as native button's `type`                                                                                                                       | ^[enum]`'button' \| 'submit' \| 'reset'`                                                                     | button  |
 | auto-insert-space | automatically insert a space between two chinese characters(this will only take effect when the text length is 2 and all characters are in Chinese.) | ^[boolean]                                                                                                   | false   |
-| color             | custom button color, automatically calculate `hover` and `active` color                                                                              | ^[string]                                                                                                    | —       |
+| color             | custom button color, automatically calculate `hover` and `active` color. Works with `link`/`text` buttons since ^(2.13.7)                            | ^[string]                                                                                                    | —       |
 | dark              | dark mode, which automatically converts `color` to dark mode colors                                                                                  | ^[boolean]                                                                                                   | false   |
 | tag ^(2.3.4)      | custom element tag                                                                                                                                   | ^[string] / ^[Component]                                                                                     | button  |
 

--- a/docs/examples/button/custom.vue
+++ b/docs/examples/button/custom.vue
@@ -6,10 +6,22 @@ import { isDark } from '~/composables/dark'
   <div>
     <el-button color="#626aef" :dark="isDark">Default</el-button>
     <el-button color="#626aef" :dark="isDark" plain>Plain</el-button>
+    <el-button color="#626aef" :dark="isDark" link>Link</el-button>
+    <el-button color="#626aef" :dark="isDark" text>Text</el-button>
+    <el-button color="#626aef" :dark="isDark" text bg>Text BG</el-button>
 
     <el-button color="#626aef" :dark="isDark" disabled>Disabled</el-button>
     <el-button color="#626aef" :dark="isDark" disabled plain>
       Disabled Plain
+    </el-button>
+    <el-button color="#626aef" :dark="isDark" disabled link>
+      Disabled Link
+    </el-button>
+    <el-button color="#626aef" :dark="isDark" disabled text>
+      Disabled Text
+    </el-button>
+    <el-button color="#626aef" :dark="isDark" disabled text bg>
+      Disabled Text BG
     </el-button>
   </div>
 </template>

--- a/packages/components/button/src/button-custom.ts
+++ b/packages/components/button/src/button-custom.ts
@@ -70,11 +70,7 @@ export function useButtonCustomStyle(props: ButtonProps) {
           'text-color': buttonColor,
           'border-color': 'transparent',
           'hover-text-color': hoverColor,
-          'hover-bg-color': 'transparent',
-          'hover-border-color': 'transparent',
-          'active-bg-color': 'transparent',
           'active-text-color': activeBgColor,
-          'active-border-color': 'transparent',
         })
 
         if (props.link) {

--- a/packages/components/button/src/button-custom.ts
+++ b/packages/components/button/src/button-custom.ts
@@ -72,12 +72,15 @@ export function useButtonCustomStyle(props: ButtonProps) {
           'hover-text-color': hoverColor,
           'hover-bg-color': 'transparent',
           'hover-border-color': 'transparent',
-          'hover-link-text-color': hoverColor,
           'active-bg-color': 'transparent',
           'active-text-color': activeBgColor,
           'active-border-color': 'transparent',
-          'active-color': activeBgColor,
         })
+
+        if (props.link) {
+          styles[ns.cssVarBlockName('hover-link-text-color')] = hoverColor
+          styles[ns.cssVarBlockName('active-color')] = activeBgColor
+        }
 
         if (_disabled.value) {
           const disabledColor = props.dark

--- a/packages/components/button/src/button-custom.ts
+++ b/packages/components/button/src/button-custom.ts
@@ -60,6 +60,33 @@ export function useButtonCustomStyle(props: ButtonProps) {
             ? darken(color, 80)
             : color.tint(80).toString()
         }
+      } else if (props.link || props.text) {
+        const hoverColor = props.dark
+          ? darken(color, 30)
+          : color.tint(30).toString()
+
+        styles = ns.cssVarBlock({
+          'bg-color': 'transparent',
+          'text-color': buttonColor,
+          'border-color': 'transparent',
+          'hover-text-color': hoverColor,
+          'hover-bg-color': 'transparent',
+          'hover-border-color': 'transparent',
+          'hover-link-text-color': hoverColor,
+          'active-bg-color': 'transparent',
+          'active-text-color': activeBgColor,
+          'active-border-color': 'transparent',
+          'active-color': activeBgColor,
+        })
+
+        if (_disabled.value) {
+          const disabledColor = props.dark
+            ? darken(color, 50)
+            : color.tint(50).toString()
+          styles[ns.cssVarBlockName('disabled-bg-color')] = 'transparent'
+          styles[ns.cssVarBlockName('disabled-text-color')] = disabledColor
+          styles[ns.cssVarBlockName('disabled-border-color')] = 'transparent'
+        }
       } else {
         const hoverBgColor = props.dark
           ? darken(color, 30)

--- a/packages/components/button/src/button-custom.ts
+++ b/packages/components/button/src/button-custom.ts
@@ -66,9 +66,7 @@ export function useButtonCustomStyle(props: ButtonProps) {
           : color.tint(30).toString()
 
         styles = ns.cssVarBlock({
-          'bg-color': 'transparent',
           'text-color': buttonColor,
-          'border-color': 'transparent',
           'hover-text-color': hoverColor,
           'active-text-color': activeBgColor,
         })


### PR DESCRIPTION
### Description

Fix `el-button` custom `color` prop not taking effect when `link` or `text` is set.

**Root cause:** In [useButtonCustomStyle](packages/components/button/src/button-custom.ts:11:0-123:1), the default branch computed `text-color` as white/black based on `color.isDark()` (designed for buttons with colored backgrounds). For link/text buttons (which have transparent backgrounds by design), the text color should be the custom color itself, not white/black.

**Fix:** Add a dedicated `else if (props.link || props.text)` branch that:
- Sets `text-color` to the custom color directly
- Computes proper hover/active/disabled color variants
- Keeps background and border transparent, Background and border transparency is handled by existing SCSS rules

close #23994
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved styling for link and text button variants: custom color now drives text, hover, and active states; transparent backgrounds for these variants; stronger disabled contrast in both light and dark modes.

* **Documentation**
  * Clarified that the color prop also applies to link and text button variants.

* **Examples**
  * Added examples for link, text, and text-with-background variants, including disabled states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->