### PR TITLE
chore(project): tweak `pnpm-workspace.yaml`

### DIFF
--- a/internal/eslint-config/package.json
+++ b/internal/eslint-config/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-vue": "^10.9.0",
     "globals": "^17.5.0",
     "prettier": "^3.8.3",
-    "typescript": "~6.0.3",
+    "typescript": "catalog:",
     "typescript-eslint": "^8.59.0",
     "vue-eslint-parser": "^10.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "rimraf": "^6.1.3",
     "tinyglobby": "^0.2.17",
     "tsx": "catalog:",
-    "typescript": "~6.0.3",
+    "typescript": "catalog:",
     "vitest": "^4.1.9",
     "vue": "catalog:",
     "vue-router": "^5.1.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,3 +48,6 @@ shellEmulator: true
 strictPeerDependencies: false
 
 minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - 'element-plus'
+  - '@element-plus/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,13 +26,14 @@ catalog:
   vue: 3.5.25
   vue-component-type-helpers: ^3.3.3
   tsx: ^4.22.4
+  typescript: ~6.0.3
   # vitest: ^2.0.5
 
 dedupePeers: true
 
 overrides:
   jwa: ^1.4.2 # 20697
-  typescript: $typescript
+  typescript: 'catalog:'
 
 patchedDependencies:
   async-validator@4.2.5: patches/async-validator@4.2.5.patch #16757
@@ -45,3 +46,5 @@ peerDependencyRules:
 
 shellEmulator: true
 strictPeerDependencies: false
+
+minimumReleaseAge: 1440


### PR DESCRIPTION
https://github.com/pnpm/pnpm/releases#:~:text=Using%20the%20%24,catalog%3A%20protocol%20instead.
> Using the `$` version reference syntax in `overrides` (e.g. `"react": "$react"`) now prints a deprecation warning. The syntax still works, but [catalogs](https://pnpm.io/catalogs) are the recommended way to keep an overridden version in sync with the rest of the workspace. Reference a catalog entry with the `catalog:` protocol instead.

https://pnpm.io/settings#minimumreleaseage
> To reduce the risk of installing compromised packages, you can delay the installation of newly published versions. In most cases, malicious releases are discovered and removed from the registry within an hour.
> 
> minimumReleaseAge defines the minimum number of minutes that must pass after a version is published before pnpm will install it. This applies to all dependencies, including transitive ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized TypeScript version management by switching package resolution to the workspace catalog.
  * Updated workspace configuration for release-age requirements, including setting a minimum release age and adding exclusions for Element Plus packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->