### PR TITLE
fix(components): [cascader] prevent duplicate root lazy-load calls

### DIFF
--- a/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
+++ b/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
@@ -599,37 +599,6 @@ describe('CascaderPanel.vue', () => {
     vi.useRealTimers()
   })
 
-  test('should not reload lazy root nodes while initial load is pending', async () => {
-    vi.useFakeTimers()
-    const lazyLoad = vi.fn<LazyLoad>((_node, resolve) => {
-      setTimeout(() => {
-        resolve([
-          {
-            value: 'loaded',
-            label: 'Loaded',
-            leaf: true,
-          },
-        ])
-      }, 1000)
-    })
-    const props: CascaderProps = {
-      lazy: true,
-      lazyLoad,
-    }
-    const wrapper = mount(() => <CascaderPanel props={props} />)
-    const vm = wrapper.findComponent(CascaderPanel).vm as any
-
-    expect(lazyLoad).toHaveBeenCalledTimes(1)
-    vm.loadLazyRootNodes()
-    expect(lazyLoad).toHaveBeenCalledTimes(1)
-
-    vi.runAllTimers()
-    await nextTick()
-    vm.loadLazyRootNodes()
-    expect(lazyLoad).toHaveBeenCalledTimes(1)
-    vi.useRealTimers()
-  })
-
   test('lazy load with loaded fails', async () => {
     vi.useFakeTimers()
     const value = ref([])

--- a/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
+++ b/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
@@ -599,6 +599,37 @@ describe('CascaderPanel.vue', () => {
     vi.useRealTimers()
   })
 
+  test('should not reload lazy root nodes while initial load is pending', async () => {
+    vi.useFakeTimers()
+    const lazyLoad = vi.fn<LazyLoad>((_node, resolve) => {
+      setTimeout(() => {
+        resolve([
+          {
+            value: 'loaded',
+            label: 'Loaded',
+            leaf: true,
+          },
+        ])
+      }, 1000)
+    })
+    const props: CascaderProps = {
+      lazy: true,
+      lazyLoad,
+    }
+    const wrapper = mount(() => <CascaderPanel props={props} />)
+    const vm = wrapper.findComponent(CascaderPanel).vm as any
+
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+    vm.loadLazyRootNodes()
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+
+    vi.runAllTimers()
+    await nextTick()
+    vm.loadLazyRootNodes()
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
+
   test('lazy load with loaded fails', async () => {
     vi.useFakeTimers()
     const value = ref([])

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -442,7 +442,7 @@ watch(
 )
 
 const loadLazyRootNodes = () => {
-  if (initialLoadedOnce.value) return
+  if (initialLoadedOnce.value || !initialLoaded.value) return
   initStore()
 }
 

--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -1410,4 +1410,40 @@ describe('Cascader.vue', () => {
     expect(firstNode.matches(':focus')).toBeTruthy()
     expect(value.value).toEqual([])
   })
+
+  test('should not reload lazy root nodes while initial load is pending', async () => {
+    vi.useFakeTimers()
+    try {
+      const lazyLoad = vi.fn((_, resolve) => {
+        setTimeout(() => {
+          resolve([
+            {
+              value: 'loaded',
+              label: 'Loaded',
+              leaf: true,
+            },
+          ])
+        }, 1000)
+      })
+      const props = {
+        lazy: true,
+        lazyLoad,
+      }
+      const wrapper = mount(() => <Cascader props={props} />)
+      const vm = wrapper.findComponent(Cascader).vm
+
+      await nextTick()
+      expect(lazyLoad).toHaveBeenCalledTimes(1)
+
+      vm.togglePopperVisible(true)
+      await nextTick()
+
+      expect(lazyLoad).toHaveBeenCalledTimes(1)
+      vi.runAllTimers()
+      await nextTick()
+      expect(lazyLoad).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

When `lazyLoad` is first triggered by the `config` watcher and has not yet been resolved, opening the panel will trigger `lazyLoad` again.

[repro](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtY2FzY2FkZXIgOnByb3BzPVwicHJvcHNcIiB2LW1vZGVsPVwidmFsdWVcIiByZWY9XCJjYXNjYWRlclJlZlwiIC8+XG48L3RlbXBsYXRlPlxuXG48c2NyaXB0IHNldHVwPlxuaW1wb3J0IHsgb25Nb3VudGVkLCByZWYsIHVzZVRlbXBsYXRlUmVmIH0gZnJvbSAndnVlJ1xuXG5jb25zdCBjYXNjYWRlclJlZiA9IHVzZVRlbXBsYXRlUmVmKCdjYXNjYWRlclJlZicpXG5cbm9uTW91bnRlZCgoKSA9PiB7XG4gIGNhc2NhZGVyUmVmLnZhbHVlPy50b2dnbGVQb3BwZXJWaXNpYmxlKHRydWUpXG59KVxuY29uc3QgdmFsdWUgPSByZWYoKVxubGV0IGlkID0gMFxuY29uc3QgcHJvcHMgPSB7XG4gIGxhenk6IHRydWUsXG4gIGxhenlMb2FkKG5vZGUsIHJlc29sdmUpIHtcbiAgICBjb25zb2xlLmxvZygnbGF6eUxvYWQgY2FsbGVkOiAnLCBub2RlLmxldmVsKVxuICAgIGNvbnN0IHsgbGV2ZWwgfSA9IG5vZGVcbiAgICBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICAgIGNvbnN0IG5vZGVzID0gQXJyYXkuZnJvbSh7IGxlbmd0aDogbGV2ZWwgKyAxIH0pLm1hcCgoKSA9PiAoe1xuICAgICAgICB2YWx1ZTogKytpZCxcbiAgICAgICAgbGFiZWw6IGBvcHRpb24ke2lkfWAsXG4gICAgICAgIGxlYWY6IGxldmVsID49IDIsXG4gICAgICB9KSlcbiAgICAgIHJlc29sdmUobm9kZXMpXG4gICAgfSwgMTAwMClcbiAgfSxcbiAgbXVsdGlwbGU6IHRydWUsXG59XG48L3NjcmlwdD5cbiIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmNzcycsICdodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvdGhlbWUtY2hhbGsvZGFyay9jc3MtdmFycy5jc3MnXS5tYXAoKHN0eWxlKSA9PiB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgICBsaW5rLmhyZWYgPSBzdHlsZVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICAgIH0pXG4gIH0pXG4gIHJldHVybiBQcm9taXNlLmFsbFNldHRsZWQoc3R5bGVzKVxufVxuIiwidHNjb25maWcuanNvbiI6IntcbiAgXCJjb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVSZXNvbHV0aW9uXCI6IFwiQnVuZGxlclwiLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdLFxuICAgIFwiYWxsb3dJbXBvcnRpbmdUc0V4dGVuc2lvbnNcIjogdHJ1ZSxcbiAgICBcImFsbG93SnNcIjogdHJ1ZSxcbiAgICBcImNoZWNrSnNcIjogdHJ1ZVxuICB9LFxuICBcInZ1ZUNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogMy4zXG4gIH1cbn1cbiIsIlBsYXlncm91bmRNYWluLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgQXBwIGZyb20gJy4vQXBwLnZ1ZSdcbmltcG9ydCB7IHNldHVwRWxlbWVudFBsdXMgfSBmcm9tICcuL2VsZW1lbnQtcGx1cy5qcydcbnNldHVwRWxlbWVudFBsdXMoKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPEFwcCAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9ydW50aW1lLWRvbUBsYXRlc3QvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L2Rpc3QvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L1wiLFxuICAgIFwiQGVsZW1lbnQtcGx1cy9pY29ucy12dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsIl9vIjp7fX0=)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cascader lazy loading behavior to prevent duplicate load requests when opening the dropdown during initial data loading.

* **Tests**
  * Added test coverage to ensure cascader lazy loading functions correctly under concurrent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->