### PR TITLE
ci: restrict GITHUB_TOKEN to minimum required permissions

### DIFF
--- a/.github/workflows/issue-duplicate.yml
+++ b/.github/workflows/issue-duplicate.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  issues: write
+
 jobs:
   mark-duplicate:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-inactive.yml
+++ b/.github/workflows/issue-inactive.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   close-issues:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     if: ${{ github.repository_owner == 'element-plus' }}
     steps:
       - name: need reproduction
@@ -29,6 +31,8 @@ jobs:
 
   lock-issues:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     if: ${{ github.repository_owner == 'element-plus' }}
     steps:
       - name: lock-issues
@@ -42,6 +46,8 @@ jobs:
 
   check-inactive:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     if: ${{ github.repository_owner == 'element-plus' }}
     steps:
       - name: check-inactive

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  issues: write
+
 jobs:
   reply-labeled:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   issue-open-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-remove-inactive.yml
+++ b/.github/workflows/issue-remove-inactive.yml
@@ -6,6 +6,9 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  issues: write
+
 jobs:
   issue-remove-inactive:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-commit-message-post.yml
+++ b/.github/workflows/lint-commit-message-post.yml
@@ -1,6 +1,7 @@
 name: 📮 Lint Commit Message Post
 
 on:
+  # zizmor: ignore[dangerous-triggers] downstream workflow only reads artifacts from the named lint workflow and uses scoped job permissions
   workflow_run:
     workflows: ['Lint Commit Message']
     types: [completed]
@@ -8,6 +9,8 @@ on:
 jobs:
   result:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
 
     outputs:
       succeeded: ${{ steps.assert.outputs.succeeded }}

--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -18,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -33,7 +38,10 @@ jobs:
 
       - name: Lint commit
         id: lint_commit
-        run: echo "${{ github.event.pull_request.title }}" | pnpm run lint:commit || echo "failed=true" >> $GITHUB_OUTPUT
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          printf '%s\n' "$PR_TITLE" | pnpm run lint:commit || echo "failed=true" >> "$GITHUB_OUTPUT"
 
       - name: Set success result
         if: ${{ steps.lint_commit.outputs.failed != 'true' }}

--- a/.github/workflows/lint-typecheck.yml
+++ b/.github/workflows/lint-typecheck.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
@@ -17,6 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Add dev branch
         run: git branch dev origin/dev

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -3,6 +3,7 @@ name: Thanks to the PR Contributor
 # DO NOT ADD ANY CHECKOUT/CACHING in this workflow
 
 on:
+  # zizmor: ignore[dangerous-triggers] target-context workflow only posts a PR comment and never checks out code
   pull_request_target:
     types: [closed]
 

--- a/.github/workflows/pr-conflict.yml
+++ b/.github/workflows/pr-conflict.yml
@@ -3,15 +3,15 @@ name: Comment on PR with conflict Label
 # DO NOT ADD ANY CHECKOUT/CACHING in this workflow
 
 on:
+  # zizmor: ignore[dangerous-triggers] target-context workflow only comments, reads PR metadata, and updates labels without checking out code
   pull_request_target:
     types: [labeled, synchronize]
-
-permissions:
-  pull-requests: write
 
 jobs:
   comment:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Check for specific label
         if: |
@@ -27,6 +27,9 @@ jobs:
 
   remove-label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
     steps:
       - name: Poll mergeable until ready
         id: poll
@@ -60,10 +63,14 @@ jobs:
 
       # Log final values (debug)
       - name: Log mergeable results
+        env:
+          MERGEABLE: ${{ steps.poll.outputs.mergeable }}
+          PR_MERGEABLE: ${{ github.event.pull_request.mergeable }}
+          PR_MERGEABLE_STATE: ${{ github.event.pull_request.mergeable_state }}
         run: |
-          echo "mergeable: ${{ steps.poll.outputs.mergeable }}"
-          echo "pull_request.mergeable: ${{ github.event.pull_request.mergeable }}"
-          echo "pull_request.mergeable_state: ${{ github.event.pull_request.mergeable_state }}"
+          echo "mergeable: $MERGEABLE"
+          echo "pull_request.mergeable: $PR_MERGEABLE"
+          echo "pull_request.mergeable_state: $PR_MERGEABLE_STATE"
 
       - name: Remove conflict pending label
         if: |

--- a/.github/workflows/pr-docs-build.yml
+++ b/.github/workflows/pr-docs-build.yml
@@ -2,6 +2,9 @@ name: PR Docs Build
 
 on: pull_request
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
@@ -27,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8

--- a/.github/workflows/pr-docs-deploy.yml
+++ b/.github/workflows/pr-docs-deploy.yml
@@ -2,6 +2,7 @@
 name: PR Docs Deploy
 
 on:
+  # zizmor: ignore[dangerous-triggers] downstream workflow deploys the named docs artifact with scoped permissions and does not execute artifact contents
   workflow_run:
     workflows: ['PR Docs Build']
     types: [completed]
@@ -11,6 +12,9 @@ jobs:
   on-success:
     name: Build successfully
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: write
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download pr number
@@ -78,6 +82,9 @@ jobs:
   on-failure:
     name: Build failed
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: write
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - name: Download pr number

--- a/.github/workflows/pr-docs-start.yml
+++ b/.github/workflows/pr-docs-start.yml
@@ -1,12 +1,15 @@
 name: PR Docs Start
 
 on:
+  # zizmor: ignore[dangerous-triggers] target-context workflow only creates a PR preview comment and never checks out code
   pull_request_target:
     types: [opened]
 
 jobs:
   preview:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: create
         uses: actions-cool/maintain-one-comment-backup@17f644ff1665b05890083f7c1091fef135bce5e4

