### PR TITLE
fix(components): [select/select-v2] restrict input-wrapper hidden mode

### DIFF
--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -2984,6 +2984,24 @@ describe('Select', () => {
     expect((select.vm as any).expanded).toBe(true)
   })
 
+  describe('input-wrapper in single mode', () => {
+    it('should not hide input-wrapper when filterable single select', async () => {
+      const wrapper = createSelect({
+        data: () => ({
+          multiple: false,
+          filterable: true,
+        }),
+      })
+      await nextTick()
+      const select = wrapper.findComponent(Select)
+      const inputWrapper = select.find('.el-select__input-wrapper')
+
+      // In single-select filterable mode, input-wrapper should never be hidden
+      // even when empty and not focused (regression from #24376)
+      expect(inputWrapper.classes()).not.toContain('is-hidden')
+    })
+  })
+
   describe('input-wrapper in multiple mode', () => {
     it('should hide input-wrapper when empty and not focused', async () => {
       const wrapper = createSelect({

--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -177,7 +177,7 @@
                   'hidden',
                   !filterable ||
                     selectDisabled ||
-                    (!states.inputValue && !isFocused)
+                    (multiple && !states.inputValue && !isFocused)
                 ),
               ]"
             >

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4402,6 +4402,20 @@ describe('Select', () => {
     vi.useRealTimers()
   })
 
+  describe('input-wrapper in single mode', () => {
+    test('should not hide input-wrapper when filterable single select', async () => {
+      wrapper = getSelectVm({
+        multiple: false,
+        filterable: true,
+      })
+      const inputWrapper = wrapper.find('.el-select__input-wrapper')
+
+      // In single-select filterable mode, input-wrapper should never be hidden
+      // even when empty and not focused (regression from #24376)
+      expect(inputWrapper.classes()).not.toContain('is-hidden')
+    })
+  })
+
   describe('input-wrapper in multiple mode', () => {
     test('should hide input-wrapper when empty and not focused', async () => {
       wrapper = getSelectVm({

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -175,7 +175,7 @@
                   'hidden',
                   !filterable ||
                     selectDisabled ||
-                    (!states.inputValue && !isFocused)
+                    (multiple && !states.inputValue && !isFocused)
                 ),
               ]"
             >


### PR DESCRIPTION
The hidden class condition added in #23394 applied to both single and multiple mode, causing single-select filterable to lose width in inline forms when empty and unfocused.

Closed #24376

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input field visibility in single-select filterable mode to remain visible when empty and unfocused, preventing unintended hiding of the input wrapper.

* **Tests**
  * Added test coverage for single-select filterable mode input wrapper visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->