### PR TITLE
fix(components): [cascader] fix select-all not working with lazy load

### DIFF
--- a/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
+++ b/packages/components/cascader-panel/__tests__/cascader-panel.test.tsx
@@ -768,7 +768,7 @@ describe('CascaderPanel.vue', () => {
     vi.useRealTimers()
   })
 
-  test('no loaded nodes should not be checked', async () => {
+  test('unloaded lazy nodes are checked when parent broadcasts', async () => {
     vi.useFakeTimers()
     const props: CascaderProps = {
       multiple: true,
@@ -804,7 +804,8 @@ describe('CascaderPanel.vue', () => {
     expect(secondMenu.exists()).toBe(true)
     expect(firstMenu.find(CHECKBOX).classes('is-checked')).toBe(false)
     expect(firstMenu.find(CHECKBOX).classes('is-indeterminate')).toBe(true)
-    expect(secondMenu.findAll(CHECKBOX)[0].classes('is-checked')).toBe(false)
+    // unloaded lazy node inherits checked state from parent broadcast
+    expect(secondMenu.findAll(CHECKBOX)[0].classes('is-checked')).toBe(true)
     expect(secondMenu.findAll(CHECKBOX)[0].classes('is-indeterminate')).toBe(
       false
     )
@@ -812,6 +813,67 @@ describe('CascaderPanel.vue', () => {
     expect(secondMenu.findAll(CHECKBOX)[1].classes('is-indeterminate')).toBe(
       false
     )
+    vi.useRealTimers()
+  })
+
+  test('checked state propagates to lazy-loaded children on expand', async () => {
+    vi.useFakeTimers()
+    const value = ref<CascaderValue[]>([])
+    const props: CascaderProps = {
+      multiple: true,
+      lazy: true,
+      lazyLoad(node, resolve) {
+        const { level } = node
+        setTimeout(() => {
+          const nodes = Array.from({ length: level + 1 }).map(() => {
+            ++id
+            return {
+              value: id,
+              label: `option${id}`,
+              leaf: level >= 2,
+            }
+          })
+          resolve(nodes)
+        }, 1000)
+      },
+    }
+    const wrapper = mount(() => (
+      <CascaderPanel v-model={value.value} props={props} />
+    ))
+
+    vi.runAllTimers()
+    await nextTick()
+    const firstMenu = wrapper.findAll(MENU)[0]
+    expect(firstMenu.exists()).toBe(true)
+
+    // Expand root → lazy load first level children (non-leaf, loaded=false)
+    await firstMenu.find(NODE).trigger('click')
+    vi.runAllTimers()
+    await nextTick()
+
+    const secondMenu = wrapper.findAll(MENU)[1]
+    expect(secondMenu.exists()).toBe(true)
+
+    // Click parent checkbox — broadcasts checked state to non-leaf children
+    await firstMenu.find(CHECKBOX).find('input').trigger('click')
+
+    // Expand non-leaf child to trigger another lazy load
+    const l1Node = secondMenu.find(NODE)
+    await l1Node.trigger('click')
+    vi.runAllTimers()
+    await nextTick()
+
+    // Second menu is now replaced with newly loaded leaf children
+    // They should inherit checked state from parent broadcast in resolve
+    const menus = wrapper.findAll(MENU)
+    expect(menus.length).toBe(3)
+    // menu2 has leaf children that were lazy-loaded; should be checked
+    const leafCheckboxes = menus[2].findAll(CHECKBOX)
+    expect(leafCheckboxes.length).toBeGreaterThan(0)
+    leafCheckboxes.forEach((cb) => {
+      expect(cb.classes('is-checked')).toBe(true)
+    })
+    expect(value.value.length).toBeGreaterThan(0)
     vi.useRealTimers()
   })
 

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -142,6 +142,15 @@ const lazyLoad: ElCascaderPanelContext['lazyLoad'] = (node, cb) => {
     _node.childrenData = _node.childrenData || []
     dataList && store?.appendNodes(dataList, parent as Node)
     dataList && cb?.(dataList)
+
+    // If parent node was checked before children loaded (e.g. via select all),
+    // propagate the checked state to newly loaded children
+    if (parent && parent.checked && dataList?.length) {
+      parent.broadcast(true)
+      parent.onChildCheck()
+      calculateCheckedValue()
+    }
+
     if (node.level === 0) {
       initialLoadedOnce.value = true
     }

--- a/packages/components/cascader-panel/src/index.vue
+++ b/packages/components/cascader-panel/src/index.vue
@@ -143,11 +143,15 @@ const lazyLoad: ElCascaderPanelContext['lazyLoad'] = (node, cb) => {
     dataList && store?.appendNodes(dataList, parent as Node)
     dataList && cb?.(dataList)
 
-    // If parent node was checked before children loaded (e.g. via select all),
-    // propagate the checked state to newly loaded children
-    if (parent && parent.checked && dataList?.length) {
-      parent.broadcast(true)
-      parent.onChildCheck()
+    if (
+      parent?.checked &&
+      config.value.multiple &&
+      !config.value.checkStrictly
+    ) {
+      if (dataList?.length) {
+        parent.broadcast(true)
+        parent.emit()
+      }
       calculateCheckedValue()
     }
 
@@ -217,6 +221,15 @@ const getCheckedNodes = (leafOnly: boolean) => {
 
 const clearCheckedNodes = () => {
   checkedNodes.value.forEach((node) => node.doCheck(false))
+  // clear hidden checked state on unloaded lazy nodes not tracked in checkedNodes
+  const allNodes = store?.getFlattedNodes(false) || []
+  const checkedSet = new Set(checkedNodes.value)
+  allNodes.forEach((node) => {
+    if (node.checked && !checkedSet.has(node)) {
+      node.checked = false
+      node.indeterminate = false
+    }
+  })
   calculateCheckedValue()
   menus.value = menus.value.slice(0, 1)
   expandingNode.value = undefined

--- a/packages/components/cascader-panel/src/node.ts
+++ b/packages/components/cascader-panel/src/node.ts
@@ -163,6 +163,8 @@ class Node {
   setCheckState(checked: boolean) {
     const totalNum = this.children.length
     const checkedNum = this.children.reduce((c, p) => {
+      // Don't count unloaded lazy nodes as checked for indeterminate calculation
+      if (!p.loaded && p.config.lazy) return c
       const num = p.checked ? 1 : p.indeterminate ? 0.5 : 0
       return c + num
     }, 0)

--- a/packages/components/cascader-panel/src/node.ts
+++ b/packages/components/cascader-panel/src/node.ts
@@ -167,6 +167,15 @@ class Node {
       return c + num
     }, 0)
 
+    // In lazy mode, if the node hasn't loaded its children yet,
+    // preserve the checked state so that "select all" works correctly.
+    // When children are loaded later, they will inherit this state.
+    if (!this.loaded && this.config.lazy) {
+      this.checked = checked
+      this.indeterminate = false
+      return
+    }
+
     this.checked =
       this.loaded &&
       this.children

--- a/packages/components/cascader-panel/src/node.ts
+++ b/packages/components/cascader-panel/src/node.ts
@@ -163,15 +163,12 @@ class Node {
   setCheckState(checked: boolean) {
     const totalNum = this.children.length
     const checkedNum = this.children.reduce((c, p) => {
-      // Don't count unloaded lazy nodes as checked for indeterminate calculation
       if (!p.loaded && p.config.lazy) return c
       const num = p.checked ? 1 : p.indeterminate ? 0.5 : 0
       return c + num
     }, 0)
 
-    // In lazy mode, if the node hasn't loaded its children yet,
-    // preserve the checked state so that "select all" works correctly.
-    // When children are loaded later, they will inherit this state.
+    // preserve checked state for unloaded lazy nodes — select-all depends on it
     if (!this.loaded && this.config.lazy) {
       this.checked = checked
       this.indeterminate = false


### PR DESCRIPTION
 fixes #24256

  ## Problem

  When using `el-cascader` with `lazy` load and `multiple` selection, the "select all" functionality doesn't work. If a
  parent node hasn't loaded its children yet, clicking "select all" won't mark it as checked.

  ## Root Cause

  1. In `node.ts`, `setCheckState` checks `this.loaded` before setting `checked`. For lazy nodes that haven't loaded
  children yet, `loaded` is `false`, so `checked` is always set to `false`.

  2. In `index.vue`, after lazy loading children, the parent's checked state wasn't propagated to newly loaded children.

  ## Fix

  1. **`node.ts` - `setCheckState`**: For lazy nodes that haven't loaded yet, preserve the `checked` state passed in.
  This allows "select all" to mark unloaded nodes as checked.

  2. **`index.vue` - `lazyLoad` resolve**: After children are loaded, if the parent node was already checked, broadcast
  the checked state to the new children using `broadcast(true)` and `onChildCheck()`.

  ## Testing

  Verified with the reproduction case in the issue - lazy load cascader with multiple selection now correctly supports
  select-all behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Cascader lazy-loading checkbox behavior so checked parents correctly propagate selection into newly resolved (previously unloaded) lazy children, keeping checked/indeterminate states and final selected values consistent.
* **Tests**
  * Updated and added lazy-loading scenarios to verify parent-to-child checked-state propagation after expanding nodes and to validate the resulting selected model values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->