### PR TITLE
fix(theme-chalk): [table] fix inconsistent outer border width

### DIFF
--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -160,7 +160,6 @@
           />
         </table>
       </div>
-      <div v-if="border || isGroup" :class="ns.e('border-left-patch')" />
     </div>
     <div
       v-show="resizeProxyVisible"

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -629,33 +629,6 @@
     }
   }
 
-  @include e(border-left-patch) {
-    top: 0;
-    left: 0;
-    width: 1px;
-    height: 100%;
-    z-index: calc(getCssVar('table-index') + 2);
-    position: absolute;
-    background-color: getCssVar('table-border-color');
-  }
-
-  @include e(border-bottom-patch) {
-    left: 0;
-    height: 1px;
-    z-index: calc(getCssVar('table-index') + 2);
-    position: absolute;
-    background-color: getCssVar('table-border-color');
-  }
-
-  @include e(border-right-patch) {
-    top: 0;
-    height: 100%;
-    width: 1px;
-    z-index: calc(getCssVar('table-index') + 2);
-    position: absolute;
-    background-color: getCssVar('table-border-color');
-  }
-
   @include m(enable-row-transition) {
     .#{$namespace}-table__body td.#{$namespace}-table__cell {
       transition: background-color 0.25s ease 1ms; // #23955


### PR DESCRIPTION
Remove redundant border-left-patch that duplicated the left pseudo-element border.


Closes #24481 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a set of extra table border patch elements and their related styling, simplifying how table borders are rendered.
  * This may resolve visual inconsistencies around tables, especially in bordered or grouped layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->