### PR TITLE
fix(components): [dropdown] clear hover state in virtual-triggering mode

### DIFF
--- a/packages/components/dropdown/src/dropdown.vue
+++ b/packages/components/dropdown/src/dropdown.vue
@@ -181,10 +181,9 @@ export default defineComponent({
     function onItemLeave() {
       const contentEl = unref(contentRef)
 
-      trigger.value.includes('hover') &&
-        contentEl?.focus({
-          preventScroll: true,
-        })
+      contentEl?.focus({
+        preventScroll: true,
+      })
       currentTabId.value = null
     }
 


### PR DESCRIPTION
Fix #24236

## Problem
When dropdown uses virtual-triggering mode, the hover state persists after pointer leaves the dropdown-item.

## Root Cause
In `onItemLeave`, the focus is only cleared when trigger includes 'hover':
```ts
trigger.value.includes('hover') && contentEl?.focus({ preventScroll: true })
```

In virtual-triggering mode, trigger is 'contextmenu', so the condition fails and hover state is never cleared.

## Fix
Remove the trigger type check so focus is always cleared:
```ts
contentEl?.focus({ preventScroll: true })
```

This ensures dropdown-item loses its active state regardless of trigger type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown item focus handling to ensure focus is properly maintained when leaving dropdown items, regardless of the trigger configuration used.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->