### PR TITLE
fix(directives): stop repeat-click after mouseup

### DIFF
--- a/packages/directives/__tests__/repeat-click.test.tsx
+++ b/packages/directives/__tests__/repeat-click.test.tsx
@@ -58,14 +58,18 @@ describe('Directives.vue', () => {
 
     vi.useFakeTimers()
     document.body.appendChild(block.element)
-    block.element.addEventListener('mouseup', (event) =>
-      event.stopPropagation()
-    )
-    await block.trigger('mousedown')
-    block.element.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
-    vi.advanceTimersByTime(PRESS_TIME)
+    try {
+      block.element.addEventListener('mouseup', (event) =>
+        event.stopPropagation()
+      )
+      await block.trigger('mousedown')
+      block.element.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+      vi.advanceTimersByTime(PRESS_TIME)
 
-    expect(handler).toHaveBeenCalledTimes(1)
-    vi.useRealTimers()
+      expect(handler).toHaveBeenCalledTimes(1)
+    } finally {
+      block.element.remove()
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/directives/__tests__/repeat-click.test.tsx
+++ b/packages/directives/__tests__/repeat-click.test.tsx
@@ -51,4 +51,21 @@ describe('Directives.vue', () => {
     expect(handler).toHaveBeenCalledTimes(2)
     vi.useRealTimers()
   })
+
+  it('stops repeating when mouseup propagation is stopped', async () => {
+    const wrapper = _mount()
+    const block = wrapper.find('#block')
+
+    vi.useFakeTimers()
+    document.body.appendChild(block.element)
+    block.element.addEventListener('mouseup', (event) =>
+      event.stopPropagation()
+    )
+    await block.trigger('mousedown')
+    block.element.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    vi.advanceTimersByTime(PRESS_TIME)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
 })

--- a/packages/directives/repeat-click/index.ts
+++ b/packages/directives/repeat-click/index.ts
@@ -52,7 +52,10 @@ export const vRepeatClick: ObjectDirective<
       clear()
       handler()
 
-      document.addEventListener('mouseup', clear, { once: true })
+      document.addEventListener('mouseup', clear, {
+        once: true,
+        capture: true,
+      })
 
       delayId = setTimeout(() => {
         intervalId = setInterval(() => {
@@ -73,7 +76,7 @@ export const vRepeatClick: ObjectDirective<
     }
     if (clear) {
       clear()
-      document.removeEventListener('mouseup', clear)
+      document.removeEventListener('mouseup', clear, true)
     }
     el[SCOPE] = null
   },


### PR DESCRIPTION
## Summary

- listen for document `mouseup` events during the capture phase
- stop repeat-click even when the target uses `mouseup.stopPropagation()`
- add regression coverage for the stopped-propagation scenario

## Tests

- `pnpm test packages/directives/__tests__/repeat-click.test.tsx --run`
- `pnpm test packages/directives/__tests__ --run`
- `pnpm typecheck:web`
- ESLint and Prettier via the commit hook

Closes #19051

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `v-repeat-click` so repeated actions stop reliably when a `mouseup` event’s propagation is prevented.
  * Corrected mouseup listener behavior to ensure proper cleanup when the directive is removed.
* **Tests**
  * Added a Vitest coverage for the stop-on-propagation-prevented `mouseup` scenario (verifies the handler runs exactly once).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->