### PR TITLE
fix(components): [input] avoid border flicker while resizing

### DIFF
--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -148,7 +148,6 @@
         @compositionstart="handleCompositionStart"
         @compositionupdate="handleCompositionUpdate"
         @compositionend="handleCompositionEnd"
-        @mousedown="handleTextareaMouseDown"
         @input="handleInput"
         @focus="handleFocus"
         @blur="handleBlur"
@@ -189,7 +188,7 @@ import {
   useSlots,
   watch,
 } from 'vue'
-import { useEventListener, useResizeObserver } from '@vueuse/core'
+import { useResizeObserver } from '@vueuse/core'
 import { isNil } from 'lodash-unified'
 import { ElIcon } from '@element-plus/components/icon'
 import { Hide, View } from '@element-plus/icons-vue'
@@ -275,7 +274,6 @@ const input = shallowRef<HTMLInputElement>()
 const textarea = shallowRef<HTMLTextAreaElement>()
 
 const hovering = ref(false)
-const isResizingTextarea = ref(false)
 const passwordVisible = ref(false)
 const countStyle = ref<StyleValue>()
 const textareaCalcStyle = shallowRef(props.inputStyle)
@@ -306,10 +304,12 @@ const passwordIcon = computed(() => (passwordVisible.value ? View : Hide))
 const containerStyle = computed<StyleValue>(() => [
   rawAttrs.style as StyleValue,
 ])
