### PR TITLE
chore(deps): separate Renovate patch grouping by dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,12 +4,12 @@
   rangeStrategy: 'bump',
   packageRules: [
     {
-      depTypeList: ['peerDependencies'],
+      matchDepTypes: ['peerDependencies'],
       enabled: false,
     },
     {
       matchUpdateTypes: ['patch'],
-      depTypeList: ['devDependencies'],
+      matchDepTypes: ['devDependencies'],
       groupName: 'all patch devDependencies',
       groupSlug: 'all-patch-dev-dependencies',
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,11 +1,17 @@
 {
-  extends: ['config:base', 'schedule:weekly', 'group:allNonMajor'],
+  extends: ['config:base', 'schedule:weekly'],
   labels: ['dependencies'],
   rangeStrategy: 'bump',
   packageRules: [
     {
       depTypeList: ['peerDependencies'],
       enabled: false,
+    },
+    {
+      matchUpdateTypes: ['patch'],
+      depTypeList: ['devDependencies'],
+      groupName: 'all patch devDependencies',
+      groupSlug: 'all-patch-dev-dependencies',
     },
   ],
   ignoreDeps: [


### PR DESCRIPTION
拆分 Renovate 分组，以便于更方便的去升级一些依赖。

before: 
group:allNonMajor
太大了，根本没办法操作
<img width="814" height="229" alt="image" src="https://github.com/user-attachments/assets/386a6f7d-848d-4bb5-9325-1309f55e6263" />

after：
可以手动选择一些 minor 去升级，然后 dev 的依赖的 patch 可以合并成一个。
minor 还是拆开按包升级比较好（语义更好，知道哪儿个 PR 调整了哪儿个依赖，修改调整也更方便）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency update configuration to group development-dependency patch updates together during automated updates.
  * Refined rules for skipping peer-dependency updates by adjusting how dependency types are matched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->