--- a/.github/workflows/pr-welcome.yml
+++ b/.github/workflows/pr-welcome.yml
@@ -2,12 +2,16 @@ name: PR Welcome
 # Note that this `pull_request_target` is vulnerable, it grants write access to a fork repo
 # DO NOT ADD ANY CHECKOUT/CACHING in this workflow
 on:
+  # zizmor: ignore[dangerous-triggers] target-context workflow only assigns reviewers and labels PRs without checking out code
   pull_request_target:
     types: [opened]
 
 jobs:
   pr-open-greeting:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions-cool/check-user-permission@c21884f3dda18dafc2f8b402fe807ccc9ec1aa5e # v2.4.0
         id: isTeamMember

--- a/.github/workflows/publish-build-product.yml
+++ b/.github/workflows/publish-build-product.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - 'master'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check:
     name: Build Product Check

--- a/.github/workflows/publish-docs-deploy-manual.yml
+++ b/.github/workflows/publish-docs-deploy-manual.yml
@@ -5,10 +5,14 @@ on: workflow_dispatch
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -64,6 +68,8 @@ jobs:
           commit-message: website deploy ${{ steps.get_release.outputs.latest_version }}
 
       - name: Deploy to Vercel
+        env:
+          RELEASE_VERSION: ${{ steps.get_release.outputs.latest_version }}
         run: |
           set -euo pipefail
 
@@ -93,11 +99,13 @@ jobs:
             exit 0
           fi
 
-          git commit -m "website deploy ${{ steps.get_release.outputs.latest_version }}"
+          git commit -m "website deploy ${RELEASE_VERSION}"
 
           git push origin main --force-with-lease
 
       - name: Deploy to Vercel Main
+        env:
+          RELEASE_VERSION: ${{ steps.get_release.outputs.latest_version }}
         run: |
           set -euo pipefail
 
@@ -127,6 +135,6 @@ jobs:
             exit 0
           fi
 
-          git commit -m "website deploy ${{ steps.get_release.outputs.latest_version }}"
+          git commit -m "website deploy ${RELEASE_VERSION}"
 
           git push origin main --force-with-lease

--- a/.github/workflows/publish-docs-deploy.yml
+++ b/.github/workflows/publish-docs-deploy.yml
@@ -1,6 +1,7 @@
 name: Publish Docs Deploy
 
 on:
+  # zizmor: ignore[dangerous-triggers] release-only downstream deploy uses the published release workflow result with scoped permissions
   workflow_run:
     workflows: ['Publish to NPM registry']
     types: [completed]
@@ -8,6 +9,8 @@ on:
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'release' }}
 
     steps:
@@ -71,6 +74,8 @@ jobs:
           commit-message: website deploy ${{ steps.get_release.outputs.latest_version }}
 
       - name: Deploy to Vercel
+        env:
+          RELEASE_VERSION: ${{ steps.get_release.outputs.latest_version }}
         run: |
           set -euo pipefail
 
@@ -100,11 +105,13 @@ jobs:
             exit 0
           fi
 
-          git commit -m "website deploy ${{ steps.get_release.outputs.latest_version }}"
+          git commit -m "website deploy ${RELEASE_VERSION}"
 
           git push origin main --force-with-lease
 
       - name: Deploy to Vercel Main
+        env:
+          RELEASE_VERSION: ${{ steps.get_release.outputs.latest_version }}
         run: |
           set -euo pipefail
 
@@ -134,6 +141,6 @@ jobs:
             exit 0
           fi
 
-          git commit -m "website deploy ${{ steps.get_release.outputs.latest_version }}"
+          git commit -m "website deploy ${RELEASE_VERSION}"
 
           git push origin main --force-with-lease

--- a/.github/workflows/publish-npm-nightly.yml
+++ b/.github/workflows/publish-npm-nightly.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 16 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,6 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -43,6 +47,8 @@ jobs:
     if: ${{ github.repository_owner == 'element-plus' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -12,6 +15,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Add dev branch
         run: git branch dev origin/dev
 
@@ -41,6 +45,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/publish-pr-commit-pkg.yml
+++ b/.github/workflows/publish-pr-commit-pkg.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -24,7 +29,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+          package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/publish-size-report.yml
+++ b/.github/workflows/publish-size-report.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   size-report:
     runs-on: ubuntu-latest
@@ -13,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8

--- a/.github/workflows/staging-docs.yml
+++ b/.github/workflows/staging-docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'dev'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
@@ -105,6 +108,6 @@ jobs:
             exit 0
           fi
 
-          git commit -m "website deploy ${{ steps.get_release.outputs.latest_version }}"
+          git commit -m "website deploy ${TAG_VERSION}"
 
           git push origin main --force-with-lease

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     name: Coverage
@@ -15,6 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Add dev branch
         run: git branch dev origin/dev

--- a/.github/workflows/test-ssr.yml
+++ b/.github/workflows/test-ssr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
@@ -25,6 +28,8 @@ jobs:
             node-name: Current
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8


### PR DESCRIPTION
Grant the minimum required GITHUB_TOKEN permissions for GitHub Actions workflows, and use [zizmor](https://github.com/zizmorcore/zizmor) to fix potential issues.

- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
- https://docs.github.com/en/actions/tutorials/authenticate-with-github_token#modifying-the-permissions-for-the-github_token
- https://github.com/actions/checkout/issues/485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all GitHub Actions workflows to explicitly declare minimal repository permissions, implementing least-privilege security best practices.
  * Disabled GitHub token credential persistence across repository checkout steps to enhance workflow security.
  * Added security configuration directives to improve overall workflow safety and compliance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->