### PR TITLE
perf(components): Replace mousemove with mouseenter

### DIFF
--- a/packages/components/mention/src/mention-dropdown.vue
+++ b/packages/components/mention/src/mention-dropdown.vue
@@ -23,7 +23,7 @@
         role="option"
         :aria-disabled="item.disabled || disabled || undefined"
         :aria-selected="hoveringIndex === index"
-        @mousemove="handleMouseEnter(index)"
+        @mouseenter="handleMouseEnter(index)"
         @click.stop="handleSelect(item)"
       >
         <slot name="label" :item="item" :index="index">

--- a/packages/components/select-v2/src/option-item.vue
+++ b/packages/components/select-v2/src/option-item.vue
@@ -12,7 +12,7 @@
       ns.is('created', created),
       ns.is('hovering', hovering),
     ]"
-    @mousemove="hoverItem"
+    @mouseenter="hoverItem"
     @mousedown="handleMousedown"
     @click.stop="selectOptionClick"
   >

--- a/packages/components/select/src/option.vue
+++ b/packages/components/select/src/option.vue
@@ -6,7 +6,7 @@
     role="option"
     :aria-disabled="isDisabled || undefined"
     :aria-selected="itemSelected"
-    @mousemove="hoverItem"
+    @mouseenter="hoverItem"
     @mousedown="handleMousedown"
     @click.stop="selectOptionClick"
   >


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

1. mention
2. Select/v2

The current implementation uses mousemove to handle highlighting. Replacing it with mouseenter achieves the same effect. **On the same element**, the mouseenter callback is triggered only once when the pointer enters the element. Previously, using mousemove caused the callback to fire multiple times, leading to unnecessary performance overhead—especially in the select option highlighting logic, where indexOf is repeatedly executed for lookups, further wasting performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hover performance in select and mention dropdown components by optimizing event detection—hover states now trigger on entry rather than continuously during pointer movement, resulting in smoother interaction and better responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->