### PR TITLE
fix(components): [table] persist filter selection only on confirm

### DIFF
--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -1299,6 +1299,86 @@ describe('Cascader.vue', () => {
       )
     })
   })
+  describe('Cascader - persistent=false keeps selected values visible', () => {
+    const runWithPersistent = (fn: () => Promise<void>) =>
+      (async () => {
+        const prev = process.env.RUN_TEST_WITH_PERSISTENT
+        process.env.RUN_TEST_WITH_PERSISTENT = 'true'
+        try {
+          await fn()
+        } finally {
+          if (prev === undefined) delete process.env.RUN_TEST_WITH_PERSISTENT
+          else process.env.RUN_TEST_WITH_PERSISTENT = prev
+        }
+      })()
+
+    it('should keep selected tags after the dropdown is destroyed (multiple)', async () => {
+      await runWithPersistent(async () => {
+        const value = ref<string[][]>([])
+        const wrapper = _mount(() => (
+          <Cascader
+            v-model={value.value}
+            options={OPTIONS}
+            props={{ multiple: true, checkOnClickNode: true }}
+            persistent={false}
+          />
+        ))
+        const trigger = wrapper.find(TRIGGER)
+        await trigger.trigger('click')
+        await nextTick()
+        const firstNode = document.querySelector(NODE) as HTMLElement
+        firstNode.click()
+        await nextTick()
+        expect(wrapper.findAll(TAG).length).toBeGreaterThan(0)
+
+        // close the dropdown, which destroys the panel
+        await trigger.trigger('keydown', {
+          key: EVENT_CODE.esc,
+          code: EVENT_CODE.esc,
+        })
+        await nextTick()
+        await nextTick()
+
+        expect(value.value.length).toBe(1)
+        // tags must remain visible even though the panel was destroyed
+        expect(wrapper.findAll(TAG).length).toBe(1)
+      })
+    })
+
+    it('should keep the selected label after the dropdown is destroyed (single)', async () => {
+      await runWithPersistent(async () => {
+        const value = ref<string[]>([])
+        const wrapper = _mount(() => (
+          <Cascader
+            v-model={value.value}
+            options={OPTIONS}
+            persistent={false}
+          />
+        ))
+        const trigger = wrapper.find(TRIGGER)
+        await trigger.trigger('click')
+        await nextTick()
+        const firstNode = document.querySelector(NODE) as HTMLElement
+        // expand the first (parent) node
+        firstNode.click()
+        await nextTick()
+        // click a leaf node to select it
+        const leafNode = Array.from(document.querySelectorAll(NODE_LABEL)).find(
+          (el) => el.textContent?.includes('Hangzhou')
+        ) as HTMLElement
+        leafNode.click()
+        await nextTick()
+        await nextTick()
+
+        expect(value.value).toEqual(['zhejiang', 'hangzhou'])
+        const input = wrapper.find('input')
+        expect((input.element as HTMLInputElement).value).toBe(
+          'Zhejiang / Hangzhou'
+        )
+      })
+    })
+  })
+
   it('should select leaf node when checkOnClickLeaf is enabled', async () => {
     const value = ref([])
     const checkOnClickLeaf = ref(true)

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -323,7 +323,7 @@ import { ArrowDown, Check, CircleClose } from '@element-plus/icons-vue'
 import { cascaderEmits } from './cascader'
 
 import type { Options } from '@element-plus/components/popper'
-import type { ComputedRef, StyleValue } from 'vue'
+import type { StyleValue } from 'vue'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
 import type { InputInstance } from '@element-plus/components/input'
 import type { ScrollbarInstance } from '@element-plus/components/scrollbar'
@@ -477,8 +477,18 @@ const readonly = computed(() => !props.filterable || multiple.value)
 const searchKeyword = computed(() =>
   multiple.value ? searchInputValue.value : inputValue.value
 )
-const checkedNodes: ComputedRef<CascaderNode[]> = computed(
-  () => cascaderPanelRef.value?.checkedNodes || []
+const lastCheckedNodes = ref<CascaderNode[]>([])
+const checkedNodes = computed(() => {
+  const nodes = cascaderPanelRef.value?.checkedNodes
+  return nodes ?? lastCheckedNodes.value
+})
+watch(
+  () => cascaderPanelRef.value?.checkedNodes,
+  (nodes) => {
+    if (nodes) {
+      lastCheckedNodes.value = nodes
+    }
+  }
 )
 
 const { wrapperRef, isFocused, handleBlur } = useFocusController(inputRef, {

--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -705,7 +705,7 @@ describe('Table.vue', () => {
       ).toEqual([])
       expect([
         ...filter.querySelector('.el-table-filter__bottom button').classList,
-      ]).toContain('is-disabled')
+      ]).not.toContain('is-disabled')
       filter.parentNode.removeChild(filter)
       wrapper.unmount()
     })

--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -629,7 +629,7 @@ describe('Table.vue', () => {
       ).toEqual([])
       expect([
         ...filter.querySelector('.el-table-filter__bottom button').classList,
-      ]).toContain('is-disabled')
+      ]).not.toContain('is-disabled')
       filter.parentNode.removeChild(filter)
       wrapper.unmount()
     })

