### PR TITLE
Fix/cascader lazy load check all

### DIFF
--- a/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
+++ b/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
@@ -1,12 +1,15 @@
-import { nextTick, ref } from 'vue'
+import { defineComponent, inject, nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { EVENT_CODE } from '@element-plus/constants'
 import { Check, Loading } from '@element-plus/icons-vue'
 import CascaderPanel from '../src/index.vue'
 import Node from '../src/node.vue'
+import { CASCADER_PANEL_INJECTION_KEY } from '../src/types'
 
+import type { PropType } from 'vue'
 import type {
+  CascaderNode,
   CascaderOption,
   CascaderProps,
   CascaderValue,
@@ -768,43 +771,70 @@ describe('CascaderPanel.vue', () => {
     vi.useRealTimers()
   })
 
-  test('no loaded nodes should not be checked', async () => {
+  test('lazy unloaded descendants should be checked when parent is checked', async () => {
     vi.useFakeTimers()
+    const value = ref<CascaderValue>([])
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve) => {
+      const childrenMap: Record<string, CascaderOption[]> = {
+        root: [
+          {
+            value: 'parent',
+            label: 'Parent',
+            leaf: false,
+          },
+        ],
+        parent: [
+          {
+            value: 'child',
+            label: 'Child',
+            leaf: false,
+          },
+          {
+            value: 'sibling',
+            label: 'Sibling',
+            leaf: true,
+          },
+        ],
+        child: [
+          {
+            value: 'grandchild',
+            label: 'Grandchild',
+            leaf: true,
+          },
+        ],
+      }
+
+      setTimeout(() => {
+        resolve(childrenMap[String(node.value ?? 'root')] ?? [])
+      }, 1000)
+    })
     const props: CascaderProps = {
       multiple: true,
       lazy: true,
-      lazyLoad(node, resolve) {
-        const { level } = node
-        setTimeout(() => {
-          const nodes = Array.from({ length: level + 1 }).map(() => {
-            ++id
-            return {
-              value: id,
-              label: `option${id}`,
-              leaf: id === 3,
-            }
-          })
-          resolve(nodes)
-        }, 1000)
-      },
+      lazyLoad,
     }
-    const wrapper = mount(() => <CascaderPanel props={props} />)
+    const wrapper = mount(() => (
+      <CascaderPanel v-model={value.value} props={props} />
+    ))
 
-    vi.runAllTimers()
+    await vi.runAllTimersAsync()
     await nextTick()
     const firstMenu = wrapper.findAll(MENU)[0]
     const firstOption = wrapper.find(NODE)
     await firstOption.trigger('click')
-    vi.runAllTimers()
+    await vi.runAllTimersAsync()
     await nextTick()
 
     await firstMenu.find(CHECKBOX).find('input').trigger('click')
+    await vi.runAllTimersAsync()
+    await nextTick()
 
     const secondMenu = wrapper.findAll(MENU)[1]
     expect(secondMenu.exists()).toBe(true)
-    expect(firstMenu.find(CHECKBOX).classes('is-checked')).toBe(false)
-    expect(firstMenu.find(CHECKBOX).classes('is-indeterminate')).toBe(true)
-    expect(secondMenu.findAll(CHECKBOX)[0].classes('is-checked')).toBe(false)
+    expect(lazyLoad).toHaveBeenCalledTimes(3)
+    expect(firstMenu.find(CHECKBOX).classes('is-checked')).toBe(true)
+    expect(firstMenu.find(CHECKBOX).classes('is-indeterminate')).toBe(false)
+    expect(secondMenu.findAll(CHECKBOX)[0].classes('is-checked')).toBe(true)
     expect(secondMenu.findAll(CHECKBOX)[0].classes('is-indeterminate')).toBe(
       false
     )
@@ -812,6 +842,532 @@ describe('CascaderPanel.vue', () => {
     expect(secondMenu.findAll(CHECKBOX)[1].classes('is-indeterminate')).toBe(
       false
     )
+    expect(value.value).toEqual([
+      ['parent', 'sibling'],
+      ['parent', 'child', 'grandchild'],
+    ])
+
+    await firstMenu.find(CHECKBOX).find('input').trigger('click')
+    await nextTick()
+    expect(lazyLoad).toHaveBeenCalledTimes(3)
+    expect(value.value).toEqual([])
+    vi.useRealTimers()
+  })
+
+  test('lazy parent check should wait for in-flight descendant load', async () => {
+    vi.useFakeTimers()
+    const value = ref<CascaderValue>([])
+    const options: CascaderOption[] = [
+      {
+        value: 'parent',
+        label: 'Parent',
+        children: [
+          {
+            value: 'child-a',
+            label: 'Child A',
+            leaf: true,
+          },
+          {
+            value: 'child-b',
+            label: 'Child B',
+            leaf: false,
+          },
+        ],
+      },
+    ]
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve) => {
+      setTimeout(() => {
+        resolve([
+          {
+            value: 'grandchild',
+            label: 'Grandchild',
+            leaf: true,
+          },
+        ])
+      }, 1000)
+    })
+    const props: CascaderProps = {
+      multiple: true,
+      lazy: true,
+      lazyLoad,
+    }
+    const wrapper = mount(() => (
+      <CascaderPanel v-model={value.value} options={options} props={props} />
+    ))
+
+    await nextTick()
+    await wrapper.find(NODE).trigger('click')
+    await nextTick()
+
+    const secondMenu = wrapper.findAll(MENU)[1]
+    await secondMenu.findAll(NODE)[1].trigger('click')
+    await nextTick()
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+
+    const parentInput = wrapper.findAll(MENU)[0].find(CHECKBOX).find('input')
+    parentInput.element.checked = true
+    await parentInput.trigger('change')
+    await nextTick()
+    expect(value.value).toEqual([])
+
+    await vi.runAllTimersAsync()
+    await nextTick()
+
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+    expect(value.value).toEqual([
+      ['parent', 'child-a'],
+      ['parent', 'child-b', 'grandchild'],
+    ])
+    vi.useRealTimers()
+  })
+
+  test('lazy load should reuse pending request for raw and reactive nodes', async () => {
+    vi.useFakeTimers()
+    const value = ref<CascaderValue>([])
+    const options: CascaderOption[] = [
+      {
+        value: 'parent',
+        label: 'Parent',
+        children: [
+          {
+            value: 'child',
+            label: 'Child',
+            leaf: false,
+          },
+        ],
+      },
+    ]
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve) => {
+      setTimeout(() => {
+        resolve([
+          {
+            value: 'grandchild',
+            label: 'Grandchild',
+            leaf: true,
+          },
+        ])
+      }, 1000)
+    })
+    const props: CascaderProps = {
+      multiple: true,
+      lazy: true,
+      lazyLoad,
+    }
+    const wrapper = mount(() => (
+      <CascaderPanel v-model={value.value} options={options} props={props} />
+    ))
+
+    await nextTick()
+    value.value = [['parent', 'child']]
+    await nextTick()
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+
+    const parentInput = wrapper.findAll(MENU)[0].find(CHECKBOX).find('input')
+    parentInput.element.checked = true
+    await parentInput.trigger('change')
+    await nextTick()
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+
+    await vi.runAllTimersAsync()
+    await nextTick()
+
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+    expect(value.value).toEqual([['parent', 'child', 'grandchild']])
+    vi.useRealTimers()
+  })
+
+  test('lazy load should run callbacks attached to pending request', async () => {
+    vi.useFakeTimers()
+    const firstCallback = vi.fn()
+    const secondCallback = vi.fn()
+    const requestedNodes = new Set<number>()
+    const loadedChildren: CascaderOption[] = [
+      {
+        value: 'grandchild',
+        label: 'Grandchild',
+        leaf: true,
+      },
+    ]
+    const options: CascaderOption[] = [
+      {
+        value: 'parent',
+        label: 'Parent',
+        children: [
+          {
+            value: 'child',
+            label: 'Child',
+            leaf: false,
+          },
+        ],
+      },
+    ]
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve) => {
+      setTimeout(() => {
+        resolve(loadedChildren)
+      }, 1000)
+    })
+    const props: CascaderProps = {
+      lazy: true,
+      lazyLoad,
+    }
+    const LazyLoadProbe = defineComponent({
+      props: {
+        node: {
+          type: Object as PropType<CascaderNode>,
+          required: true,
+        },
+      },
+      setup(props) {
+        const panel = inject(CASCADER_PANEL_INJECTION_KEY)!
+
+        if (
+          props.node.value === 'child' &&
+          !requestedNodes.has(props.node.uid)
+        ) {
+          requestedNodes.add(props.node.uid)
+          panel.lazyLoad(props.node, firstCallback)
+          panel.lazyLoad(props.node, secondCallback)
+        }
+
+        return () => props.node.label
+      },
+    })
+    const wrapper = mount(() => (
+      <CascaderPanel options={options} props={props}>
+        {({ node }: { node: CascaderNode }) => <LazyLoadProbe node={node} />}
+      </CascaderPanel>
+    ))
+
+    await wrapper.find(NODE).trigger('click')
+    await nextTick()
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+
+    await vi.runAllTimersAsync()
+    await nextTick()
+
+    expect(firstCallback).toHaveBeenCalledTimes(1)
+    expect(secondCallback).toHaveBeenCalledTimes(1)
+    expect(firstCallback).toHaveBeenCalledWith(loadedChildren)
+    expect(secondCallback).toHaveBeenCalledWith(loadedChildren)
+    vi.useRealTimers()
+  })
+
+  test('lazy load should reject when lazyLoad throws', async () => {
+    const loadError = new Error('lazy load failed')
+    let caughtError: unknown
+    const requestedNodes = new Set<number>()
+    const options: CascaderOption[] = [
+      {
+        value: 'parent',
+        label: 'Parent',
+        children: [
+          {
+            value: 'child',
+            label: 'Child',
+            leaf: false,
+          },
+        ],
+      },
+    ]
+    const props: CascaderProps = {
+      lazy: true,
+      lazyLoad: () => {
+        throw loadError
+      },
+    }
+    const LazyLoadProbe = defineComponent({
+      props: {
+        node: {
+          type: Object as PropType<CascaderNode>,
+          required: true,
+        },
+      },
+      setup(props) {
+        const panel = inject(CASCADER_PANEL_INJECTION_KEY)!
+
+        if (
+          props.node.value === 'child' &&
+          !requestedNodes.has(props.node.uid)
+        ) {
+          requestedNodes.add(props.node.uid)
+          panel.lazyLoad(props.node).catch((error: unknown) => {
+            caughtError = error
+          })
+        }
+
+        return () => props.node.label
+      },
+    })
+    const wrapper = mount(() => (
+      <CascaderPanel options={options} props={props}>
+        {({ node }: { node: CascaderNode }) => <LazyLoadProbe node={node} />}
+      </CascaderPanel>
+    ))
+
+    await wrapper.find(NODE).trigger('click')
+    await Promise.resolve()
+
+    expect(caughtError).toBe(loadError)
+  })
+
+  test('lazy parent check should be cancelled by parent uncheck', async () => {
+    vi.useFakeTimers()
+    const value = ref<CascaderValue>([])
+    const options: CascaderOption[] = [
+      {
+        value: 'parent',
+        label: 'Parent',
+        children: [
+          {
+            value: 'child',
+            label: 'Child',
+            leaf: false,
+          },
+        ],
+      },
+    ]
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve) => {
+      setTimeout(() => {
+        resolve([
+          {
+            value: 'grandchild',
+            label: 'Grandchild',
+            leaf: true,
+          },
+        ])
+      }, 1000)
+    })
+    const props: CascaderProps = {
+      multiple: true,
+      lazy: true,
+      lazyLoad,
+    }
+    const wrapper = mount(() => (
+      <CascaderPanel v-model={value.value} options={options} props={props} />
+    ))
+
+    await nextTick()
+
+    const parentInput = wrapper.find(CHECKBOX).find('input')
+    parentInput.element.checked = true
+    await parentInput.trigger('change')
+    await nextTick()
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+
+    parentInput.element.checked = false
+    await parentInput.trigger('change')
+    await nextTick()
+
+    await vi.runAllTimersAsync()
+    await nextTick()
+
+    expect(wrapper.find(CHECKBOX).classes('is-checked')).toBe(false)
+    expect(value.value).toEqual([])
+    vi.useRealTimers()
+  })
+
+  test('lazy parent check should be cancelled by descendant change', async () => {
+    vi.useFakeTimers()
+    const value = ref<CascaderValue>([])
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve) => {
+      const childrenMap: Record<string, CascaderOption[]> = {
+        root: [
+          {
+            value: 'parent',
+            label: 'Parent',
+            leaf: false,
+          },
+        ],
+        parent: [
+          {
+            value: 'child-a',
+            label: 'Child A',
+            leaf: true,
+          },
+          {
+            value: 'child-b',
+            label: 'Child B',
+            leaf: false,
+          },
+        ],
+        'child-b': [
+          {
+            value: 'grandchild',
+            label: 'Grandchild',
+            leaf: true,
+          },
+        ],
+      }
+
+      setTimeout(() => {
+        resolve(childrenMap[String(node.value ?? 'root')] ?? [])
+      }, 1000)
+    })
+    const props: CascaderProps = {
+      multiple: true,
+      lazy: true,
+      lazyLoad,
+    }
+    const wrapper = mount(() => (
+      <CascaderPanel v-model={value.value} props={props} />
+    ))
+
+    await vi.runAllTimersAsync()
+    await nextTick()
+    await wrapper.find(NODE).trigger('click')
+    await vi.runAllTimersAsync()
+    await nextTick()
+
+    const secondMenu = wrapper.findAll(MENU)[1]
+    const childAInput = secondMenu.findAll(CHECKBOX)[0].find('input')
+    childAInput.element.checked = true
+    await childAInput.trigger('change')
+    await nextTick()
+    expect(value.value).toEqual([['parent', 'child-a']])
+
+    const parentInput = wrapper.findAll(MENU)[0].find(CHECKBOX).find('input')
+    parentInput.element.checked = true
+    await parentInput.trigger('change')
+    await nextTick()
+
+    childAInput.element.checked = false
+    await childAInput.trigger('change')
+    await nextTick()
+    expect(value.value).toEqual([])
+
+    await vi.runAllTimersAsync()
+    await nextTick()
+
+    const menus = wrapper.findAll(MENU)
+    expect(lazyLoad).toHaveBeenCalledTimes(3)
+    expect(menus[0].find(CHECKBOX).classes('is-checked')).toBe(false)
+    expect(menus[0].find(CHECKBOX).classes('is-indeterminate')).toBe(false)
+    expect(menus[1].findAll(CHECKBOX)[0].classes('is-checked')).toBe(false)
+    expect(menus[1].findAll(CHECKBOX)[1].classes('is-checked')).toBe(false)
+    expect(value.value).toEqual([])
+    vi.useRealTimers()
+  })
+
+  test('lazy parent check should be cancelled by external model update', async () => {
+    vi.useFakeTimers()
+    const value = ref<CascaderValue>([['parent', 'child-a']])
+    const options: CascaderOption[] = [
+      {
+        value: 'parent',
+        label: 'Parent',
+        children: [
+          {
+            value: 'child-a',
+            label: 'Child A',
+            leaf: true,
+          },
+          {
+            value: 'child-b',
+            label: 'Child B',
+            leaf: false,
+          },
+        ],
+      },
+    ]
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve) => {
+      const childrenMap: Record<string, CascaderOption[]> = {
+        'child-b': [
+          {
+            value: 'grandchild',
+            label: 'Grandchild',
+            leaf: true,
+          },
+        ],
+      }
+
+      setTimeout(() => {
+        resolve(childrenMap[String(node.value)] ?? [])
+      }, 1000)
+    })
+    const props: CascaderProps = {
+      multiple: true,
+      lazy: true,
+      lazyLoad,
+    }
+    const wrapper = mount(() => (
+      <CascaderPanel v-model={value.value} options={options} props={props} />
+    ))
+
+    await nextTick()
+
+    let menus = wrapper.findAll(MENU)
+    expect(menus[0].find(CHECKBOX).classes('is-indeterminate')).toBe(true)
+    expect(menus[1].findAll(CHECKBOX)[0].classes('is-checked')).toBe(true)
+
+    const parentInput = menus[0].find(CHECKBOX).find('input')
+    parentInput.element.checked = true
+    await parentInput.trigger('change')
+    await nextTick()
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+
+    value.value = []
+    await nextTick()
+    await nextTick()
+    expect(value.value).toEqual([])
+
+    await vi.runAllTimersAsync()
+    await nextTick()
+
+    menus = wrapper.findAll(MENU)
+    expect(menus[0].find(CHECKBOX).classes('is-checked')).toBe(false)
+    expect(menus[0].find(CHECKBOX).classes('is-indeterminate')).toBe(false)
+    expect(menus[1].findAll(CHECKBOX)[0].classes('is-checked')).toBe(false)
+    expect(menus[1].findAll(CHECKBOX)[1].classes('is-checked')).toBe(false)
+    expect(value.value).toEqual([])
+    vi.useRealTimers()
+  })
+
+  test('lazy parent check should retry after load rejected', async () => {
+    vi.useFakeTimers()
+    const value = ref<CascaderValue>([])
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve, reject) => {
+      const { level } = node
+      setTimeout(() => {
+        const nodes = Array.from({ length: level + 1 }).map(() => ({
+          value: ++id,
+          label: `option${id}`,
+          leaf: level >= 2,
+        }))
+        if (level === 1) {
+          reject()
+          return
+        }
+        resolve(nodes)
+      }, 1000)
+    })
+    const props: CascaderProps = {
+      multiple: true,
+      lazy: true,
+      lazyLoad,
+    }
+    const wrapper = mount(() => (
+      <CascaderPanel v-model={value.value} props={props} />
+    ))
+
+    await vi.runAllTimersAsync()
+    await nextTick()
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+
+    await wrapper.find(CHECKBOX).find('input').trigger('click')
+    await vi.runAllTimersAsync()
+    await nextTick()
+
+    expect(lazyLoad).toHaveBeenCalledTimes(2)
+    expect(wrapper.find(CHECKBOX).classes('is-checked')).toBe(false)
+    expect(value.value).toEqual([])
+
+    await wrapper.find(CHECKBOX).find('input').trigger('click')
+    await vi.runAllTimersAsync()
+    await nextTick()
+
+    expect(lazyLoad).toHaveBeenCalledTimes(3)
+    expect(wrapper.find(CHECKBOX).classes('is-checked')).toBe(false)
+    expect(value.value).toEqual([])
     vi.useRealTimers()
   })
 

