### PR TITLE
chore: update files field in package.json

### DIFF
--- a/packages/element-plus/package.json
+++ b/packages/element-plus/package.json
@@ -15,6 +15,16 @@
     "url": "https://github.com/element-plus/element-plus/issues"
   },
   "license": "MIT",
+  "files": [
+    "dist",
+    "es",
+    "lib",
+    "theme-chalk",
+    "global.d.ts",
+    "attributes.json",
+    "tags.json",
+    "web-types.json"
+  ],
   "main": "lib/index.js",
   "module": "es/index.mjs",
   "types": "es/index.d.ts",

--- a/packages/element-plus/package.json
+++ b/packages/element-plus/package.json
@@ -23,7 +23,9 @@
     "global.d.ts",
     "attributes.json",
     "tags.json",
-    "web-types.json"
+    "web-types.json",
+    "LICENSE",
+    "README.md"
   ],
   "main": "lib/index.js",
   "module": "es/index.mjs",


### PR DESCRIPTION
fix #24605

This should be the cause: https://github.com/pnpm/pnpm/releases/tag/v11.13.0#:~:text=pnpm%20pack%20now%20respects%20workspace%2Droot%20.npmignore%20and%20.gitignore%20files%20when%20packing%20workspace%20packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the published package contents to include the required distribution builds, styles, type declarations, and related metadata (while ensuring only intended release artifacts are shipped).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->