### PR TITLE
fix(components): [tree-v2] allow falsy current keys

### DIFF
--- a/packages/components/tree-v2/__tests__/tree.test.ts
+++ b/packages/components/tree-v2/__tests__/tree.test.ts
@@ -1184,6 +1184,54 @@ describe('Virtual Tree', () => {
     expect(nodes[1].classes()).toContain('is-current')
   })
 
+  test('currentNodeKey with zero key', async () => {
+    const { wrapper, treeRef } = createTree({
+      data() {
+        return {
+          currentNodeKey: 0,
+          data: [
+            {
+              id: 0,
+              label: 'node-0',
+            },
+          ],
+        }
+      },
+    })
+    await nextTick()
+    const nodes = wrapper.findAll(TREE_NODE_CLASS_NAME)
+    expect(nodes[0].classes()).toContain('is-current')
+    expect(treeRef.getCurrentKey()).toBe(0)
+    expect(treeRef.getCurrentNode()).toMatchObject({
+      id: 0,
+      label: 'node-0',
+    })
+  })
+
+  test('currentNodeKey with empty string key', async () => {
+    const { wrapper, treeRef } = createTree({
+      data() {
+        return {
+          currentNodeKey: '',
+          data: [
+            {
+              id: '',
+              label: 'empty',
+            },
+          ],
+        }
+      },
+    })
+    await nextTick()
+    const nodes = wrapper.findAll(TREE_NODE_CLASS_NAME)
+    expect(nodes[0].classes()).toContain('is-current')
+    expect(treeRef.getCurrentKey()).toBe('')
+    expect(treeRef.getCurrentNode()).toMatchObject({
+      id: '',
+      label: 'empty',
+    })
+  })
+
   test('customNodeClass', async () => {
     const { wrapper } = createTree({
       data() {

--- a/packages/components/tree-v2/src/composables/useTree.ts
+++ b/packages/components/tree-v2/src/composables/useTree.ts
@@ -268,7 +268,7 @@ export function useTree(
   }
 
   function getCurrentNode(): TreeNodeData | undefined {
-    if (!currentKey.value) return undefined
+    if (currentKey.value === undefined) return undefined
     return tree.value?.treeNodeMap.get(currentKey.value)?.data
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fix:https://github.com/element-plus/element-plus/issues/24363


### Summary

Fixes TreeV2 `getCurrentNode()` returning `undefined` when the current node key is numeric `0`.

The component already supports `0` as a valid `TreeKey`, and the node can be highlighted correctly. The issue was limited to the exposed `getCurrentNode()` API using a falsy check for `currentKey`.

### Changes

- Update `getCurrentNode()` to only treat `undefined` as no current key
- Add regression coverage for `currentNodeKey: 0`
- Add regression coverage for an empty string key, which is also a valid string `TreeKey`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed node retrieval in the tree component to correctly handle falsy-but-valid keys (e.g., `0`, empty string) when getting the current node.

* **Tests**
  * Added test cases to verify behavior when node keys are falsy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->