### PR TITLE
i18n(locale): finish Norwegian Bokmal (nb-no) translation

### DIFF
--- a/packages/locale/lang/nb-no.ts
+++ b/packages/locale/lang/nb-no.ts
@@ -2,22 +2,22 @@ export default {
   name: 'nb-no',
   el: {
     breadcrumb: {
-      label: 'Breadcrumb', // to be translated
+      label: 'Brødsmulesti',
     },
     colorpicker: {
       confirm: 'OK',
       clear: 'Tøm',
-      defaultLabel: 'color picker', // to be translated
+      defaultLabel: 'fargevelger',
       description:
-        'current color is {color}. press enter to select a new color.', // to be translated
-      alphaLabel: 'pick alpha value', // to be translated
-      alphaDescription: 'alpha {alpha}, current color is {color}', // to be translated
-      hueLabel: 'pick hue value', // to be translated
-      hueDescription: 'hue {hue}, current color is {color}', // to be translated
-      svLabel: 'pick saturation and brightness value', // to be translated
+        'gjeldende farge er {color}. trykk enter for å velge en ny farge.',
+      alphaLabel: 'velg alfaverdi',
+      alphaDescription: 'alfa {alpha}, gjeldende farge er {color}',
+      hueLabel: 'velg fargetone',
+      hueDescription: 'fargetone {hue}, gjeldende farge er {color}',
+      svLabel: 'velg metning og lysstyrke',
       svDescription:
-        'saturation {saturation}, brightness {brightness}, current color is {color}', // to be translated
-      predefineDescription: 'select {value} as the color', // to be translated
+        'metning {saturation}, lysstyrke {brightness}, gjeldende farge er {color}',
+      predefineDescription: 'velg {value} som farge',
     },
     datepicker: {
       now: 'Nå',
@@ -26,10 +26,10 @@ export default {
       clear: 'Tøm',
       confirm: 'OK',
       dateTablePrompt:
-        'Use the arrow keys and enter to select the day of the month', // to be translated
-      monthTablePrompt: 'Use the arrow keys and enter to select the month', // to be translated
-      yearTablePrompt: 'Use the arrow keys and enter to select the year', // to be translated
-      selectedDate: 'Selected date', // to be translated
+        'Bruk piltastene og enter for å velge dag i måneden',
+      monthTablePrompt: 'Bruk piltastene og enter for å velge måned',
+      yearTablePrompt: 'Bruk piltastene og enter for å velge år',
+      selectedDate: 'Valgt dato',
       selectDate: 'Velg dato',
       selectTime: 'Velg tidspunkt',
       startDate: 'Startdato',
@@ -63,13 +63,13 @@ export default {
         sat: 'Lør',
       },
       weeksFull: {
-        sun: 'Sunday', // to be translated
-        mon: 'Monday', // to be translated
-        tue: 'Tuesday', // to be translated
-        wed: 'Wednesday', // to be translated
-        thu: 'Thursday', // to be translated
-        fri: 'Friday', // to be translated
-        sat: 'Saturday', // to be translated
+        sun: 'Søndag',
+        mon: 'Mandag',
+        tue: 'Tirsdag',
+        wed: 'Onsdag',
+        thu: 'Torsdag',
+        fri: 'Fredag',
+        sat: 'Lørdag',
       },
       months: {
         jan: 'Jan',
@@ -87,8 +87,8 @@ export default {
       },
     },
     inputNumber: {
-      decrease: 'decrease number', // to be translated
-      increase: 'increase number', // to be translated
+      decrease: 'reduser tall',
+      increase: 'øk tall',
     },
     select: {
       loading: 'Laster',
@@ -100,7 +100,7 @@ export default {
       loading: 'Laster',
     },
     dropdown: {
-      toggleDropdown: 'Toggle Dropdown', // to be translated
+      toggleDropdown: 'Veksle nedtrekksmeny',
     },
     cascader: {
       noMatch: 'Ingen samsvarende resultater',
@@ -113,27 +113,27 @@ export default {
       pagesize: '/side',
       total: 'Total {total}',
       pageClassifier: '',
-      page: 'Page', // to be translated
-      prev: 'Go to previous page', // to be translated
-      next: 'Go to next page', // to be translated
-      currentPage: 'page {pager}', // to be translated
-      prevPages: 'Previous {pager} pages', // to be translated
-      nextPages: 'Next {pager} pages', // to be translated
+      page: 'Side',
+      prev: 'Gå til forrige side',
+      next: 'Gå til neste side',
+      currentPage: 'side {pager}',
+      prevPages: 'Forrige {pager} sider',
+      nextPages: 'Neste {pager} sider',
       deprecationWarning:
-        'Deprecated usages detected, please refer to the el-pagination documentation for more details', // to be translated
+        'Utdatert bruk oppdaget, se el-pagination-dokumentasjonen for flere detaljer',
     },
     dialog: {
-      close: 'Close this dialog', // to be translated
+      close: 'Lukk denne dialogen',
     },
     drawer: {
-      close: 'Close this dialog', // to be translated
+      close: 'Lukk denne dialogen',
     },
     messagebox: {
-      title: 'Message', // to be translated
+      title: 'Melding',
       confirm: 'OK',
       cancel: 'Avbryt',
       error: 'Ugyldig input',
-      close: 'Close this dialog', // to be translated
+      close: 'Lukk denne dialogen',
     },
     upload: {
       deleteTip: 'trykk på x for å slette',
@@ -142,9 +142,9 @@ export default {
       continue: 'Fortsett',
     },
     slider: {
-      defaultLabel: 'slider between {min} and {max}', // to be translated
-      defaultRangeStartLabel: 'pick start value', // to be translated
-      defaultRangeEndLabel: 'pick end value', // to be translated
+      defaultLabel: 'glidebryter mellom {min} og {max}',
+      defaultRangeStartLabel: 'velg startverdi',
+      defaultRangeEndLabel: 'velg sluttverdi',
     },
     table: {
       emptyText: 'Ingen Data',
@@ -152,21 +152,21 @@ export default {
       resetFilter: 'Tilbakestill',
       clearFilter: 'Alle',
       sumText: 'Sum',
-      selectAllLabel: 'Select all rows', // to be translated
-      selectRowLabel: 'Select this row', // to be translated
-      expandRowLabel: 'Expand this row', // to be translated
-      collapseRowLabel: 'Collapse this row', // to be translated
-      sortLabel: 'Sort by {column}', // to be translated
-      filterLabel: 'Filter by {column}', // to be translated
+      selectAllLabel: 'Velg alle rader',
+      selectRowLabel: 'Velg denne raden',
+      expandRowLabel: 'Utvid denne raden',
+      collapseRowLabel: 'Skjul denne raden',
+      sortLabel: 'Sorter etter {column}',
+      filterLabel: 'Filtrer etter {column}',
     },
     tag: {
-      close: 'Close this tag', // to be translated
+      close: 'Lukk denne taggen',
     },
     tour: {
-      next: 'Next', // to be translated
-      previous: 'Previous', // to be translated
-      finish: 'Finish', // to be translated
-      close: 'Close this dialog', // to be translated
+      next: 'Neste',
+      previous: 'Forrige',
+      finish: 'Fullfør',
+      close: 'Lukk denne dialogen',
     },
     tree: {
       emptyText: 'Ingen Data',
@@ -190,13 +190,13 @@ export default {
       cancelButtonText: 'Nei',
     },
     carousel: {
-      leftArrow: 'Carousel arrow left', // to be translated
-      rightArrow: 'Carousel arrow right', // to be translated
-      indicator: 'Carousel switch to index {index}', // to be translated
+      leftArrow: 'Karusellpil venstre',
+      rightArrow: 'Karusellpil høyre',
+      indicator: 'Karusell bytt til indeks {index}',
     },
     inputOTP: {
-      groupLabel: 'OTP Input', // to be translated
-      defaultLabel: 'Please enter OTP character {index}', // to be translated
+      groupLabel: 'OTP-inndata',
+      defaultLabel: 'Skriv inn OTP-tegn {index}',
     },
   },
 }

--- a/packages/locale/lang/nb-no.ts
+++ b/packages/locale/lang/nb-no.ts
@@ -25,8 +25,7 @@ export default {
       cancel: 'Avbryt',
       clear: 'Tøm',
       confirm: 'OK',
-      dateTablePrompt:
-        'Bruk piltastene og enter for å velge dag i måneden',
+      dateTablePrompt: 'Bruk piltastene og enter for å velge dag i måneden',
       monthTablePrompt: 'Bruk piltastene og enter for å velge måned',
       yearTablePrompt: 'Bruk piltastene og enter for å velge år',
       selectedDate: 'Valgt dato',


### PR DESCRIPTION
## Summary

Completes the Norwegian Bokmål (`nb-no`) locale. 54 strings were still in English (each marked `// to be translated`): colorpicker labels/descriptions, datepicker prompts + `weeksFull`, `inputNumber`, dropdown, pagination, dialog/drawer/messagebox `close`, slider, table aria labels, tag, tour, carousel and `inputOTP`. All are now translated to Bokmål and the `// to be translated` comments removed.

## Verification

Diffed against `en.ts`: 140/140 keys present, key parity is exact, and there are 0 interpolation-placeholder mismatches ({color}, {pager}, {index}, {min}/{max}, etc. all preserved). The file transpiles cleanly. Merging into the `dev` branch.

## Disclosure

These translations were produced with AI assistance (Claude) and reviewed by a native Norwegian (Bokmål) speaker. Happy to adjust any wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Localization**
  * Refreshed Norwegian (nb-no) language strings across the user interface, including breadcrumb, color picker, date picker prompts (and selected date), weekday names, number input controls, dropdown toggles, pagination, deprecation messaging, close labels for dialogs/drawers/message boxes, sliders, table row actions (select/expand/sort/filter), tags, tour navigation, carousel controls, and OTP inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->