### PR TITLE
fix(components): [split-panel] allow resize while collapsed

### DIFF
--- a/packages/components/splitter/src/split-panel.vue
+++ b/packages/components/splitter/src/split-panel.vue
@@ -80,13 +80,7 @@ const nextPanel = computed(() => {
 
 const isResizable = computed(() => {
   if (!nextPanel.value) return false
-  return (
-    props.resizable &&
-    nextPanel.value?.resizable &&
-    // If it is 0, it means it is collapsed => check if the minimum value is set
-    (panelSize.value !== 0 || !props.min) &&
-    (nextSize.value !== 0 || !nextPanel.value.min)
-  )
+  return props.resizable && nextPanel.value?.resizable
 })
 
 // The last panel doesn't need a drag bar


### PR DESCRIPTION
fix #24088

## Task list:
- [x] Allow resize while [split-panel] is collapsed.
- [ ] Allow collapse while width is `0`.
- [ ] While resized to the half of `:min` (or some custom distance), collapse [split-panel] automatically.



Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified split panel drag-bar behavior for more consistent resizing interactions, removing size-based constraints from enablement logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->