### PR TITLE
fix(components): [scrollbar] update component on transition and animation end

### DIFF
--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -6,6 +6,8 @@
       :style="wrapStyle"
       :tabindex="tabindex"
       @scroll="handleScroll"
+      @transitionend="updateBar"
+      @animationend="updateBar"
     >
       <component
         :is="tag"
@@ -218,6 +220,9 @@ const update = () => {
   if (wrapRef.value) barRef.value?.handleScroll(wrapRef.value)
 }
 
+// Transform-driven overflow (e.g. slide transitions) is not observable via
+// resize observers, so refresh the bar when transitions/animations end —
+// this applies even when `noresize` is set.
 const updateBar = () => {
   if (rafId) return
   rafId = requestAnimationFrame(() => {
@@ -247,11 +252,6 @@ watch(
   },
   { immediate: true }
 )
-
-// Transform-driven overflow (e.g. slide transitions) is not observable via
-// resize observers, so refresh the bar when transitions/animations end —
-// this applies even when `noresize` is set.
-useEventListener(wrapRef, ['transitionend', 'animationend'], updateBar)
 
 watch(
   () => [props.maxHeight, props.height],

--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -82,8 +82,6 @@ let stopWrapResizeObserver: (() => void) | undefined = undefined
 let stopResizeListener: (() => void) | undefined = undefined
 let stopTransitionListener: (() => void) | undefined = undefined
 let rafId = 0
-let lastScrollWidth = -1
-let lastScrollHeight = -1
 let wrapScrollTop = 0
 let wrapScrollLeft = 0
 let direction = '' as ScrollbarDirection
@@ -227,16 +225,9 @@ const updateBar = () => {
     rafId = 0
     if (!wrapRef.value) return
 
-    if (
-      wrapRef.value.scrollWidth === lastScrollWidth &&
-      wrapRef.value.scrollHeight === lastScrollHeight
-    ) {
-      return
-    }
-
-    lastScrollWidth = wrapRef.value.scrollWidth
-    lastScrollHeight = wrapRef.value.scrollHeight
-
+    // Bar state may be stale even when the final scroll dimensions match a
+    // previously seen value (e.g. `onUpdated` measured the transient
+    // overflow mid-transition), so always refresh the bar here.
     barRef.value?.update()
     barRef.value?.handleScroll(wrapRef.value)
   })

--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -80,7 +80,6 @@ const ns = useNamespace('scrollbar')
 let stopResizeObserver: (() => void) | undefined = undefined
 let stopWrapResizeObserver: (() => void) | undefined = undefined
 let stopResizeListener: (() => void) | undefined = undefined
-let stopTransitionListener: (() => void) | undefined = undefined
 let rafId = 0
 let wrapScrollTop = 0
 let wrapScrollLeft = 0
@@ -240,24 +239,19 @@ watch(
       stopResizeObserver?.()
       stopWrapResizeObserver?.()
       stopResizeListener?.()
-      stopTransitionListener?.()
-      if (rafId) {
-        cancelAnimationFrame(rafId)
-        rafId = 0
-      }
     } else {
       ;({ stop: stopResizeObserver } = useResizeObserver(resizeRef, update))
       ;({ stop: stopWrapResizeObserver } = useResizeObserver(wrapRef, update))
       stopResizeListener = useEventListener('resize', update)
-      stopTransitionListener = useEventListener(
-        wrapRef,
-        ['transitionend', 'animationend'],
-        updateBar
-      )
     }
   },
   { immediate: true }
 )
+
+// Transform-driven overflow (e.g. slide transitions) is not observable via
+// resize observers, so refresh the bar when transitions/animations end —
+// this applies even when `noresize` is set.
+useEventListener(wrapRef, ['transitionend', 'animationend'], updateBar)
 
 watch(
   () => [props.maxHeight, props.height],

--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -80,6 +80,10 @@ const ns = useNamespace('scrollbar')
 let stopResizeObserver: (() => void) | undefined = undefined
 let stopWrapResizeObserver: (() => void) | undefined = undefined
 let stopResizeListener: (() => void) | undefined = undefined
+let stopTransitionListener: (() => void) | undefined = undefined
+let rafId = 0
+let lastScrollWidth = -1
+let lastScrollHeight = -1
 let wrapScrollTop = 0
 let wrapScrollLeft = 0
 let direction = '' as ScrollbarDirection
@@ -217,6 +221,27 @@ const update = () => {
   if (wrapRef.value) barRef.value?.handleScroll(wrapRef.value)
 }
 
+const updateBar = () => {
+  if (rafId) return
+  rafId = requestAnimationFrame(() => {
+    rafId = 0
+    if (!wrapRef.value) return
+
+    if (
+      wrapRef.value.scrollWidth === lastScrollWidth &&
+      wrapRef.value.scrollHeight === lastScrollHeight
+    ) {
+      return
+    }
+
+    lastScrollWidth = wrapRef.value.scrollWidth
+    lastScrollHeight = wrapRef.value.scrollHeight
+
+    barRef.value?.update()
+    barRef.value?.handleScroll(wrapRef.value)
+  })
+}
+
 watch(
   () => props.noresize,
   (noresize) => {
@@ -224,10 +249,20 @@ watch(
       stopResizeObserver?.()
       stopWrapResizeObserver?.()
       stopResizeListener?.()
+      stopTransitionListener?.()
+      if (rafId) {
+        cancelAnimationFrame(rafId)
+        rafId = 0
+      }
     } else {
       ;({ stop: stopResizeObserver } = useResizeObserver(resizeRef, update))
       ;({ stop: stopWrapResizeObserver } = useResizeObserver(wrapRef, update))
       stopResizeListener = useEventListener('resize', update)
+      stopTransitionListener = useEventListener(
+        wrapRef,
+        ['transitionend', 'animationend'],
+        updateBar
+      )
     }
   },
   { immediate: true }


### PR DESCRIPTION
Regarding fixing this issue:
fix #24507

`ElScrollbar` leaves a scroll thumb after a horizontal slide in/out transition in a container

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrollbar responsiveness when content changes during active transitions or animations.
  * Refined the automatic resize behavior to correctly stop and restart transition/animation update listeners, avoiding stale or duplicated updates.
  * Ensures updates are throttled to animation frames and skipped when scroll dimensions haven’t changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->