### PR TITLE
fix(components): [scrollbar] fix height

### DIFF
--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="scrollbarRef" :class="ns.b()">
+  <div ref="scrollbarRef" :class="ns.b()" :style="{ height }">
     <div
       ref="wrapRef"
       :class="wrapKls"
@@ -89,6 +89,10 @@ const distanceScrollState = {
   right: false,
   left: false,
 }
+
+const height = computed(() => {
+  return addUnit(props.height) || '100%'
+})
 
 const scrollbarRef = ref<HTMLDivElement>()
 const wrapRef = ref<HTMLDivElement>()


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

通过 height 属性设置滚动条高度，若不设置则根据父容器高度自适应。
Before:
我设置了40高度,`.el-scrollbar__wrap`确实设置了40,但是`el-scrollbar`仍然是100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed scrollbar component to properly apply dynamic height styling based on configuration, with automatic fallback to fill available space when height is not explicitly specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->