### PR TITLE
chore: update prettier to v3.9.5 and format

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ CHANGELOG.en-US.md
 pnpm-lock.yaml
 docs/components.d.ts
 docs/.vitepress/cache
+.pnpm-store

--- a/docs/en-US/component/calendar.md
+++ b/docs/en-US/component/calendar.md
@@ -87,11 +87,7 @@ Note, date time locale (month name, first day of the week ...) are also configur
 
 ```ts
 type CalendarDateType =
-  | 'prev-month'
-  | 'next-month'
-  | 'prev-year'
-  | 'next-year'
-  | 'today'
+  'prev-month' | 'next-month' | 'prev-year' | 'next-year' | 'today'
 ```
 
 </details>

--- a/docs/en-US/component/form.md
+++ b/docs/en-US/component/form.md
@@ -252,8 +252,7 @@ type ArrayMethodKey = keyof any[]
 type TupleKey<T extends ReadonlyArray<any>> = Exclude<keyof T, ArrayMethodKey>
 type ArrayKey = number
 type PathImpl<K extends string | number, V> = V extends
-  | Primitive
-  | BrowserNativeObject
+  Primitive | BrowserNativeObject
   ? `${K}`
   : `${K}` | `${K}.${Path<V>}`
 type Path<T> =

--- a/internal/eslint-config/package.json
+++ b/internal/eslint-config/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-unicorn": "^64.0.0",
     "eslint-plugin-vue": "^10.9.0",
     "globals": "^17.5.0",
-    "prettier": "^3.8.3",
+    "prettier": "^3.9.5",
     "typescript": "catalog:",
     "typescript-eslint": "^8.59.0",
     "vue-eslint-parser": "^10.4.0"

--- a/packages/components/autocomplete/src/autocomplete.ts
+++ b/packages/components/autocomplete/src/autocomplete.ts
@@ -39,12 +39,7 @@ export type AutocompleteFetchSuggestions<
   | AutocompleteData<T>
 
 export type AutocompletePlacement =
-  | 'top'
-  | 'top-start'
-  | 'top-end'
-  | 'bottom'
-  | 'bottom-start'
-  | 'bottom-end'
+  'top' | 'top-start' | 'top-end' | 'bottom' | 'bottom-start' | 'bottom-end'
 
 export interface AutocompleteProps<
   T extends AutocompleteDataItem = AutocompleteDataItem,

--- a/packages/components/calendar/src/calendar.ts
+++ b/packages/components/calendar/src/calendar.ts
@@ -9,11 +9,7 @@ import { INPUT_EVENT, UPDATE_MODEL_EVENT } from '@element-plus/constants'
 import type { ExtractPublicPropTypes } from 'vue'
 
 export type CalendarDateType =
-  | 'prev-month'
-  | 'next-month'
-  | 'prev-year'
-  | 'next-year'
-  | 'today'
+  'prev-month' | 'next-month' | 'prev-year' | 'next-year' | 'today'
 
 const isValidRange = (range: unknown): range is [Date, Date] =>
   isArray(range) && range.length === 2 && range.every((item) => isDate(item))

--- a/packages/components/date-picker-panel/src/props/basic-date-table.ts
+++ b/packages/components/date-picker-panel/src/props/basic-date-table.ts
@@ -31,7 +31,4 @@ export type WeekPickerEmits = {
 }
 
 export type DateTableEmits =
-  | RangePickerEmits
-  | DatePickerEmits
-  | DatesPickerEmits
-  | WeekPickerEmits
+  RangePickerEmits | DatePickerEmits | DatesPickerEmits | WeekPickerEmits

--- a/packages/components/image-viewer/src/image-viewer.ts
+++ b/packages/components/image-viewer/src/image-viewer.ts
@@ -9,10 +9,7 @@ import type { Component, ExtractPublicPropTypes } from 'vue'
 import type ImageViewer from './image-viewer.vue'
 
 export type ImageViewerAction =
