### PR TITLE
fix(components): [message-box] hide btns container when both buttons are hidden

### DIFF
--- a/packages/components/message-box/__tests__/message-box.test.ts
+++ b/packages/components/message-box/__tests__/message-box.test.ts
@@ -504,7 +504,7 @@ describe('MessageBox', () => {
       title: '消息',
       message: '这是一段内容',
       showConfirmButton: false,
-      showCancelButton: false
+      showCancelButton: false,
     })
     await rAF()
     const btns = document.querySelector('.el-message-box__btns')

--- a/packages/components/message-box/__tests__/message-box.test.ts
+++ b/packages/components/message-box/__tests__/message-box.test.ts
@@ -498,20 +498,18 @@ describe('MessageBox', () => {
       expect(error.textContent).toBe('error message')
     })
   })
+
   test('should hide btns container when both buttons are hidden', async () => {
-  MessageBox({
-    title: '消息',
-    message: '这是一段内容',
-    showConfirmButton: false,
-    showCancelButton: false,
+    MessageBox({
+      title: '消息',
+      message: '这是一段内容',
+      showConfirmButton: false,
+      showCancelButton: false
+    })
+    await rAF()
+    const btns = document.querySelector('.el-message-box__btns')
+    expect(btns).toBeNull()
   })
-
-  await rAF()
-
-  const btns = document.querySelector('.el-message-box__btns')
-
-  expect(btns).toBeNull()
-})
 
   test('should work with confirmButtonType and cancelButtonType props', async () => {
     MessageBox({

--- a/packages/components/message-box/__tests__/message-box.test.ts
+++ b/packages/components/message-box/__tests__/message-box.test.ts
@@ -498,6 +498,20 @@ describe('MessageBox', () => {
       expect(error.textContent).toBe('error message')
     })
   })
+  test('should hide btns container when both buttons are hidden', async () => {
+  MessageBox({
+    title: '消息',
+    message: '这是一段内容',
+    showConfirmButton: false,
+    showCancelButton: false,
+  })
+
+  await rAF()
+
+  const btns = document.querySelector('.el-message-box__btns')
+
+  expect(btns).toBeNull()
+})
 
   test('should work with confirmButtonType and cancelButtonType props', async () => {
     MessageBox({

--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -113,7 +113,7 @@
                 </div>
               </div>
             </div>
-            <div :class="ns.e('btns')">
+            <div :class="ns.e('btns')" v-if="showCancelButton || showConfirmButton">
               <el-button
                 v-if="showCancelButton"
                 :type="cancelButtonType === 'text' ? '' : cancelButtonType"

--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -113,7 +113,7 @@
                 </div>
               </div>
             </div>
-            <div :class="ns.e('btns')" v-if="showCancelButton || showConfirmButton">
+            <div v-if="showCancelButton || showConfirmButton" :class="ns.e('btns')">
               <el-button
                 v-if="showCancelButton"
                 :type="cancelButtonType === 'text' ? '' : cancelButtonType"

--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -113,7 +113,10 @@
                 </div>
               </div>
             </div>
-            <div v-if="showCancelButton || showConfirmButton" :class="ns.e('btns')">
+            <div
+              v-if="showCancelButton || showConfirmButton"
+              :class="ns.e('btns')"
+            >
               <el-button
                 v-if="showCancelButton"
                 :type="cancelButtonType === 'text' ? '' : cancelButtonType"


### PR DESCRIPTION
Fix #24281

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message box no longer renders an empty button container when both action buttons are hidden, removing unnecessary layout gaps and reducing DOM clutter and potential accessibility confusion.

* **Tests**
  * Added an accessibility test that verifies the button container is not present when both confirm and cancel buttons are hidden.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->