### PR TITLE
docs(docs): add documentation formatting guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,15 @@ After completing your coding tasks, please note:
 5. In the description section, you can add more information about your changes, to help the reviewers for better
    understanding the context here.
 
+## Documentation Formatting Guidelines
+
+When updating documentation API tables, keep descriptions consistent:
+
+1. Keep attribute and prop names lowercase.
+2. Start API descriptions with an uppercase letter.
+3. Preserve code terms wrapped in backticks, such as `slot`, `Tooltip`, and `Popover`.
+4. Avoid broad reformatting changes unrelated to the current documentation update.
+
 ## Commit Template
 
 We have prepared a commit message template for you to refer to, you can also follow the instructions of the CLI tool to generate


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Summary

Fixes #23692.

This PR adds a small documentation formatting guideline section for API table descriptions.
It documents the expected casing for attribute and prop names, API descriptions, and code terms wrapped in backticks.

## Changes

- add documentation formatting guidance to `CONTRIBUTING.md`
- keep the change docs-only
- avoid broad reformatting of existing component documentation

## Validation

- ran `git diff --check`
- checked Node.js `v24.14.1` and pnpm `11.5.0`
- attempted `pnpm exec prettier --check --experimental-cli CONTRIBUTING.md`, but local dependencies are not installed, so `prettier` was not available

## Runtime impact

None. This is a documentation-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with new documentation formatting standards for API table descriptions, including conventions for attribute naming, description formatting, and code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->