-  | 'zoomIn'
-  | 'zoomOut'
-  | 'clockwise'
-  | 'anticlockwise'
+  'zoomIn' | 'zoomOut' | 'clockwise' | 'anticlockwise'
 
 export type ImageViewerCrossorigin = 'anonymous' | 'use-credentials' | ''
 

--- a/packages/components/image/src/image.ts
+++ b/packages/components/image/src/image.ts
@@ -9,12 +9,7 @@ import type { ExtractPublicPropTypes } from 'vue'
 import type Image from './image.vue'
 
 export type ImageFitType =
-  | ''
-  | 'contain'
-  | 'cover'
-  | 'fill'
-  | 'none'
-  | 'scale-down'
+  '' | 'contain' | 'cover' | 'fill' | 'none' | 'scale-down'
 export type ImageCrossorigin = 'anonymous' | 'use-credentials' | ''
 
 export interface ImageProps {

--- a/packages/components/link/src/link.ts
+++ b/packages/components/link/src/link.ts
@@ -26,11 +26,7 @@ export interface LinkProps {
    * @description same as native hyperlink's `target`
    */
   target?:
-    | '_blank'
-    | '_parent'
-    | '_self'
-    | '_top'
-    | (string & NonNullable<unknown>)
+    '_blank' | '_parent' | '_self' | '_top' | (string & NonNullable<unknown>)
 
   /**
    * @description icon component

--- a/packages/components/message-box/src/message-box.type.ts
+++ b/packages/components/message-box/src/message-box.type.ts
@@ -17,8 +17,7 @@ export interface MessageBoxInputData {
 }
 
 export type MessageBoxInputValidator =
-  | ((value: string) => boolean | string)
-  | undefined
+  ((value: string) => boolean | string) | undefined
 export type CloseFn = () => void
 export interface MessageBoxActionHandlers {
   confirm: CloseFn
@@ -74,8 +73,7 @@ export declare interface MessageBoxState {
 }
 
 export type Callback =
-  | ((value: string, action: Action) => any)
-  | ((action: Action) => any)
+  ((value: string, action: Action) => any) | ((action: Action) => any)
 
 /** Options used in MessageBox */
 export interface ElMessageBoxOptions {
@@ -228,7 +226,7 @@ export type ElMessageBoxShortcutMethod = ((
   ) => Promise<MessageBoxData>)
 
 export interface IElMessageBox {
-  _context: AppContext | null;
+  _context: AppContext | null
 
   /** Show a message box */
   // (message: string, title?: string, type?: string): Promise<MessageBoxData>

--- a/packages/components/message/src/message.ts
+++ b/packages/components/message/src/message.ts
@@ -271,8 +271,7 @@ export type MessageParamsNormalized = Omit<MessageProps, 'id'> & {
 }
 export type MessageOptionsWithType = Omit<MessageOptions, 'type'>
 export type MessageParamsWithType =
-  | MessageOptionsWithType
-  | MessageOptions['message']
+  MessageOptionsWithType | MessageOptions['message']
 
 export interface MessageHandler {
   /**

--- a/packages/components/message/src/method.ts
+++ b/packages/components/message/src/method.ts
@@ -63,8 +63,7 @@ const normalizePlacement = (normalized: MessageOptions) => {
     messageConfig.placement
   ) {
     normalized.placement = messageConfig.placement as
-      | MessagePlacement
-      | undefined
+      MessagePlacement | undefined
   }
   // if placement is not passed and global has no config, use default config
   if (!normalized.placement) {

--- a/packages/components/notification/src/notification.ts
+++ b/packages/components/notification/src/notification.ts
@@ -16,10 +16,7 @@ export const notificationTypes = [
 export type NotificationType = (typeof notificationTypes)[number] | ''
 
 export type NotificationPosition =
-  | 'top-right'
-  | 'top-left'
-  | 'bottom-right'
-  | 'bottom-left'
+  'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'
 
 export interface NotificationProps {
   /**
@@ -226,9 +223,7 @@ export interface NotificationHandle {
 
 export type NotificationParams = Partial<NotificationOptions> | string | VNode
 export type NotificationParamsTyped =
-  | Partial<NotificationOptionsTyped>
-  | string
-  | VNode
+  Partial<NotificationOptionsTyped> | string | VNode
 
 export interface NotifyFn {
   (

--- a/packages/components/pagination/src/pagination.ts
+++ b/packages/components/pagination/src/pagination.ts
@@ -46,14 +46,7 @@ import type {
 const isAbsent = (v: unknown): v is undefined => typeof v !== 'number'
 
 type LayoutKey =
-  | 'prev'
-  | 'pager'
-  | 'next'
-  | 'jumper'
-  | '->'
-  | 'total'
-  | 'sizes'
-  | 'slot'
+  'prev' | 'pager' | 'next' | 'jumper' | '->' | 'total' | 'sizes' | 'slot'
 
 export const paginationProps = buildProps({
   /**

--- a/packages/components/popper/src/popper.ts
+++ b/packages/components/popper/src/popper.ts
@@ -25,8 +25,7 @@ export const roleTypes = [
 ] as const
 
 export type PopperEffect =
-  | (typeof effects)[number]
-  | (string & NonNullable<unknown>)
+  (typeof effects)[number] | (string & NonNullable<unknown>)
 export type PopperTrigger = (typeof triggers)[number]
 
 export interface PopperProps {

--- a/packages/components/rate/src/rate.vue
+++ b/packages/components/rate/src/rate.vue
@@ -207,8 +207,7 @@ const decimalStyle = computed(() => {
 const componentMap = computed(() => {
   let icons = isArray(props.icons) ? [...props.icons] : { ...props.icons }
   icons = markRaw(icons) as
-    | Array<string | Component>
-    | Record<number, string | Component>
+    Array<string | Component> | Record<number, string | Component>
   return isArray(icons)
     ? {
         [props.lowThreshold]: icons[0],

--- a/packages/components/scrollbar/src/thumb.vue
+++ b/packages/components/scrollbar/src/thumb.vue
@@ -46,8 +46,9 @@ let cursorLeave = false
 let baseScrollHeight = 0
 let baseScrollWidth = 0
 let originalOnSelectStart:
-  | ((this: GlobalEventHandlers, ev: Event) => any)
-  | null = isClient ? document.onselectstart : null
+  ((this: GlobalEventHandlers, ev: Event) => any) | null = isClient
+  ? document.onselectstart
+  : null
 
 const bar = computed(() => BAR_MAP[props.vertical ? 'vertical' : 'horizontal'])
 

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -628,9 +628,7 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
 
   const scrollToOption = (
     option:
-      | OptionPublicInstance
-      | OptionPublicInstance[]
-      | SelectStates['selected']
+      OptionPublicInstance | OptionPublicInstance[] | SelectStates['selected']
   ) => {
     const targetOption = isArray(option) ? option[option.length - 1] : option
     let target = null

--- a/packages/components/slider/src/composables/use-marks.ts
+++ b/packages/components/slider/src/composables/use-marks.ts
@@ -19,13 +19,11 @@ export const useMarks = (props: SliderProps) => {
       .map(Number.parseFloat)
       .sort((a, b) => a - b)
       .filter((point) => point <= props.max && point >= props.min)
-      .map(
-        (point): Mark => ({
-          point,
-          position: ((point - props.min) * 100) / (props.max - props.min),
-          mark: props.marks![point],
-        })
-      )
+      .map((point): Mark => ({
+        point,
+        position: ((point - props.min) * 100) / (props.max - props.min),
+        mark: props.marks![point],
+      }))
   })
 
   watchEffect(() => {

--- a/packages/components/table/src/table-body/events-helper.ts
+++ b/packages/components/table/src/table-body/events-helper.ts
@@ -143,13 +143,11 @@ function useEvents<T extends DefaultRow>(props: Partial<TableBodyProps<T>>) {
     const cellChild = (event.target as HTMLElement).querySelector(
       '.cell'
     ) as HTMLElement
-    if (
-      !(
-        hasClass(cellChild, `${namespace}-tooltip`) &&
-        cellChild.childNodes.length &&
-        cellChild.textContent?.trim()
-      )
-    ) {
+    if (!(
+      hasClass(cellChild, `${namespace}-tooltip`) &&
+      cellChild.childNodes.length &&
+      cellChild.textContent?.trim()
+    )) {
       return
     }
     // use range width instead of scrollWidth to determine whether the text is overflowing

--- a/packages/components/table/src/table/defaults.ts
+++ b/packages/components/table/src/table/defaults.ts
@@ -89,8 +89,7 @@ interface Table<T extends DefaultRow = any> extends Omit<
 
 type ColumnCls<T> = string | ((data: { row: T; rowIndex: number }) => string)
 type ColumnStyle<T> =
-  | CSSProperties
-  | ((data: { row: T; rowIndex: number }) => CSSProperties)
+  CSSProperties | ((data: { row: T; rowIndex: number }) => CSSProperties)
 type CellCls<T extends DefaultRow> =
   | string
   | ((data: {

--- a/packages/components/upload/src/upload.ts
+++ b/packages/components/upload/src/upload.ts
@@ -103,8 +103,7 @@ export interface UploadBaseProps {
    * @description additions options of request
    */
   data?:
-    | Awaitable<UploadData>
-    | ((rawFile: UploadRawFile) => Awaitable<UploadData>)
+    Awaitable<UploadData> | ((rawFile: UploadRawFile) => Awaitable<UploadData>)
   /**
    * @description whether uploading multiple files is permitted
    */

--- a/packages/components/virtual-list/src/types.ts
+++ b/packages/components/virtual-list/src/types.ts
@@ -7,9 +7,7 @@ export type ItemSize = (idx: number) => number
 export type Direction = 'ltr' | 'rtl'
 export type LayoutDirection = 'horizontal' | 'vertical'
 export type RTLOffsetType =
-  | 'negative'
-  | 'positive-descending'
-  | 'positive-ascending'
+  'negative' | 'positive-descending' | 'positive-ascending'
 
 export type ItemProps<T> = {
   data: T

--- a/packages/components/watermark/src/watermark.ts
+++ b/packages/components/watermark/src/watermark.ts
@@ -12,12 +12,7 @@ export interface WatermarkFontType {
   fontGap?: number
   textAlign?: 'start' | 'end' | 'left' | 'right' | 'center'
   textBaseline?:
-    | 'top'
-    | 'hanging'
-    | 'middle'
-    | 'alphabetic'
-    | 'ideographic'
-    | 'bottom'
+    'top' | 'hanging' | 'middle' | 'alphabetic' | 'ideographic' | 'bottom'
 }
 
 export interface WatermarkProps {

--- a/packages/hooks/use-throttle-render/index.ts
+++ b/packages/hooks/use-throttle-render/index.ts
@@ -4,8 +4,7 @@ import { isNumber, isObject, isUndefined } from '@element-plus/utils'
 import type { Ref } from 'vue'
 
 export type ThrottleType =
-  | { leading?: number; trailing?: number; initVal?: boolean }
-  | number
+  { leading?: number; trailing?: number; initVal?: boolean } | number
 
 export const useThrottleRender = (
   loading: Ref<boolean>,

--- a/packages/utils/typescript.ts
+++ b/packages/utils/typescript.ts
@@ -62,8 +62,7 @@ type ArrayKey = number
  * 用于通过一个类型递归构建路径的辅助类型
  */
 type PathImpl<K extends string | number, V> = V extends
-  | Primitive
-  | BrowserNativeObject
+  Primitive | BrowserNativeObject
   ? `${K}`
   : `${K}` | `${K}.${Path<V>}`
 

--- a/packages/utils/vue/props/types.ts
+++ b/packages/utils/vue/props/types.ts
@@ -71,10 +71,7 @@ export type EpPropInputDefault<
  * 原生 prop `类型，BooleanConstructor`、`StringConstructor`、`null`、`undefined` 等
  */
 export type NativePropType =
-  | ((...args: any) => any)
-  | { new (...args: any): any }
-  | undefined
-  | null
+  ((...args: any) => any) | { new (...args: any): any } | undefined | null
 export type IfNativePropType<T, Y, N> = [T] extends [NativePropType] ? Y : N
 
 /**

--- a/packages/utils/vue/typescript.ts
+++ b/packages/utils/vue/typescript.ts
@@ -32,20 +32,20 @@ type ExtractEventNames<T> =
   ComponentEmit<T> extends (event: string, ...args: any[]) => any
     ? never
     : keyof {
-        [K in keyof ComponentProps<T> as K extends `on${infer Event}`
-          ? ComponentEmit<T> extends (
-              event: Uncapitalize<Event>,
-              ...args: any[]
-            ) => any
-            ? K
+        [
+          K in keyof ComponentProps<T> as K extends `on${infer Event}`
+            ? ComponentEmit<T> extends (
+                event: Uncapitalize<Event>,
+                ...args: any[]
+              ) => any
+              ? K
+              : never
             : never
-          : never]: unknown
+        ]: unknown
       }
 
 type ExcludedProps<T> =
-  | ExtractEventNames<T>
-  | keyof VNodeProps
-  | keyof AllowedComponentProps
+  ExtractEventNames<T> | keyof VNodeProps | keyof AllowedComponentProps
 
 export type SFCWithInstall<T> = T & ObjectPlugin & SFCWithPropsDefaultsSetter<T>
 
@@ -57,9 +57,11 @@ export type SFCWithPropsDefaultsSetter<T> = T extends Component
   ? {
       setPropsDefaults: (
         defaults: InferDefaults<{
-          [K in keyof ComponentProps<T> as K extends ExcludedProps<T>
-            ? never
-            : K]?: ComponentProps<T>[K]
+          [
+            K in keyof ComponentProps<T> as K extends ExcludedProps<T>
+              ? never
+              : K
+          ]?: ComponentProps<T>[K]
         }>
       ) => void
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,7 +436,7 @@ importers:
         version: 3.1.2(eslint@10.7.0)
       eslint-plugin-prettier:
         specifier: ^5.5.5
-        version: 5.5.5(eslint-config-prettier@10.1.8)(eslint@10.7.0)(prettier@3.8.3)
+        version: 5.5.5(eslint-config-prettier@10.1.8)(eslint@10.7.0)(prettier@3.9.5)
       eslint-plugin-unicorn:
         specifier: ^64.0.0
         version: 64.0.0(eslint@10.7.0)
@@ -447,8 +447,8 @@ importers:
         specifier: ^17.5.0
         version: 17.5.0
       prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
+        specifier: ^3.9.5
+        version: 3.9.5
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -5857,11 +5857,6 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   prettier@3.9.5:
     resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
     engines: {node: '>=14'}
@@ -10796,10 +10791,10 @@ snapshots:
     transitivePeerDependencies:
       - '@eslint/json'
 
-  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8)(eslint@10.7.0)(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8)(eslint@10.7.0)(prettier@3.9.5):
     dependencies:
       eslint: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
-      prettier: 3.8.3
+      prettier: 3.9.5
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
@@ -12677,8 +12672,6 @@ snapshots:
   prettier-linter-helpers@1.0.1:
     dependencies:
       fast-diff: 1.3.0
-
-  prettier@3.8.3: {}
 
   prettier@3.9.5: {}
 


### PR DESCRIPTION
close #24586

After upgrading to Prettier 3.9, most of the formatting changes come from this update:
https://prettier.io/blog/2026/06/27/3.9.0#change-18827-2

I think the previous style was easier to read and maintain, but in 3.9, Prettier seems to prioritize fitting as much content as possible onto a single line. 🤷

rel: https://github.com/element-plus/element-plus/pull/24493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated formatting tools to ignore local package-store files.
  * Updated the supported Prettier peer version.

* **Refactor**
  * Standardized TypeScript type formatting across components, utilities, hooks, and documentation.
  * Simplified several type expressions and callback layouts without changing behavior or supported values.
  * Clarified internal conditional and mapped type formatting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->