### PR TITLE
fix(components): [input-otp] avoid sticky hover on touch devices

### DIFF
--- a/packages/theme-chalk/src/input-otp.scss
+++ b/packages/theme-chalk/src/input-otp.scss
@@ -8,6 +8,12 @@
   box-shadow: 0 0 0 1px $color inset;
 }
 
+@mixin hover-available {
+  @media (hover: hover) {
+    @content;
+  }
+}
+
 @include b(input-otp) {
   @include set-component-css-var('input-otp', $input-otp);
   @include set-css-var-value(
@@ -95,8 +101,10 @@
     @include e(input-field) {
       @include mixed-input-border(#{getCssVar('border-color')});
 
-      &:hover {
-        @include mixed-input-border(#{getCssVar('color-primary-light-5')});
+      @include hover-available {
+        &:hover {
+          @include mixed-input-border(#{getCssVar('color-primary-light-5')});
+        }
       }
 
       &:focus-within {
@@ -108,8 +116,10 @@
       @include e(input-field) {
         background-color: getCssVar('fill-color', 'light');
 
-        &:hover {
-          @include mixed-input-border(#{getCssVar('border-color')});
+        @include hover-available {
+          &:hover {
+            @include mixed-input-border(#{getCssVar('border-color')});
+          }
         }
       }
     }
@@ -119,8 +129,10 @@
     @include e(input-field) {
       background-color: getCssVar('fill-color', '');
 
-      &:hover {
-        background-color: getCssVar('fill-color', 'dark');
+      @include hover-available {
+        &:hover {
+          background-color: getCssVar('fill-color', 'dark');
+        }
       }
 
       &:focus-within {
@@ -133,8 +145,10 @@
       @include e(input-field) {
         background-color: getCssVar('fill-color', 'light');
 
-        &:hover {
-          background-color: getCssVar('fill-color', 'light');
+        @include hover-available {
+          &:hover {
+            background-color: getCssVar('fill-color', 'light');
+          }
         }
       }
     }
@@ -153,8 +167,10 @@
         left: 0;
       }
 
-      &:hover::after {
-        background-color: getCssVar('color-primary-light-5');
+      @include hover-available {
+        &:hover::after {
+          background-color: getCssVar('color-primary-light-5');
+        }
       }
 
       &:focus-within::after {
@@ -164,8 +180,10 @@
 
     @include when(disabled) {
       @include e(input-field) {
-        &:hover::after {
-          background-color: getCssVar('border-color');
+        @include hover-available {
+          &:hover::after {
+            background-color: getCssVar('border-color');
+          }
         }
       }
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Wrap InputOtp hover styles with `@media (hover: hover)` so hover feedback is only applied on devices that actually support hover interactions.

This avoids sticky hover styles on touch devices after tapping OTP input fields.

Before:
(第一个输入框边框样式)

https://github.com/user-attachments/assets/6c0579ab-a443-4f7a-93ef-54bfcb57bd33

After:

https://github.com/user-attachments/assets/3bb0631b-4e0a-46e6-8458-8e8e96b5bd49





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved hover state handling for the input component on devices that support hover functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->