### PR TITLE
fix(components): [select] prevent tag max-width from collapsing to negative value (#24457)

### DIFF
--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -340,7 +340,7 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
           gapWidth -
           inputSlotWidth
         : states.selectionWidth - inputSlotWidth
-    return { maxWidth: `${maxWidth}px` }
+    return maxWidth > 0 ? { maxWidth: `${maxWidth}px` } : {}
   })
 
   const collapseTagStyle = computed(() => {

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -904,7 +904,7 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
           gapWidth -
           inputSlotWidth
         : states.selectionWidth - inputSlotWidth
-    return { maxWidth: `${maxWidth}px` }
+    return maxWidth > 0 ? { maxWidth: `${maxWidth}px` } : {}
   })
 
   const collapseTagStyle = computed(() => {


### PR DESCRIPTION
## Description

Fix tag display issue in `el-select` and `el-select-v2` when used inside an inline form.

### Root Cause

In `tagStyle` computed, the tag`s `maxWidth` is calculated as:

```
maxWidth = selectionWidth - collapseItemWidth - gapWidth - inputSlotWidth
```

When the select is inside an inline form, the `selectionWidth` can shrink below the combined width of the collapse tag, gap, and input slot, causing `maxWidth` to be negative. This makes the tag completely invisible.

### Fix

Only apply the calculated `maxWidth` when it is positive. When space is insufficient, let the tag render at its natural width instead of collapsing to zero.

### Affected Components

- `el-select` — `packages/components/select/src/useSelect.ts`
- `el-select-v2` — `packages/components/select-v2/src/useSelect.ts`

### Closes

Closes #24457

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved select tag layout so width styling is only applied when the available space is positive.
  * Prevented invalid or unwanted width values from being applied in edge cases, resulting in more consistent tag and input rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->