### PR TITLE
docs: disable the leave transition of the version tag to prevent layout shifting

### DIFF
--- a/docs/.vitepress/vitepress/components/dev/version-tag.vue
+++ b/docs/.vitepress/vitepress/components/dev/version-tag.vue
@@ -5,7 +5,13 @@ defineProps<{
 </script>
 
 <template>
-  <el-tag size="small" effect="plain" hit round>
+  <el-tag class="version-tag" size="small" effect="plain" hit round>
     {{ version }}
   </el-tag>
 </template>
+
+<style scoped lang="scss">
+.version-tag.el-zoom-in-center-leave-active {
+  --el-transition-duration: 0s;
+}
+</style>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


https://github.com/user-attachments/assets/3b41fba8-f900-41dd-ad34-9c825e046c5a

Rel https://github.com/element-plus/element-plus/pull/22671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced version tag styling and animations throughout the documentation site. Optimized component animation behavior by removing unnecessary transition delays when tags are dismissed, improving overall responsiveness, visual polish, and perceived performance. This delivers a cleaner, snappier, and more responsive user experience with better interaction feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->