### PR TITLE
fix(components): [config-provider] preserve zero zIndex

### DIFF
--- a/packages/components/config-provider/__tests__/config-provider.test.tsx
+++ b/packages/components/config-provider/__tests__/config-provider.test.tsx
@@ -1,7 +1,11 @@
 import { computed, defineComponent, nextTick, reactive, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useLocale, useNamespace } from '@element-plus/hooks'
+import {
+  defaultInitialZIndex,
+  useLocale,
+  useNamespace,
+} from '@element-plus/hooks'
 import Chinese from '@element-plus/locale/lang/zh-cn'
 import English from '@element-plus/locale/lang/en'
 import {
@@ -523,6 +527,24 @@ describe('config-provider', () => {
       ))
 
       expect(receiverRef.value.zIndex.initialZIndex).toBe(0)
+    })
+
+    it('should fall back to default zIndex for NaN global configuration', () => {
+      const receiverRef = ref()
+      const ReceiverComponent = defineComponent({
+        setup() {
+          receiverRef.value = useGlobalComponentSettings('button')
+        },
+        template: '<div></div>',
+      })
+
+      mount(() => (
+        <ConfigProvider zIndex={Number.NaN}>
+          <ReceiverComponent />
+        </ConfigProvider>
+      ))
+
+      expect(receiverRef.value.zIndex.initialZIndex).toBe(defaultInitialZIndex)
     })
 
     // #18004

--- a/packages/components/config-provider/__tests__/config-provider.test.tsx
+++ b/packages/components/config-provider/__tests__/config-provider.test.tsx
@@ -507,6 +507,24 @@ describe('config-provider', () => {
       expect(vm.size).toBe('small')
     })
 
+    it('should respect zero as global configured zIndex', () => {
+      const receiverRef = ref()
+      const ReceiverComponent = defineComponent({
+        setup() {
+          receiverRef.value = useGlobalComponentSettings('button')
+        },
+        template: '<div></div>',
+      })
+
+      mount(() => (
+        <ConfigProvider zIndex={0}>
+          <ReceiverComponent />
+        </ConfigProvider>
+      ))
+
+      expect(receiverRef.value.zIndex.initialZIndex).toBe(0)
+    })
+
     // #18004
     it('dynamically modify global size configuration', async () => {
       const size = ref<ComponentSize>('small')

--- a/packages/components/config-provider/src/hooks/use-global-config.ts
+++ b/packages/components/config-provider/src/hooks/use-global-config.ts
@@ -58,7 +58,7 @@ export function useGlobalComponentSettings(
 
   const locale = useLocale(computed(() => config.value?.locale))
   const zIndex = useZIndex(
-    computed(() => config.value?.zIndex || defaultInitialZIndex)
+    computed(() => config.value?.zIndex ?? defaultInitialZIndex)
   )
   const size = computed(() => unref(sizeFallback) || config.value?.size || '')
   provideGlobalConfig(computed(() => unref(config) || {}))

--- a/packages/components/config-provider/src/hooks/use-global-config.ts
+++ b/packages/components/config-provider/src/hooks/use-global-config.ts
@@ -58,7 +58,12 @@ export function useGlobalComponentSettings(
 
   const locale = useLocale(computed(() => config.value?.locale))
   const zIndex = useZIndex(
-    computed(() => config.value?.zIndex ?? defaultInitialZIndex)
+    computed(() => {
+      const zIndex = config.value?.zIndex
+      return zIndex == null || Number.isNaN(zIndex)
+        ? defaultInitialZIndex
+        : zIndex
+    })
   )
   const size = computed(() => unref(sizeFallback) || config.value?.size || '')
   provideGlobalConfig(computed(() => unref(config) || {}))

--- a/packages/components/config-provider/src/hooks/use-global-config.ts
+++ b/packages/components/config-provider/src/hooks/use-global-config.ts
@@ -12,6 +12,7 @@ import {
   useZIndex,
   zIndexContextKey,
 } from '@element-plus/hooks'
+import { isNil } from 'lodash-unified'
 import { configProviderContextKey } from '../constants'
 
 import type { App, MaybeRef, Ref } from 'vue'
@@ -60,7 +61,7 @@ export function useGlobalComponentSettings(
   const zIndex = useZIndex(
     computed(() => {
       const zIndex = config.value?.zIndex
-      return zIndex == null || Number.isNaN(zIndex)
+      return isNil(zIndex) || Number.isNaN(zIndex)
         ? defaultInitialZIndex
         : zIndex
     })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


## Summary
fix: https://github.com/element-plus/element-plus/issues/24330

- Preserve `0` as a valid global z-index value.
- Add a regression test for `ConfigProvider zIndex={0}`.

## Problem

`useGlobalComponentSettings` used `||` to fall back to `defaultInitialZIndex`:

```ts
computed(() => config.value?.zIndex || defaultInitialZIndex)
```

This caused `0` to be treated as missing because `0` is falsy.

## Solution

Use `??` so only `null` or `undefined` fall back to the default:

```ts
computed(() => config.value?.zIndex ?? defaultInitialZIndex)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ConfigProvider now correctly treats an explicit zIndex of 0 as valid and only falls back to the default initial z-index for missing or invalid numeric values (e.g., NaN), preventing accidental overrides from falsy values.

* **Tests**
  * Added tests verifying explicit zIndex=0 is preserved and that invalid/missing zIndex values fall back to the default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->