--- a/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
+++ b/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, inject, nextTick, ref } from 'vue'
+import { defineComponent, inject, nextTick, ref, toRaw } from 'vue'
 import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { cloneDeep } from 'lodash-unified'
@@ -14,6 +14,7 @@ import type {
   CascaderOption,
   CascaderProps,
   CascaderValue,
+  ElCascaderPanelContext,
   LazyLoad,
 } from '../src/types'
 
@@ -112,6 +113,7 @@ const MENU = '.el-cascader-menu'
 const NODE = '.el-cascader-node'
 const VALID_NODE = '.el-cascader-node:not(.is-disabled)'
 const EXPAND_ARROW = '.arrow-right.el-cascader-node__postfix'
+const LOADING_ICON = '.is-loading.el-cascader-node__postfix'
 const CHECKBOX = '.el-checkbox__input'
 const RADIO = '.el-radio__input'
 
@@ -827,10 +829,22 @@ describe('CascaderPanel.vue', () => {
     await nextTick()
 
     await firstMenu.find(CHECKBOX).find('input').trigger('click')
+    await nextTick()
+
+    let secondMenu = wrapper.findAll(MENU)[1]
+    expect(lazyLoad).toHaveBeenCalledTimes(3)
+    expect(firstMenu.find(NODE).find(LOADING_ICON).exists()).toBe(true)
+    expect(firstMenu.find(CHECKBOX).classes('is-checked')).toBe(false)
+    expect(firstMenu.find(CHECKBOX).classes('is-indeterminate')).toBe(true)
+    expect(firstMenu.find(CHECKBOX).find('input').element.disabled).toBe(true)
+    expect(secondMenu.findAll(CHECKBOX)[0].classes('is-checked')).toBe(false)
+    expect(secondMenu.findAll(CHECKBOX)[1].classes('is-checked')).toBe(true)
+    expect(value.value).toEqual([['parent', 'sibling']])
+
     await vi.runAllTimersAsync()
     await nextTick()
 
-    const secondMenu = wrapper.findAll(MENU)[1]
+    secondMenu = wrapper.findAll(MENU)[1]
     expect(secondMenu.exists()).toBe(true)
     expect(lazyLoad).toHaveBeenCalledTimes(3)
     expect(firstMenu.find(CHECKBOX).classes('is-checked')).toBe(true)
@@ -855,7 +869,7 @@ describe('CascaderPanel.vue', () => {
     vi.useRealTimers()
   })
 
-  test('lazy parent check should wait for in-flight descendant load', async () => {
+  test('lazy parent check should be ignored while descendant is loading', async () => {
     vi.useFakeTimers()
     const value = ref<CascaderValue>([])
     const options: CascaderOption[] = [
@@ -905,7 +919,11 @@ describe('CascaderPanel.vue', () => {
     await nextTick()
     expect(lazyLoad).toHaveBeenCalledTimes(1)
 
-    const parentInput = wrapper.findAll(MENU)[0].find(CHECKBOX).find('input')
+    let parentNode = wrapper.findAll(MENU)[0].find(NODE)
+    let parentCheckbox = wrapper.findAll(MENU)[0].find(CHECKBOX)
+    let parentInput = parentCheckbox.find('input')
+    expect(parentNode.find(LOADING_ICON).exists()).toBe(true)
+    expect(parentInput.element.disabled).toBe(true)
     parentInput.element.checked = true
     await parentInput.trigger('change')
     await nextTick()
@@ -914,7 +932,20 @@ describe('CascaderPanel.vue', () => {
     await vi.runAllTimersAsync()
     await nextTick()
 
+    parentNode = wrapper.findAll(MENU)[0].find(NODE)
+    parentCheckbox = wrapper.findAll(MENU)[0].find(CHECKBOX)
+    parentInput = parentCheckbox.find('input')
     expect(lazyLoad).toHaveBeenCalledTimes(1)
+    expect(parentNode.find(LOADING_ICON).exists()).toBe(false)
+    expect(parentInput.element.disabled).toBe(false)
+    expect(parentCheckbox.classes('is-checked')).toBe(false)
+    expect(value.value).toEqual([])
+
+    parentInput.element.checked = true
+    await parentInput.trigger('change')
+    await nextTick()
+
+    expect(parentCheckbox.classes('is-checked')).toBe(true)
     expect(value.value).toEqual([
       ['parent', 'child-a'],
       ['parent', 'child-b', 'grandchild'],
@@ -922,7 +953,7 @@ describe('CascaderPanel.vue', () => {
     vi.useRealTimers()
   })
 
-  test('lazy load should reuse pending request for raw and reactive nodes', async () => {
+  test('lazy parent check should be ignored while model sync loads descendant', async () => {
     vi.useFakeTimers()
     const value = ref<CascaderValue>([])
     const options: CascaderOption[] = [
@@ -961,9 +992,11 @@ describe('CascaderPanel.vue', () => {
     await nextTick()
     value.value = [['parent', 'child']]
     await nextTick()
+    await nextTick()
     expect(lazyLoad).toHaveBeenCalledTimes(1)
 
     const parentInput = wrapper.findAll(MENU)[0].find(CHECKBOX).find('input')
+    expect(parentInput.element.disabled).toBe(true)
     parentInput.element.checked = true
     await parentInput.trigger('change')
     await nextTick()
@@ -973,6 +1006,74 @@ describe('CascaderPanel.vue', () => {
     await nextTick()
 
     expect(lazyLoad).toHaveBeenCalledTimes(1)
+    expect(value.value).toEqual([['parent', 'child']])
+    expect(wrapper.findAll(MENU)[0].find(CHECKBOX).classes('is-checked')).toBe(
+      false
+    )
+    vi.useRealTimers()
+  })
+
+  test('lazy model sync should wait for pending descendant load', async () => {
+    vi.useFakeTimers()
+    const value = ref<CascaderValue>([])
+    const options: CascaderOption[] = [
+      {
+        value: 'parent',
+        label: 'Parent',
+        children: [
+          {
+            value: 'child',
+            label: 'Child',
+            leaf: false,
+          },
+        ],
+      },
+    ]
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve) => {
+      setTimeout(() => {
+        resolve([
+          {
+            value: 'grandchild',
+            label: 'Grandchild',
+            leaf: true,
+          },
+        ])
+      }, 1000)
+    })
+    const props: CascaderProps = {
+      multiple: true,
+      lazy: true,
+      lazyLoad,
+    }
+    const wrapper = mount(() => (
+      <CascaderPanel v-model={value.value} options={options} props={props} />
+    ))
+
+    await nextTick()
+    await wrapper.find(NODE).trigger('click')
+    await nextTick()
+
+    await wrapper.findAll(MENU)[1].find(NODE).trigger('click')
+    await nextTick()
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+
+    value.value = [['parent', 'child', 'grandchild']]
+    await nextTick()
+    await nextTick()
+
+    const parentNode = wrapper.findAll(MENU)[0].find(NODE)
+    const parentInput = parentNode.find(CHECKBOX).find('input')
+    expect(parentNode.find(LOADING_ICON).exists()).toBe(true)
+    expect(parentInput.element.disabled).toBe(true)
+
+    await vi.runAllTimersAsync()
+    await nextTick()
+
+    const menus = wrapper.findAll(MENU)
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+    expect(menus[0].find(CHECKBOX).classes('is-checked')).toBe(true)
+    expect(menus[1].find(CHECKBOX).classes('is-checked')).toBe(true)
+    expect(menus[2].find(CHECKBOX).classes('is-checked')).toBe(true)
     expect(value.value).toEqual([['parent', 'child', 'grandchild']])
     vi.useRealTimers()
   })
@@ -1026,7 +1127,7 @@ describe('CascaderPanel.vue', () => {
           !requestedNodes.has(props.node.uid)
         ) {
           requestedNodes.add(props.node.uid)
-          panel.lazyLoad(props.node, firstCallback)
+          panel.lazyLoad(toRaw(props.node), firstCallback)
           panel.lazyLoad(props.node, secondCallback)
         }
 
@@ -1053,9 +1154,10 @@ describe('CascaderPanel.vue', () => {
     vi.useRealTimers()
   })
 
-  test('lazy load should reject when lazyLoad throws', async () => {
+  test('lazy load should resolve false when lazyLoad throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const loadError = new Error('lazy load failed')
-    let caughtError: unknown
+    let loaded: boolean | undefined
     const requestedNodes = new Set<number>()
     const options: CascaderOption[] = [
       {
@@ -1091,8 +1193,8 @@ describe('CascaderPanel.vue', () => {
           !requestedNodes.has(props.node.uid)
         ) {
           requestedNodes.add(props.node.uid)
-          panel.lazyLoad(props.node).catch((error: unknown) => {
-            caughtError = error
+          panel.lazyLoad(props.node).then((isLoaded) => {
+            loaded = isLoaded
           })
         }
 
@@ -1106,12 +1208,90 @@ describe('CascaderPanel.vue', () => {
     ))
 
     await wrapper.find(NODE).trigger('click')
-    await Promise.resolve()
+    await flushPromises()
 
-    expect(caughtError).toBe(loadError)
+    expect(loaded).toBe(false)
+    expect(warn).toHaveBeenCalledWith(loadError)
+    warn.mockRestore()
   })
 
-  test('lazy parent check should be cancelled by parent uncheck', async () => {
+  test('lazy load should clear pending request when callback throws', async () => {
+    const callbackError = new Error('callback failed')
+    let panel: ElCascaderPanelContext | undefined
+    let childNode: CascaderNode | undefined
+    let resolveLazyLoad!: (dataList?: CascaderOption[]) => void
+    const options: CascaderOption[] = [
+      {
+        value: 'parent',
+        label: 'Parent',
+        children: [
+          {
+            value: 'child',
+            label: 'Child',
+            leaf: false,
+          },
+        ],
+      },
+    ]
+    const loadedChildren: CascaderOption[] = [
+      {
+        value: 'grandchild',
+        label: 'Grandchild',
+        leaf: true,
+      },
+    ]
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve) => {
+      resolveLazyLoad = resolve
+    })
+    const props: CascaderProps = {
+      lazy: true,
+      lazyLoad,
+    }
+    const LazyLoadProbe = defineComponent({
+      props: {
+        node: {
+          type: Object as PropType<CascaderNode>,
+          required: true,
+        },
+      },
+      setup(props) {
+        panel = inject(CASCADER_PANEL_INJECTION_KEY)!
+        if (props.node.value === 'child') {
+          childNode = props.node
+        }
+
+        return () => props.node.label
+      },
+    })
+    const wrapper = mount(() => (
+      <CascaderPanel options={options} props={props}>
+        {({ node }: { node: CascaderNode }) => <LazyLoadProbe node={node} />}
+      </CascaderPanel>
+    ))
+
+    await wrapper.find(NODE).trigger('click')
+    await nextTick()
+
+    if (!panel || !childNode) {
+      throw new Error('Expected child node to be rendered')
+    }
+
+    const firstPromise = panel.lazyLoad(childNode, () => {
+      throw callbackError
+    })
+
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+    expect(() => resolveLazyLoad(loadedChildren)).toThrow(callbackError)
+    await expect(firstPromise).resolves.toBe(true)
+
+    const secondPromise = panel.lazyLoad(childNode)
+
+    expect(lazyLoad).toHaveBeenCalledTimes(2)
+    resolveLazyLoad()
+    await expect(secondPromise).resolves.toBe(true)
+  })
+
+  test('lazy parent uncheck should be ignored while descendants are loading', async () => {
     vi.useFakeTimers()
     const value = ref<CascaderValue>([])
     const options: CascaderOption[] = [
@@ -1154,6 +1334,7 @@ describe('CascaderPanel.vue', () => {
     await parentInput.trigger('change')
     await nextTick()
     expect(lazyLoad).toHaveBeenCalledTimes(1)
+    expect(parentInput.element.disabled).toBe(true)
 
     parentInput.element.checked = false
     await parentInput.trigger('change')
@@ -1162,12 +1343,12 @@ describe('CascaderPanel.vue', () => {
     await vi.runAllTimersAsync()
     await nextTick()
 
-    expect(wrapper.find(CHECKBOX).classes('is-checked')).toBe(false)
-    expect(value.value).toEqual([])
+    expect(wrapper.find(CHECKBOX).classes('is-checked')).toBe(true)
+    expect(value.value).toEqual([['parent', 'child', 'grandchild']])
     vi.useRealTimers()
   })
 
-  test('lazy parent check should be cancelled by descendant change', async () => {
+  test('lazy parent check should preserve loaded descendant changes', async () => {
     vi.useFakeTimers()
     const value = ref<CascaderValue>([])
     const lazyLoad = vi.fn<LazyLoad>((node, resolve) => {
@@ -1242,11 +1423,151 @@ describe('CascaderPanel.vue', () => {
     const menus = wrapper.findAll(MENU)
     expect(lazyLoad).toHaveBeenCalledTimes(3)
     expect(menus[0].find(CHECKBOX).classes('is-checked')).toBe(false)
-    expect(menus[0].find(CHECKBOX).classes('is-indeterminate')).toBe(false)
+    expect(menus[0].find(CHECKBOX).classes('is-indeterminate')).toBe(true)
     expect(menus[1].findAll(CHECKBOX)[0].classes('is-checked')).toBe(false)
-    expect(menus[1].findAll(CHECKBOX)[1].classes('is-checked')).toBe(false)
-    expect(value.value).toEqual([])
+    expect(menus[1].findAll(CHECKBOX)[1].classes('is-checked')).toBe(true)
+    expect(value.value).toEqual([['parent', 'child-b', 'grandchild']])
     vi.useRealTimers()
+  })
+
+  test('lazy parent check should preserve successful descendants when sibling load fails', async () => {
+    vi.useFakeTimers()
+    const value = ref<CascaderValue>([])
+    const options: CascaderOption[] = [
+      {
+        value: 'parent',
+        label: 'Parent',
+        children: [
+          {
+            value: 'loaded-leaf',
+            label: 'Loaded leaf',
+            leaf: true,
+          },
+          {
+            value: 'success-child',
+            label: 'Success child',
+            leaf: false,
+          },
+          {
+            value: 'failing-child',
+            label: 'Failing child',
+            leaf: false,
+          },
+        ],
+      },
+    ]
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve, reject) => {
+      setTimeout(() => {
+        if (node.value === 'failing-child') {
+          reject()
+          return
+        }
+
+        resolve([
+          {
+            value: 'success-grandchild',
+            label: 'Success grandchild',
+            leaf: true,
+          },
+        ])
+      }, 1000)
+    })
+    const props: CascaderProps = {
+      multiple: true,
+      lazy: true,
+      lazyLoad,
+    }
+    const wrapper = mount(() => (
+      <CascaderPanel v-model={value.value} options={options} props={props} />
+    ))
+
+    await nextTick()
+    await wrapper.find(NODE).trigger('click')
+    await nextTick()
+
+    const parentInput = wrapper.findAll(MENU)[0].find(CHECKBOX).find('input')
+    parentInput.element.checked = true
+    await parentInput.trigger('change')
+    await vi.runAllTimersAsync()
+    await nextTick()
+
+    const menus = wrapper.findAll(MENU)
+    expect(lazyLoad).toHaveBeenCalledTimes(2)
+    expect(menus[0].find(CHECKBOX).classes('is-checked')).toBe(false)
+    expect(menus[0].find(CHECKBOX).classes('is-indeterminate')).toBe(true)
+    expect(menus[1].findAll(CHECKBOX)[0].classes('is-checked')).toBe(true)
+    expect(menus[1].findAll(CHECKBOX)[1].classes('is-checked')).toBe(true)
+    expect(menus[1].findAll(CHECKBOX)[2].classes('is-checked')).toBe(false)
+    expect(value.value).toEqual([
+      ['parent', 'loaded-leaf'],
+      ['parent', 'success-child', 'success-grandchild'],
+    ])
+    vi.useRealTimers()
+  })
+
+  test('lazy parent check should handle thrown lazy load error', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const loadError = new Error('lazy load failed')
+    const value = ref<CascaderValue>([])
+    const options: CascaderOption[] = [
+      {
+        value: 'parent',
+        label: 'Parent',
+        children: [
+          {
+            value: 'loaded-leaf',
+            label: 'Loaded leaf',
+            leaf: true,
+          },
+          {
+            value: 'failing-child',
+            label: 'Failing child',
+            leaf: false,
+          },
+        ],
+      },
+    ]
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve) => {
+      if (node.value === 'failing-child') {
+        throw loadError
+      }
+
+      resolve([
+        {
+          value: 'grandchild',
+          label: 'Grandchild',
+          leaf: true,
+        },
+      ])
+    })
+    const props: CascaderProps = {
+      multiple: true,
+      lazy: true,
+      lazyLoad,
+    }
+    const wrapper = mount(() => (
+      <CascaderPanel v-model={value.value} options={options} props={props} />
+    ))
+
+    await nextTick()
+    await wrapper.find(NODE).trigger('click')
+    await nextTick()
+
+    const parentInput = wrapper.findAll(MENU)[0].find(CHECKBOX).find('input')
+    parentInput.element.checked = true
+    await parentInput.trigger('change')
+    await flushPromises()
+    await nextTick()
+
+    const menus = wrapper.findAll(MENU)
+    expect(lazyLoad).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(loadError)
+    expect(menus[0].find(CHECKBOX).classes('is-checked')).toBe(false)
+    expect(menus[0].find(CHECKBOX).classes('is-indeterminate')).toBe(true)
+    expect(menus[1].findAll(CHECKBOX)[0].classes('is-checked')).toBe(true)
+    expect(menus[1].findAll(CHECKBOX)[1].classes('is-checked')).toBe(false)
+    expect(value.value).toEqual([['parent', 'loaded-leaf']])
+    warn.mockRestore()
   })
 
   test('lazy parent check should be cancelled by external model update', async () => {

--- a/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
+++ b/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
@@ -1,6 +1,7 @@
 import { defineComponent, inject, nextTick, ref } from 'vue'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { cloneDeep } from 'lodash-unified'
 import { EVENT_CODE } from '@element-plus/constants'
 import { Check, Loading } from '@element-plus/icons-vue'
 import CascaderPanel from '../src/index.vue'
@@ -1320,6 +1321,97 @@ describe('CascaderPanel.vue', () => {
     expect(menus[1].findAll(CHECKBOX)[1].classes('is-checked')).toBe(false)
     expect(value.value).toEqual([])
     vi.useRealTimers()
+  })
+
+  test('delayed model echo should cancel older pending lazy checks', async () => {
+    const value = ref<CascaderValue>([])
+    const pendingValue = ref<CascaderValue>([])
+    const resolvers = new Map<string, (dataList?: CascaderOption[]) => void>()
+    const lazyLoad = vi.fn<LazyLoad>((node, resolve) => {
+      resolvers.set(String(node.value), resolve)
+    })
+    const handleUpdateModelValue = vi.fn((modelValue: CascaderValue) => {
+      pendingValue.value = cloneDeep(modelValue)
+    })
+    const props: CascaderProps = {
+      multiple: true,
+      lazy: true,
+      lazyLoad,
+    }
+    const options: CascaderOption[] = [
+      {
+        value: 'parent-a',
+        label: 'Parent A',
+        leaf: false,
+      },
+      {
+        value: 'parent-b',
+        label: 'Parent B',
+        leaf: false,
+      },
+    ]
+    const applyPendingModelValue = () => {
+      value.value = cloneDeep(pendingValue.value)
+    }
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          return () => (
+            <CascaderPanel
+              modelValue={value.value}
+              options={options}
+              props={props}
+              {...{
+                'onUpdate:modelValue': handleUpdateModelValue,
+              }}
+            />
+          )
+        },
+      })
+    )
+
+    const [firstCheckbox, secondCheckbox] = wrapper.findAll(CHECKBOX)
+    await firstCheckbox.find('input').trigger('click')
+    await secondCheckbox.find('input').trigger('click')
+
+    expect(lazyLoad).toHaveBeenCalledTimes(2)
+
+    resolvers.get('parent-a')?.([
+      {
+        value: 'child-a',
+        label: 'Child A',
+        leaf: true,
+      },
+    ])
+    await flushPromises()
+    await nextTick()
+    await nextTick()
+
+    expect(handleUpdateModelValue).toHaveBeenCalledTimes(1)
+    expect(pendingValue.value).toEqual([['parent-a', 'child-a']])
+
+    await nextTick()
+    applyPendingModelValue()
+    await flushPromises()
+    await nextTick()
+    await nextTick()
+
+    resolvers.get('parent-b')?.([
+      {
+        value: 'child-b',
+        label: 'Child B',
+        leaf: true,
+      },
+    ])
+    await flushPromises()
+    await nextTick()
+    await nextTick()
+
+    const checkboxes = wrapper.findAll(CHECKBOX)
+    expect(handleUpdateModelValue).toHaveBeenCalledTimes(1)
+    expect(value.value).toEqual([['parent-a', 'child-a']])
+    expect(checkboxes[0].classes('is-checked')).toBe(true)
+    expect(checkboxes[1].classes('is-checked')).toBe(false)
   })
 
   test('lazy parent check should retry after load rejected', async () => {

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -36,6 +36,7 @@ import {
 import { cloneDeep, flattenDeep, isEqual } from 'lodash-unified'
 import {
   castArray,
+  debugWarn,
   focusNode,
   getEventCode,
   getSibling,
@@ -53,7 +54,7 @@ import { useNamespace } from '@element-plus/hooks'
 import ElCascaderMenu from './menu.vue'
 import Store from './store'
 import Node from './node'
-import { createLazyCheck } from './lazy-check'
+import { createLazyCheck, hasLoadingDescendant } from './lazy-check'
 import {
   CASCADER_PANEL_HEIGHT,
   CASCADER_PANEL_ITEM_SIZE,
@@ -113,6 +114,7 @@ const checkedValue = ref<CascaderValue>()
 const menus = ref<CascaderNode[][]>([])
 const expandingNode = ref<CascaderNode>()
 const checkedNodes = ref<CascaderNode[]>([])
+const lazyLoadStateVersion = ref(0)
 
 const isHoverMenu = computed(() => config.value.expandTrigger === 'hover')
 const renderLabelFn = computed(() => props.renderLabel || slots.default)
@@ -124,6 +126,13 @@ const lazyCheck = createLazyCheck({
   loadNode: (node) => lazyLoad(node),
   handleCheckChange: (...args) => handleCheckChange(...args),
 })
+
+const hasLoadingNode: ElCascaderPanelContext['hasLoadingNode'] = (node) => {
+  const isLazyLoadStateVersionValid = lazyLoadStateVersion.value >= 0
+  return (
+    isLazyLoadStateVersionValid && (node.loading || hasLoadingDescendant(node))
+  )
+}
 
 const resetExpectedModelValueEcho = () => {
   shouldSkipNextModelValueInvalidate = false
@@ -179,12 +188,12 @@ const lazyLoad: ElCascaderPanelContext['lazyLoad'] = (node, cb) => {
   }
 
   _node.loading = true
+  lazyLoadStateVersion.value += 1
 
   let resolveLoad!: (loaded: boolean) => void
-  let rejectLoad!: (reason: unknown) => void
-  const promise = new Promise<boolean>((resolve, reject) => {
+  let finished = false
+  const promise = new Promise<boolean>((resolve) => {
     resolveLoad = resolve
-    rejectLoad = reject
   })
   const request: LazyLoadRequest = {
     promise,
@@ -202,6 +211,9 @@ const lazyLoad: ElCascaderPanelContext['lazyLoad'] = (node, cb) => {
   }
 
   const finish = (loaded: boolean) => {
+    if (finished) return
+    finished = true
+    lazyLoadStateVersion.value += 1
     clearRequest()
     resolveLoad(loaded)
   }
@@ -211,14 +223,17 @@ const lazyLoad: ElCascaderPanelContext['lazyLoad'] = (node, cb) => {
     _node.loading = false
     _node.loaded = true
     _node.childrenData = _node.childrenData || []
-    if (dataList) {
-      store?.appendNodes(dataList, parent as Node)
-      request.callbacks.forEach((callback) => callback(dataList))
+    try {
+      if (dataList) {
+        store?.appendNodes(dataList, parent as Node)
+        request.callbacks.forEach((callback) => callback(dataList))
+      }
+    } finally {
+      if (_node.level === 0) {
+        initialLoadedOnce.value = true
+      }
+      finish(true)
     }
-    if (_node.level === 0) {
-      initialLoadedOnce.value = true
-    }
-    finish(true)
   }
 
   const reject = () => {
@@ -233,13 +248,17 @@ const lazyLoad: ElCascaderPanelContext['lazyLoad'] = (node, cb) => {
   try {
     cfg.lazyLoad(_node, resolve, reject)
   } catch (error) {
+    if (finished) {
+      throw error
+    }
+
     _node.loading = false
     _node.loaded = false
     if (_node.level === 0) {
       initialLoaded.value = true
     }
-    clearRequest()
-    rejectLoad(error)
+    debugWarn(error instanceof Error ? error : new Error(String(error)))
+    finish(false)
   }
 
   return promise
@@ -332,7 +351,7 @@ const syncCheckedValue = (loaded = false, forced = false) => {
     )
     const nodes = values
       .map((val) => store?.getNodeByValue(val))
-      .filter((node) => !!node && !node.loaded && !node.loading) as Node[]
+      .filter((node) => !!node && !node.loaded) as Node[]
 
     if (nodes.length) {
       nodes.forEach((node) => {
@@ -488,6 +507,7 @@ provide(
     virtualScroll,
     itemSize,
     height,
+    hasLoadingNode,
     lazyLoad,
     expandNode,
     handleCheckChange,

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -29,6 +29,7 @@ import {
   provide,
   reactive,
   ref,
+  toRaw,
   useSlots,
   watch,
 } from 'vue'
@@ -52,6 +53,7 @@ import { useNamespace } from '@element-plus/hooks'
 import ElCascaderMenu from './menu.vue'
 import Store from './store'
 import Node from './node'
+import { createLazyCheck } from './lazy-check'
 import {
   CASCADER_PANEL_HEIGHT,
   CASCADER_PANEL_ITEM_SIZE,
@@ -87,6 +89,15 @@ const emit = defineEmits(cascaderPanelEmits)
 // for interrupt sync check status in lazy mode
 let manualChecked = false
 
+type LazyLoadCallback = (dataList: CascaderOption[]) => void
+
+interface LazyLoadRequest {
+  promise: Promise<boolean>
+  callbacks: LazyLoadCallback[]
+}
+
+const lazyLoadRequests = new WeakMap<Node, LazyLoadRequest>()
+
 const ns = useNamespace('cascader')
 const config = useCascaderConfig(props)
 const slots = useSlots()
@@ -106,10 +117,16 @@ const virtualScroll = computed(() => props.virtualScroll)
 const itemSize = computed(() => props.itemSize)
 const height = computed(() => props.height)
 
+const lazyCheck = createLazyCheck({
+  loadNode: (node) => lazyLoad(node),
+  handleCheckChange: (...args) => handleCheckChange(...args),
+})
+
 const initStore = () => {
   const { options } = props
   const cfg = config.value
 
+  lazyCheck.invalidateAll()
   manualChecked = false
   store = new Store(options, cfg)
   menus.value = [store.getNodes()]
@@ -131,31 +148,80 @@ const initStore = () => {
 
 const lazyLoad: ElCascaderPanelContext['lazyLoad'] = (node, cb) => {
   const cfg = config.value
-  node! = node || new Node({}, cfg, undefined, true)
-  node.loading = true
+  const _node = (node || new Node({}, cfg, undefined, true)) as Node
+  const lazyLoadKey = node ? toRaw(_node) : undefined
+  const pending = lazyLoadKey ? lazyLoadRequests.get(lazyLoadKey) : undefined
+
+  if (pending) {
+    cb && pending.callbacks.push(cb)
+    return pending.promise
+  }
+
+  _node.loading = true
+
+  let resolveLoad!: (loaded: boolean) => void
+  let rejectLoad!: (reason: unknown) => void
+  const promise = new Promise<boolean>((resolve, reject) => {
+    resolveLoad = resolve
+    rejectLoad = reject
+  })
+  const request: LazyLoadRequest = {
+    promise,
+    callbacks: cb ? [cb] : [],
+  }
+
+  if (lazyLoadKey) {
+    lazyLoadRequests.set(lazyLoadKey, request)
+  }
+
+  const clearRequest = () => {
+    if (lazyLoadKey && lazyLoadRequests.get(lazyLoadKey) === request) {
+      lazyLoadRequests.delete(lazyLoadKey)
+    }
+  }
+
+  const finish = (loaded: boolean) => {
+    clearRequest()
+    resolveLoad(loaded)
+  }
 
   const resolve = (dataList?: CascaderOption[]) => {
-    const _node = node as Node
     const parent = _node.root ? null : _node
     _node.loading = false
     _node.loaded = true
     _node.childrenData = _node.childrenData || []
-    dataList && store?.appendNodes(dataList, parent as Node)
-    dataList && cb?.(dataList)
-    if (node.level === 0) {
+    if (dataList) {
+      store?.appendNodes(dataList, parent as Node)
+      request.callbacks.forEach((callback) => callback(dataList))
+    }
+    if (_node.level === 0) {
       initialLoadedOnce.value = true
     }
+    finish(true)
   }
 
   const reject = () => {
-    node!.loading = false
-    node!.loaded = false
-    if (node!.level === 0) {
+    _node.loading = false
+    _node.loaded = false
+    if (_node.level === 0) {
       initialLoaded.value = true
     }
+    finish(false)
   }
 
-  cfg.lazyLoad(node, resolve, reject)
+  try {
+    cfg.lazyLoad(_node, resolve, reject)
+  } catch (error) {
+    _node.loading = false
+    _node.loaded = false
+    if (_node.level === 0) {
+      initialLoaded.value = true
+    }
+    clearRequest()
+    rejectLoad(error)
+  }
+
+  return promise
 }
 
 const expandNode: ElCascaderPanelContext['expandNode'] = (node, silent) => {
@@ -185,6 +251,7 @@ const handleCheckChange: ElCascaderPanelContext['handleCheckChange'] = (
   const { checkStrictly, multiple } = config.value
   const oldNode = checkedNodes.value[0]
   manualChecked = true
+  lazyCheck.invalidateBranch(node)
 
   !multiple && oldNode?.doCheck(false)
   node.doCheck(checked)
@@ -207,6 +274,7 @@ const getCheckedNodes = (leafOnly: boolean) => {
 }
 
 const clearCheckedNodes = () => {
+  lazyCheck.invalidateAll()
   checkedNodes.value.forEach((node) => node.doCheck(false))
   calculateCheckedValue()
   menus.value = menus.value.slice(0, 1)
@@ -402,6 +470,8 @@ provide(
     lazyLoad,
     expandNode,
     handleCheckChange,
+    handleLazyCheckChange: lazyCheck.handleLazyCheckChange,
+    isLazyCheckPending: lazyCheck.isPending,
   })
 )
 
@@ -422,7 +492,10 @@ watch(() => props.options, initStore, {
 
 watch(
   () => props.modelValue,
-  () => {
+  (modelValue) => {
+    if (!manualChecked || !isEqual(modelValue, checkedValue.value)) {
+      lazyCheck.invalidateAll()
+    }
     manualChecked = false
     syncCheckedValue()
   },

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -88,6 +88,9 @@ const emit = defineEmits(cascaderPanelEmits)
 
 // for interrupt sync check status in lazy mode
 let manualChecked = false
+let shouldSkipNextModelValueInvalidate = false
+let expectedModelValueEcho: CascaderValue
+let expectedModelValueEchoToken = 0
 
 type LazyLoadCallback = (dataList: CascaderOption[]) => void
 
@@ -122,12 +125,30 @@ const lazyCheck = createLazyCheck({
   handleCheckChange: (...args) => handleCheckChange(...args),
 })
 
+const resetExpectedModelValueEcho = () => {
+  shouldSkipNextModelValueInvalidate = false
+  expectedModelValueEcho = undefined
+}
+
+const markExpectedModelValueEcho = (value: CascaderValue) => {
+  const token = ++expectedModelValueEchoToken
+  shouldSkipNextModelValueInvalidate = true
+  expectedModelValueEcho = cloneDeep(value ?? undefined)
+
+  nextTick(() => {
+    if (expectedModelValueEchoToken === token) {
+      resetExpectedModelValueEcho()
+    }
+  })
+}
+
 const initStore = () => {
   const { options } = props
   const cfg = config.value
 
   lazyCheck.invalidateAll()
   manualChecked = false
+  resetExpectedModelValueEcho()
   store = new Store(options, cfg)
   menus.value = [store.getNodes()]
 
@@ -493,9 +514,15 @@ watch(() => props.options, initStore, {
 watch(
   () => props.modelValue,
   (modelValue) => {
-    if (!manualChecked || !isEqual(modelValue, checkedValue.value)) {
+    const isExpectedModelValueEcho =
+      shouldSkipNextModelValueInvalidate &&
+      isEqual(modelValue, expectedModelValueEcho)
+
+    if (!isExpectedModelValueEcho) {
       lazyCheck.invalidateAll()
     }
+
+    resetExpectedModelValueEcho()
     manualChecked = false
     syncCheckedValue()
   },
@@ -508,6 +535,7 @@ watch(
   () => checkedValue.value,
   (val) => {
     if (!isEqual(val, props.modelValue)) {
+      markExpectedModelValueEcho(val)
       emit(UPDATE_MODEL_EVENT, val)
       emit(CHANGE_EVENT, val)
     }

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -89,7 +89,7 @@ const emit = defineEmits(cascaderPanelEmits)
 // for interrupt sync check status in lazy mode
 let manualChecked = false
 let shouldSkipNextModelValueInvalidate = false
-let expectedModelValueEcho: CascaderValue
+let expectedModelValueEcho: CascaderValue | undefined
 let expectedModelValueEchoToken = 0
 
 type LazyLoadCallback = (dataList: CascaderOption[]) => void
@@ -130,7 +130,7 @@ const resetExpectedModelValueEcho = () => {
   expectedModelValueEcho = undefined
 }
 
-const markExpectedModelValueEcho = (value: CascaderValue) => {
+const markExpectedModelValueEcho = (value: CascaderValue | undefined) => {
   const token = ++expectedModelValueEchoToken
   shouldSkipNextModelValueInvalidate = true
   expectedModelValueEcho = cloneDeep(value ?? undefined)

--- a/packages/components/cascader-panel/src/lazy-check.ts
+++ b/packages/components/cascader-panel/src/lazy-check.ts
@@ -1,0 +1,153 @@
+import type Node from './node'
+import type { CascaderNode, ElCascaderPanelContext } from './types'
+
+type LoadNode = (node: Node) => Promise<boolean>
+type HandleCheckChange = ElCascaderPanelContext['handleCheckChange']
+
+interface LazyCheckTask {
+  order: number
+  version: number
+}
+
+interface LazyCheckOptions {
+  loadNode: LoadNode
+  handleCheckChange: HandleCheckChange
+}
+
+const isSameBranch = (node: Node, target: Node) =>
+  node === target ||
+  node.pathNodes.includes(target) ||
+  target.pathNodes.includes(node)
+
+export const createLazyCheck = ({
+  loadNode,
+  handleCheckChange,
+}: LazyCheckOptions) => {
+  let checkVersion = 0
+  let checkOrder = 0
+  let currentCommitOrder: number | undefined
+  const nodeVersionMap = new Map<Node, number>()
+  const activeNodeVersionMap = new Map<Node, number>()
+  const activeNodeOrderMap = new Map<Node, number>()
+
+  const invalidateAll = () => {
+    checkVersion += 1
+    nodeVersionMap.clear()
+    activeNodeVersionMap.clear()
+    activeNodeOrderMap.clear()
+  }
+
+  const invalidateBranchBefore = (
+    node: CascaderNode,
+    preserveOrder: number
+  ) => {
+    const target = node as Node
+
+    activeNodeOrderMap.forEach((order, lazyCheckNode) => {
+      if (order < preserveOrder && isSameBranch(lazyCheckNode, target)) {
+        const version = nodeVersionMap.get(lazyCheckNode) ?? 0
+        nodeVersionMap.set(lazyCheckNode, version + 1)
+        activeNodeVersionMap.delete(lazyCheckNode)
+        activeNodeOrderMap.delete(lazyCheckNode)
+      }
+    })
+  }
+
+  const invalidateBranch = (node: CascaderNode) => {
+    invalidateBranchBefore(node, currentCommitOrder ?? Number.POSITIVE_INFINITY)
+  }
+
+  const createTask = (node: Node, active: boolean): LazyCheckTask => {
+    const version = (nodeVersionMap.get(node) ?? 0) + 1
+    const order = ++checkOrder
+    nodeVersionMap.set(node, version)
+
+    if (active) {
+      activeNodeVersionMap.set(node, version)
+      activeNodeOrderMap.set(node, order)
+    } else {
+      activeNodeVersionMap.delete(node)
+      activeNodeOrderMap.delete(node)
+    }
+
+    invalidateBranchBefore(node, order)
+
+    return {
+      order,
+      version,
+    }
+  }
+
+  const finishTask = (node: Node, task: LazyCheckTask) => {
+    if (activeNodeVersionMap.get(node) === task.version) {
+      activeNodeVersionMap.delete(node)
+      activeNodeOrderMap.delete(node)
+    }
+  }
+
+  const commitTask = (task: LazyCheckTask, commit: () => void) => {
+    const previousCommitOrder = currentCommitOrder
+    currentCommitOrder = task.order
+    try {
+      commit()
+    } finally {
+      currentCommitOrder = previousCommitOrder
+    }
+  }
+
+  const isTaskStale = (
+    node: Node,
+    currentCheckVersion: number,
+    task: LazyCheckTask
+  ) =>
+    currentCheckVersion !== checkVersion ||
+    task.version !== nodeVersionMap.get(node)
+
+  const loadDescendants = async (node: Node): Promise<boolean> => {
+    if (node.isDisabled || node.isLeaf) return true
+
+    if (!node.loaded) {
+      if (!(await loadNode(node))) return false
+    }
+
+    const results = await Promise.all(node.children.map(loadDescendants))
+    return results.every(Boolean)
+  }
+
+  const handleLazyCheckChange: ElCascaderPanelContext['handleLazyCheckChange'] =
+    async (node, checked, emitClose = true) => {
+      const currentNode = node as Node
+      const currentCheckVersion = checkVersion
+      const currentTask = createTask(currentNode, checked)
+
+      try {
+        if (checked === node.checked) return false
+
+        if (checked) {
+          const loaded = await loadDescendants(currentNode)
+          if (
+            isTaskStale(currentNode, currentCheckVersion, currentTask) ||
+            !loaded
+          )
+            return false
+        }
+
+        commitTask(currentTask, () =>
+          handleCheckChange(node, checked, emitClose)
+        )
+        return true
+      } finally {
+        finishTask(currentNode, currentTask)
+      }
+    }
+
+  const isPending = (node: CascaderNode) =>
+    activeNodeVersionMap.has(node as Node)
+
+  return {
+    handleLazyCheckChange,
+    invalidateAll,
+    invalidateBranch,
+    isPending,
+  }
+}

--- a/packages/components/cascader-panel/src/lazy-check.ts
+++ b/packages/components/cascader-panel/src/lazy-check.ts
@@ -14,10 +14,13 @@ interface LazyCheckOptions {
   handleCheckChange: HandleCheckChange
 }
 
-const isSameBranch = (node: Node, target: Node) =>
-  node === target ||
-  node.pathNodes.includes(target) ||
-  target.pathNodes.includes(node)
+const isSameOrDescendant = (node: Node, target: Node) =>
+  node === target || node.pathNodes.includes(target)
+
+export const hasLoadingDescendant = (node: CascaderNode): boolean =>
+  !node.isDisabled &&
+  !node.isLeaf &&
+  node.children.some((child) => child.loading || hasLoadingDescendant(child))
 
 export const createLazyCheck = ({
   loadNode,
@@ -44,7 +47,7 @@ export const createLazyCheck = ({
     const target = node as Node
 
     activeNodeOrderMap.forEach((order, lazyCheckNode) => {
-      if (order < preserveOrder && isSameBranch(lazyCheckNode, target)) {
+      if (order < preserveOrder && isSameOrDescendant(lazyCheckNode, target)) {
         const version = nodeVersionMap.get(lazyCheckNode) ?? 0
         nodeVersionMap.set(lazyCheckNode, version + 1)
         activeNodeVersionMap.delete(lazyCheckNode)
@@ -107,34 +110,64 @@ export const createLazyCheck = ({
     if (node.isDisabled || node.isLeaf) return true
 
     if (!node.loaded) {
-      if (!(await loadNode(node))) return false
+      try {
+        if (!(await loadNode(node))) return false
+      } catch {
+        return false
+      }
     }
 
     const results = await Promise.all(node.children.map(loadDescendants))
     return results.every(Boolean)
   }
 
+  const collectUnloadedDescendants = (node: Node): Node[] => {
+    if (node.isDisabled || node.isLeaf) return []
+    if (!node.loaded) return [node]
+
+    return node.children.flatMap(collectUnloadedDescendants)
+  }
+
   const handleLazyCheckChange: ElCascaderPanelContext['handleLazyCheckChange'] =
     async (node, checked, emitClose = true) => {
       const currentNode = node as Node
+
+      if (
+        checked === node.checked ||
+        currentNode.loading ||
+        hasLoadingDescendant(currentNode)
+      )
+        return false
+
       const currentCheckVersion = checkVersion
       const currentTask = createTask(currentNode, checked)
-
-      try {
-        if (checked === node.checked) return false
-
-        if (checked) {
-          const loaded = await loadDescendants(currentNode)
-          if (
-            isTaskStale(currentNode, currentCheckVersion, currentTask) ||
-            !loaded
-          )
-            return false
-        }
-
+      const commitCheckChange = () =>
         commitTask(currentTask, () =>
           handleCheckChange(node, checked, emitClose)
         )
+      const commitLoadedDescendants = (nodes: Node[]) =>
+        commitTask(currentTask, () => {
+          nodes.forEach((node) => {
+            node.loaded && handleCheckChange(node, checked, emitClose)
+          })
+        })
+
+      try {
+        if (checked) {
+          const unloadedDescendants = collectUnloadedDescendants(currentNode)
+
+          commitCheckChange()
+
+          const loaded = await loadDescendants(currentNode)
+          if (isTaskStale(currentNode, currentCheckVersion, currentTask))
+            return false
+          commitLoadedDescendants(unloadedDescendants)
+          if (!loaded) return false
+        }
+
+        if (!checked) {
+          commitCheckChange()
+        }
         return true
       } finally {
         finishTask(currentNode, currentTask)

--- a/packages/components/cascader-panel/src/node.vue
+++ b/packages/components/cascader-panel/src/node.vue
@@ -124,6 +124,18 @@ const doLoad = () => {
   })
 }
 
+const hasUnloadedLazyDescendant = (node: CascaderNode): boolean =>
+  !node.isDisabled &&
+  !node.isLeaf &&
+  (!node.loaded || node.children.some(hasUnloadedLazyDescendant))
+
+const shouldHandleLazyCheck = (checked: boolean) =>
+  panel.config.lazy &&
+  multiple.value &&
+  !checkStrictly.value &&
+  (checked || panel.isLazyCheckPending(props.node)) &&
+  hasUnloadedLazyDescendant(props.node)
+
 const handleHoverExpand = (e: Event) => {
   if (!isHoverMenu.value) return
   handleExpand()
@@ -168,12 +180,22 @@ const handleSelectCheck = (checked: CheckboxValueType | undefined) => {
   }
 }
 
-const handleCheck = (checked: boolean) => {
+const handleCheck = async (checked: boolean) => {
+  if (shouldHandleLazyCheck(checked)) {
+    const checkedChanged = await panel.handleLazyCheckChange(
+      props.node,
+      checked
+    )
+    checkedChanged && props.node.loaded && doExpand()
+    return
+  }
+
   if (!props.node.loaded) {
     doLoad()
-  } else {
-    doCheck(checked)
-    !checkStrictly.value && doExpand()
+    return
   }
+
+  doCheck(checked)
+  !checkStrictly.value && doExpand()
 }
 </script>

--- a/packages/components/cascader-panel/src/node.vue
+++ b/packages/components/cascader-panel/src/node.vue
@@ -23,7 +23,7 @@
       v-if="multiple && showPrefix"
       :model-value="node.checked"
       :indeterminate="node.indeterminate"
-      :disabled="isDisabled"
+      :disabled="isCheckDisabled"
       @click.stop
       @update:model-value="handleSelectCheck"
     />
@@ -49,7 +49,10 @@
     <node-content :node="node" />
     <!-- postfix -->
     <template v-if="!isLeaf">
-      <el-icon v-if="node.loading" :class="[ns.is('loading'), ns.e('postfix')]">
+      <el-icon
+        v-if="isNodeLoading"
+        :class="[ns.is('loading'), ns.e('postfix')]"
+      >
         <loading />
       </el-icon>
       <el-icon v-else :class="['arrow-right', ns.e('postfix')]">
@@ -92,6 +95,17 @@ const showPrefix = computed(() => panel.config.showPrefix)
 const checkedNodeId = computed(() => panel.checkedNodes[0]?.uid)
 const isDisabled = computed(() => props.node.isDisabled)
 const isLeaf = computed(() => props.node.isLeaf)
+const isNodeLoading = computed(
+  () => panel.config.lazy && panel.hasLoadingNode(props.node)
+)
+const hasLoadingLazyNode = computed(() => {
+  if (!panel.config.lazy || !multiple.value || checkStrictly.value) return false
+
+  return isNodeLoading.value
+})
+const isCheckDisabled = computed(
+  () => isDisabled.value || hasLoadingLazyNode.value
+)
 const expandable = computed(
   () => (checkStrictly.value && !isLeaf.value) || !isDisabled.value
 )
@@ -161,7 +175,7 @@ const handleClick = () => {
     ((panel.config.checkOnClickNode &&
       (multiple.value || checkStrictly.value)) ||
       (isLeaf.value && panel.config.checkOnClickLeaf)) &&
-    !isDisabled.value
+    !isCheckDisabled.value
   ) {
     handleSelectCheck(!props.node.checked)
   } else if (!isHoverMenu.value) {
@@ -170,6 +184,8 @@ const handleClick = () => {
 }
 
 const handleSelectCheck = (checked: CheckboxValueType | undefined) => {
+  if (isCheckDisabled.value) return
+
   if (checkStrictly.value) {
     doCheck(checked as boolean)
     if (props.node.loaded) {

--- a/packages/components/cascader-panel/src/types.ts
+++ b/packages/components/cascader-panel/src/types.ts
@@ -71,13 +71,19 @@ export interface ElCascaderPanelContext {
   lazyLoad: (
     node?: CascaderNode,
     cb?: (dataList: CascaderOption[]) => void
-  ) => void
+  ) => Promise<boolean>
   expandNode: (node: CascaderNode, silent?: boolean) => void
   handleCheckChange: (
     node: CascaderNode,
     checked: boolean,
     emitClose?: boolean
   ) => void
+  handleLazyCheckChange: (
+    node: CascaderNode,
+    checked: boolean,
+    emitClose?: boolean
+  ) => Promise<boolean>
+  isLazyCheckPending: (node: CascaderNode) => boolean
 }
 
 export const CASCADER_PANEL_INJECTION_KEY: InjectionKey<ElCascaderPanelContext> =

--- a/packages/components/cascader-panel/src/types.ts
+++ b/packages/components/cascader-panel/src/types.ts
@@ -68,6 +68,7 @@ export interface ElCascaderPanelContext {
   virtualScroll: boolean
   itemSize: number
   height: number
+  hasLoadingNode: (node: CascaderNode) => boolean
   lazyLoad: (
     node?: CascaderNode,
     cb?: (dataList: CascaderOption[]) => void


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


### Description

Fixes #24256.

This PR fixes an issue where Cascader in `lazy` + `multiple` mode could not correctly check all descendants when selecting a parent node whose child nodes were not fully loaded yet.

Before this change, clicking the parent checkbox only triggered lazy loading for unloaded nodes, but the selected state was not applied again after those descendants were resolved. As a result, the parent remained unchecked or indeterminate, and unloaded leaf nodes were not included in `modelValue`.

After this change, Cascader recursively loads selectable lazy descendants before applying the parent checked state. Once loading is complete, it reuses the existing check calculation flow so checked nodes and emitted values stay consistent with normal multiple selection behavior.

### What is Changed

- Added an internal lazy node loading helper that can be reused by checkbox selection.
- Added recursive descendant loading before checking a lazy parent node in non-strict multiple mode.
- Kept uncheck behavior immediate, without triggering extra lazy load requests.
- Added regression coverage for checking a lazy parent with unloaded descendants.

### Tests

- `pnpm test packages/components/cascader-panel/__tests__/cascader-panel.test.tsx`
- `pnpm exec eslint packages/components/cascader-panel/src/index.vue packages/components/cascader-panel/src/node.vue packages/components/cascader-panel/src/types.ts packages/components/cascader-panel/__tests__/cascader-panel.test.tsx --max-warnings 0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cascader panel multi-select checkbox synchronization during lazy-loading operations
  * Improved handling of parent and child checkbox interactions when descendants are loading
  * Enhanced error recovery and retry behavior for failed lazy-load operations
  * Better management of concurrent lazy-loading requests to prevent state inconsistencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/element-plus/element-plus/pull/24335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->