### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/en-US/guide/installation.md
+++ b/docs/en-US/guide/installation.md
@@ -66,6 +66,10 @@ $ yarn add element-plus
 $ pnpm install element-plus
 ```
 
+```shell [deno]
+$ deno add element-plus
+```
+
 :::
 
 If your network environment is not good, it is recommended to use a mirror registry [cnpm](https://github.com/cnpm/cnpm) or [npmmirror](https://npmmirror.com/).


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install `code-group` lists pnpm / npm / yarn / bun. Since Deno is a drop-in replacement for npm these days, this adds a Deno tab in parity (element-plus resolves and runs the same way under Deno):

```sh
deno add element-plus
```

Docs-only change. Totally fine to close this if you'd rather not. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Deno installation instructions to the installation guide alongside existing package manager options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->