### PR TITLE
fix(components): [autocomplete] clear stale suggestions on refocus

### DIFF
--- a/packages/components/autocomplete/__tests__/autocomplete.test.tsx
+++ b/packages/components/autocomplete/__tests__/autocomplete.test.tsx
@@ -716,5 +716,25 @@ describe('Autocomplete.vue', () => {
       await input.trigger('keydown', { code: EVENT_CODE.numpadEnter })
       expect(target.modelValue).toBe('Java')
     })
+
+    test('clears stale suggestions on refocus before debounce completes', async () => {
+      const wrapper = _mount({ debounce: 300 })
+      const input = wrapper.find('input')
+      const target = getAutocompleteVm(wrapper)
+
+      await input.trigger('focus')
+      vi.runAllTimers()
+      await nextTick()
+      await input.trigger('keydown', { code: EVENT_CODE.down })
+
+      expect(target.suggestions).toHaveLength(4)
+      expect(target.highlightedIndex).toBe(0)
+
+      await input.trigger('blur')
+      await input.trigger('focus')
+
+      expect(target.suggestions).toHaveLength(0)
+      expect(target.highlightedIndex).toBe(-1)
+    })
   })
 })

--- a/packages/components/autocomplete/src/autocomplete.vue
+++ b/packages/components/autocomplete/src/autocomplete.vue
@@ -294,6 +294,8 @@ const handleFocus = (evt: FocusEvent) => {
     emit('focus', evt)
     const queryString = props.modelValue ?? ''
     if (props.triggerOnFocus && !readonly) {
+      suggestions.value = []
+      highlightedIndex.value = -1
       debouncedGetData(String(queryString))
     }
   } else {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

desc

When trigger-on-focus is enabled, refocusing the input activates the suggestion dropdown immediately while the previous suggestions are still retained. As a result, stale suggestions are briefly displayed during the debounce period before the loading state begins.

Clear stale suggestions before starting the debounced fetch to prevent the previous results from flashing when the input is refocused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined autocomplete focus behavior: when focus-triggered fetching is enabled (and the field is editable), the component now clears any stale suggestions and resets the highlighted option before starting a new debounced request.
  * Added a regression test to ensure stale suggestions/highlight don’t appear when refocusing occurs before an in-flight debounce completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->