### PR TITLE
fix(components): [calendar] reject invalid cross-year range

### DIFF
--- a/packages/components/calendar/src/use-calendar.ts
+++ b/packages/components/calendar/src/use-calendar.ts
@@ -96,7 +96,7 @@ export const useCalendar = (
       return calculateValidatedDateRange(startDayjs, endDayjs)
     } else {
       // two months
-      if (startDayjs.add(1, 'month').month() !== endDayjs.month()) {
+      if (!startDayjs.add(1, 'month').isSame(endDayjs, 'month')) {
         debugWarn(
           componentName,
           'start time and end time interval must not exceed two months'


### PR DESCRIPTION
 ### Description

  `validatedRange` compared only month numbers without checking year, so cross-year ranges exceeding two months (e.g. `Dec 2024 to Jan 2026`) were incorrectly accepted. Use dayjs `isSame('month')`to compare both year and month.

  ### Related

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved the calendar component's date range validation to more accurately handle month boundary edge cases when validating two-month intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->