### PR TITLE
fix(components): [time-select] prevent hang on invalid start or end time

### DIFF
--- a/packages/components/time-select/src/utils.ts
+++ b/packages/components/time-select/src/utils.ts
@@ -8,6 +8,9 @@ export const parseTime = (time: string): null | Time => {
   if (values.length >= 2) {
     let hours = Number.parseInt(values[0], 10)
     const minutes = Number.parseInt(values[1], 10)
+    if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+      return null
+    }
     const timeUpper = time.toUpperCase()
     if (timeUpper.includes('AM') && hours === 12) {
       hours = 0


### PR DESCRIPTION
### Problem

  Passing an invalid `start` or `end` time like `start="abc:00"` to
  `el-time-select` causes the component to hang indefinitely.

  The root cause is in `parseTime()` — when `Number.parseInt('abc', 10)`
  returns `NaN`, it still returns a truthy object `{ hours: NaN, minutes: 0 }`.
  Then `compareTime()` never terminates because NaN comparisons always
  return false, creating an infinite loop.

  ### Solution

  Added a NaN check in `parseTime()` — if either `hours` or `minutes`
  parses to NaN, return `null`. This lets all callers handle it as
  an invalid time naturally.

  ### Testing

  - All 2500+ existing tests pass
  - Manually verified that `start="abc:00"` no longer hangs

  Closes #24328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced time input validation to reject malformed or invalid time values, ensuring more reliable time selection behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->