### PR TITLE
chore(deps): prevent renovate from bumping vue packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,6 +35,11 @@
     "cypress",
     "jsdom",
     // can't work in v0.34.0
-    "unocss"
+    "unocss",
+    // locked due to test regressions in newer patch versions
+    "vue",
+    "@vue/server-renderer",
+    "@vue/shared",
+    "@vue/test-utils"
   ]
 }


### PR DESCRIPTION
vue 关联的 patch 依赖会导致其他包无法升 patch

试了一下锁住能通过 https://github.com/element-plus/element-plus/pull/24210
<img width="457" height="438" alt="image" src="https://github.com/user-attachments/assets/da625782-da5d-4fec-8517-025b05ea152a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to exclude specific packages from automatic updates, including Vue-related dependencies and UnoCSS, to maintain stability and prevent potential compatibility issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24219)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->