### PR TITLE
fix(theme-chalk): checkbox/radio-button border color when checked

### DIFF
--- a/packages/theme-chalk/src/checkbox-button.scss
+++ b/packages/theme-chalk/src/checkbox-button.scss
@@ -76,7 +76,6 @@
       color: getCssVar('checkbox-button-checked-text-color');
       background-color: getCssVar('checkbox-button-checked-bg-color');
       border-color: getCssVar('checkbox-button-checked-border-color');
-      box-shadow: -1px 0 0 0 getCssVar('color-primary-light-7');
     }
     &:first-child .#{$namespace}-checkbox-button__inner {
       border-left-color: getCssVar('checkbox-button-checked-border-color');

--- a/packages/theme-chalk/src/checkbox-button.scss
+++ b/packages/theme-chalk/src/checkbox-button.scss
@@ -13,6 +13,10 @@
   position: relative;
   display: inline-block;
 
+  & + & {
+    margin-left: -1px;
+  }
+
   @include e(inner) {
     display: inline-block;
     line-height: 1;
@@ -24,7 +28,7 @@
       #{getCssVarName('button-bg-color')},
       map.get($button, 'bg-color')
     );
-    outline: getCssVar('border');
+    border: getCssVar('border');
     color: var(
       #{getCssVarName('button-text-color')},
       map.get($button, 'text-color')
@@ -66,6 +70,8 @@
   }
 
   &.is-checked {
+    z-index: 1;
+
     & .#{$namespace}-checkbox-button__inner {
       color: getCssVar('checkbox-button-checked-text-color');
       background-color: getCssVar('checkbox-button-checked-bg-color');

--- a/packages/theme-chalk/src/radio-button.scss
+++ b/packages/theme-chalk/src/radio-button.scss
@@ -14,6 +14,10 @@
   display: inline-block;
   outline: none;
 
+  & + & {
+    margin-left: -1px;
+  }
+
   @include e(inner) {
     display: inline-block;
     line-height: 1;
@@ -23,7 +27,7 @@
       #{getCssVarName('button-bg-color')},
       map.get($button, 'bg-color')
     );
-    outline: getCssVar('border');
+    border: getCssVar('border');
     font-weight: var(
       #{getCssVarName('button-font-weight')},
       map.get($button, 'font-weight')
@@ -70,6 +74,8 @@
   }
 
   @include when(active) {
+    z-index: 1;
+
     @include e(original-radio) {
       &:not(:disabled) {
         & + .#{$namespace}-radio-button__inner {

--- a/packages/theme-chalk/src/radio-button.scss
+++ b/packages/theme-chalk/src/radio-button.scss
@@ -91,11 +91,6 @@
             'radio-button-checked-border-color',
             map.get($radio-button, 'checked-border-color')
           );
-          box-shadow: -1px 0 0 0
-            getCssVarWithDefault(
-              'radio-button-checked-border-color',
-              map.get($radio-button, 'checked-border-color')
-            );
         }
       }
     }


### PR DESCRIPTION
Use `border` instead of `outline` so that `border-color` overrides in checked/active state take effect. Add `margin-left: -1px` on adjacent items to prevent 2px border stacking, and `z-index: 1` on checked items to ensure the colored border stacks on top.

fix #24382

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced gaps between adjacent checkbox and radio button controls for a tighter, more compact layout.
  * Harmonized border rendering for consistent appearance across interactive states.
  * Adjusted stacking and selected-state visuals (removed an inner shadow and promoted selected controls) for clearer focus and selection feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->