### PR TITLE
fix(components): [input/select] prevent box-shadow noise

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -239,8 +239,7 @@
     transition: getCssVar('transition-box-shadow');
 
     // Keep the 3D transform to avoid Chromium inset box-shadow noise.
-    // The CSS variable prevents Lightning CSS from reducing it to 2D.
-    transform: translateZ(var(--el-input-composite-z, 0px));
+    transform: translateZ(0);
     @include inset-input-border(
       var(
         #{getCssVarName('input-border-color')},

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -237,7 +237,9 @@
     );
     cursor: text;
     transition: getCssVar('transition-box-shadow');
-    transform: translate3d(0, 0, 0);
+    // Keep the 3D transform to avoid Chromium inset box-shadow noise.
+    // The CSS variable prevents Lightning CSS from reducing it to 2D.
+    transform: translateZ(var(--el-input-composite-z, 0px));
     @include inset-input-border(
       var(
         #{getCssVarName('input-border-color')},

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -237,7 +237,10 @@
     );
     cursor: text;
     transition: getCssVar('transition-box-shadow');
-    transform: translate3d(0, 0, 0);
+
+    // Keep the 3D transform to avoid Chromium inset box-shadow noise.
+    // The CSS variable prevents Lightning CSS from reducing it to 2D.
+    transform: translateZ(var(--el-input-composite-z, 0px));
     @include inset-input-border(
       var(
         #{getCssVarName('input-border-color')},

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -37,7 +37,9 @@
     border-radius: getCssVar('border-radius-base');
     background-color: getCssVar('fill-color', 'blank');
     transition: getCssVar('transition', 'duration');
-    transform: translate3d(0, 0, 0);
+    // Keep the 3D transform to avoid Chromium inset box-shadow noise.
+    // The CSS variable prevents Lightning CSS from reducing it to 2D.
+    transform: translateZ(var(--el-select-composite-z, 0px));
     @include mixed-input-border(#{getCssVar('border-color')});
 
     @include when(filterable) {

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -39,8 +39,7 @@
     transition: getCssVar('transition', 'duration');
 
     // Keep the 3D transform to avoid Chromium inset box-shadow noise.
-    // The CSS variable prevents Lightning CSS from reducing it to 2D.
-    transform: translateZ(var(--el-select-composite-z, 0px));
+    transform: translateZ(0);
     @include mixed-input-border(#{getCssVar('border-color')});
 
     @include when(filterable) {

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -37,7 +37,10 @@
     border-radius: getCssVar('border-radius-base');
     background-color: getCssVar('fill-color', 'blank');
     transition: getCssVar('transition', 'duration');
-    transform: translate3d(0, 0, 0);
+
+    // Keep the 3D transform to avoid Chromium inset box-shadow noise.
+    // The CSS variable prevents Lightning CSS from reducing it to 2D.
+    transform: translateZ(var(--el-select-composite-z, 0px));
     @include mixed-input-border(#{getCssVar('border-color')});
 
     @include when(filterable) {


### PR DESCRIPTION
Preserve a 3D transform operation after Lightning CSS minification.

This keeps Chromium inset box shadows free of edge artifacts.

Closes #24617

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual rendering for input and select components in Chromium.
  * Updated 3D transform handling to keep inset box-shadow appearance stable and reduce related rendering noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->