### PR TITLE
fix:The issue of incorrect loading judgment caused by the update trig…

### DIFF
--- a/packages/components/loading/src/directive.ts
+++ b/packages/components/loading/src/directive.ts
@@ -81,6 +81,9 @@ const vLoading: Directive<ElementLoading, LoadingBinding> = {
     }
   },
   updated(el, binding) {
+    if(binding.oldValue === binding.value){
+			return;
+		}
     const instance = el[INSTANCE_KEY]
     if (!binding.value) {
       instance?.instance.close()


### PR DESCRIPTION
…gered by the repair factor component update

The update of a child component in the DOM will also trigger the updated hook of the directive. Here, a judgment is made: only when the bound variable changes will the corresponding logic be executed

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading directive efficiency by skipping unnecessary updates when the bound value hasn't changed, reducing redundant processing and enhancing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->