### PR TITLE
fix(components): [time-select] prevent hang on invalid start or end time

### DIFF
--- a/packages/components/time-select/src/utils.ts
+++ b/packages/components/time-select/src/utils.ts
@@ -8,6 +8,9 @@ export const parseTime = (time: string): null | Time => {
   if (values.length >= 2) {
     let hours = Number.parseInt(values[0], 10)
     const minutes = Number.parseInt(values[1], 10)
+    if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+      return null
+    }
     const timeUpper = time.toUpperCase()
     if (timeUpper.includes('AM') && hours === 12) {
       hours = 0


### PR DESCRIPTION
When start or end time has an invalid format (e.g. 'abc:00'), parseTime returns NaN hours/minutes. This causes an infinite loop in the items computed property because NaN comparisons always return false. Add NaN validation in parseTime to return null for invalid parsed values.

Closes #24328

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced time input validation to properly detect and handle invalid hour and minute values, preventing malformed entries from being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->