### PR TITLE
chore(deps): `@popperjs/core` use catalog ptotocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@element-plus/theme-chalk": "workspace:*",
     "@element-plus/utils": "workspace:*",
     "@floating-ui/dom": "catalog:",
-    "@popperjs/core": "npm:@sxzz/popperjs-es@^2.11.8",
+    "@popperjs/core": "catalog:",
     "@types/lodash": "^4.17.24",
     "@types/lodash-es": "^4.17.12",
     "@vueuse/core": "catalog:",

--- a/packages/element-plus/package.json
+++ b/packages/element-plus/package.json
@@ -83,7 +83,7 @@
     "@ctrl/tinycolor": "catalog:",
     "@element-plus/icons-vue": "^2.3.2",
     "@floating-ui/dom": "catalog:",
-    "@popperjs/core": "npm:@sxzz/popperjs-es@^2.11.7",
+    "@popperjs/core": "catalog:",
     "@types/lodash": "^4.17.24",
     "@types/lodash-es": "^4.17.12",
     "@vueuse/core": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ catalogs:
       specifier: ^1.0.1
       version: 1.7.4
     '@popperjs/core':
-      specifier: npm:@sxzz/popperjs-es@^2.11.7
+      specifier: npm:@sxzz/popperjs-es@^2.11.8
       version: 2.11.8
     '@vitejs/plugin-vue':
       specifier: ^6.0.6
@@ -94,7 +94,7 @@ importers:
         specifier: 'catalog:'
         version: 1.7.4
       '@popperjs/core':
-        specifier: npm:@sxzz/popperjs-es@^2.11.8
+        specifier: 'catalog:'
         version: '@sxzz/popperjs-es@2.11.8'
       '@types/lodash':
         specifier: ^4.17.24
@@ -568,8 +568,8 @@ importers:
         specifier: 'catalog:'
         version: 1.7.4
       '@popperjs/core':
-        specifier: npm:@sxzz/popperjs-es@^2.11.7
-        version: '@sxzz/popperjs-es@2.11.7'
+        specifier: 'catalog:'
+        version: '@sxzz/popperjs-es@2.11.8'
       '@types/lodash':
         specifier: ^4.17.24
         version: 4.17.24
@@ -2647,9 +2647,6 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@sxzz/popperjs-es@2.11.7':
-    resolution: {integrity: sha512-Ccy0NlLkzr0Ex2FKvh2X+OyERHXJ88XJ1MXtsI9y9fGexlaXaVTPzBCRBwIxFkORuOb+uBqeu+RqnpgYTEZRUQ==}
 
   '@sxzz/popperjs-es@2.11.8':
     resolution: {integrity: sha512-wOwESXvvED3S8xBmcPWHs2dUuzrE4XiZeFu7e1hROIJkm02a49N120pmOXxY33sBb6hArItm5W5tcg1cBtV+HQ==}
@@ -9045,8 +9042,6 @@ snapshots:
   '@simple-libs/stream-utils@1.2.0': {}
 
   '@standard-schema/spec@1.1.0': {}
-
-  '@sxzz/popperjs-es@2.11.7': {}
 
   '@sxzz/popperjs-es@2.11.8': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,22 +5,22 @@ packages:
   - internal/*
 
 allowBuilds:
-  '@parcel/watcher': true
+  "@parcel/watcher": true
   esbuild: true
   puppeteer: true
   vue-demi: true
 
 catalog:
-  '@ctrl/tinycolor': ^4.2.0
-  '@element-plus/icons-vue': ^2.3.2
-  '@floating-ui/dom': ^1.0.1
-  '@popperjs/core': npm:@sxzz/popperjs-es@^2.11.7
-  '@vitejs/plugin-vue': ^6.0.6
-  '@vitejs/plugin-vue-jsx': ^5.1.5
-  '@vue/server-renderer': ^3.5.22
-  '@vue/shared': ^3.5.22
-  '@vue/test-utils': ^2.4.6
-  '@vueuse/core': 14.2.1
+  "@ctrl/tinycolor": ^4.2.0
+  "@element-plus/icons-vue": ^2.3.2
+  "@floating-ui/dom": ^1.0.1
+  "@popperjs/core": npm:@sxzz/popperjs-es@^2.11.8
+  "@vitejs/plugin-vue": ^6.0.6
+  "@vitejs/plugin-vue-jsx": ^5.1.5
+  "@vue/server-renderer": ^3.5.22
+  "@vue/shared": ^3.5.22
+  "@vue/test-utils": ^2.4.6
+  "@vueuse/core": 14.2.1
   lodash-unified: ^1.0.3
   normalize-wheel-es: ^1.2.0
   vue: ^3.5.22

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,22 +5,22 @@ packages:
   - internal/*
 
 allowBuilds:
-  "@parcel/watcher": true
+  '@parcel/watcher': true
   esbuild: true
   puppeteer: true
   vue-demi: true
 
 catalog:
-  "@ctrl/tinycolor": ^4.2.0
-  "@element-plus/icons-vue": ^2.3.2
-  "@floating-ui/dom": ^1.0.1
-  "@popperjs/core": npm:@sxzz/popperjs-es@^2.11.8
-  "@vitejs/plugin-vue": ^6.0.6
-  "@vitejs/plugin-vue-jsx": ^5.1.5
-  "@vue/server-renderer": ^3.5.22
-  "@vue/shared": ^3.5.22
-  "@vue/test-utils": ^2.4.6
-  "@vueuse/core": 14.2.1
+  '@ctrl/tinycolor': ^4.2.0
+  '@element-plus/icons-vue': ^2.3.2
+  '@floating-ui/dom': ^1.0.1
+  '@popperjs/core': npm:@sxzz/popperjs-es@^2.11.8
+  '@vitejs/plugin-vue': ^6.0.6
+  '@vitejs/plugin-vue-jsx': ^5.1.5
+  '@vue/server-renderer': ^3.5.22
+  '@vue/shared': ^3.5.22
+  '@vue/test-utils': ^2.4.6
+  '@vueuse/core': 14.2.1
   lodash-unified: ^1.0.3
   normalize-wheel-es: ^1.2.0
   vue: ^3.5.22


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

#24154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped @popperjs/core from 2.11.7 to 2.11.8 across the monorepo.
  * Switched dependency resolution from direct npm aliases to workspace catalog-managed entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->