### PR TITLE
fix(components): [cascader] allow check-all on unloaded lazy nodes

### DIFF
--- a/packages/components/cascader-panel/src/node.vue
+++ b/packages/components/cascader-panel/src/node.vue
@@ -118,9 +118,10 @@ const doCheck = (checked: boolean) => {
   panel.handleCheckChange(node, checked)
 }
 
-const doLoad = () => {
+const doLoad = (cb?: () => void) => {
   panel.lazyLoad(props.node, () => {
     if (!isLeaf.value) doExpand()
+    cb?.()
   })
 }
 
@@ -170,7 +171,7 @@ const handleSelectCheck = (checked: CheckboxValueType | undefined) => {
 
 const handleCheck = (checked: boolean) => {
   if (!props.node.loaded) {
-    doLoad()
+    doLoad(() => doCheck(checked))
   } else {
     doCheck(checked)
     !checkStrictly.value && doExpand()


### PR DESCRIPTION
close #24256

### Bug Description

In cascader with lazy + multiple mode, clicking the checkbox on a parent node that has not finished loading its children does nothing.

### Root Cause

In node.vue, handleCheck called doLoad() when !node.loaded, but doLoad only loaded children and expanded the menu - it never called doCheck(checked).

### Fix

Modified doLoad to accept an optional callback parameter. Modified handleCheck to pass doCheck(checked) as the callback.

All 70 existing cascader tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the cascader panel where checking a node that requires lazy loading now properly applies the check state immediately after data loads, eliminating the need for a separate action.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->