### PR TITLE
.643647360741672:ff393ab1b5575eb25ce1c8973d17a176_69e0f83d2c1911a50baa640a.69e0f86c2c1911a50baa640e.69e0f86cdf7f18710713456b:Trae CN.T(2026/4/16 22:55:40)

### DIFF
--- a/packages/components/image-viewer/src/image-viewer.vue
+++ b/packages/components/image-viewer/src/image-viewer.vue
@@ -57,7 +57,7 @@
                 :actions="handleActions"
                 :prev="prev"
                 :next="next"
-                :reset="toggleMode"
+                :reset="reset"
                 :active-index="activeIndex"
                 :set-active-item="setActiveItem"
               >
@@ -77,6 +77,10 @@
                 </el-icon>
                 <el-icon @click="handleActions('clockwise')">
                   <RefreshRight />
+                </el-icon>
+                <i :class="ns.e('actions__divider')" />
+                <el-icon @click="reset">
+                  <Refresh />
                 </el-icon>
               </slot>
             </div>
@@ -138,6 +142,7 @@ import {
   ArrowRight,
   Close,
   FullScreen,
+  Refresh,
   RefreshLeft,
   RefreshRight,
   ScaleToOriginal,
@@ -299,10 +304,17 @@ function registerEventListener() {
   })
   const mousewheelHandler = throttle((e: WheelEvent) => {
     const delta = e.deltaY || e.deltaX
-    handleActions(delta < 0 ? 'zoomIn' : 'zoomOut', {
-      zoomRate: props.zoomRate,
-      enableTransition: false,
-    })
+    if (e.ctrlKey) {
+      handleActions(delta < 0 ? 'clockwise' : 'anticlockwise', {
+        rotateDeg: 15,
+        enableTransition: false,
+      })
+    } else {
+      handleActions(delta < 0 ? 'zoomIn' : 'zoomOut', {
+        zoomRate: props.zoomRate,
+        enableTransition: false,
+      })
+    }
   })
 
   scopeEventListener.run(() => {

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -579,6 +579,8 @@ const handleInput = async (event: Event) => {
 }
 
 const handleChange = async (event: Event) => {
+  if (isComposing.value) return
+
   let { value } = event.target as TargetElement
 
   value = formatValue(value)


### PR DESCRIPTION
添加独立的刷新重置按钮，并优化鼠标滚轮操作逻辑
当按住ctrl键时使用滚轮旋转图片，否则进行缩放操作

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reset button to the image viewer toolbar for quick image restoration.
  * Ctrl+scroll wheel now rotates the image; regular scroll continues to zoom as before.

* **Bug Fixes**
  * Input composition (IME) no longer emits change events while composing, preventing premature updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->