### PR TITLE
fix(components): [table-v2, carousel] correct element attributes

### DIFF
--- a/packages/components/carousel/__tests__/carousel.test.tsx
+++ b/packages/components/carousel/__tests__/carousel.test.tsx
@@ -130,6 +130,14 @@ describe('Carousel', () => {
     expect(wrapper.find('.el-carousel__button span').text()).toBe('1')
   })
 
+  it('indicator buttons should not submit a parent form', () => {
+    wrapper = createComponent({ autoplay: false })
+
+    wrapper.findAll('.el-carousel__button').forEach((button) => {
+      expect(button.attributes('type')).toBe('button')
+    })
+  })
+
   describe('manual control', () => {
     it('hover', async () => {
       vi.useFakeTimers()

--- a/packages/components/carousel/src/carousel.vue
+++ b/packages/components/carousel/src/carousel.vue
@@ -62,6 +62,7 @@
           @click.stop="handleIndicatorClick(index)"
         >
           <button
+            type="button"
             :class="ns.e('button')"
             :aria-label="t('el.carousel.indicator', { index: index + 1 })"
           >

--- a/packages/components/table-v2/__tests__/table-v2.test.tsx
+++ b/packages/components/table-v2/__tests__/table-v2.test.tsx
@@ -9,7 +9,7 @@ import type {
   TableV2HeaderRowCellRendererParams,
   TableV2RowCellRenderParam,
 } from '../src/components'
-import type { SortBy } from '../src/types'
+import type { SortBy, SortState } from '../src/types'
 
 const generateColumns = (length = 10, prefix = 'column-', props?: any) =>
   Array.from({ length }).map((_, columnIndex) => ({
@@ -315,22 +315,23 @@ describe('TableV2.vue', () => {
       ))
 
       const expandButton = wrapper.find('.el-table-v2__expand-icon')
-      expect(expandButton.attributes('arialabel')).toBe('Expand this row')
-      expect(expandButton.attributes('ariaexpanded')).toBe('false')
+      expect(expandButton.attributes('aria-label')).toBe('Expand this row')
+      expect(expandButton.attributes('aria-expanded')).toBe('false')
 
       await expandButton.trigger('click')
       await nextTick()
-      expect(expandButton.attributes('ariaexpanded')).toBe('true')
+      expect(expandButton.attributes('aria-expanded')).toBe('true')
     })
 
-    test('sort button', async () => {
-      const sortState = ref<SortBy>({
+    test('sort button', () => {
+      const sortBy: SortBy = {
         key: 'column-0',
         order: TableV2SortOrder.ASC,
-      })
+      }
       const columns = generateColumns(10)
       const data = generateData(columns, 20)
       columns[0].sortable = true
+      columns[1].sortable = true
 
       const wrapper = mount(() => (
         <TableV2
@@ -338,17 +339,109 @@ describe('TableV2.vue', () => {
           data={data}
           width={700}
           height={400}
-          sortBy={sortState.value}
+          sortBy={sortBy}
         />
       ))
 
       const sortButton = wrapper.find('.el-table-v2__sort-icon')
-      const header = wrapper.find('.el-table-v2__header-cell.is-sortable')
-      console.log(header.attributes())
+      const headers = wrapper.findAll('.el-table-v2__header-cell.is-sortable')
 
       expect(sortButton.attributes('aria-label')).toBe('Sort by Column 0')
-      expect(header.attributes('ariasort')).toBe('ascending')
-      expect(header.attributes('role')).toBe('columnheader')
+      expect(headers[0].attributes('aria-sort')).toBe('ascending')
+      expect(headers[0].attributes('role')).toBe('columnheader')
+      expect(headers[1].attributes('aria-sort')).toBeUndefined()
+
+      const unsortedWrapper = mount(() => (
+        <TableV2 columns={columns} data={data} width={700} height={400} />
+      ))
+      const unsortedHeaders = unsortedWrapper.findAll(
+        '.el-table-v2__header-cell.is-sortable'
+      )
+      expect(unsortedHeaders[0].attributes('aria-sort')).toBeUndefined()
+      expect(unsortedHeaders[1].attributes('aria-sort')).toBeUndefined()
+    })
+
+    test('reports aria-sort only for the primary multi-sort column', () => {
+      const sortState: SortState = {
+        'column-1': TableV2SortOrder.DESC,
+        'column-0': TableV2SortOrder.ASC,
+      }
+      const columns = generateColumns(10)
+      const data = generateData(columns, 20)
+      columns[0].sortable = true
+      columns[1].sortable = true
+
+      const wrapper = mount(() => (
+        <TableV2
+          columns={columns}
+          data={data}
+          width={700}
+          height={400}
+          sortState={sortState}
+        />
+      ))
+      const headers = wrapper.findAll('.el-table-v2__header-cell.is-sortable')
+
+      expect(headers[0].attributes('aria-sort')).toBeUndefined()
+      expect(headers[1].attributes('aria-sort')).toBe('descending')
+    })
+
+    test('selects the primary sort from renderable sortable columns', () => {
+      const sortState: SortState = {
+        removed: TableV2SortOrder.DESC,
+        'column-0': TableV2SortOrder.DESC,
+        'column-2': TableV2SortOrder.DESC,
+        'column-1': TableV2SortOrder.ASC,
+      }
+      const columns = generateColumns(3)
+      const data = generateData(columns, 20)
+      columns[0].sortable = false
+      columns[1].sortable = true
+      columns[2].sortable = true
+      columns[2].hidden = true
+
+      const wrapper = mount(() => (
+        <TableV2
+          columns={columns}
+          data={data}
+          width={700}
+          height={400}
+          sortState={sortState}
+        />
+      ))
+      const sortedHeaders = wrapper.findAll('[aria-sort]')
+
+      expect(sortedHeaders).toHaveLength(1)
+      expect(sortedHeaders[0].attributes('data-key')).toBe('column-1')
+      expect(sortedHeaders[0].attributes('aria-sort')).toBe('ascending')
+    })
+
+    test('reports aria-sort only on the leaf header row', () => {
+      const sortBy: SortBy = {
+        key: 'column-0',
+        order: TableV2SortOrder.ASC,
+      }
+      const columns = generateColumns(2, 'column-', { sortable: true })
+      const data = generateData(columns, 20)
+
+      const wrapper = mount(() => (
+        <TableV2
+          columns={columns}
+          data={data}
+          width={700}
+          height={400}
+          headerHeight={[40, 50]}
+          sortBy={sortBy}
+        />
+      ))
+      const headerRows = wrapper.findAll('.el-table-v2__header-row')
+
+      expect(headerRows).toHaveLength(2)
+      expect(headerRows[0].find('[aria-sort]').exists()).toBe(false)
+      expect(headerRows[1].findAll('[aria-sort]')).toHaveLength(1)
+      expect(
+        headerRows[1].find('[data-key="column-0"]').attributes('aria-sort')
+      ).toBe('ascending')
     })
   })
 

--- a/packages/components/table-v2/src/components/expand-icon.tsx
+++ b/packages/components/table-v2/src/components/expand-icon.tsx
@@ -18,8 +18,8 @@ const ExpandIcon = (
 
   const expandIconProps = {
     onClick: expandable ? () => onExpand(!expanded) : undefined,
-    ariaLabel,
-    ariaExpanded: expanded,
+    'aria-label': ariaLabel,
+    'aria-expanded': expanded,
     class: props.class,
   } as any
 

--- a/packages/components/table-v2/src/composables/use-columns.ts
+++ b/packages/components/table-v2/src/composables/use-columns.ts
@@ -24,6 +24,29 @@ function useColumns(
     return unref(_columns).filter((column) => !column.hidden)
   })
 
+  const primarySortKey = computed(() => {
+    const { sortState } = props
+    if (!sortState) return undefined
+
+    const renderableColumns = unref(visibleColumns).filter(
+      (column) => column.sortable
+    )
+    const isSameKey = (columnKey: KeyType, stateKey: PropertyKey) =>
+      typeof columnKey === 'symbol'
+        ? columnKey === stateKey
+        : String(columnKey) === String(stateKey)
+    const primaryStateKey = Reflect.ownKeys(sortState).find(
+      (stateKey) =>
+        Boolean(oppositeOrderMap[sortState[stateKey]]) &&
+        renderableColumns.some((column) => isSameKey(column.key, stateKey))
+    )
+    if (primaryStateKey === undefined) return undefined
+
+    return renderableColumns.find((column) =>
+      isSameKey(column.key, primaryStateKey)
+    )?.key
+  })
+
   const fixedColumnsOnLeft = computed(() =>
     unref(visibleColumns).filter(
       (column) => column.fixed === 'left' || column.fixed === true
@@ -120,6 +143,7 @@ function useColumns(
     hasFixedColumns,
     mainColumns,
     normalColumns,
+    primarySortKey,
     visibleColumns,
 
     getColumn,

--- a/packages/components/table-v2/src/renderers/header-cell.tsx
+++ b/packages/components/table-v2/src/renderers/header-cell.tsx
@@ -10,11 +10,16 @@ import type { Translator, UseNamespaceReturn } from '@element-plus/hooks'
 import type { TableV2HeaderRowCellRendererParams } from '../components'
 import type { UseTableReturn } from '../use-table'
 import type { TableV2Props } from '../table'
+import type { KeyType } from '../types'
 
 export type HeaderCellRendererProps = TableV2HeaderRowCellRendererParams &
   UnwrapNestedRefs<Pick<UseTableReturn, 'onColumnSorted'>> &
-  Pick<TableV2Props, 'sortBy' | 'sortState' | 'headerCellProps'> & {
+  Pick<
+    TableV2Props,
+    'sortBy' | 'sortState' | 'headerCellProps' | 'headerHeight'
+  > & {
     ns: UseNamespaceReturn
+    primarySortKey?: KeyType
     t: Translator
   }
 
@@ -55,15 +60,31 @@ const HeaderCellRenderer: FunctionalComponent<HeaderCellRendererProps> = (
   /**
    * Render cell container and sort indicator
    */
-  const { sortBy, sortState, headerCellProps } = props
+  const {
+    sortBy,
+    sortState,
+    primarySortKey,
+    headerCellProps,
+    headerHeight,
+    headerIndex,
+  } = props
+  const isLeafHeader =
+    !Array.isArray(headerHeight) || headerIndex === headerHeight.length - 1
 
-  let sorting: boolean, sortOrder: SortOrder, ariaSort: string | undefined
+  let sorting: boolean,
+    ariaSorting: boolean,
+    sortOrder: SortOrder,
+    ariaSort: string | undefined
   if (sortState) {
     const order = sortState[column.key!]
     sorting = Boolean(oppositeOrderMap[order])
+    // ARIA cannot express multi-sort precedence, so only expose the first
+    // renderable active key while preserving every visual indicator.
+    ariaSorting = column.key === primarySortKey
     sortOrder = sorting ? order : SortOrder.ASC
   } else {
     sorting = column.key === sortBy.key
+    ariaSorting = sorting
     sortOrder = sorting ? sortBy.order : SortOrder.ASC
   }
   if (sortOrder === SortOrder.ASC) {
@@ -85,7 +106,8 @@ const HeaderCellRenderer: FunctionalComponent<HeaderCellRendererProps> = (
   const cellWrapperProps = {
     ...tryCall(headerCellProps, props),
     onClick: column.sortable ? onColumnSorted : undefined,
-    ariaSort: sortable ? ariaSort : undefined,
+    ['aria-sort']:
+      sortable && ariaSorting && isLeafHeader ? ariaSort : undefined,
     class: cellKls,
     style: cellStyle,
     ['data-key']: column.key,

--- a/packages/components/table-v2/src/table-v2.tsx
+++ b/packages/components/table-v2/src/table-v2.tsx
@@ -51,6 +51,7 @@ const TableV2 = defineComponent({
       fixedColumnsOnLeft,
       fixedColumnsOnRight,
       mainColumns,
+      primarySortKey,
       mainTableHeight,
       fixedTableHeight,
       leftTableWidth,
@@ -267,6 +268,8 @@ const TableV2 = defineComponent({
 
         sortBy,
         sortState,
+        primarySortKey: unref(primarySortKey),
+        headerHeight,
         headerCellProps,
         onColumnSorted,
       }

--- a/packages/components/table-v2/src/use-table.ts
+++ b/packages/components/table-v2/src/use-table.ts
@@ -32,6 +32,7 @@ function useTable(props: TableV2Props) {
     fixedColumnsOnRight,
     hasFixedColumns,
     mainColumns,
+    primarySortKey,
 
     onColumnSorted,
   } = useColumns(props, toRef(props, 'columns'), toRef(props, 'fixed'))
@@ -198,6 +199,7 @@ function useTable(props: TableV2Props) {
     fixedColumnsOnLeft,
     fixedColumnsOnRight,
     mainColumns,
+    primarySortKey,
     // metadata
     bodyWidth,
     emptyStyle,

--- a/packages/components/tag/__tests__/tag.test.tsx
+++ b/packages/components/tag/__tests__/tag.test.tsx
@@ -1,3 +1,4 @@
+import { defineComponent } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, test } from 'vitest'
 import Tag from '../src/tag.vue'
@@ -50,10 +51,23 @@ describe('Tag.vue', () => {
   })
 
   test('disableTransitions', () => {
-    const wrapper = mount(() => <Tag disableTransitions={true} />)
-    const vm = wrapper.vm
-    // FIXME: This check actually is useless as there is no the class `md-fade-center` in the code.
-    expect(vm.$el.classList.contains('md-fade-center')).toEqual(false)
+    const TransitionStub = defineComponent({
+      setup(_, { slots }) {
+        return () => <div class="transition-stub">{slots.default?.()}</div>
+      },
+    })
+    const wrapper = mount(Tag, {
+      props: {
+        disableTransitions: true,
+      },
+      global: {
+        stubs: {
+          transition: TransitionStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('.transition-stub').exists()).toBe(false)
   })
 
   test('color', () => {

--- a/packages/hooks/__tests__/use-throttle-render.test.tsx
+++ b/packages/hooks/__tests__/use-throttle-render.test.tsx
@@ -3,6 +3,25 @@ import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useThrottleRender } from '../use-throttle-render'
 
+import type { Ref } from 'vue'
+import type { ThrottleType } from '../use-throttle-render'
+
+const mountThrottleRender = (loading: Ref<boolean>, throttle: ThrottleType) => {
+  let throttled!: Ref<boolean>
+  let initialValue!: boolean
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        throttled = useThrottleRender(loading, throttle)
+        initialValue = throttled.value
+        return () => null
+      },
+    })
+  )
+
+  return { initialValue, throttled, wrapper }
+}
+
 const Comp = defineComponent({
   setup() {
     const loading = ref(false)
@@ -14,7 +33,7 @@ const Comp = defineComponent({
   },
 })
 
-describe.concurrent('useThrottleRender', () => {
+describe('useThrottleRender', () => {
   beforeEach(() => {
     vi.useFakeTimers()
   })
@@ -37,19 +56,21 @@ describe.concurrent('useThrottleRender', () => {
 
   it('should return false immediately when loading is false', () => {
     const loading = ref(false)
-    const throttled = useThrottleRender(loading, 1000)
+    const { throttled, wrapper } = mountThrottleRender(loading, 1000)
     expect(throttled.value).toBe(false)
+    wrapper.unmount()
   })
 
   it('should return the same value immediately when throttle is 0', () => {
     const loading = ref(true)
-    const throttled = useThrottleRender(loading, 0)
+    const { throttled, wrapper } = mountThrottleRender(loading, 0)
     expect(throttled.value).toBe(true) // should be same as loading
+    wrapper.unmount()
   })
 
   it('should throttle rendering and update when loading changes', async () => {
     const loading = ref(true)
-    const throttled = useThrottleRender(loading, 1000)
+    const { throttled, wrapper } = mountThrottleRender(loading, 1000)
     expect(throttled.value).toBe(false) // initially false
     loading.value = false
     expect(throttled.value).toBe(false) // should remain false immediately
@@ -59,19 +80,25 @@ describe.concurrent('useThrottleRender', () => {
 
     loading.value = true
     expect(throttled.value).toBe(false) // should still be false after throttle time
+    wrapper.unmount()
   })
 
-  it('should use `initVal` as initial value when pass `{ initVal: true/false }`', async () => {
+  it('should use `initVal` as initial value when pass `{ initVal: true/false }`', () => {
     const loading = ref(false)
-    const throttled = useThrottleRender(loading, { initVal: true })
-    expect(throttled.value).toBe(true)
-    const throttled2 = useThrottleRender(loading, { initVal: false })
-    expect(throttled2.value).toBe(false)
+    const { initialValue, wrapper } = mountThrottleRender(loading, {
+      initVal: true,
+    })
+    expect(initialValue).toBe(true)
+    const { initialValue: initialValue2, wrapper: wrapper2 } =
+      mountThrottleRender(loading, { initVal: false })
+    expect(initialValue2).toBe(false)
+    wrapper.unmount()
+    wrapper2.unmount()
   })
 
   it('should throttle on display and disappear when pass `{ leading: xxx, trailing: xxx }`', async () => {
     const loading = ref(false)
-    const throttled = useThrottleRender(loading, {
+    const { throttled, wrapper } = mountThrottleRender(loading, {
       leading: 200,
       trailing: 200,
     })
@@ -92,5 +119,6 @@ describe.concurrent('useThrottleRender', () => {
     await nextTick()
 
     expect(throttled.value).toBe(false) // should be false after trailing time
+    wrapper.unmount()
   })
 })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.



## Summary

This PR fixes invalid accessibility attributes in Table V2 and prevents Carousel indicator buttons from submitting a parent form.

It also improves related test coverage and removes several sources of test noise.

## Changes

### Table V2

- Replace the invalid `arialabel` attribute with `aria-label`.
- Replace the invalid `ariaexpanded` attribute with `aria-expanded`.
- Replace the invalid `ariasort` attribute with `aria-sort`.
- Update accessibility tests to assert the standard ARIA attributes.
- Remove a leftover `console.log` from the test suite.

Previously, camel-cased ARIA property names passed through object spreads were rendered as non-standard lowercase attributes, which could not be reliably recognized by assistive technologies.

### Carousel

- Add `type="button"` to indicator buttons.
- Add a regression test covering the button type.

Without an explicit button type, clicking a Carousel indicator inside a `<form>` could trigger an unintended form submission.

### Test improvements

- Replace the ineffective Tag `disableTransitions` assertion with a test that verifies the Transition wrapper is actually disabled.
- Run `useThrottleRender` tests inside a Vue component lifecycle.
- Remove the Vue `onMounted` warnings caused by invoking the composable outside `setup()`.
- Ensure mounted test components are properly unmounted.

## Testing

The following checks passed:

- `pnpm test --run`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`

Focused tests also passed for:

- Table V2
- Carousel
- Tag
- `useThrottleRender`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Carousel indicator buttons no longer trigger unintended form submissions inside forms.
  * Table V2 accessibility was improved with standards-compliant expand/collapse and sorting ARIA attributes, including accurate multi-sort behavior.

* **Tests**
  * Expanded coverage for Carousel, Table V2, Tag transition disabling, and `useThrottleRender`, including mounting and cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->