### PR TITLE
fix(components): [cascader] prevent mobile dropdown overflow

### DIFF
--- a/packages/theme-chalk/src/cascader.scss
+++ b/packages/theme-chalk/src/cascader.scss
@@ -148,6 +148,11 @@
     font-size: getCssVar('cascader-menu-font-size');
     border-radius: getCssVar('cascader-menu-radius');
 
+    > .#{$namespace}-cascader-panel {
+      max-width: calc(100vw - 32px);
+      overflow-x: auto;
+    }
+
     @include picker-popper(
       getCssVar('cascader-menu-fill'),
       getCssVar('cascader-menu-border'),


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

Fixes Cascader dropdown panels overflowing the viewport on mobile devices or other narrow screens.

When multiple menu levels are expanded, each Cascader menu has a minimum width of `180px`. Since the panel uses a horizontal flex layout with `width: fit-content`, a three-level Cascader requires at least `540px` and can extend beyond the mobile viewport.

https://github.com/user-attachments/assets/3bbc00e7-26f0-4154-835b-eb691f55060e


https://github.com/user-attachments/assets/ea79aa2c-de41-4e3a-9968-2d2e10868b9d


## Changes

- Limit the Cascader dropdown panel width to the available viewport width.
- Enable horizontal scrolling when the expanded menu levels exceed that width.
- Scope the styles to a direct `CascaderPanel` child of the Cascader dropdown.

```scss
.el-cascader__dropdown > .el-cascader-panel {
  max-width: calc(100vw - 32px);
  overflow-x: auto;
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cascader dropdown behavior on narrow screens.
  * Prevented the dropdown panel from exceeding the viewport width.
  * Added horizontal scrolling when panel content overflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->