### PR TITLE
improvement(components): [switch] add warning for invalid `model-value`

### DIFF
--- a/packages/components/switch/src/switch.vue
+++ b/packages/components/switch/src/switch.vue
@@ -184,7 +184,7 @@ const actualValue = computed(() => {
 const checked = computed(() => actualValue.value === props.activeValue)
 
 if (![props.activeValue, props.inactiveValue].includes(actualValue.value)) {
-  debugWarn(COMPONENT_NAME, 'modelValue must be activeValue or inactiveValue')
+  debugWarn(COMPONENT_NAME, 'model-value must be active-value or inactive-value')
   emit(UPDATE_MODEL_EVENT, props.inactiveValue)
   emit(CHANGE_EVENT, props.inactiveValue)
   emit(INPUT_EVENT, props.inactiveValue)

--- a/packages/components/switch/src/switch.vue
+++ b/packages/components/switch/src/switch.vue
@@ -184,7 +184,10 @@ const actualValue = computed(() => {
 const checked = computed(() => actualValue.value === props.activeValue)
 
 if (![props.activeValue, props.inactiveValue].includes(actualValue.value)) {
-  debugWarn(COMPONENT_NAME, 'model-value must be active-value or inactive-value')
+  debugWarn(
+    COMPONENT_NAME,
+    'model-value must be active-value or inactive-value'
+  )
   emit(UPDATE_MODEL_EVENT, props.inactiveValue)
   emit(CHANGE_EVENT, props.inactiveValue)
   emit(INPUT_EVENT, props.inactiveValue)

--- a/packages/components/switch/src/switch.vue
+++ b/packages/components/switch/src/switch.vue
@@ -184,6 +184,7 @@ const actualValue = computed(() => {
 const checked = computed(() => actualValue.value === props.activeValue)
 
 if (![props.activeValue, props.inactiveValue].includes(actualValue.value)) {
+  debugWarn(COMPONENT_NAME, 'modelValue must be activeValue or inactiveValue')
   emit(UPDATE_MODEL_EVENT, props.inactiveValue)
   emit(CHANGE_EVENT, props.inactiveValue)
   emit(INPUT_EVENT, props.inactiveValue)


### PR DESCRIPTION
For now, [switch] could adjust the `modelValue` to the correctly `inactiveValue`, while developer passed an invalid value in. But this change is silently, adding a debug warning will be more friendly for developers.

<img width="535" height="305" alt="image" src="https://github.com/user-attachments/assets/0c6f7c6b-75cc-4e47-b45f-a21a7aaee733" />

fix #18197

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switch component now emits a clear warning when provided an invalid value and consistently falls back to the inactive state. This makes incorrect usage easier to detect in development and ensures predictable toggle behavior across update/change/input flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->