--- a/packages/components/table/src/filter-panel.vue
+++ b/packages/components/table/src/filter-panel.vue
@@ -41,12 +41,7 @@
           </el-scrollbar>
         </div>
         <div :class="ns.e('bottom')">
-          <button
-            :class="ns.is('disabled', filteredValue.length === 0)"
-            :disabled="filteredValue.length === 0"
-            type="button"
-            @click="handleConfirm"
-          >
+          <button type="button" @click="handleConfirm">
             {{ t('el.table.confirmFilter') }}
           </button>
           <button type="button" @click="handleReset">

--- a/packages/components/table/src/filter-panel.vue
+++ b/packages/components/table/src/filter-panel.vue
@@ -26,7 +26,7 @@
         <div :class="ns.e('content')">
           <el-scrollbar :wrap-class="ns.e('wrap')">
             <el-checkbox-group
-              v-model="filteredValue"
+              v-model="storeFilteredValue"
               :class="ns.e('checkbox-group')"
             >
               <el-checkbox
@@ -40,12 +40,7 @@
           </el-scrollbar>
         </div>
         <div :class="ns.e('bottom')">
-          <button
-            :class="ns.is('disabled', filteredValue.length === 0)"
-            :disabled="filteredValue.length === 0"
-            type="button"
-            @click="handleConfirm"
-          >
+          <button type="button" @click="handleConfirm">
             {{ t('el.table.confirmFilter') }}
           </button>
           <button type="button" @click="handleReset">
@@ -164,6 +159,7 @@ export default defineComponent({
     const tooltipRef = ref<TooltipInstance | null>(null)
     const rootRef = ref<HTMLElement | null>(null)
     const checkedIndex = ref(0)
+    const storeFilteredValue = ref<string[]>([])
 
     const filters = computed(() => {
       return props.column && props.column.filters
@@ -212,12 +208,14 @@ export default defineComponent({
       tooltipRef.value?.onClose()
     }
     const handleConfirm = () => {
-      confirmFilter(filteredValue.value)
+      filteredValue.value = storeFilteredValue.value
+      confirmFilter(storeFilteredValue.value)
       hidden()
     }
     const handleReset = () => {
+      storeFilteredValue.value = []
       filteredValue.value = []
-      confirmFilter(filteredValue.value)
+      confirmFilter([])
       hidden()
     }
     const handleSelect = (_filterValue: string | null, index: number) => {
@@ -238,6 +236,7 @@ export default defineComponent({
       props.store?.updateAllSelected()
     }
     const handleShowTooltip = () => {
+      storeFilteredValue.value = [...(props.column?.filteredValue || [])]
       rootRef.value?.focus()
       !multiple.value && initCheckedIndex()
       if (props.column) {
@@ -307,6 +306,7 @@ export default defineComponent({
       multiple,
       filterClassName,
       filteredValue,
+      storeFilteredValue,
       filterValue,
       filters,
       handleConfirm,

--- a/packages/components/table/src/filter-panel.vue
+++ b/packages/components/table/src/filter-panel.vue
@@ -167,7 +167,8 @@ export default defineComponent({
         if (props.column?.filterOpened) {
           storeFilteredValue.value = [...(val || [])]
         }
-      }
+      },
+      { deep: true }
     )
 
     const filters = computed(() => {

--- a/packages/components/table/src/filter-panel.vue
+++ b/packages/components/table/src/filter-panel.vue
@@ -99,7 +99,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, getCurrentInstance, ref } from 'vue'
+import { computed, defineComponent, getCurrentInstance, ref, watch } from 'vue'
 import { ElCheckbox, ElCheckboxGroup } from '@element-plus/components/checkbox'
 import { ElIcon } from '@element-plus/components/icon'
 import { ArrowDown, ArrowUp } from '@element-plus/icons-vue'
@@ -160,6 +160,15 @@ export default defineComponent({
     const rootRef = ref<HTMLElement | null>(null)
     const checkedIndex = ref(0)
     const storeFilteredValue = ref<string[]>([])
+
+    watch(
+      () => props.column?.filteredValue,
+      (val) => {
+        if (props.column?.filterOpened) {
+          storeFilteredValue.value = [...(val || [])]
+        }
+      }
+    )
 
     const filters = computed(() => {
       return props.column && props.column.filters


### PR DESCRIPTION
Use local storeFilteredValue ref to isolate checkbox state from the column's filteredValue. Changes in the filter panel are no longer written back to the column until the confirm button is clicked.

- Remove disabled state on the confirm button so users can submit an empty selection to clear the filter
- Initialize local state from column.filteredValue on panel open
- Revert local state on panel close without confirm

close #24360

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table filter behavior for multiple and single-select filters, including reset, confirmation, and synchronization of selected values.
  * Corrected handling of partially selected tree rows and filters on initially unfiltered columns.
  * Prevented issues when closing tables while fixed-column updates are pending.
  * Ensured the filter confirmation button remains available after clearing selections.
  * Preserved selected Cascader values when its dropdown panel is closed or destroyed.

* **Tests**
  * Added regression coverage for updated table filtering, unmounting, and Cascader selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->