### PR TITLE
docs: implement creating new issues for a specifc component

### DIFF
--- a/docs/.vitepress/crowdin/en-US/component/component-meta.json
+++ b/docs/.vitepress/crowdin/en-US/component/component-meta.json
@@ -1,5 +1,6 @@
 {
   "changelog": "Changelog",
   "view-full-changelog": "View full changelog",
+  "create-new-issue": "Create New issue",
   "open-issues": "Open issues"
 }

--- a/docs/.vitepress/crowdin/en-US/component/component-meta.json
+++ b/docs/.vitepress/crowdin/en-US/component/component-meta.json
@@ -1,6 +1,6 @@
 {
   "changelog": "Changelog",
   "view-full-changelog": "View full changelog",
-  "create-new-issue": "Create New issue",
+  "create-new-issue": "Create new issue",
   "open-issues": "Open issues"
 }

--- a/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
+++ b/docs/.vitepress/vitepress/components/globals/vp-component-meta.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { Clock, Loading, Warning } from '@element-plus/icons-vue'
+import { CirclePlus, Clock, Loading, Warning } from '@element-plus/icons-vue'
 import { useWindowSize } from '@vueuse/core'
 import { useIssueCount } from '../../composables/use-issue-count'
 import { useLocale } from '../../composables/locale'
@@ -83,6 +83,15 @@ const openDrawer = () => {
 const openIssues = () => {
   window.open(issuesUrl.value, '_blank', 'noopener,noreferrer')
 }
+
+const createNewIssue = () => {
+  const params = `?bugType=Component&component=${props.component}`
+  window.open(
+    `https://issue.element-plus.org${params}`,
+    '_blank',
+    'noopener,noreferrer'
+  )
+}
 </script>
 
 <template>
@@ -91,6 +100,9 @@ const openIssues = () => {
       <el-button-group class="component-meta-card" size="small">
         <el-button :icon="Clock" @click="openDrawer">
           {{ locale['changelog'] }}
+        </el-button>
+        <el-button :icon="CirclePlus" @click="createNewIssue">
+          {{ locale['create-new-issue'] }}
         </el-button>
         <el-button :icon="Warning" @click="openIssues">
           {{ locale['open-issues'] }}


### PR DESCRIPTION
Here is the effect.

https://github.com/user-attachments/assets/4a242a9c-da73-4bae-98f8-64f819b92ea9

Related: https://github.com/element-plus/element-plus-issue-helper/pull/4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Create new issue" button to component documentation pages, enabling users to report issues directly with pre-filled component context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->