### PR TITLE
fix(components): [calendar] correctly validate date ranges that span across years

### DIFF
--- a/packages/components/calendar/__tests__/calendar.test.tsx
+++ b/packages/components/calendar/__tests__/calendar.test.tsx
@@ -89,6 +89,22 @@ describe('Calendar.vue', () => {
     expect(cell?.classList.contains('is-selected')).toBeTruthy()
   })
 
+  it('falls back to normal calendar when range crosses years by more than two months', () => {
+    const wrapper = mount(() => (
+      <Calendar
+        modelValue={new Date(2024, 11, 2)}
+        range={[new Date(2024, 11, 2), new Date(2026, 0, 4)]}
+      />
+    ))
+
+    expect(
+      wrapper.element.querySelector('.el-calendar__button-group')
+    ).not.toBeNull()
+    expect(
+      wrapper.element.querySelectorAll('.el-calendar-table.is-range')
+    ).toHaveLength(0)
+  })
+
   // https://github.com/element-plus/element-plus/issues/3155
   it('range tow monthes when the start date will be calculated to last month', async () => {
     const wrapper = mount(() => (

--- a/packages/components/calendar/src/use-calendar.ts
+++ b/packages/components/calendar/src/use-calendar.ts
@@ -96,7 +96,7 @@ export const useCalendar = (
       return calculateValidatedDateRange(startDayjs, endDayjs)
     } else {
       // two months
-      if (startDayjs.add(1, 'month').month() !== endDayjs.month()) {
+      if (!startDayjs.add(1, 'month').isSame(endDayjs, 'month')) {
         debugWarn(
           componentName,
           'start time and end time interval must not exceed two months'


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Summary

fix: https://github.com/element-plus/element-plus/issues/24326

- Validate Calendar range month boundaries using Dayjs month-unit comparison.
- Add a regression test for a cross-year range longer than two months.

## Problem

`el-calendar` previously checked whether a range exceeded two months by comparing only the numeric month value:

```ts
startDayjs.add(1, 'month').month() !== endDayjs.month()
```

This ignores the year, so a range like `2024-12-02` to `2026-01-04` could be treated as valid because both dates resolve to January after the month-only comparison.

## Solution

Use Dayjs `isSame(..., 'month')` so the comparison includes both year and month:

```ts
!startDayjs.add(1, 'month').isSame(endDayjs, 'month')
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date range validation in the Calendar component to properly handle ranges spanning more than two months across different years. The component now correctly falls back to non-range calendar behavior when appropriate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->