### PR TITLE
fix(components): [time-picker] skip key handling during IME

### DIFF
--- a/packages/components/time-picker/__tests__/time-picker.test.tsx
+++ b/packages/components/time-picker/__tests__/time-picker.test.tsx
@@ -297,6 +297,41 @@ describe('TimePicker', () => {
     expect(handleVisibleChange).toHaveBeenCalledTimes(3)
   })
 
+  it('does not handle Enter while an IME composition is active', async () => {
+    const handleVisibleChange = vi.fn()
+    const value = ref(new Date(2016, 9, 10, 18, 40))
+
+    const wrapper = mount(() => (
+      <TimePicker v-model={value.value} onVisibleChange={handleVisibleChange} />
+    ))
+
+    const input = wrapper.find('input')
+    input.trigger('focus')
+    await nextTick()
+    await rAF()
+    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+
+    // Pressing Enter to confirm an IME candidate must not close the panel or
+    // swallow the keystroke that commits the composition.
+    const composingEnter = new KeyboardEvent('keydown', {
+      code: EVENT_CODE.enter,
+      isComposing: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    input.element.dispatchEvent(composingEnter)
+    await nextTick()
+    await rAF()
+    expect(handleVisibleChange).toHaveBeenCalledTimes(1)
+    expect(composingEnter.defaultPrevented).toBe(false)
+
+    // A normal Enter (composition already finished) still closes the panel.
+    input.trigger('keydown', { code: EVENT_CODE.enter })
+    await nextTick()
+    await rAF()
+    expect(handleVisibleChange).toHaveBeenCalledTimes(2)
+  })
+
   it('should cancel correctly the right value after manual input', async () => {
     const value = ref<[Date, Date]>([
       new Date(2016, 9, 10, 8, 40),

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -567,6 +567,10 @@ const handleKeydownInput = async (event: Event | KeyboardEvent) => {
 
   const code = getEventCode(event as KeyboardEvent)
   emitKeydown(event as KeyboardEvent)
+  // Skip internal key handling while an IME composition is active so that
+  // confirming/closing a candidate with Enter is not swallowed by
+  // preventDefault. Matches the guard in input-tag, select, mention, etc.
+  if ((event as KeyboardEvent).isComposing) return
   if (code === EVENT_CODE.esc) {
     if (pickerVisible.value === true) {
       pickerVisible.value = false


### PR DESCRIPTION
## What

`common/picker.vue` is the keydown handler shared by `el-time-picker` and `el-date-picker`. `handleKeydownInput` runs its esc / arrow / enter logic for every keydown, including the ones that fire while an IME composition is active.

When a CJK user presses Enter to confirm a conversion candidate, `event.code` is still `Enter` (the physical key), so the handler enters the Enter branch, calls `event.preventDefault()` / `event.stopPropagation()` and closes the panel. The Enter that was meant to commit the composition instead closes the picker in the middle of typing.

Steps to reproduce (Japanese, Chinese or any other IME):

1. Use an editable `el-date-picker` or `el-time-picker`.
2. Focus the input and start typing with the IME on, so a candidate is being composed.
3. Press Enter to confirm the candidate.

Expected: Enter confirms the IME candidate and the picker stays open.
Actual: the picker closes and `preventDefault()` is called on the composing Enter.

## How

Return early from `handleKeydownInput` when `event.isComposing` is true, before the internal esc / arrow / enter handling. This is the same guard the other editable components already use (`input-tag`, `select`, `mention`, `cascader`, `autocomplete`). The public `keydown` event is still emitted exactly as before, so only the picker's own key handling is skipped while composing.

## Test

Added a regression test in `time-picker.test.tsx`: it dispatches an `Enter` keydown with `isComposing: true` and asserts the panel stays open and the event is not default-prevented, while a normal Enter still closes the panel. Reverting the guard makes the new test fail because the composing Enter closes the panel. The `time-picker`, `date-picker` and `date-picker-panel` suites pass.

I did not find an existing issue for this, so there is no linked issue to reference.

---

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/dev/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/dev/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/dev/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/dev/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling in the time picker so Enter won’t accidentally close or confirm while IME text input is in progress.
  * Kept the picker panel open during composition, preventing unwanted interruption of non-Latin text entry.
  * Added coverage to verify Enter behaves normally once composition has ended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->