### PR TITLE
refactor(components): [popover] replace attrs with props for better type inference

### DIFF
--- a/packages/components/popover/__tests__/popover.test.tsx
+++ b/packages/components/popover/__tests__/popover.test.tsx
@@ -77,8 +77,6 @@ describe('Popover.vue', () => {
       <Popover
         content={content}
         teleported={false}
-        // type checking failed as `virtualRef` is a fallthrough attribute
-        // @ts-ignore
         virtualRef={virtualRef}
         virtualTriggering
       />

--- a/packages/components/popover/src/popover.ts
+++ b/packages/components/popover/src/popover.ts
@@ -6,12 +6,16 @@ import {
 } from '@element-plus/components/tooltip'
 import { dropdownProps } from '@element-plus/components/dropdown'
 import { popperArrowPropsDefaults } from '@element-plus/components/popper'
+import { omit } from 'lodash-unified'
 
 import type { UseTooltipProps } from '@element-plus/components/tooltip'
 import type { ExtractPublicPropTypes } from 'vue'
 import type Popover from './popover.vue'
 
-export interface PopoverProps extends UseTooltipProps {
+export interface PopoverProps extends Omit<
+  UseTooltipProps,
+  'ariaLabel' | 'rawContent'
+> {
   /**
    * @description [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) of Popover
    */
@@ -30,7 +34,7 @@ export interface PopoverProps extends UseTooltipProps {
  * @deprecated Removed after 3.0.0, Use `PopoverProps` instead.
  */
 export const popoverProps = buildProps({
-  ...useTooltipProps,
+  ...omit(useTooltipProps, ['ariaLabel', 'rawContent']),
   /**
    * @description popover placement
    */

--- a/packages/components/popover/src/popover.ts
+++ b/packages/components/popover/src/popover.ts
@@ -14,7 +14,7 @@ import type Popover from './popover.vue'
 
 export interface PopoverProps extends Omit<
   UseTooltipProps,
-  'ariaLabel' | 'rawContent'
+  'ariaLabel' | 'gpuAcceleration' | 'rawContent'
 > {
   /**
    * @description [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) of Popover
@@ -34,7 +34,7 @@ export interface PopoverProps extends Omit<
  * @deprecated Removed after 3.0.0, Use `PopoverProps` instead.
  */
 export const popoverProps = buildProps({
-  ...omit(useTooltipProps, ['ariaLabel', 'rawContent']),
+  ...omit(useTooltipProps, ['ariaLabel', 'gpuAcceleration', 'rawContent']),
   /**
    * @description popover placement
    */

--- a/packages/components/popover/src/popover.ts
+++ b/packages/components/popover/src/popover.ts
@@ -40,6 +40,13 @@ export const popoverProps = buildProps({
    */
   tabindex: dropdownProps.tabindex,
   /**
+   * @description Tooltip theme, built-in theme: `dark` / `light`
+   */
+  effect: {
+    ...useTooltipProps.effect,
+    default: 'light',
+  },
+  /**
    * @description popover title
    */
   title: String,
@@ -49,6 +56,20 @@ export const popoverProps = buildProps({
   width: {
     type: [String, Number],
     default: 150,
+  },
+  /**
+   * @description popover offset
+   */
+  offset: {
+    ...useTooltipProps.offset,
+    default: undefined,
+  },
+  /**
+   * @description when popover inactive and `persistent` is `false` , popover will be destroyed
+   */
+  persistent: {
+    ...useTooltipProps.persistent,
+    default: true,
   },
 } as const)
 

--- a/packages/components/popover/src/popover.ts
+++ b/packages/components/popover/src/popover.ts
@@ -1,89 +1,21 @@
 import { buildProps, isBoolean } from '@element-plus/utils'
 import {
-  useTooltipContentProps,
-  useTooltipTriggerProps,
+  useTooltipContentPropsDefaults,
+  useTooltipProps,
+  useTooltipTriggerPropsDefaults,
 } from '@element-plus/components/tooltip'
 import { dropdownProps } from '@element-plus/components/dropdown'
-import { EVENT_CODE } from '@element-plus/constants'
+import { popperArrowPropsDefaults } from '@element-plus/components/popper'
 
-import type { ExtractPublicPropTypes, PropType } from 'vue'
+import type { UseTooltipProps } from '@element-plus/components/tooltip'
+import type { ExtractPublicPropTypes } from 'vue'
 import type Popover from './popover.vue'
-import type { Placement } from '@element-plus/components/popper'
-import type { Options } from '@popperjs/core'
-import type {
-  ElTooltipContentProps,
-  UseTooltipTriggerProps,
-} from '@element-plus/components/tooltip'
 
-export interface PopoverProps {
-  /**
-   * @description how the popover is triggered, not valid in controlled mode
-   */
-  trigger?: UseTooltipTriggerProps['trigger']
-  /**
-   * @description When you click the mouse to focus on the trigger element, you can define a set of keyboard codes to control the display of popover through the keyboard, not valid in controlled mode
-   */
-  triggerKeys?: UseTooltipTriggerProps['triggerKeys']
-  /**
-   * @description Indicates whether virtual triggering is enabled
-   */
-  virtualTriggering?: UseTooltipTriggerProps['virtualTriggering']
-  /**
-   * @description Indicates the reference element to which the popover is attached
-   */
-  virtualRef?: UseTooltipTriggerProps['virtualRef']
-  /**
-   * @description popover placement
-   */
-  placement?: Placement
-  /**
-   * @description whether Popover is disabled
-   */
-  disabled?: UseTooltipTriggerProps['disabled']
-  /**
-   * @description whether popover is visible
-   */
-  visible?: ElTooltipContentProps['visible']
-  /**
-   * @description popover transition animation
-   */
-  transition?: ElTooltipContentProps['transition']
-  /**
-   * @description parameters for [popper.js](https://popper.js.org/docs/v2/)
-   */
-  popperOptions?: Partial<Options>
+export interface PopoverProps extends UseTooltipProps {
   /**
    * @description [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) of Popover
    */
   tabindex?: string | number
-  /**
-   * @description popover content, can be replaced with a default `slot`
-   */
-  content?: ElTooltipContentProps['content']
-  /**
-   * @description custom style for popover
-   */
-  popperStyle?: ElTooltipContentProps['popperStyle']
-  /**
-   * @description custom class name for popover
-   */
-  popperClass?: ElTooltipContentProps['popperClass']
-  /**
-   * @description whether the mouse can enter the popover
-   */
-  enterable?: ElTooltipContentProps['enterable']
-  /**
-   * @description Tooltip theme, built-in theme: `dark` / `light`
-   */
-  effect?: ElTooltipContentProps['effect']
-  /**
-   * @description whether popover dropdown is teleported to the body
-   */
-  teleported?: ElTooltipContentProps['teleported']
-  /**
-   * @description which select dropdown appends to
-   */
-  appendTo?: ElTooltipContentProps['appendTo']
   /**
    * @description popover title
    */
@@ -92,111 +24,21 @@ export interface PopoverProps {
    * @description popover width
    */
   width?: string | number
-  /**
-   * @description popover offset
-   */
-  offset?: number
-  /**
-   * @description delay of appearance, in millisecond, not valid in controlled mode
-   */
-  showAfter?: number
-  /**
-   * @description delay of disappear, in millisecond, not valid in controlled mode
-   */
-  hideAfter?: number
-  /**
-   * @description timeout in milliseconds to hide tooltip, not valid in controlled mode
-   */
-  autoClose?: number
-  /**
-   * @description whether a tooltip arrow is displayed or not. For more info, please refer to [ElPopper](https://github.com/element-plus/element-plus/tree/dev/packages/components/popper)
-   */
-  showArrow?: boolean
-  /**
-   * @description when popover inactive and `persistent` is `false` , popover will be destroyed
-   */
-  persistent?: boolean
-  /**
-   * @description update:visible event handler
-   */
-  'onUpdate:visible'?: (visible: boolean) => void
 }
 
 /**
  * @deprecated Removed after 3.0.0, Use `PopoverProps` instead.
  */
 export const popoverProps = buildProps({
-  /**
-   * @description how the popover is triggered, not valid in controlled mode
-   */
-  trigger: useTooltipTriggerProps.trigger,
-  /**
-   * @description When you click the mouse to focus on the trigger element, you can define a set of keyboard codes to control the display of popover through the keyboard, not valid in controlled mode
-   */
-  triggerKeys: useTooltipTriggerProps.triggerKeys,
-  /**
-   * @description Indicates whether virtual triggering is enabled
-   */
-  virtualTriggering: useTooltipTriggerProps.virtualTriggering,
-  /**
-   * @description Indicates the reference element to which the popover is attached
-   */
-  virtualRef: useTooltipTriggerProps.virtualRef,
+  ...useTooltipProps,
   /**
    * @description popover placement
    */
   placement: dropdownProps.placement,
   /**
-   * @description whether Popover is disabled
-   */
-  disabled: useTooltipTriggerProps.disabled,
-  /**
-   * @description whether popover is visible
-   */
-  visible: useTooltipContentProps.visible,
-  /**
-   * @description popover transition animation
-   */
-  transition: useTooltipContentProps.transition,
-  /**
-   * @description parameters for [popper.js](https://popper.js.org/docs/v2/)
-   */
-  popperOptions: dropdownProps.popperOptions,
-  /**
    * @description [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) of Popover
    */
   tabindex: dropdownProps.tabindex,
-  /**
-   * @description popover content, can be replaced with a default `slot`
-   */
-  content: useTooltipContentProps.content,
-  /**
-   * @description custom style for popover
-   */
-  popperStyle: useTooltipContentProps.popperStyle,
-  /**
-   * @description custom class name for popover
-   */
-  popperClass: useTooltipContentProps.popperClass,
-  enterable: {
-    ...useTooltipContentProps.enterable,
-    default: true,
-  },
-  /**
-   * @description Tooltip theme, built-in theme: `dark` / `light`
-   */
-  effect: {
-    ...useTooltipContentProps.effect,
-    default: 'light',
-  },
-  /**
-   * @description whether popover dropdown is teleported to the body
-   */
-  teleported: useTooltipContentProps.teleported,
-  /**
-   * @description which select dropdown appends to
-   */
-  appendTo: useTooltipContentProps.appendTo,
   /**
    * @description popover title
    */
@@ -207,51 +49,6 @@ export const popoverProps = buildProps({
   width: {
     type: [String, Number],
     default: 150,
-  },
-  /**
-   * @description popover offset
-   */
-  offset: {
-    type: Number,
-    default: undefined,
-  },
-  /**
-   * @description delay of appearance, in millisecond, not valid in controlled mode
-   */
-  showAfter: {
-    type: Number,
-    default: 0,
-  },
-  /**
-   * @description delay of disappear, in millisecond, not valid in controlled mode
-   */
-  hideAfter: {
-    type: Number,
-    default: 200,
-  },
-  /**
-   * @description timeout in milliseconds to hide tooltip, not valid in controlled mode
-   */
-  autoClose: {
-    type: Number,
-    default: 0,
-  },
-  /**
-   * @description whether a tooltip arrow is displayed or not. For more info, please refer to [ElPopper](https://github.com/element-plus/element-plus/tree/dev/packages/components/popper)
-   */
-  showArrow: {
-    type: Boolean,
-    default: true,
-  },
-  /**
-   * @description when popover inactive and `persistent` is `false` , popover will be destroyed
-   */
-  persistent: {
-    type: Boolean,
-    default: true,
-  },
-  'onUpdate:visible': {
-    type: Function as PropType<(visible: boolean) => void>,
   },
 } as const)
 
@@ -275,27 +72,14 @@ export type PopoverInstance = InstanceType<typeof Popover> & unknown
  * @description default values for PopoverProps
  */
 export const popoverPropsDefaults = {
-  trigger: 'hover',
-  triggerKeys: () => [
-    EVENT_CODE.enter,
-    EVENT_CODE.numpadEnter,
-    EVENT_CODE.space,
-  ],
-  placement: 'bottom',
-  visible: null,
-  popperOptions: () => ({}),
+  ...useTooltipContentPropsDefaults,
+  ...useTooltipTriggerPropsDefaults,
+  ...popperArrowPropsDefaults,
+  title: undefined,
   tabindex: 0,
-  content: '',
-  popperClass: undefined,
-  popperStyle: undefined,
-  enterable: true,
   effect: 'light',
-  teleported: true,
   width: 150,
   offset: undefined,
-  showAfter: 0,
-  hideAfter: 200,
-  autoClose: 0,
   showArrow: true,
   persistent: true,
 } as const

--- a/packages/components/popover/src/popover.ts
+++ b/packages/components/popover/src/popover.ts
@@ -25,6 +25,14 @@ export interface PopoverProps {
    */
   triggerKeys?: UseTooltipTriggerProps['triggerKeys']
   /**
+   * @description Indicates whether virtual triggering is enabled
+   */
+  virtualTriggering?: UseTooltipTriggerProps['virtualTriggering']
+  /**
+   * @description Indicates the reference element to which the popover is attached
+   */
+  virtualRef?: UseTooltipTriggerProps['virtualRef']
+  /**
    * @description popover placement
    */
   placement?: Placement
@@ -126,6 +134,14 @@ export const popoverProps = buildProps({
    * @description When you click the mouse to focus on the trigger element, you can define a set of keyboard codes to control the display of popover through the keyboard, not valid in controlled mode
    */
   triggerKeys: useTooltipTriggerProps.triggerKeys,
+  /**
+   * @description Indicates whether virtual triggering is enabled
+   */
+  virtualTriggering: useTooltipTriggerProps.virtualTriggering,
+  /**
+   * @description Indicates the reference element to which the popover is attached
+   */
+  virtualRef: useTooltipTriggerProps.virtualRef,
   /**
    * @description popover placement
    */

--- a/packages/components/popover/src/popover.vue
+++ b/packages/components/popover/src/popover.vue
@@ -28,8 +28,8 @@
 
 <script lang="ts" setup>
 import { computed, ref, unref } from 'vue'
-import { pick } from 'lodash-unified'
-import { ElTooltip, useTooltipProps } from '@element-plus/components/tooltip'
+import { isArray, pick } from 'lodash-unified'
+import { ElTooltip } from '@element-plus/components/tooltip'
 import { addUnit } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { popoverEmits, popoverPropsDefaults } from './popover'
@@ -45,7 +45,8 @@ const props = withDefaults(defineProps<PopoverProps>(), popoverPropsDefaults)
 const emit = defineEmits(popoverEmits)
 
 const passTooltipProps = computed(() => {
-  const keys = Object.keys(useTooltipProps)
+  const tooltipProps = ElTooltip.props
+  const keys = isArray(tooltipProps) ? tooltipProps : Object.keys(tooltipProps)
   return pick(props, keys)
 })
 

--- a/packages/components/popover/src/popover.vue
+++ b/packages/components/popover/src/popover.vue
@@ -28,9 +28,9 @@
 
 <script lang="ts" setup>
 import { computed, ref, unref } from 'vue'
-import { isArray, pick } from 'lodash-unified'
+import { pick } from 'lodash-unified'
 import { ElTooltip } from '@element-plus/components/tooltip'
-import { addUnit } from '@element-plus/utils'
+import { addUnit, isArray } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { popoverEmits, popoverPropsDefaults } from './popover'
 

--- a/packages/components/popover/src/popover.vue
+++ b/packages/components/popover/src/popover.vue
@@ -6,7 +6,6 @@
     :popper-class="kls"
     :popper-style="style"
     :gpu-acceleration="gpuAcceleration"
-    @update:visible="onUpdateVisible"
     @before-show="beforeEnter"
     @before-hide="beforeLeave"
     @show="afterEnter"
@@ -48,12 +47,6 @@ const emit = defineEmits(popoverEmits)
 const passTooltipProps = computed(() => {
   const keys = Object.keys(useTooltipProps)
   return pick(props, keys)
-})
-
-const updateEventKeyRaw = `onUpdate:visible` as const
-
-const onUpdateVisible = computed(() => {
-  return props[updateEventKeyRaw]
 })
 
 const ns = useNamespace('popover')

--- a/packages/components/popover/src/popover.vue
+++ b/packages/components/popover/src/popover.vue
@@ -4,6 +4,8 @@
     v-bind="$attrs"
     :trigger="trigger"
     :trigger-keys="triggerKeys"
+    :virtual-ref="virtualRef"
+    :virtual-triggering="virtualTriggering"
     :placement="placement"
     :disabled="disabled"
     :visible="visible"

--- a/packages/components/popover/src/popover.vue
+++ b/packages/components/popover/src/popover.vue
@@ -1,31 +1,10 @@
 <template>
   <el-tooltip
     ref="tooltipRef"
-    v-bind="$attrs"
-    :trigger="trigger"
-    :trigger-keys="triggerKeys"
-    :virtual-ref="virtualRef"
-    :virtual-triggering="virtualTriggering"
-    :placement="placement"
-    :disabled="disabled"
-    :visible="visible"
-    :transition="transition"
-    :popper-options="popperOptions"
-    :tabindex="tabindex"
-    :content="content"
-    :offset="offset"
-    :show-after="showAfter"
-    :hide-after="hideAfter"
-    :auto-close="autoClose"
-    :show-arrow="showArrow"
+    v-bind="passTooltipProps"
     :aria-label="title"
-    :effect="effect"
-    :enterable="enterable"
     :popper-class="kls"
     :popper-style="style"
-    :teleported="teleported"
-    :append-to="appendTo"
-    :persistent="persistent"
     :gpu-acceleration="gpuAcceleration"
     @update:visible="onUpdateVisible"
     @before-show="beforeEnter"
@@ -50,7 +29,8 @@
 
 <script lang="ts" setup>
 import { computed, ref, unref } from 'vue'
-import { ElTooltip } from '@element-plus/components/tooltip'
+import { pick } from 'lodash-unified'
+import { ElTooltip, useTooltipProps } from '@element-plus/components/tooltip'
 import { addUnit } from '@element-plus/utils'
 import { useNamespace } from '@element-plus/hooks'
 import { popoverEmits, popoverPropsDefaults } from './popover'
@@ -64,6 +44,11 @@ defineOptions({
 
 const props = withDefaults(defineProps<PopoverProps>(), popoverPropsDefaults)
 const emit = defineEmits(popoverEmits)
+
+const passTooltipProps = computed(() => {
+  const keys = Object.keys(useTooltipProps)
+  return pick(props, keys)
+})
 
 const updateEventKeyRaw = `onUpdate:visible` as const
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix: #24570 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved how popover forwards tooltip configuration by passing the complete, computed set of tooltip options through a unified binding.
  - Updated popover prop typings so tooltip-derived properties are reflected directly on popovers for more consistent behavior and better type safety.

- **Tests**
  - Updated the popover virtual-ref test to remove an unnecessary TypeScript suppression while keeping the same runtime assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->