### PR TITLE
fix(style): [drawer] include popup lockscreen styles on import

### DIFF
--- a/packages/theme-chalk/src/drawer.scss
+++ b/packages/theme-chalk/src/drawer.scss
@@ -1,6 +1,7 @@
 @use 'mixins/mixins' as *;
 @use 'mixins/var' as *;
 @use 'common/var' as *;
+@use 'common/popup' as *;
 
 $directions: rtl, ltr, ttb, btt;
 


### PR DESCRIPTION
## Summary

This PR focuses specifically on the el-popup-parent--hidden issue.

As for the layout shift on the right side, since the fix involves shared hooks, I've moved it to a separate PR:
https://github.com/element-plus/element-plus/pull/24491

Adds `@use 'common/popup'` to `drawer.scss` so on-demand Drawer style imports include `.el-popup-parent--hidden { overflow: hidden }`.

before revision:

https://github.com/user-attachments/assets/fa467e69-07f3-4296-8a8e-09664d0bef87

after modification：

https://github.com/user-attachments/assets/7a07394b-534d-4573-a4e9-8a3180f175cc




Closes #24488 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated component styling setup to use shared popup styling resources, with no visible behavior changes for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->