### PR TITLE
docs: prevent white flash during theme transitions

### DIFF
--- a/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
+++ b/docs/.vitepress/vitepress/components/common/vp-theme-toggler.vue
@@ -10,6 +10,7 @@ defineOptions({ inheritAttrs: false })
 
 const darkMode = ref(isDark.value)
 const switchRef = ref<SwitchInstance>()
+let latestTransitionId = 0
 
 watch(
   () => isDark.value,
@@ -53,29 +54,26 @@ const beforeChange = () => {
     const referR = Math.hypot(innerWidth, innerHeight) / Math.SQRT2
     const ratioR = (100 * endRadius) / referR
 
+    const transitionId = ++latestTransitionId
+    const root = document.documentElement
+    root.dataset.themeTransition = isDark.value ? 'to-light' : 'to-dark'
+    root.style.setProperty('--theme-transition-x', `${ratioX}%`)
+    root.style.setProperty('--theme-transition-y', `${ratioY}%`)
+    root.style.setProperty('--theme-transition-radius', `${ratioR}%`)
+
     // @ts-expect-error: Transition API
     const transition = document.startViewTransition(async () => {
       resolve(true)
       await nextTick()
     })
-    transition.ready.then(() => {
-      const clipPath = [
-        `circle(0% at ${ratioX}% ${ratioY}%)`,
-        `circle(${ratioR}% at ${ratioX}% ${ratioY}%)`,
-      ]
-      document.documentElement.animate(
-        {
-          clipPath: isDark.value ? [...clipPath].reverse() : clipPath,
-        },
-        {
-          duration: 400,
-          easing: 'ease-in',
-          fill: 'both',
-          pseudoElement: isDark.value
-            ? '::view-transition-old(root)'
-            : '::view-transition-new(root)',
-        }
-      )
+
+    transition.finished.finally(() => {
+      if (transitionId !== latestTransitionId) return
+
+      delete root.dataset.themeTransition
+      root.style.removeProperty('--theme-transition-x')
+      root.style.removeProperty('--theme-transition-y')
+      root.style.removeProperty('--theme-transition-radius')
     })
   })
 }

--- a/docs/.vitepress/vitepress/styles/base.scss
+++ b/docs/.vitepress/vitepress/styles/base.scss
@@ -324,10 +324,36 @@ details[open]::details-content {
   z-index: 2147483646;
 }
 
-.dark::view-transition-old(root) {
+html[data-theme-transition='to-dark']::view-transition-old(root) {
   z-index: 2147483646;
+  animation: theme-change 400ms ease-in both;
 }
 
-.dark::view-transition-new(root) {
+html[data-theme-transition='to-dark']::view-transition-new(root) {
   z-index: 1;
+}
+
+html[data-theme-transition='to-light']::view-transition-old(root) {
+  z-index: 1;
+}
+
+html[data-theme-transition='to-light']::view-transition-new(root) {
+  z-index: 2147483646;
+  animation: theme-change 400ms ease-in both;
+  animation-direction: reverse;
+}
+
+@keyframes theme-change {
+  from {
+    clip-path: circle(
+      var(--theme-transition-radius) at var(--theme-transition-x)
+        var(--theme-transition-y)
+    );
+  }
+
+  to {
+    clip-path: circle(
+      0% at var(--theme-transition-x) var(--theme-transition-y)
+    );
+  }
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
Closes #24589 
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

https://github.com/user-attachments/assets/8e7be111-8950-4aca-811c-132800c0c551

https://github.com/user-attachments/assets/1e9542bb-51bd-45a9-8be7-52292ac8bd3b



修复文档站主题切换时的闪白问题：退出暗色模式时，白色主题从切换按钮向外扩散，未覆盖区域保持暗色；进入暗色模式时，亮色区域向按钮收缩，避免过渡快照提前全屏显示。
Fixed the flickering issue when switching themes on the document station: When exiting dark mode, the white theme expands outward from the toggle button while the uncovered areas remain dark; when entering dark mode, the light-colored regions contract toward the button to prevent the transition snapshot from displaying the full screen prematurely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Style**
  * Improved dark/light theme switching by enhancing view-transition behavior for smoother, more fluid animations.
  * Refined the circular expand/collapse effect, including more reliable layering so the correct side appears above during the switch.
  * Updated the animation control to use HTML theme-transition data attributes and CSS variables for consistent origin, radius, and coordinates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->