### PR TITLE
fix(components): prevent outline clipping in checkbox/radio button group

### DIFF
--- a/packages/theme-chalk/src/checkbox-group.scss
+++ b/packages/theme-chalk/src/checkbox-group.scss
@@ -4,4 +4,5 @@
 @include b(checkbox-group) {
   font-size: 0;
   line-height: 0;
+  padding: 1px;
 }

--- a/packages/theme-chalk/src/radio-group.scss
+++ b/packages/theme-chalk/src/radio-group.scss
@@ -6,4 +6,5 @@
   align-items: center;
   flex-wrap: wrap;
   font-size: 0;
+  padding: 1px;
 }


### PR DESCRIPTION
Add 1px padding to checkbox-group and radio-group containers to prevent outline borders from being clipped by parent overflow: hidden.

 When the parent container of `checkbox-group` or `radio-group` has `overflow: hidden`, the outline borders of unselected `checkbox-button` / `radio-button` are clipped. Although users  could work around this externally (e.g., adding padding to the parent), the component should handle it properly so it works out of the box.

fix #24361

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted padding on checkbox group components for improved visual spacing.
  * Adjusted padding on radio group components for improved visual spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->