### PR TITLE
fix(theme-chalk): [menu] horizontal menu-item line-height causes overflow when height is customized

### DIFF
--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -135,6 +135,7 @@
 
       & .#{$namespace}-sub-menu__title {
         height: 100%;
+        line-height: normal;
         border-bottom: 2px solid transparent;
         color: getCssVar('menu-text-color');
 

--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -103,6 +103,7 @@
       align-items: center;
 
       height: 100%;
+      line-height: normal;
       margin: 0;
       border-bottom: 2px solid transparent;
       color: getCssVar('menu-text-color');


### PR DESCRIPTION
closes #24015

## Summary
- In horizontal mode, `el-menu-item` has `height: 100%`, but it still inherits `line-height: var(--el-menu-item-height)` (56px by default) from the `@mixin menu-item`.
- When users customize the horizontal `el-menu` height to a value smaller than the default item height (e.g. `height: 25px` for a footer menu), the inline content's line box stays at 56px and overflows downward, producing an unexpected vertical scrollbar on the page.
- Set `line-height: normal` for horizontal menu-item so the inline content fits within the flex-aligned item box. Vertical centering is already handled by `align-items: center` on the inline-flex item, so default rendering is unaffected.

## Test plan
- [ ] Reproduce #24015 with `<el-footer><el-menu mode="horizontal" style="height: 25px"><el-menu-item>...</el-menu-item></el-menu></el-footer>` inside a `100vh` container — vertical scrollbar should no longer appear.
- [ ] Default horizontal menu (no height override) still renders with the same visual layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined horizontal menu styling by explicitly normalizing line-height for menu items and sub-menu titles to ensure consistent vertical alignment and improved spacing across horizontal menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->