### PR TITLE
fix(components): [time-select] guard invalid time values

### DIFF
--- a/packages/components/time-select/__tests__/time-select.test.tsx
+++ b/packages/components/time-select/__tests__/time-select.test.tsx
@@ -8,25 +8,12 @@ import Select from '@element-plus/components/select'
 import { ElForm, ElFormItem } from '@element-plus/components/form'
 import TimeSelect from '../src/time-select.vue'
 
-import type { VNode } from 'vue'
-import type { VueWrapper } from '@vue/test-utils'
-
 dayjs.extend(customParseFormat)
 
 const { Option } = Select
 
-const mountedWrappers: VueWrapper[] = []
-const _mount = (render: () => VNode, options?: Parameters<typeof mount>[1]) => {
-  const wrapper = mount(render, options)
-  mountedWrappers.push(wrapper)
-  return wrapper
-}
-
-afterEach(async () => {
-  mountedWrappers.forEach((wrapper) => wrapper.unmount())
-  mountedWrappers.length = 0
-  document.body.innerHTML = ''
-  await new Promise((resolve) => setTimeout(resolve, 0))
+afterEach(() => {
+  document.documentElement.innerHTML = ''
 })
 
 const WRAPPER_CLASS_NAME = 'el-select__wrapper'
@@ -34,7 +21,7 @@ const PLACEHOLDER_CLASS_NAME = 'el-select__placeholder'
 
 describe('TimeSelect', () => {
   it('create', async () => {
-    const wrapper = _mount(() => (
+    const wrapper = mount(() => (
       <TimeSelect style={{ color: 'red' }} class="customClass" />
     ))
 
@@ -44,7 +31,7 @@ describe('TimeSelect', () => {
   })
 
   it('should show clear btn on focus', async () => {
-    const wrapper = _mount(() => <TimeSelect modelValue="08:30" clearable />)
+    const wrapper = mount(() => <TimeSelect modelValue="08:30" clearable />)
     const input = wrapper.find('input')
     await input.trigger('blur')
     await input.trigger('focus')
@@ -53,7 +40,7 @@ describe('TimeSelect', () => {
 
   it('set default value', async () => {
     const value = ref('14:30')
-    const wrapper = _mount(() => <TimeSelect v-model={value.value} />)
+    const wrapper = mount(() => <TimeSelect v-model={value.value} />)
 
     const input = wrapper.find('input')
     input.trigger('blur')
@@ -64,7 +51,7 @@ describe('TimeSelect', () => {
   })
 
   it('set minTime', async () => {
-    const wrapper = _mount(() => <TimeSelect minTime="14:30" />)
+    const wrapper = mount(() => <TimeSelect minTime="14:30" />)
 
     const input = wrapper.find('input')
     input.trigger('blur')
@@ -76,7 +63,7 @@ describe('TimeSelect', () => {
   })
 
   it('set maxTime', async () => {
-    const wrapper = _mount(() => <TimeSelect maxTime="14:30" />)
+    const wrapper = mount(() => <TimeSelect maxTime="14:30" />)
 
     const input = wrapper.find('input')
     input.trigger('blur')
@@ -88,7 +75,7 @@ describe('TimeSelect', () => {
 
   it('set value update', async () => {
     const value = ref('10:00')
-    const wrapper = _mount(() => <TimeSelect v-model={value.value} />)
+    const wrapper = mount(() => <TimeSelect v-model={value.value} />)
 
     await nextTick()
     const input = wrapper.find('input')
@@ -107,7 +94,7 @@ describe('TimeSelect', () => {
 
   it('update value', async () => {
     const value = ref('10:00')
-    const wrapper = _mount(() => <TimeSelect v-model={value.value} />)
+    const wrapper = mount(() => <TimeSelect v-model={value.value} />)
 
     await nextTick()
     const vm = wrapper.findComponent({ name: 'ElTimeSelect' }).vm
@@ -128,7 +115,7 @@ describe('TimeSelect', () => {
   it('set disabled', async () => {
     const value = ref('10:00')
     const disabled = ref(false)
-    const wrapper = _mount(() => (
+    const wrapper = mount(() => (
       <TimeSelect v-model={value.value} disabled={disabled.value} />
     ))
 
@@ -143,7 +130,7 @@ describe('TimeSelect', () => {
   it('set editable', async () => {
     const value = ref('10:00')
     const editable = ref(false)
-    const wrapper = _mount(() => (
+    const wrapper = mount(() => (
       <TimeSelect v-model={value.value} editable={editable.value} />
     ))
 
@@ -156,7 +143,7 @@ describe('TimeSelect', () => {
   })
 
   it('should include end time', async () => {
-    const wrapper = _mount(() => (
+    const wrapper = mount(() => (
       <TimeSelect
         start="00:00"
         step="00:05"
@@ -175,7 +162,7 @@ describe('TimeSelect', () => {
   })
 
   it('should not duplicate end time when includeEndTime with custom format', async () => {
-    const wrapper = _mount(() => (
+    const wrapper = mount(() => (
       <TimeSelect
         start="08:30"
         step="00:15"
@@ -195,7 +182,7 @@ describe('TimeSelect', () => {
   })
 
   it('should not include end time', async () => {
-    const wrapper = _mount(() => (
+    const wrapper = mount(() => (
       <TimeSelect start="00:00" step="00:05" end="23:59" />
     ))
     const select = wrapper.findComponent({ name: 'ElTimeSelect' })
@@ -209,7 +196,7 @@ describe('TimeSelect', () => {
   })
 
   it('should include end whenever includeEndTime is false', async () => {
-    const wrapper = _mount(() => (
+    const wrapper = mount(() => (
       <TimeSelect start="00:10" end="00:20" step="00:02" />
     ))
     const select = wrapper.findComponent({ name: 'ElTimeSelect' })
@@ -223,7 +210,7 @@ describe('TimeSelect', () => {
   })
 
   it('ref focus', async () => {
-    const wrapper = _mount(() => <TimeSelect />, {
+    const wrapper = mount(() => <TimeSelect />, {
       attachTo: document.body,
     })
 
@@ -240,7 +227,7 @@ describe('TimeSelect', () => {
   })
 
   it('ref blur', async () => {
-    const wrapper = _mount(() => <TimeSelect />, {
+    const wrapper = mount(() => <TimeSelect />, {
       attachTo: document.body,
     })
 
@@ -259,7 +246,7 @@ describe('TimeSelect', () => {
 
   it('set format', async () => {
     const value = ref('')
-    const wrapper = _mount(() => (
+    const wrapper = mount(() => (
       <TimeSelect
         v-model={value.value}
         start="13:00"
@@ -277,13 +264,13 @@ describe('TimeSelect', () => {
   })
 
   it('should pass name to inner input', () => {
-    const wrapper = _mount(() => <TimeSelect name="timeSelectName" />)
+    const wrapper = mount(() => <TimeSelect name="timeSelectName" />)
     const input = wrapper.find('input')
     expect(input.attributes('name')).toBe('timeSelectName')
   })
 
   it('should fallback to default step when step is 00:00', async () => {
-    const wrapper = _mount(() => (
+    const wrapper = mount(() => (
       <TimeSelect start="09:00" end="10:00" step="00:00" />
     ))
     const input = wrapper.find('input')
@@ -294,7 +281,7 @@ describe('TimeSelect', () => {
   })
 
   it('should fallback to default start time when start time is invalid', async () => {
-    const wrapper = _mount(() => <TimeSelect start="abc:00" end="18:00" />)
+    const wrapper = mount(() => <TimeSelect start="abc:00" end="18:00" />)
 
     const input = wrapper.find('input')
     await input.trigger('click')
@@ -305,7 +292,7 @@ describe('TimeSelect', () => {
   })
 
   it('should fallback to default start time when start time is negative', async () => {
-    const wrapper = _mount(() => <TimeSelect start="-12:00" end="18:00" />)
+    const wrapper = mount(() => <TimeSelect start="-12:00" end="18:00" />)
 
     const input = wrapper.find('input')
     await input.trigger('click')
@@ -316,7 +303,7 @@ describe('TimeSelect', () => {
   })
 
   it('should fallback to default end time when end time is invalid', async () => {
-    const wrapper = _mount(() => <TimeSelect start="17:00" end="abc:00" />)
+    const wrapper = mount(() => <TimeSelect start="17:00" end="abc:00" />)
 
     const input = wrapper.find('input')
     await input.trigger('click')
@@ -327,7 +314,7 @@ describe('TimeSelect', () => {
   })
 
   it('should fallback to default end time when end time is negative', async () => {
-    const wrapper = _mount(() => <TimeSelect start="17:00" end="-12:00" />)
+    const wrapper = mount(() => <TimeSelect start="17:00" end="-12:00" />)
 
     const input = wrapper.find('input')
     await input.trigger('click')
@@ -339,7 +326,7 @@ describe('TimeSelect', () => {
 
   describe('form item accessibility integration', () => {
     it('automatic id attachment', async () => {
-      const wrapper = _mount(() => (
+      const wrapper = mount(() => (
         <ElFormItem label="Foobar" data-test-ref="item">
           <TimeSelect />
         </ElFormItem>
@@ -356,7 +343,7 @@ describe('TimeSelect', () => {
     })
 
     it('specified id attachment', async () => {
-      const wrapper = _mount(() => (
+      const wrapper = mount(() => (
         <ElFormItem label="Foobar" data-test-ref="item">
           <TimeSelect
             // type checking failed as `id` is a fallthrough attribute
@@ -378,7 +365,7 @@ describe('TimeSelect', () => {
     })
 
     it('form item role is group when multiple inputs', async () => {
-      const wrapper = _mount(() => (
+      const wrapper = mount(() => (
         <ElFormItem label="Foobar" data-test-ref="item">
           <TimeSelect />
           <TimeSelect />
@@ -391,7 +378,7 @@ describe('TimeSelect', () => {
     })
 
     it('The disabled state of a component has higher priority than that of a form', async () => {
-      const wrapper = _mount(() => (
+      const wrapper = mount(() => (
         <ElForm disabled>
           <TimeSelect disabled={false} />
         </ElForm>

--- a/packages/components/time-select/__tests__/time-select.test.tsx
+++ b/packages/components/time-select/__tests__/time-select.test.tsx
@@ -8,12 +8,25 @@ import Select from '@element-plus/components/select'
 import { ElForm, ElFormItem } from '@element-plus/components/form'
 import TimeSelect from '../src/time-select.vue'
 
+import type { VNode } from 'vue'
+import type { VueWrapper } from '@vue/test-utils'
+
 dayjs.extend(customParseFormat)
 
 const { Option } = Select
 
-afterEach(() => {
-  document.documentElement.innerHTML = ''
+const mountedWrappers: VueWrapper[] = []
+const _mount = (render: () => VNode, options?: Parameters<typeof mount>[1]) => {
+  const wrapper = mount(render, options)
+  mountedWrappers.push(wrapper)
+  return wrapper
+}
+
+afterEach(async () => {
+  mountedWrappers.forEach((wrapper) => wrapper.unmount())
+  mountedWrappers.length = 0
+  document.body.innerHTML = ''
+  await new Promise((resolve) => setTimeout(resolve, 0))
 })
 
 const WRAPPER_CLASS_NAME = 'el-select__wrapper'
@@ -21,7 +34,7 @@ const PLACEHOLDER_CLASS_NAME = 'el-select__placeholder'
 
 describe('TimeSelect', () => {
   it('create', async () => {
-    const wrapper = mount(() => (
+    const wrapper = _mount(() => (
       <TimeSelect style={{ color: 'red' }} class="customClass" />
     ))
 
@@ -31,7 +44,7 @@ describe('TimeSelect', () => {
   })
 
   it('should show clear btn on focus', async () => {
-    const wrapper = mount(() => <TimeSelect modelValue="08:30" clearable />)
+    const wrapper = _mount(() => <TimeSelect modelValue="08:30" clearable />)
     const input = wrapper.find('input')
     await input.trigger('blur')
     await input.trigger('focus')
@@ -40,7 +53,7 @@ describe('TimeSelect', () => {
 
   it('set default value', async () => {
     const value = ref('14:30')
-    const wrapper = mount(() => <TimeSelect v-model={value.value} />)
+    const wrapper = _mount(() => <TimeSelect v-model={value.value} />)
 
     const input = wrapper.find('input')
     input.trigger('blur')
@@ -51,7 +64,7 @@ describe('TimeSelect', () => {
   })
 
   it('set minTime', async () => {
-    const wrapper = mount(() => <TimeSelect minTime="14:30" />)
+    const wrapper = _mount(() => <TimeSelect minTime="14:30" />)
 
     const input = wrapper.find('input')
     input.trigger('blur')
@@ -63,7 +76,7 @@ describe('TimeSelect', () => {
   })
 
   it('set maxTime', async () => {
-    const wrapper = mount(() => <TimeSelect maxTime="14:30" />)
+    const wrapper = _mount(() => <TimeSelect maxTime="14:30" />)
 
     const input = wrapper.find('input')
     input.trigger('blur')
@@ -75,7 +88,7 @@ describe('TimeSelect', () => {
 
   it('set value update', async () => {
     const value = ref('10:00')
-    const wrapper = mount(() => <TimeSelect v-model={value.value} />)
+    const wrapper = _mount(() => <TimeSelect v-model={value.value} />)
 
     await nextTick()
     const input = wrapper.find('input')
@@ -94,7 +107,7 @@ describe('TimeSelect', () => {
 
   it('update value', async () => {
     const value = ref('10:00')
-    const wrapper = mount(() => <TimeSelect v-model={value.value} />)
+    const wrapper = _mount(() => <TimeSelect v-model={value.value} />)
 
     await nextTick()
     const vm = wrapper.findComponent({ name: 'ElTimeSelect' }).vm
@@ -115,7 +128,7 @@ describe('TimeSelect', () => {
   it('set disabled', async () => {
     const value = ref('10:00')
     const disabled = ref(false)
-    const wrapper = mount(() => (
+    const wrapper = _mount(() => (
       <TimeSelect v-model={value.value} disabled={disabled.value} />
     ))
 
@@ -130,7 +143,7 @@ describe('TimeSelect', () => {
   it('set editable', async () => {
     const value = ref('10:00')
     const editable = ref(false)
-    const wrapper = mount(() => (
+    const wrapper = _mount(() => (
       <TimeSelect v-model={value.value} editable={editable.value} />
     ))
 
@@ -143,7 +156,7 @@ describe('TimeSelect', () => {
   })
 
   it('should include end time', async () => {
-    const wrapper = mount(() => (
+    const wrapper = _mount(() => (
       <TimeSelect
         start="00:00"
         step="00:05"
@@ -162,7 +175,7 @@ describe('TimeSelect', () => {
   })
 
   it('should not duplicate end time when includeEndTime with custom format', async () => {
-    const wrapper = mount(() => (
+    const wrapper = _mount(() => (
       <TimeSelect
         start="08:30"
         step="00:15"
@@ -182,7 +195,7 @@ describe('TimeSelect', () => {
   })
 
   it('should not include end time', async () => {
-    const wrapper = mount(() => (
+    const wrapper = _mount(() => (
       <TimeSelect start="00:00" step="00:05" end="23:59" />
     ))
     const select = wrapper.findComponent({ name: 'ElTimeSelect' })
@@ -196,7 +209,7 @@ describe('TimeSelect', () => {
   })
 
   it('should include end whenever includeEndTime is false', async () => {
-    const wrapper = mount(() => (
+    const wrapper = _mount(() => (
       <TimeSelect start="00:10" end="00:20" step="00:02" />
     ))
     const select = wrapper.findComponent({ name: 'ElTimeSelect' })
@@ -210,7 +223,7 @@ describe('TimeSelect', () => {
   })
 
   it('ref focus', async () => {
-    const wrapper = mount(() => <TimeSelect />, {
+    const wrapper = _mount(() => <TimeSelect />, {
       attachTo: document.body,
     })
 
@@ -227,7 +240,7 @@ describe('TimeSelect', () => {
   })
 
   it('ref blur', async () => {
-    const wrapper = mount(() => <TimeSelect />, {
+    const wrapper = _mount(() => <TimeSelect />, {
       attachTo: document.body,
     })
 
@@ -246,7 +259,7 @@ describe('TimeSelect', () => {
 
   it('set format', async () => {
     const value = ref('')
-    const wrapper = mount(() => (
+    const wrapper = _mount(() => (
       <TimeSelect
         v-model={value.value}
         start="13:00"
@@ -264,13 +277,13 @@ describe('TimeSelect', () => {
   })
 
   it('should pass name to inner input', () => {
-    const wrapper = mount(() => <TimeSelect name="timeSelectName" />)
+    const wrapper = _mount(() => <TimeSelect name="timeSelectName" />)
     const input = wrapper.find('input')
     expect(input.attributes('name')).toBe('timeSelectName')
   })
 
   it('should fallback to default step when step is 00:00', async () => {
-    const wrapper = mount(() => (
+    const wrapper = _mount(() => (
       <TimeSelect start="09:00" end="10:00" step="00:00" />
     ))
     const input = wrapper.find('input')
@@ -281,7 +294,7 @@ describe('TimeSelect', () => {
   })
 
   it('should fallback to default start time when start time is invalid', async () => {
-    const wrapper = mount(() => <TimeSelect start="abc:00" end="18:00" />)
+    const wrapper = _mount(() => <TimeSelect start="abc:00" end="18:00" />)
 
     const input = wrapper.find('input')
     await input.trigger('click')
@@ -292,7 +305,7 @@ describe('TimeSelect', () => {
   })
 
   it('should fallback to default start time when start time is negative', async () => {
-    const wrapper = mount(() => <TimeSelect start="-12:00" end="18:00" />)
+    const wrapper = _mount(() => <TimeSelect start="-12:00" end="18:00" />)
 
     const input = wrapper.find('input')
     await input.trigger('click')
@@ -303,7 +316,7 @@ describe('TimeSelect', () => {
   })
 
   it('should fallback to default end time when end time is invalid', async () => {
-    const wrapper = mount(() => <TimeSelect start="17:00" end="abc:00" />)
+    const wrapper = _mount(() => <TimeSelect start="17:00" end="abc:00" />)
 
     const input = wrapper.find('input')
     await input.trigger('click')
@@ -314,7 +327,7 @@ describe('TimeSelect', () => {
   })
 
   it('should fallback to default end time when end time is negative', async () => {
-    const wrapper = mount(() => <TimeSelect start="17:00" end="-12:00" />)
+    const wrapper = _mount(() => <TimeSelect start="17:00" end="-12:00" />)
 
     const input = wrapper.find('input')
     await input.trigger('click')
@@ -326,7 +339,7 @@ describe('TimeSelect', () => {
 
   describe('form item accessibility integration', () => {
     it('automatic id attachment', async () => {
-      const wrapper = mount(() => (
+      const wrapper = _mount(() => (
         <ElFormItem label="Foobar" data-test-ref="item">
           <TimeSelect />
         </ElFormItem>
@@ -343,7 +356,7 @@ describe('TimeSelect', () => {
     })
 
     it('specified id attachment', async () => {
-      const wrapper = mount(() => (
+      const wrapper = _mount(() => (
         <ElFormItem label="Foobar" data-test-ref="item">
           <TimeSelect
             // type checking failed as `id` is a fallthrough attribute
@@ -365,7 +378,7 @@ describe('TimeSelect', () => {
     })
 
     it('form item role is group when multiple inputs', async () => {
-      const wrapper = mount(() => (
+      const wrapper = _mount(() => (
         <ElFormItem label="Foobar" data-test-ref="item">
           <TimeSelect />
           <TimeSelect />
@@ -378,7 +391,7 @@ describe('TimeSelect', () => {
     })
 
     it('The disabled state of a component has higher priority than that of a form', async () => {
-      const wrapper = mount(() => (
+      const wrapper = _mount(() => (
         <ElForm disabled>
           <TimeSelect disabled={false} />
         </ElForm>

--- a/packages/components/time-select/__tests__/time-select.test.tsx
+++ b/packages/components/time-select/__tests__/time-select.test.tsx
@@ -280,6 +280,50 @@ describe('TimeSelect', () => {
     expect([...items].at(-1)?.textContent).toBe('10:00')
   })
 
+  it('should fallback to default start time when start time is invalid', async () => {
+    const wrapper = mount(() => <TimeSelect start="abc:00" end="18:00" />)
+
+    const input = wrapper.find('input')
+    await input.trigger('click')
+    const items = document.querySelectorAll('.el-select-dropdown__item>span')
+    expect(items).toHaveLength(19)
+    expect([...items].at(0)?.textContent).toBe('09:00')
+    expect([...items].at(-1)?.textContent).toBe('18:00')
+  })
+
+  it('should fallback to default start time when start time is negative', async () => {
+    const wrapper = mount(() => <TimeSelect start="-12:00" end="18:00" />)
+
+    const input = wrapper.find('input')
+    await input.trigger('click')
+    const items = document.querySelectorAll('.el-select-dropdown__item>span')
+    expect(items).toHaveLength(19)
+    expect([...items].at(0)?.textContent).toBe('09:00')
+    expect([...items].at(-1)?.textContent).toBe('18:00')
+  })
+
+  it('should fallback to default end time when end time is invalid', async () => {
+    const wrapper = mount(() => <TimeSelect start="17:00" end="abc:00" />)
+
+    const input = wrapper.find('input')
+    await input.trigger('click')
+    const items = document.querySelectorAll('.el-select-dropdown__item>span')
+    expect(items).toHaveLength(3)
+    expect([...items].at(0)?.textContent).toBe('17:00')
+    expect([...items].at(-1)?.textContent).toBe('18:00')
+  })
+
+  it('should fallback to default end time when end time is negative', async () => {
+    const wrapper = mount(() => <TimeSelect start="17:00" end="-12:00" />)
+
+    const input = wrapper.find('input')
+    await input.trigger('click')
+    const items = document.querySelectorAll('.el-select-dropdown__item>span')
+    expect(items).toHaveLength(3)
+    expect([...items].at(0)?.textContent).toBe('17:00')
+    expect([...items].at(-1)?.textContent).toBe('18:00')
+  })
+
   describe('form item accessibility integration', () => {
     it('automatic id attachment', async () => {
       const wrapper = mount(() => (

--- a/packages/components/time-select/src/time-select.ts
+++ b/packages/components/time-select/src/time-select.ts
@@ -88,6 +88,8 @@ export interface TimeSelectProps extends UseEmptyValuesProps {
   popperStyle?: string | CSSProperties
 }
 
+export const DEFAULT_START = '09:00'
+export const DEFAULT_END = '18:00'
 export const DEFAULT_STEP = '00:30'
 
 /**
@@ -148,14 +150,14 @@ export const timeSelectProps = buildProps({
    */
   start: {
     type: String,
-    default: '09:00',
+    default: DEFAULT_START,
   },
   /**
    * @description end time
    */
   end: {
     type: String,
-    default: '18:00',
+    default: DEFAULT_END,
   },
   /**
    * @description time step

--- a/packages/components/time-select/src/time-select.vue
+++ b/packages/components/time-select/src/time-select.vue
@@ -46,7 +46,13 @@ import ElIcon from '@element-plus/components/icon'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { CircleClose, Clock } from '@element-plus/icons-vue'
-import { compareTime, formatTime, nextTime, parseTime } from './utils'
+import {
+  compareTime,
+  formatTime,
+  isValidTime,
+  nextTime,
+  parseTime,
+} from './utils'
 import { debugWarn } from '@element-plus/utils'
 import { DEFAULT_END, DEFAULT_START, DEFAULT_STEP } from './time-select'
 
@@ -87,13 +93,7 @@ const { lang } = useLocale()
 const value = computed(() => props.modelValue)
 const start = computed(() => {
   const time = parseTime(props.start)
-  const isInvalidStart =
-    !time ||
-    time.hours < 0 ||
-    time.minutes < 0 ||
-    Number.isNaN(time.hours) ||
-    Number.isNaN(time.minutes)
-  if (isInvalidStart) {
+  if (!isValidTime(time)) {
     debugWarn(
       'ElTimeSelect',
       `invalid start, fallback to default start (${DEFAULT_START}).`
@@ -105,13 +105,7 @@ const start = computed(() => {
 
 const end = computed(() => {
   const time = parseTime(props.end)
-  const isInvalidEnd =
-    !time ||
-    time.hours < 0 ||
-    time.minutes < 0 ||
-    Number.isNaN(time.hours) ||
-    Number.isNaN(time.minutes)
-  if (isInvalidEnd) {
+  if (!isValidTime(time)) {
     debugWarn(
       'ElTimeSelect',
       `invalid end, fallback to default end (${DEFAULT_END}).`
@@ -134,12 +128,7 @@ const maxTime = computed(() => {
 const step = computed(() => {
   const time = parseTime(props.step)
   const isInvalidStep =
-    !time ||
-    time.hours < 0 ||
-    time.minutes < 0 ||
-    Number.isNaN(time.hours) ||
-    Number.isNaN(time.minutes) ||
-    (time.hours === 0 && time.minutes === 0)
+    !isValidTime(time) || (time.hours === 0 && time.minutes === 0)
   if (isInvalidStep) {
     debugWarn(
       'ElTimeSelect',

--- a/packages/components/time-select/src/time-select.vue
+++ b/packages/components/time-select/src/time-select.vue
@@ -143,26 +143,22 @@ const items = computed(() => {
     })
   }
 
-  if (start.value && end.value && step.value) {
-    let current = start.value
-    let currentTime: string
-    while (current && end.value && compareTime(current, end.value) <= 0) {
-      currentTime = dayjs(current, 'HH:mm')
-        .locale(lang.value)
-        .format(props.format)
-      push(currentTime, current)
-      current = nextTime(current, step.value!)
-    }
-    if (
-      props.includeEndTime &&
-      end.value &&
-      result[result.length - 1]?.rawValue !== end.value
-    ) {
-      const formattedValue = dayjs(end.value, 'HH:mm')
-        .locale(lang.value)
-        .format(props.format)
-      push(formattedValue, end.value)
-    }
+  let current = start.value
+  while (compareTime(current, end.value) <= 0) {
+    const currentTime = dayjs(current, 'HH:mm')
+      .locale(lang.value)
+      .format(props.format)
+    push(currentTime, current)
+    current = nextTime(current, step.value)
+  }
+  if (
+    props.includeEndTime &&
+    result[result.length - 1]?.rawValue !== end.value
+  ) {
+    const formattedValue = dayjs(end.value, 'HH:mm')
+      .locale(lang.value)
+      .format(props.format)
+    push(formattedValue, end.value)
   }
   return result
 })

--- a/packages/components/time-select/src/time-select.vue
+++ b/packages/components/time-select/src/time-select.vue
@@ -48,7 +48,7 @@ import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import { CircleClose, Clock } from '@element-plus/icons-vue'
 import { compareTime, formatTime, nextTime, parseTime } from './utils'
 import { debugWarn } from '@element-plus/utils'
-import { DEFAULT_STEP } from './time-select'
+import { DEFAULT_END, DEFAULT_START, DEFAULT_STEP } from './time-select'
 
 import type { TimeSelectProps } from './time-select'
 
@@ -68,8 +68,8 @@ const props = withDefaults(defineProps<TimeSelectProps>(), {
   editable: true,
   effect: 'light',
   clearable: true,
-  start: '09:00',
-  end: '18:00',
+  start: DEFAULT_START,
+  end: DEFAULT_END,
   step: DEFAULT_STEP,
   prefixIcon: () => Clock,
   clearIcon: () => CircleClose,
@@ -87,12 +87,38 @@ const { lang } = useLocale()
 const value = computed(() => props.modelValue)
 const start = computed(() => {
   const time = parseTime(props.start)
-  return time ? formatTime(time) : null
+  const isInvalidStart =
+    !time ||
+    time.hours < 0 ||
+    time.minutes < 0 ||
+    Number.isNaN(time.hours) ||
+    Number.isNaN(time.minutes)
+  if (isInvalidStart) {
+    debugWarn(
+      'ElTimeSelect',
+      `invalid start, fallback to default start (${DEFAULT_START}).`
+    )
+    return DEFAULT_START
+  }
+  return formatTime(time)
 })
 
 const end = computed(() => {
   const time = parseTime(props.end)
-  return time ? formatTime(time) : null
+  const isInvalidEnd =
+    !time ||
+    time.hours < 0 ||
+    time.minutes < 0 ||
+    Number.isNaN(time.hours) ||
+    Number.isNaN(time.minutes)
+  if (isInvalidEnd) {
+    debugWarn(
+      'ElTimeSelect',
+      `invalid end, fallback to default end (${DEFAULT_END}).`
+    )
+    return DEFAULT_END
+  }
+  return formatTime(time)
 })
 
 const minTime = computed(() => {
@@ -135,7 +161,7 @@ const items = computed(() => {
     })
   }
 
-  if (props.start && props.end && props.step) {
+  if (start.value && end.value && step.value) {
     let current = start.value
     let currentTime: string
     while (current && end.value && compareTime(current, end.value) <= 0) {

--- a/packages/components/time-select/src/time-select.vue
+++ b/packages/components/time-select/src/time-select.vue
@@ -90,30 +90,32 @@ const select = ref<typeof ElSelect>()
 const _disabled = useFormDisabled()
 const { lang } = useLocale()
 
-const value = computed(() => props.modelValue)
-const start = computed(() => {
-  const time = parseTime(props.start)
-  if (!isValidTime(time)) {
+const getValidTimeOrDefault = (
+  value: string,
+  propName: 'start' | 'end' | 'step',
+  defaultValue: string,
+  allowZero = true
+) => {
+  const time = parseTime(value)
+  if (
+    !isValidTime(time) ||
+    (!allowZero && time.hours === 0 && time.minutes === 0)
+  ) {
     debugWarn(
       'ElTimeSelect',
-      `invalid start, fallback to default start (${DEFAULT_START}).`
+      `invalid ${propName}, fallback to default ${propName} (${defaultValue}).`
     )
-    return DEFAULT_START
+    return defaultValue
   }
   return formatTime(time)
-})
+}
 
-const end = computed(() => {
-  const time = parseTime(props.end)
-  if (!isValidTime(time)) {
-    debugWarn(
-      'ElTimeSelect',
-      `invalid end, fallback to default end (${DEFAULT_END}).`
-    )
-    return DEFAULT_END
-  }
-  return formatTime(time)
-})
+const value = computed(() => props.modelValue)
+const start = computed(() =>
+  getValidTimeOrDefault(props.start, 'start', DEFAULT_START)
+)
+
+const end = computed(() => getValidTimeOrDefault(props.end, 'end', DEFAULT_END))
 
 const minTime = computed(() => {
   const time = parseTime(props.minTime || '')
@@ -125,18 +127,9 @@ const maxTime = computed(() => {
   return time ? formatTime(time) : null
 })
 
-const step = computed(() => {
-  const time = parseTime(props.step)
-  const isInvalidStep =
-    !isValidTime(time) || (time.hours === 0 && time.minutes === 0)
-  if (isInvalidStep) {
-    debugWarn(
-      'ElTimeSelect',
-      `invalid step, fallback to default step (${DEFAULT_STEP}).`
-    )
-  }
-  return !isInvalidStep ? formatTime(time) : DEFAULT_STEP
-})
+const step = computed(() =>
+  getValidTimeOrDefault(props.step, 'step', DEFAULT_STEP, false)
+)
 
 const items = computed(() => {
   const result: { value: string; rawValue: string; disabled: boolean }[] = []

--- a/packages/components/time-select/src/utils.ts
+++ b/packages/components/time-select/src/utils.ts
@@ -8,6 +8,8 @@ export const parseTime = (time: string): null | Time => {
   if (values.length >= 2) {
     let hours = Number.parseInt(values[0], 10)
     const minutes = Number.parseInt(values[1], 10)
+    if (Number.isNaN(hours) || Number.isNaN(minutes)) return null
+
     const timeUpper = time.toUpperCase()
     if (timeUpper.includes('AM') && hours === 12) {
       hours = 0

--- a/packages/components/time-select/src/utils.ts
+++ b/packages/components/time-select/src/utils.ts
@@ -25,6 +25,13 @@ export const parseTime = (time: string): null | Time => {
   return null
 }
 
+export const isValidTime = (time: null | Time): time is Time =>
+  !!time &&
+  time.hours >= 0 &&
+  time.minutes >= 0 &&
+  !Number.isNaN(time.hours) &&
+  !Number.isNaN(time.minutes)
+
 export const compareTime = (time1: string, time2: string): number => {
   const value1 = parseTime(time1)
   if (!value1) return -1


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

## Summary
fix https://github.com/element-plus/element-plus/issues/24328

- Treat parsed `NaN` hour or minute values as invalid time input.
- Add a regression test for an invalid `start` value.

## Problem

`parseTime` accepted strings like `abc:00` because they contained at least two colon-separated pieces. This produced a `Time` object with `hours: NaN`.

That invalid value reached TimeSelect option generation, where `compareTime` kept returning `-1` and `nextTime` kept producing `NaN:*` values. As a result, the option-generation loop could run forever and freeze the page.

## Solution

Guard `parseTime` against invalid numeric parts:

```ts
if (Number.isNaN(hours) || Number.isNaN(minutes)) return null
```

This keeps invalid time strings out of the option-generation loop.

## Tests

```bash
pnpm exec vitest run packages/components/time-select/__tests__/time-select.test.tsx
```

## Notes

The regression test verifies that TimeSelect does not generate options when `start` is invalid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TimeSelect now validates malformed start/end inputs, emits a debug warning, and reliably falls back to sensible default start (09:00) and end (18:00) times so displayed time options remain correct.

* **Tests**
  * Added tests covering fallback behavior and correct time-item generation when start/end props are invalid or negative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->