### PR TITLE
ci: fix commit hash version tag

### DIFF
--- a/.github/workflows/publish-size-report.yml
+++ b/.github/workflows/publish-size-report.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 24
           cache: 'pnpm'
 
-      - uses: preactjs/compressed-size-action@f38486648b00a34e8854dd44e21ba901f51d7454
+      - uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # 2.9.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: './dist/element-plus/dist/*.{js,mjs,css}'

--- a/.github/workflows/publish-size-report.yml
+++ b/.github/workflows/publish-size-report.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 24
           cache: 'pnpm'
 
-      - uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2.9.1
+      - uses: preactjs/compressed-size-action@f38486648b00a34e8854dd44e21ba901f51d7454
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: './dist/element-plus/dist/*.{js,mjs,css}'


### PR DESCRIPTION
<img width="775" height="643" alt="image" src="https://github.com/user-attachments/assets/68b1d030-9d45-4997-a84a-6a632b8d11e2" />
<img width="1385" height="762" alt="image" src="https://github.com/user-attachments/assets/152d1697-eb58-4aeb-b0c5-59da5903a15a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Corrected a version comment for the package size reporting tool in CI workflow metadata to clarify the referenced version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->