### PR TITLE
fix(components): [select/v2] ios click listening

### DIFF
--- a/packages/components/select-v2/src/option-item.vue
+++ b/packages/components/select-v2/src/option-item.vue
@@ -12,7 +12,7 @@
       ns.is('created', created),
       ns.is('hovering', hovering),
     ]"
-    @mousemove="hoverItem"
+    @[mouseMoveEventName]="hoverItem"
     @mousedown="handleMousedown"
     @click.stop="selectOptionClick"
   >
@@ -29,7 +29,7 @@ import { useOption } from './useOption'
 import { useProps } from './useProps'
 import { optionV2Emits, optionV2Props } from './defaults'
 import { selectV2InjectionKey } from './token'
-import { isFocusable } from '@element-plus/utils'
+import { isFocusable, isIOS } from '@element-plus/utils'
 
 export default defineComponent({
   props: optionV2Props,
@@ -37,6 +37,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const select = inject(selectV2InjectionKey)!
     const ns = useNamespace('select')
+    const mouseMoveEventName = isIOS ? null : 'mousemove'
     const { hoverItem, selectOptionClick } = useOption(props, { emit })
     const { getLabel } = useProps(select.props)
     const contentId = select.contentId
@@ -58,6 +59,7 @@ export default defineComponent({
     return {
       ns,
       contentId,
+      mouseMoveEventName,
       hoverItem,
       handleMousedown,
       selectOptionClick,

--- a/packages/components/select/src/option.vue
+++ b/packages/components/select/src/option.vue
@@ -6,7 +6,7 @@
     role="option"
     :aria-disabled="isDisabled || undefined"
     :aria-selected="itemSelected"
-    @mousemove="hoverItem"
+    @[mouseMoveEventName]="hoverItem"
     @mousedown="handleMousedown"
     @click.stop="selectOptionClick"
   >
@@ -30,7 +30,7 @@ import {
 import { useId, useNamespace } from '@element-plus/hooks'
 import { useOption } from './useOption'
 import { COMPONENT_NAME, optionProps } from './option'
-import { isFocusable } from '@element-plus/utils'
+import { isFocusable, isIOS } from '@element-plus/utils'
 
 import type {
   OptionExposed,
@@ -62,6 +62,7 @@ export default defineComponent({
       hover: false,
     })
 
+    const mouseMoveEventName = isIOS ? null : 'mousemove'
     const {
       currentLabel,
       itemSelected,
@@ -124,7 +125,7 @@ export default defineComponent({
       visible,
       hover,
       states,
-
+      mouseMoveEventName,
       hoverItem,
       handleMousedown,
       updateOption,

--- a/packages/components/select/src/type.ts
+++ b/packages/components/select/src/type.ts
@@ -60,6 +60,7 @@ export interface OptionExposed {
   handleMousedown: (event: MouseEvent) => void
   updateOption: (query: string) => void
   selectOptionClick: () => void
+  mouseMoveEventName: 'mousemove' | null
 }
 export type OptionPublicInstance = ComponentPublicInstance<
   OptionProps,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

**Desc**
The cause of the issue is the same as in related: element-plus/element-plus/pull/16393. The difference is that the `<li>` above `el-option` does not handle the `mousemove` event.

By the way, removing the mousemove event on mobile devices does not affect the original functionality, and it also avoids the impact of events like mousemove and mouseenter on click.
<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/b791d979-ece2-4c77-80bb-39cd10b2dab0" />


related: element-plus/element-plus/issues/23486
related: element-plus/element-plus/pull/16393
realted: element-plus/element-plus/pull/23881

The following examples all occur occasionally.

1. In this case, it happens occasionally. Please note that when clicking `Option 4`, the click event is not triggered in the console.

https://github.com/user-attachments/assets/f349164e-f4af-408e-b4c7-82fc94588b7f

2. Note that I clicked the `Beijing` option, but it was not selected. Instead, only the mousemove hover highlight appeared, and a scrollbar showed up. https://github.com/element-plus/element-plus/issues/23486#issuecomment-4219667209

https://github.com/user-attachments/assets/e51652a4-5daf-4464-bd83-4ccd7bf0caac

3. I just tested select-v2 as well, and this issue occasionally happens there too.


https://github.com/user-attachments/assets/28fe8187-7124-42f0-aae1-6b1f956969c2





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled hover-based option highlighting on iOS to prevent spurious hover behavior while keeping hover interactions on other platforms.
  * No changes to public component APIs or visible props; non-iOS behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->