### PR TITLE
fix(components): [tree-v2] get current key before node click

### DIFF
--- a/packages/components/tree-v2/__tests__/tree.test.ts
+++ b/packages/components/tree-v2/__tests__/tree.test.ts
@@ -220,6 +220,36 @@ describe('Virtual Tree', () => {
     expect(treeVm.flattenTree.length).toBeGreaterThanOrEqual(NODE_NUMBER)
   })
 
+  test('getCurrentKey returns clicked node key in node-click event', async () => {
+    const currentKeys: TreeKey[] = []
+    const { wrapper } = createTree({
+      data() {
+        return {
+          data: [
+            {
+              id: '1',
+              label: 'node-1',
+            },
+            {
+              id: '2',
+              label: 'node-2',
+            },
+          ],
+        }
+      },
+      methods: {
+        onNodeClick() {
+          currentKeys.push(this.$refs.tree.getCurrentKey())
+        },
+      },
+    })
+    await nextTick()
+    const nodes = wrapper.findAll(TREE_NODE_CLASS_NAME)
+    await nodes[0].trigger('click')
+    await nodes[1].trigger('click')
+    expect(currentKeys).toEqual(['1', '2'])
+  })
+
   test('drop on node', async () => {
     const onNodeDrop = vi.fn()
     const { wrapper, treeVm } = createTree({

--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -199,8 +199,8 @@ export function useTree(
   }
 
   function handleNodeClick(node: TreeNode, e: MouseEvent) {
-    emit(NODE_CLICK, node.data, node, e)
     handleCurrentChange(node)
+    emit(NODE_CLICK, node.data, node, e)
     if (props.expandOnClickNode) {
       toggleExpand(node)
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

close #24231

This also fixes the inconsistent event triggering order. [repro](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtdHJlZVxuICAgIHN0eWxlPVwibWF4LXdpZHRoOiA2MDBweFwiXG4gICAgOmRhdGE9XCJkYXRhMVwiXG4gICAgOnByb3BzPVwiZGVmYXVsdFByb3BzXCJcbiAgICBAbm9kZS1jbGljaz1cIigpID0+IGNvbnNvbGUubG9nKCd0cmVlOiBub2RlLWNsaWNrJylcIlxuICAgIEBjdXJyZW50LWNoYW5nZT1cIigpID0+IGNvbnNvbGUubG9nKCd0cmVlOiBjdXJyZW50LWNoYW5nZScpXCJcbiAgLz5cblxuICA8aHIgLz5cblxuICA8ZWwtdHJlZS12MlxuICAgIHN0eWxlPVwibWF4LXdpZHRoOiA2MDBweFwiXG4gICAgOmRhdGE9XCJkYXRhMlwiXG4gICAgOnByb3BzPVwicHJvcHNcIlxuICAgIDpoZWlnaHQ9XCIyMDBcIlxuICAgIEBub2RlLWNsaWNrPVwiKCkgPT4gY29uc29sZS5sb2coJ3RyZWUtdjI6IG5vZGUtY2xpY2snKVwiXG4gICAgQGN1cnJlbnQtY2hhbmdlPVwiKCkgPT4gY29uc29sZS5sb2coJ3RyZWUtdjI6IGN1cnJlbnQtY2hhbmdlJylcIlxuICAvPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmludGVyZmFjZSBUcmVlIHtcbiAgbGFiZWw6IHN0cmluZ1xuICBjaGlsZHJlbj86IFRyZWVbXVxufVxuXG5pbnRlcmZhY2UgVHJlZVYyIHtcbiAgaWQ6IHN0cmluZ1xuICBsYWJlbDogc3RyaW5nXG4gIGNoaWxkcmVuPzogVHJlZVtdXG59XG5cbmNvbnN0IGdldEtleSA9IChwcmVmaXg6IHN0cmluZywgaWQ6IG51bWJlcikgPT4ge1xuICByZXR1cm4gYCR7cHJlZml4fS0ke2lkfWBcbn1cblxuY29uc3QgY3JlYXRlRGF0YSA9IChcbiAgbWF4RGVlcDogbnVtYmVyLFxuICBtYXhDaGlsZHJlbjogbnVtYmVyLFxuICBtaW5Ob2Rlc051bWJlcjogbnVtYmVyLFxuICBkZWVwID0gMSxcbiAga2V5ID0gJ25vZGUnXG4pOiBUcmVlVjJbXSA9PiB7XG4gIGxldCBpZCA9IDBcbiAgcmV0dXJuIEFycmF5LmZyb20oeyBsZW5ndGg6IG1pbk5vZGVzTnVtYmVyIH0pXG4gICAgLmZpbGwoZGVlcClcbiAgICAubWFwKCgpID0+IHtcbiAgICAgIGNvbnN0IGNoaWxkcmVuTnVtYmVyID1cbiAgICAgICAgZGVlcCA9PT0gbWF4RGVlcCA/IDAgOiBNYXRoLnJvdW5kKE1hdGgucmFuZG9tKCkgKiBtYXhDaGlsZHJlbilcbiAgICAgIGNvbnN0IG5vZGVLZXkgPSBnZXRLZXkoa2V5LCArK2lkKVxuICAgICAgcmV0dXJuIHtcbiAgICAgICAgaWQ6IG5vZGVLZXksXG4gICAgICAgIGxhYmVsOiBub2RlS2V5LFxuICAgICAgICBjaGlsZHJlbjogY2hpbGRyZW5OdW1iZXJcbiAgICAgICAgICA/IGNyZWF0ZURhdGEobWF4RGVlcCwgbWF4Q2hpbGRyZW4sIGNoaWxkcmVuTnVtYmVyLCBkZWVwICsgMSwgbm9kZUtleSlcbiAgICAgICAgICA6IHVuZGVmaW5lZCxcbiAgICAgIH1cbiAgICB9KVxufVxuXG5jb25zdCBwcm9wcyA9IHtcbiAgdmFsdWU6ICdpZCcsXG4gIGxhYmVsOiAnbGFiZWwnLFxuICBjaGlsZHJlbjogJ2NoaWxkcmVuJyxcbn1cbmNvbnN0IGRhdGEyOiBUcmVlVjJbXSA9IGNyZWF0ZURhdGEoMiwgNCwgNClcblxuY29uc3QgZGF0YTE6IFRyZWVbXSA9IFtcbiAge1xuICAgIGxhYmVsOiAnTGV2ZWwgb25lIDEnLFxuICAgIGNoaWxkcmVuOiBbXG4gICAgICB7XG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDEtMScsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgbGFiZWw6ICdMZXZlbCB0aHJlZSAxLTEtMScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgXSxcbiAgfSxcbiAge1xuICAgIGxhYmVsOiAnTGV2ZWwgb25lIDInLFxuICAgIGNoaWxkcmVuOiBbXG4gICAgICB7XG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDItMScsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgbGFiZWw6ICdMZXZlbCB0aHJlZSAyLTEtMScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDItMicsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgbGFiZWw6ICdMZXZlbCB0aHJlZSAyLTItMScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgXSxcbiAgfSxcbiAge1xuICAgIGxhYmVsOiAnTGV2ZWwgb25lIDMnLFxuICAgIGNoaWxkcmVuOiBbXG4gICAgICB7XG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDMtMScsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgbGFiZWw6ICdMZXZlbCB0aHJlZSAzLTEtMScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDMtMicsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgbGFiZWw6ICdMZXZlbCB0aHJlZSAzLTItMScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgXSxcbiAgfSxcbl1cblxuY29uc3QgZGVmYXVsdFByb3BzID0ge1xuICBjaGlsZHJlbjogJ2NoaWxkcmVuJyxcbiAgbGFiZWw6ICdsYWJlbCcsXG59XG48L3NjcmlwdD5cbiIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmNzcycsICdodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvdGhlbWUtY2hhbGsvZGFyay9jc3MtdmFycy5jc3MnXS5tYXAoKHN0eWxlKSA9PiB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgICBsaW5rLmhyZWYgPSBzdHlsZVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICAgIH0pXG4gIH0pXG4gIHJldHVybiBQcm9taXNlLmFsbFNldHRsZWQoc3R5bGVzKVxufVxuIiwidHNjb25maWcuanNvbiI6IntcbiAgXCJjb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVSZXNvbHV0aW9uXCI6IFwiQnVuZGxlclwiLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdLFxuICAgIFwiYWxsb3dJbXBvcnRpbmdUc0V4dGVuc2lvbnNcIjogdHJ1ZSxcbiAgICBcImFsbG93SnNcIjogdHJ1ZSxcbiAgICBcImNoZWNrSnNcIjogdHJ1ZVxuICB9LFxuICBcInZ1ZUNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogMy4zXG4gIH1cbn1cbiIsIlBsYXlncm91bmRNYWluLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgQXBwIGZyb20gJy4vQXBwLnZ1ZSdcbmltcG9ydCB7IHNldHVwRWxlbWVudFBsdXMgfSBmcm9tICcuL2VsZW1lbnQtcGx1cy5qcydcbnNldHVwRWxlbWVudFBsdXMoKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPEFwcCAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9ydW50aW1lLWRvbUBsYXRlc3QvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L2Rpc3QvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L1wiLFxuICAgIFwiQGVsZW1lbnQtcGx1cy9pY29ucy12dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsIl9vIjp7fX0=)

<img width="252" height="134" alt="image" src="https://github.com/user-attachments/assets/054376d0-68f3-4531-8a86-346a2043f03c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case to verify that tree nodes return the correct current key after triggering clicks on multiple nodes, with key collection performed through the node click event handler.

* **Bug Fixes**
  * Reordered operations in tree node click handling to ensure internal state updates complete before the click event is emitted, maintaining consistency between state and events.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24232)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->