### PR TITLE
refactor(components): [cascader] replace `defineSlots` with `useSlots`

### DIFF
--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -223,6 +223,7 @@ import {
   onMounted,
   ref,
   useAttrs,
+  useSlots,
   watch,
 } from 'vue'
 import { cloneDeep } from 'lodash-unified'
@@ -330,7 +331,7 @@ const props = withDefaults(defineProps<CascaderComponentProps>(), {
 })
 const emit = defineEmits(cascaderEmits)
 const attrs = useAttrs()
-const slots = defineSlots()
+const slots = useSlots()
 
 let inputInitialHeight = 0
 let pressDeleteCount = 0


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

`defineSlots` does not support automatic type inference, whereas `useSlots` does.

Before
<img width="370" height="102" alt="image" src="https://github.com/user-attachments/assets/9baa1d48-fc35-47c3-82b5-12a68a01a232" />


After
<img width="438" height="197" alt="image" src="https://github.com/user-attachments/assets/3bd7abbe-4da8-4d99-aa97-e68cb5f2d689" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cascader component's prefix slot detection and layout handling to ensure proper styling adjustments when a prefix slot is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->