### PR TITLE
docs(components): update pagination examples to use v-model

### DIFF
--- a/docs/en-US/component/pagination.md
+++ b/docs/en-US/component/pagination.md
@@ -55,7 +55,7 @@ pagination/auto-hide-pagination
 
 Add more modules based on your scenario.
 
-:::demo This example is a complete use case. It uses `size-change` and `current-change` event to handle page size changes and current page changes. `page-sizes` accepts an array of integers, each of which represents a different page size in the `sizes` select options, e.g. `[100, 200, 300, 400]` indicates that the select will have four options: 100, 200, 300 or 400 items per page.
+:::demo This example is a complete use case. It uses `v-model` for two-way data binding to handle page size changes and current page changes. `page-sizes` accepts an array of integers, each of which represents a different page size in the `sizes` select options, e.g. `[100, 200, 300, 400]` indicates that the select will have four options: 100, 200, 300 or 400 items per page.
 
 pagination/more-elements
 

--- a/docs/examples/pagination/more-elements.vue
+++ b/docs/examples/pagination/more-elements.vue
@@ -27,8 +27,6 @@
       :background="background"
       layout="total, prev, pager, next"
       :total="1000"
-      @size-change="handleSizeChange"
-      @current-change="handleCurrentChange"
     />
   </div>
   <div class="demo-pagination-block">
@@ -42,8 +40,6 @@
       :background="background"
       layout="sizes, prev, pager, next"
       :total="1000"
-      @size-change="handleSizeChange"
-      @current-change="handleCurrentChange"
     />
   </div>
   <div class="demo-pagination-block">
@@ -56,8 +52,6 @@
       :background="background"
       layout="prev, pager, next, jumper"
       :total="1000"
-      @size-change="handleSizeChange"
-      @current-change="handleCurrentChange"
     />
   </div>
   <div class="demo-pagination-block">
@@ -71,8 +65,6 @@
       :background="background"
       layout="total, sizes, prev, pager, next, jumper"
       :total="400"
-      @size-change="handleSizeChange"
-      @current-change="handleCurrentChange"
     />
   </div>
 </template>
@@ -93,12 +85,7 @@ const size = ref<ComponentSize>('default')
 const background = ref(false)
 const disabled = ref(false)
 
-const handleSizeChange = (val: number) => {
-  console.log(`${val} items per page`)
-}
-const handleCurrentChange = (val: number) => {
-  console.log(`current page: ${val}`)
-}
+
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

Updated pagination documentation examples to use `v-model` for two-way data binding instead of the deprecated events (`@size-change`, `@current-change`).

## Changes

- **docs/examples/pagination/more-elements.vue**: Removed all `@size-change` and `@current-change` event handlers from the four pagination examples, and removed the unused `handleSizeChange` and `handleCurrentChange` functions.
- **docs/en-US/component/pagination.md**: Updated the description for the "More elements" example to reference `v-model` instead of the deprecated events.

## Why

The pagination documentation already warns that events are deprecated and recommends using `v-model`:
> "Events above are not recommended(but are still supported for compatible reason), better choice is to use the two-way data binding by v-model."

However, the examples were still using the deprecated events, which could confuse users (as noted in #7383).

## Test Plan

- Verify the documentation builds successfully
- Verify the examples render correctly in the docs site
- No component logic changes, only documentation updates

Fixes #7383


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pagination documentation examples to demonstrate v-model-based two-way binding for page size and current page changes.

* **Refactor**
  * Simplified pagination examples by removing event handler callbacks in favor of direct binding approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->