### PR TITLE
fix(components): [popover] omit `gpuAcceleration` default value

### DIFF
--- a/packages/components/popover/src/popover.ts
+++ b/packages/components/popover/src/popover.ts
@@ -97,7 +97,7 @@ export type PopoverInstance = InstanceType<typeof Popover> & unknown
  * @description default values for PopoverProps
  */
 export const popoverPropsDefaults = {
-  ...useTooltipContentPropsDefaults,
+  ...omit(useTooltipContentPropsDefaults, ['gpuAcceleration']),
   ...useTooltipTriggerPropsDefaults,
   ...popperArrowPropsDefaults,
   title: undefined,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

rel #24571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated popover default settings to prevent an unsupported GPU acceleration option from being applied.
  * Improves consistency and reliability in popover positioning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->