### PR TITLE
fix(components): [menu] fix hover-bg-color calculation error when usi…

### DIFF
--- a/packages/components/menu/src/use-menu-color.ts
+++ b/packages/components/menu/src/use-menu-color.ts
@@ -6,7 +6,9 @@ import type { MenuProps } from './menu'
 export default function useMenuColor(props: MenuProps) {
   const menuBarColor = computed(() => {
     const color = props.backgroundColor
-    return color ? new TinyColor(color).shade(20).toString() : ''
+    if (!color) return ''
+    if (typeof color === 'string' && color.startsWith('var(')) return ''
+    return new TinyColor(color).shade(20).toString()
   })
   return menuBarColor
 }


### PR DESCRIPTION
## Description

Fixes the issue where `hover-bg-color` is calculated incorrectly when using CSS variables for Menu component colors.

## Issue

When passing CSS variables to Menu component:

```vue
<ElMenu background-color="var(--mk-aside-bg-color)" ... />
```

The `hover-bg-color` was incorrectly calculated as `rgb(204, 204, 204)` because the source code used `TinyColor` to process the color value, which could not recognize CSS variables like `var(--mk-aside-bg-color)`.

**Before:**
```css
--el-menu-hover-bg-color: rgb(204, 204, 204); /* Incorrect */
```

## Solution

Added CSS variable detection in `use-menu-color.ts`. When the color value starts with `var(`, return an empty string to let CSS handle the hover color itself via CSS variable inheritance.

**After:**
```css
/* When background-color is a CSS var, hover-bg-color will be empty, 
   allowing CSS to compute the correct value or use inherited values */
--el-menu-hover-bg-color: ; 
```

## Files Changed

- `packages/components/menu/src/use-menu-color.ts`

## Additional Context

Fixes #4606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu bar color computation for better handling of custom color values and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24249)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->