### PR TITLE
fix(components): [input-otp] fix field line-height

### DIFF
--- a/packages/theme-chalk/src/input-otp.scss
+++ b/packages/theme-chalk/src/input-otp.scss
@@ -71,6 +71,7 @@
     height: 100%;
     position: relative;
     border-radius: getCssVar('border-radius-base');
+    line-height: 1;
   }
 
   @include e(input) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Fix input-otp field line-height issue

 closes  #24465 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the vertical alignment of text in the OTP input field by tightening its line spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->