### PR TITLE
chore(play): replace `esbuild` with `oxc`

### DIFF
--- a/play/vite.config.mts
+++ b/play/vite.config.mts
@@ -75,8 +75,8 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
     optimizeDeps: {
       include: ['vue', '@vue/shared', ...dependencies, ...optimizeDeps],
     },
-    esbuild: {
-      target: 'chrome64',
+    oxc: {
+      target: 'chrome85',
     },
   }
 })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

https://vite.dev/config/shared-options#esbuild:~:text=This%20option%20is%20converted%20to%20oxc%20option%20internally.%20Use%20oxc%20option%20instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to target newer browser versions and improve transpilation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->