### PR TITLE
fix(components): [time-picker] emit blur with input value

### DIFF
--- a/packages/components/time-picker/__tests__/time-picker.test.tsx
+++ b/packages/components/time-picker/__tests__/time-picker.test.tsx
@@ -318,8 +318,8 @@ describe('TimePicker', () => {
     await currentHour.trigger('mouseover')
     await picker.find('.el-time-panel__btn.cancel').trigger('click')
     const secondInput = wrapper.findAll('.el-range-input')[1]
-    await secondInput.setValue('07:40:00')
-    expect(secondInput.element.value).toBe('07:40:00')
+    await secondInput.setValue('09:40:00')
+    expect(secondInput.element.value).toBe('09:40:00')
     await input.trigger('blur')
     expect(secondInput.element.value).toBe('09:40:00')
   })

--- a/packages/components/time-picker/__tests__/time-picker.test.tsx
+++ b/packages/components/time-picker/__tests__/time-picker.test.tsx
@@ -11,7 +11,6 @@ import { EVENT_CODE } from '@element-plus/constants'
 import TimePicker from '../src/time-picker'
 import Picker from '../src/common/picker.vue'
 import PanelTimePick from '../src/time-picker-com/panel-time-pick.vue'
-import PanelTimeRangePick from '../src/time-picker-com/panel-time-range.vue'
 
 const makeRange = (start, end) => {
   const result = []
@@ -295,33 +294,6 @@ describe('TimePicker', () => {
     await nextTick()
     await rAF()
     expect(handleVisibleChange).toHaveBeenCalledTimes(3)
-  })
-
-  it('should cancel correctly the right value after manual input', async () => {
-    const value = ref<[Date, Date]>([
-      new Date(2016, 9, 10, 8, 40),
-      new Date(2016, 9, 10, 9, 40),
-    ])
-    const wrapper = mount(() => (
-      <>
-        <TimePicker v-model={value.value} is-range />
-        <button>click me</button>
-      </>
-    ))
-    const input = wrapper.find('input')
-    await input.trigger('focus')
-
-    const picker = wrapper.findComponent(PanelTimeRangePick)
-    const secondPanel = picker.findAll('.el-time-range-picker__cell')[1]
-    const currentHour = secondPanel.find('.el-time-spinner__item.is-active')
-    expect(currentHour.text()).toBe('09')
-    await currentHour.trigger('mouseover')
-    await picker.find('.el-time-panel__btn.cancel').trigger('click')
-    const secondInput = wrapper.findAll('.el-range-input')[1]
-    await secondInput.setValue('09:40:00')
-    expect(secondInput.element.value).toBe('09:40:00')
-    await input.trigger('blur')
-    expect(secondInput.element.value).toBe('09:40:00')
   })
 
   it('selectableRange ', async () => {
@@ -1027,7 +999,7 @@ describe('TimePicker(range)', () => {
       picker.vm.onPick('', false)
       await rAF() // Picker triggers popup close, event propagation
       await rAF() // Focus trap recognizes focusout event, and propagation
-      expect(document.activeElement).toBe(wrapper.find('input').element)
+      expect(document.activeElement).not.toBe(wrapper.find('input').element)
       expect(document.querySelector('.el-time-panel')).toBeFalsy()
       input.vm.$emit('input', 'a')
       await rAF()

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -534,8 +534,8 @@ const handleChange = () => {
     if (value) {
       if (isValidValue(value)) {
         emitInput(dayOrDaysToDate(value))
+        userInput.value = null
       }
-      userInput.value = null
     }
   }
   if (userInput.value === '' || isRangeEmpty) {

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -19,6 +19,7 @@
     :hide-after="0"
     persistent
     @before-show="onBeforeShow"
+    @before-hide="onBeforeHide"
     @show="onShow"
     @hide="onHide"
   >
@@ -386,6 +387,10 @@ const onBeforeShow = () => {
 
 const onShow = () => {
   emit('visible-change', true)
+}
+
+const onBeforeHide = () => {
+  blur()
 }
 
 const onHide = () => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

This PR is to fix #24093 

The issue is caused by #22880 

I believe manually modifying the time value should not be considered an incorrect time. When a user modifies it manually, it subjectively means they want to change it.

And #22880  will cause the blur event to be unable to capture the value, which can cause significant confusion for the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Range time-picker now preserves manual input when validation fails and only clears input on successful parse.
  * Picker ensures inputs lose focus before the popup hides, preventing focus-related focus/blur glitches.

* **Tests**
  * Removed an outdated range manual-input cancellation test and updated an accessibility test to reflect the adjusted focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->