### PR TITLE
fix(components): [splitter] expand panel with initial zero size

### DIFF
--- a/packages/components/splitter/__tests__/splitter.test.tsx
+++ b/packages/components/splitter/__tests__/splitter.test.tsx
@@ -316,6 +316,32 @@ describe('Splitter', () => {
     expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
   })
 
+  it('should expand a collapsible panel whose initial size is 0 to its min size', async () => {
+    const size = ref(0)
+    const wrapper = mount(() => (
+      <ElSplitter>
+        <ElSplitterPanel v-model:size={size.value} min={100} collapsible>
+          Left Panel
+        </ElSplitterPanel>
+        <ElSplitterPanel min={200}>Right Panel</ElSplitterPanel>
+      </ElSplitter>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 100px;')
+    expect(size.value).toBe(100)
+  })
+
   it('should not update panel size until drag ends when lazy is true', async () => {
     const wrapper = mount(() => (
       <div style={{ width: '400px', height: '400px' }}>

--- a/packages/components/splitter/src/hooks/useResize.ts
+++ b/packages/components/splitter/src/hooks/useResize.ts
@@ -130,7 +130,11 @@ export function useResize(
   const cacheCollapsedSize: number[] = []
   const onCollapse = (index: number, type: 'start' | 'end') => {
     if (!cacheCollapsedSize.length) {
-      cacheCollapsedSize.push(...pxSizes.value)
+      cacheCollapsedSize.push(
+        ...pxSizes.value.map((size, i) =>
+          size <= 0 ? getLimitSize(limitSizes.value[i]?.[0], 0) : size
+        )
+      )
     }
 
     const currentSizes = pxSizes.value

--- a/packages/components/splitter/src/hooks/useResize.ts
+++ b/packages/components/splitter/src/hooks/useResize.ts
@@ -1,4 +1,5 @@
 import { computed, ref, watch } from 'vue'
+import { clamp } from 'lodash-unified'
 import { getPct, getPx, isPct, isPx } from './useSize'
 import { NOOP } from '@element-plus/utils'
 
@@ -152,7 +153,11 @@ export function useResize(
     } else {
       const totalSize = currentSize + targetSize
 
-      const targetCacheCollapsedSize = cacheCollapsedSize[index]
+      const targetCacheCollapsedSize = clamp(
+        cacheCollapsedSize[index],
+        0,
+        totalSize
+      )
       const currentCacheCollapsedSize = totalSize - targetCacheCollapsedSize
 
       currentSizes[targetIndex] = targetCacheCollapsedSize


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

close #24088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Splitter collapse/expand now respects configured minimum sizes and clamps restored sizes within valid bounds, preventing out-of-range resizing during redistribution.

* **Tests**
  * Added a test verifying two-way bound collapsible panels restore to minimum size from a collapsed state and update the bound size value accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->