### PR TITLE
docs(components): fix autocomplete exposed type casing

### DIFF
--- a/docs/en-US/component/autocomplete.md
+++ b/docs/en-US/component/autocomplete.md
@@ -70,7 +70,7 @@ autocomplete/custom-header-footer
 | value-key                            | key name of the input suggestion object for display                                                                        | ^[string]                                                                                | value        |
 | debounce                             | debounce delay when typing, in milliseconds                                                                                | ^[number]                                                                                | 300          |
 | placement                            | placement of the popup menu                                                                                                | ^[enum]`'top' \| 'top-start' \| 'top-end' \| 'bottom' \| 'bottom-start' \| 'bottom-end'` | bottom-start |
-| fetch-suggestions                    | a method to fetch input suggestions. When suggestions are ready, invoke `callback(data:[])` to return them to Autocomplete | ^[Array] / ^[Function]`(queryString: string, callback: callbackfn) => void`              | —            |
+| fetch-suggestions                    | a method to fetch input suggestions. When suggestions are ready, invoke `callback(data:[])` to return them to Autocomplete | ^[array] / ^[Function]`(queryString: string, callback: callbackfn) => void`              | —            |
 | trigger-on-focus                     | whether show suggestions when input focus                                                                                  | ^[boolean]                                                                               | true         |
 | select-when-unmatched                | whether to emit a `select` event on enter when there is no autocomplete match                                              | ^[boolean]                                                                               | false        |
 | name                                 | same as `name` in native input                                                                                             | ^[string]                                                                                | —            |
@@ -120,12 +120,12 @@ autocomplete/custom-header-footer
 | blur             | blur the input element                      | ^[Function]`() => void`                             |
 | close            | collapse suggestion list                    | ^[Function]`() => void`                             |
 | focus            | focus the input element                     | ^[Function]`() => void`                             |
-| handleSelect     | triggers when a suggestion is clicked       | ^[Function]`(item: any) => promise<void>`           |
-| handleKeyEnter   | handle keyboard enter event                 | ^[Function]`() => promise<void>`                    |
+| handleSelect     | triggers when a suggestion is clicked       | ^[Function]`(item: any) => Promise<void>`           |
+| handleKeyEnter   | handle keyboard enter event                 | ^[Function]`() => Promise<void>`                    |
 | highlightedIndex | the index of the currently highlighted item | ^[object]`Ref<number>`                              |
 | highlight        | highlight an item in a suggestion           | ^[Function]`(itemIndex: number) => void`            |
 | inputRef         | el-input component instance                 | ^[object]`Ref<ElInputInstance>`                     |
 | loading          | remote search loading indicator             | ^[object]`Ref<boolean>`                             |
 | popperRef        | el-tooltip component instance               | ^[object]`Ref<ElTooltipInstance>`                   |
 | suggestions      | fetch suggestions result                    | ^[object]`Ref<record<string, any>[]>`               |
-| getData ^(2.8.4) | loading suggestion list                     | ^[Function]`(queryString: string) => promise<void>` |
+| getData ^(2.8.4) | loading suggestion list                     | ^[Function]`(queryString: string) => Promise<void>` |


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

### Summary

This PR updates the Autocomplete documentation type casing to keep it consistent with the docs type style.

### Changes

- Change `fetch-suggestions` type from `^[Array]` to `^[array]`
- Change exposed async method return types from `promise<void>` to `Promise<void>`
  - `handleSelect`
  - `handleKeyEnter`
  - `getData`

### Motivation

The current Autocomplete docs use inconsistent casing for type annotations. `^[Array]` should follow the lowercase docs type marker style, and TypeScript promise return types should use the correct built-in type name `Promise<void>`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized AutoComplete component documentation with consistent type notation and method signature formatting for improved clarity and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->