### PR TITLE
style(components): [input] fix textarea scrollbar cursor in dialog

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -50,6 +50,7 @@
   font-size: getCssVar('font-size', 'base');
 
   @include e(inner) {
+    cursor: auto;
     position: relative;
     display: block;
     resize: vertical;


### PR DESCRIPTION
## Summary

- Fix incorrect `cursor: text` when hovering the scrollbar of `el-input type="textarea"` inside `el-dialog`
- Explicitly set `cursor: auto` on `.el-textarea__inner` so the text area keeps the I-beam cursor while the scrollbar uses the default arrow cursor

Fixes #24518

## Background

In #24518, the reporter observed that when a textarea inside a dialog shows a vertical scrollbar, hovering over the scrollbar displays a text cursor instead of the expected default/pointer cursor. The same component behaves correctly outside of a dialog.

`.el-textarea__inner` did not explicitly declare a `cursor` value. In overlay contexts (fixed positioning, overflow, focus trap), the inherited cursor can cause the scrollbar region to show `cursor: text` as well.

## Reproduction notes

I was **unable to reproduce this issue locally on Windows 11 or macOS** using the same setup from the issue.

However, the bug **can be reproduced on Element Plus Playground**:

[[demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZGl2IGNsYXNzPVwiZmxleCBmbGV4LXdyYXAgZ2FwLTFcIj5cbiAgICA8ZWwtYnV0dG9uIGNsYXNzPVwiIW1sLTBcIiBwbGFpbiBAY2xpY2s9XCJkaWFsb2dGb3JtVmlzaWJsZSA9IHRydWVcIj5cbiAgICAgIE9wZW4gYSBGb3JtIG5lc3RlZCBEaWFsb2dcbiAgICA8L2VsLWJ1dHRvbj5cbiAgPC9kaXY+XG5cbiAgPGVsLWRpYWxvZyB2LW1vZGVsPVwiZGlhbG9nRm9ybVZpc2libGVcIiB0aXRsZT1cIlNoaXBwaW5nIGFkZHJlc3NcIiB3aWR0aD1cIjUwMFwiPlxuICAgIDxlbC1mb3JtIDptb2RlbD1cImZvcm1cIj5cbiAgICAgIDxlbC1mb3JtLWl0ZW0gbGFiZWw9XCJQcm9tb3Rpb24gbmFtZVwiIDpsYWJlbC13aWR0aD1cImZvcm1MYWJlbFdpZHRoXCI+XG4gICAgICAgIDxlbC1pbnB1dCB2LW1vZGVsPVwiZm9ybS5uYW1lXCIgYXV0b2NvbXBsZXRlPVwib2ZmXCIgdHlwZT1cInRleHRhcmVhXCIgOnJvd3M9XCIzXCIvPlxuICAgICAgPC9lbC1mb3JtLWl0ZW0+XG4gICAgPC9lbC1mb3JtPlxuICAgIDx0ZW1wbGF0ZSAjZm9vdGVyPlxuICAgICAgPGRpdiBjbGFzcz1cImRpYWxvZy1mb290ZXJcIj5cbiAgICAgICAgPGVsLWJ1dHRvbiBAY2xpY2s9XCJkaWFsb2dGb3JtVmlzaWJsZSA9IGZhbHNlXCI+Q2FuY2VsPC9lbC1idXR0b24+XG4gICAgICAgIDxlbC1idXR0b24gdHlwZT1cInByaW1hcnlcIiBAY2xpY2s9XCJkaWFsb2dGb3JtVmlzaWJsZSA9IGZhbHNlXCI+XG4gICAgICAgICAgQ29uZmlybVxuICAgICAgICA8L2VsLWJ1dHRvbj5cbiAgICAgIDwvZGl2PlxuICAgIDwvdGVtcGxhdGU+XG4gIDwvZWwtZGlhbG9nPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBsYW5nPVwidHNcIiBzZXR1cD5cbmltcG9ydCB7IHJlYWN0aXZlLCByZWYgfSBmcm9tICd2dWUnXG5cbmNvbnN0IGRpYWxvZ0Zvcm1WaXNpYmxlID0gcmVmKHRydWUpXG5jb25zdCBmb3JtTGFiZWxXaWR0aCA9ICcxNDBweCdcblxuY29uc3QgZm9ybSA9IHJlYWN0aXZlKHtcbiAgbmFtZTogJzFcXG4yXFxuM1xcbjQnLFxufSlcbjwvc2NyaXB0PlxuIiwiZWxlbWVudC1wbHVzLmpzIjoiaW1wb3J0IEVsZW1lbnRQbHVzIGZyb20gJ2VsZW1lbnQtcGx1cydcbmltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcblxubGV0IGluc3RhbGxlZCA9IGZhbHNlXG5hd2FpdCBsb2FkU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gc2V0dXBFbGVtZW50UGx1cygpIHtcbiAgaWYgKGluc3RhbGxlZCkgcmV0dXJuXG4gIGNvbnN0IGluc3RhbmNlID0gZ2V0Q3VycmVudEluc3RhbmNlKClcbiAgaW5zdGFuY2UuYXBwQ29udGV4dC5hcHAudXNlKEVsZW1lbnRQbHVzKVxuICBpbnN0YWxsZWQgPSB0cnVlXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkU3R5bGUoKSB7XG4gIGNvbnN0IHN0eWxlcyA9IFsnaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L2Rpc3QvaW5kZXguY3NzJywgJ2h0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC90aGVtZS1jaGFsay9kYXJrL2Nzcy12YXJzLmNzcyddLm1hcCgoc3R5bGUpID0+IHtcbiAgICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICAgIGxpbmsuaHJlZiA9IHN0eWxlXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2xvYWQnLCByZXNvbHZlKVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdlcnJvcicsIHJlamVjdClcbiAgICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gICAgfSlcbiAgfSlcbiAgcmV0dXJuIFByb21pc2UuYWxsU2V0dGxlZChzdHlsZXMpXG59XG4iLCJ0c2NvbmZpZy5qc29uIjoie1xuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcbiAgICBcImpzeFwiOiBcInByZXNlcnZlXCIsXG4gICAgXCJtb2R1bGVcIjogXCJFU05leHRcIixcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXG4gICAgXCJ0eXBlc1wiOiBbXCJlbGVtZW50LXBsdXMvZ2xvYmFsLmQudHNcIl0sXG4gICAgXCJhbGxvd0ltcG9ydGluZ1RzRXh0ZW5zaW9uc1wiOiB0cnVlLFxuICAgIFwiYWxsb3dKc1wiOiB0cnVlLFxuICAgIFwiY2hlY2tKc1wiOiB0cnVlXG4gIH0sXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiAzLjNcbiAgfVxufVxuIiwiUGxheWdyb3VuZE1haW4udnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBBcHAgZnJvbSAnLi9BcHAudnVlJ1xuaW1wb3J0IHsgc2V0dXBFbGVtZW50UGx1cyB9IGZyb20gJy4vZWxlbWVudC1wbHVzLmpzJ1xuc2V0dXBFbGVtZW50UGx1cygpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8QXBwIC8+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3J1bnRpbWUtZG9tQGxhdGVzdC9kaXN0L3J1bnRpbWUtZG9tLmVzbS1icm93c2VyLmpzXCIsXG4gICAgXCJAdnVlL3NoYXJlZFwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9zaGFyZWRAbGF0ZXN0L2Rpc3Qvc2hhcmVkLmVzbS1idW5kbGVyLmpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXNcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvZGlzdC9pbmRleC5mdWxsLm1pbi5tanNcIixcbiAgICBcImVsZW1lbnQtcGx1cy9cIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvXCIsXG4gICAgXCJAZWxlbWVudC1wbHVzL2ljb25zLXZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQGVsZW1lbnQtcGx1cy9pY29ucy12dWVAMi9kaXN0L2luZGV4Lm1pbi5qc1wiXG4gIH0sXG4gIFwic2NvcGVzXCI6IHt9XG59IiwiQ29tcC52dWUiOiIiLCJfbyI6e319)]

Steps:
1. Open the playground link above
2. Hover the mouse over the textarea scrollbar

On Playground, the scrollbar incorrectly shows a text cursor. Adding the following override resolves it:

```vue
<style>
.el-textarea__inner {
  cursor: auto;
}
</style>
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the textarea input area so the cursor displays normally instead of using a text-style pointer when hovering or editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->