+const textareaHeight = ref()
 const textareaStyle = computed<StyleValue>(() => [
   props.inputStyle,
   textareaCalcStyle.value,
   { resize: props.resize },
+  textareaHeight.value ? { height: textareaHeight.value } : undefined,
 ])
 const nativeInputValue = computed(() =>
   isNil(props.modelValue) ? '' : String(props.modelValue)
@@ -410,7 +410,12 @@ const resizeTextarea = () => {
 const createOnceInitResize = (resizeTextarea: () => void) => {
   let isInit = false
   return () => {
-    if (isInit || !props.autosize) return
+    if (isInit || !props.autosize) {
+      if (props.resize !== 'none') {
+        textareaHeight.value = textarea.value?.style.height
+      }
+      return
+    }
     const isElHidden = textarea.value?.offsetParent === null
     if (!isElHidden) {
       setTimeout(resizeTextarea)
@@ -600,26 +605,6 @@ const {
   handleCompositionEnd,
 } = useComposition({ emit, afterComposition: handleInput })
 
-useEventListener('mouseup', () => {
-  const isResizing = isResizingTextarea.value
-
-  isResizingTextarea.value = false
-  if (isResizing && !textarea.value?.matches(':hover')) {
-    textarea.value?.dispatchEvent(
-      new MouseEvent('mouseleave', { bubbles: true })
-    )
-  }
-})
-
-const handleTextareaMouseDown = () => {
-  const { type, resize } = props
-  if (type !== 'textarea' || resize === 'none') {
-    isResizingTextarea.value = false
-    return
-  }
-  isResizingTextarea.value = true
-}
-
 const handlePasswordVisible = () => {
   passwordVisible.value = !passwordVisible.value
 }
@@ -629,13 +614,11 @@ const focus = () => _ref.value?.focus()
 const blur = () => _ref.value?.blur()
 
 const handleMouseLeave = (evt: MouseEvent) => {
-  if (isResizingTextarea.value) return
   hovering.value = false
   emit('mouseleave', evt)
 }
 
 const handleMouseEnter = (evt: MouseEvent) => {
-  if (isResizingTextarea.value) return
   hovering.value = true
   emit('mouseenter', evt)
 }

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -278,6 +278,7 @@ const passwordVisible = ref(false)
 const countStyle = ref<StyleValue>()
 const textareaCalcStyle = shallowRef(props.inputStyle)
 const saveValue = ref('')
+const textareaHeight = ref()
 
 const _ref = computed(() => input.value || textarea.value)
 
@@ -304,7 +305,6 @@ const passwordIcon = computed(() => (passwordVisible.value ? View : Hide))
 const containerStyle = computed<StyleValue>(() => [
   rawAttrs.style as StyleValue,
 ])
-const textareaHeight = ref()
 const textareaStyle = computed<StyleValue>(() => [
   props.inputStyle,
   textareaCalcStyle.value,

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -645,7 +645,10 @@ const clear = (evt?: MouseEvent) => {
 watch(
   () => props.modelValue,
   () => {
-    nextTick(() => resizeTextarea())
+    nextTick(() => {
+      resizeTextarea()
+      textareaHeight.value = undefined
+    })
     if (props.validateEvent) {
       elFormItem?.validate?.('change').catch(NOOP)
     }

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -647,7 +647,9 @@ watch(
   () => {
     nextTick(() => {
       resizeTextarea()
-      textareaHeight.value = undefined
+      if (props.autosize) {
+        textareaHeight.value = undefined
+      }
     })
     if (props.validateEvent) {
       elFormItem?.validate?.('change').catch(NOOP)

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -278,7 +278,7 @@ const passwordVisible = ref(false)
 const countStyle = ref<StyleValue>()
 const textareaCalcStyle = shallowRef(props.inputStyle)
 const saveValue = ref('')
-const textareaHeight = ref()
+const textareaHeight = ref<string>()
 
 const _ref = computed(() => input.value || textarea.value)
 
@@ -412,7 +412,11 @@ const createOnceInitResize = (resizeTextarea: () => void) => {
   return () => {
     if (isInit || !props.autosize) {
       if (props.resize !== 'none') {
-        textareaHeight.value = textarea.value?.style.height
+        // The execution here may occur before `setTimeout(resizeTextarea)`,
+        // potentially causing a regression of issue #21836, so the assignment needs to be deferred.
+        setTimeout(() => {
+          textareaHeight.value = textarea.value?.style.height
+        })
       }
       return
     }

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -606,7 +606,10 @@ useEventListener('mouseup', () => {
 
 const handleTextareaMouseDown = () => {
   const { type, resize } = props
-  if (type !== 'textarea' || resize === 'none') return
+  if (type !== 'textarea' || resize === 'none') {
+    isResizingTextarea.value = false
+    return
+  }
   isResizingTextarea.value = true
 }
 

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -148,6 +148,7 @@
         @compositionstart="handleCompositionStart"
         @compositionupdate="handleCompositionUpdate"
         @compositionend="handleCompositionEnd"
+        @mousedown="handleTextareaMouseDown"
         @input="handleInput"
         @focus="handleFocus"
         @blur="handleBlur"
@@ -188,7 +189,7 @@ import {
   useSlots,
   watch,
 } from 'vue'
-import { useResizeObserver } from '@vueuse/core'
+import { useEventListener, useResizeObserver } from '@vueuse/core'
 import { isNil } from 'lodash-unified'
 import { ElIcon } from '@element-plus/components/icon'
 import { Hide, View } from '@element-plus/icons-vue'
@@ -274,6 +275,7 @@ const input = shallowRef<HTMLInputElement>()
 const textarea = shallowRef<HTMLTextAreaElement>()
 
 const hovering = ref(false)
+const isResizingTextarea = ref(false)
 const passwordVisible = ref(false)
 const countStyle = ref<StyleValue>()
 const textareaCalcStyle = shallowRef(props.inputStyle)
@@ -598,6 +600,16 @@ const {
   handleCompositionEnd,
 } = useComposition({ emit, afterComposition: handleInput })
 
+useEventListener('mouseup', () => {
+  isResizingTextarea.value = false
+})
+
+const handleTextareaMouseDown = () => {
+  const { type, resize } = props
+  if (type !== 'textarea' || resize === 'none') return
+  isResizingTextarea.value = true
+}
+
 const handlePasswordVisible = () => {
   passwordVisible.value = !passwordVisible.value
 }
@@ -607,11 +619,13 @@ const focus = () => _ref.value?.focus()
 const blur = () => _ref.value?.blur()
 
 const handleMouseLeave = (evt: MouseEvent) => {
+  if (isResizingTextarea.value) return
   hovering.value = false
   emit('mouseleave', evt)
 }
 
 const handleMouseEnter = (evt: MouseEvent) => {
+  if (isResizingTextarea.value) return
   hovering.value = true
   emit('mouseenter', evt)
 }

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -601,7 +601,14 @@ const {
 } = useComposition({ emit, afterComposition: handleInput })
 
 useEventListener('mouseup', () => {
+  const isResizing = isResizingTextarea.value
+
   isResizingTextarea.value = false
+  if (isResizing && !textarea.value?.matches(':hover')) {
+    textarea.value?.dispatchEvent(
+      new MouseEvent('mouseleave', { bubbles: true })
+    )
+  }
 })
 
 const handleTextareaMouseDown = () => {

--- a/packages/components/input/src/utils.ts
+++ b/packages/components/input/src/utils.ts
@@ -41,6 +41,7 @@ type NodeStyle = {
 type TextAreaHeight = {
   height: string
   minHeight?: string
+  maxHeight?: string
 }
 
 export const looseToNumber = (val: any): any => {
@@ -123,6 +124,7 @@ export function calcTextareaHeight(
       maxHeight = maxHeight + paddingSize + borderSize
     }
     height = Math.min(maxHeight, height)
+    result.maxHeight = `${maxHeight}px`
   }
   result.height = `${height}px`
   hiddenTextarea.parentNode?.removeChild(hiddenTextarea)

--- a/packages/components/input/src/utils.ts
+++ b/packages/components/input/src/utils.ts
@@ -41,7 +41,6 @@ type NodeStyle = {
 type TextAreaHeight = {
   height: string
   minHeight?: string
-  maxHeight?: string
 }
 
 export const looseToNumber = (val: any): any => {
@@ -124,7 +123,6 @@ export function calcTextareaHeight(
       maxHeight = maxHeight + paddingSize + borderSize
     }
     height = Math.min(maxHeight, height)
-    result.maxHeight = `${maxHeight}px`
   }
   result.height = `${height}px`
   hiddenTextarea.parentNode?.removeChild(hiddenTextarea)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fix #24076

This happens because resizing triggers frequent `mouseenter` and `mouseleave` events as the cursor moves, causing `hovering.value` to change repeatedly. As a result, the clear icon is constantly created and destroyed, leading to layout reflow.

There is no event for detecting textarea resize, so this is a workaround. If there’s a better approach, please let me know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved textarea auto-resizing so height is calculated and applied reliably after value changes, and manual/resizable textareas preserve and respect explicit heights when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->