### PR TITLE
fix(components): [table] correct colspan width in span-method

### DIFF
--- a/packages/components/table/src/table-body/styles-helper.ts
+++ b/packages/components/table/src/table-body/styles-helper.ts
@@ -148,7 +148,7 @@ function useStyles<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
       .map(({ realWidth, width }) => realWidth || width)
       .slice(index, index + colspan)
     return Number(
-      widthArr.reduce((acc, width) => Number(acc) + Number(width), -1)
+      widthArr.reduce((acc, width) => Number(acc) + Number(width), 0)
     )
   }
 


### PR DESCRIPTION
fix #24244

## Bug
 function has an off-by-one error: the  initial value is  instead of , causing merged cells to be 1px narrower than expected.

## Root Cause


## Fix
Changed the reduce initial value from  to  in .

## Testing
- ✅ All 141 table component tests pass
- ✅ ESLint and Prettier checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed colspan width calculation in table components to compute accurate column span widths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->