### PR TITLE
fix(components): keep button outlines inside box

### DIFF
--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -672,6 +672,9 @@ describe('check-button', () => {
     expect(
       checkbox.find('.el-checkbox-button__inner').attributes('style')
     ).contains('border-color: #ff0000;')
+    expect(
+      checkbox.find('.el-checkbox-button__inner').attributes('style')
+    ).contains('outline-color: rgb(255, 0, 0);')
   })
 
   test('button group tag', () => {

--- a/packages/components/checkbox/src/checkbox-button.vue
+++ b/packages/components/checkbox/src/checkbox-button.vue
@@ -77,6 +77,7 @@ const activeStyle = computed<CSSProperties>(() => {
   return {
     backgroundColor: fillValue,
     borderColor: fillValue,
+    outlineColor: fillValue,
     color: checkboxGroup?.textColor?.value ?? '',
     boxShadow: fillValue ? `-1px 0 0 0 ${fillValue}` : undefined,
   }

--- a/packages/components/radio/__tests__/radio.test.tsx
+++ b/packages/components/radio/__tests__/radio.test.tsx
@@ -382,7 +382,7 @@ describe('Radio Button', () => {
     ))
     const radio1 = wrapper.find('.el-radio-button')
     expect(radio1.find('span').attributes('style')).toContain(
-      'background-color: rgb(0, 0, 0); border-color: #000; box-shadow: -1px 0 0 0 #000; color: rgb(255, 255, 0);'
+      'background-color: rgb(0, 0, 0); border-color: #000; outline-color: rgb(0, 0, 0); box-shadow: -1px 0 0 0 #000; color: rgb(255, 255, 0);'
     )
   })
 

--- a/packages/components/radio/src/radio-button.vue
+++ b/packages/components/radio/src/radio-button.vue
@@ -58,6 +58,7 @@ const activeStyle = computed<CSSProperties>(() => {
   return {
     backgroundColor: radioGroup?.fill || '',
     borderColor: radioGroup?.fill || '',
+    outlineColor: radioGroup?.fill || '',
     boxShadow: radioGroup?.fill ? `-1px 0 0 0 ${radioGroup.fill}` : '',
     color: radioGroup?.textColor || '',
   }

--- a/packages/theme-chalk/src/checkbox-button.scss
+++ b/packages/theme-chalk/src/checkbox-button.scss
@@ -25,6 +25,7 @@
       map.get($button, 'bg-color')
     );
     outline: getCssVar('border');
+    outline-offset: -1px;
     color: var(
       #{getCssVarName('button-text-color')},
       map.get($button, 'text-color')
@@ -70,6 +71,7 @@
       color: getCssVar('checkbox-button-checked-text-color');
       background-color: getCssVar('checkbox-button-checked-bg-color');
       border-color: getCssVar('checkbox-button-checked-border-color');
+      outline-color: getCssVar('checkbox-button-checked-border-color');
       box-shadow: -1px 0 0 0 getCssVar('color-primary-light-7');
     }
     &:first-child .#{$namespace}-checkbox-button__inner {
@@ -90,6 +92,10 @@
         #{getCssVarName('button-disabled-border-color')},
         map.get($button, 'disabled-border-color')
       );
+      outline-color: var(
+        #{getCssVarName('button-disabled-border-color')},
+        map.get($button, 'disabled-border-color')
+      );
       box-shadow: none;
     }
     &:first-child .#{$namespace}-checkbox-button__inner {
@@ -102,6 +108,10 @@
     @include when(checked) {
       .#{$namespace}-checkbox-button__inner {
         background-color: getCssVar('checkbox-button-disabled-checked-fill');
+        outline-color: var(
+          #{getCssVarName('button-disabled-border-color')},
+          map.get($button, 'disabled-border-color')
+        );
       }
     }
   }

--- a/packages/theme-chalk/src/radio-button.scss
+++ b/packages/theme-chalk/src/radio-button.scss
@@ -24,6 +24,7 @@
       map.get($button, 'bg-color')
     );
     outline: getCssVar('border');
+    outline-offset: -1px;
     font-weight: var(
       #{getCssVarName('button-font-weight')},
       map.get($button, 'font-weight')
@@ -82,6 +83,10 @@
             map.get($radio-button, 'checked-bg-color')
           );
           border-color: getCssVarWithDefault(
+            'radio-button-checked-border-color',
+            map.get($radio-button, 'checked-border-color')
+          );
+          outline-color: getCssVarWithDefault(
             'radio-button-checked-border-color',
             map.get($radio-button, 'checked-border-color')
           );


### PR DESCRIPTION
## Summary

Fixes #24382.

Keep radio-button and checkbox-button outlines inside the button box, and make the checked outline use the checked border color.

## Reproduction

The issue reproduces with grouped radio/checkbox buttons where the checked and unchecked states should keep the same visual box. The current outline-based border can make the top/bottom edge look inconsistent, especially with darker checked colors.

## Root cause

#22073 changed radio-button and checkbox-button borders to `outline` to avoid border layout issues when wrapped. The default outline still paints outside the box and the checked state only changed `border-color`, which does not affect the outline. As a result, checked and unchecked button edges can look visually inconsistent.

## Changes

- Set `outline-offset: -1px` for radio-button and checkbox-button inner elements so the outline is painted inside the box.
- Set the checked radio-button outline color to the checked border color.
- Set the checked checkbox-button outline color to the checked border color.
- Keep the outline-based approach from #22073 instead of reverting to layout-affecting borders.

## Tests

- `pnpm build:theme`
- `pnpm test packages/components/radio/__tests__/radio.test.tsx packages/components/checkbox/__tests__/checkbox.test.tsx --run`
- `pnpm exec prettier --check packages/theme-chalk/src/radio-button.scss packages/theme-chalk/src/checkbox-button.scss`
- `pnpm exec lint-staged`
- `git diff --check`
- Puppeteer style check confirmed radio/checkbox checked and unchecked buttons keep equal heights and checked outlines use the theme color.

Note: I ran pnpm through `npx pnpm@11` with Node 22.13.0 because the local corepack pnpm shim fails signature verification in this environment.

## Screenshots/Logs

N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved checkbox button focus and checked visuals (tighter outline offset, updated checked/disabled outline colors) and active styling that reflects group color.
  * Enhanced radio button focus and checked visuals (tighter outline offset, updated checked outline color) and active styling that reflects group color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->