### PR TITLE
docs(components): fix carousel change event type

### DIFF
--- a/docs/en-US/component/carousel.md
+++ b/docs/en-US/component/carousel.md
@@ -97,9 +97,9 @@ carousel/vertical
 
 ### Carousel Events
 
-| Name   | Description                                                                                                                                              | Type                                                    |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| change | triggers when the active slide switches, it has two parameters, the one is the index of the new active slide, and other is index of the old active slide | ^[Function]`(current: number, prev: number) => boolean` |
+| Name   | Description                                                                                                                                              | Type                                                 |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| change | triggers when the active slide switches, it has two parameters, the one is the index of the new active slide, and other is index of the old active slide | ^[Function]`(current: number, prev: number) => void` |
 
 ### Carousel Slots
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

Fix the Carousel `change` event listener type in docs from `boolean` to `void`.

The boolean return value in `carouselEmits.change` is only used for payload validation, while the public event listener signature should not return a value.

### Changes

- Update Carousel `change` event docs:
  - `(current: number, prev: number) => boolean`
  - `(current: number, prev: number) => void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the documented type signature for the Carousel component's `change` event to accurately reflect its return behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->