### PR TITLE
chore: add minimum release age for renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,11 @@
   },
   "packageRules": [
     {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "1 day",
+      "internalChecksFilter": "strict"
+    },
+    {
       "matchDepTypes": ["peerDependencies"],
       "enabled": false
     },


### PR DESCRIPTION
pnpm 现在会检查依赖包发布是否大于一天，防止安全性问题。

https://pnpm.io/settings#minimumreleaseage

<img width="1548" height="523" alt="image" src="https://github.com/user-attachments/assets/366b4440-62ce-45dd-bea6-cce5375645f5" />

renovate 的配置也需要对应调整。 不然创建的 pr 永远会挂。

https://docs.renovatebot.com/configuration-options/

<img width="1477" height="553" alt="image" src="https://github.com/user-attachments/assets/8a4abc5b-1cfd-4978-98cd-a90a98489a16" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency management configuration to enhance package stability and validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->