### PR TITLE
fix(components): [dropdown] clear hover state in virtual-triggering mode

### DIFF
--- a/packages/components/dropdown/src/dropdown.vue
+++ b/packages/components/dropdown/src/dropdown.vue
@@ -106,7 +106,7 @@ import ElIcon from '@element-plus/components/icon'
 import ElRovingFocusGroup from '@element-plus/components/roving-focus-group'
 import { ElOnlyChild } from '@element-plus/components/slot'
 import { useFormSize } from '@element-plus/components/form'
-import { addUnit, ensureArray } from '@element-plus/utils'
+import { addUnit } from '@element-plus/utils'
 import { ArrowDown } from '@element-plus/icons-vue'
 import { useId, useLocale, useNamespace } from '@element-plus/hooks'
 import { dropdownProps } from './dropdown'
@@ -151,7 +151,6 @@ export default defineComponent({
       maxHeight: addUnit(props.maxHeight),
     }))
     const dropdownTriggerKls = computed(() => [ns.m(dropdownSize.value)])
-    const trigger = computed(() => ensureArray(props.trigger))
 
     const defaultTriggerId = useId().value
     const triggerId = computed<string>(() => props.id || defaultTriggerId)
@@ -177,14 +176,12 @@ export default defineComponent({
     function onItemEnter() {
       // NOOP for now
     }
-
     function onItemLeave() {
       const contentEl = unref(contentRef)
 
-      trigger.value.includes('hover') &&
-        contentEl?.focus({
-          preventScroll: true,
-        })
+      contentEl?.focus({
+        preventScroll: true,
+      })
       currentTabId.value = null
     }
 


### PR DESCRIPTION
Fix #24236

## Problem
When dropdown uses virtual-triggering mode (trigger='contextmenu'), the hover state persists after pointer leaves the dropdown-item.

## Root Cause
In , the focus is only cleared when trigger includes 'hover':
```ts
trigger.value.includes('hover') && contentEl?.focus({ preventScroll: true })
```

In virtual-triggering mode, trigger is 'contextmenu', so the condition fails and focus is never transferred back to the content container. The dropdown-item keeps focus, so CSS  pseudo-class keeps the background color visible.

## Fix
1. Remove the trigger type check so focus is always transferred:
```diff
- trigger.value.includes('hover') &&
-   contentEl?.focus({
-     preventScroll: true,
-   })
+ contentEl?.focus({
+   preventScroll: true,
+ })
```

2. Remove unused  computed variable and  import

## Testing
- All 32 dropdown component tests pass
- Verified the fix clears hover state in virtual-triggering mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved dropdown focus behavior during item navigation, ensuring consistent focus management across all trigger types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->