### PR TITLE
fix(components): [space] clone spacer vnode

### DIFF
--- a/packages/components/space/__tests__/space.test.tsx
+++ b/packages/components/space/__tests__/space.test.tsx
@@ -1,4 +1,5 @@
-import { nextTick } from 'vue'
+import { createSSRApp, h, nextTick, ref } from 'vue'
+import { renderToString } from '@vue/server-renderer'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import Space from '../src/space'
@@ -94,6 +95,25 @@ describe('Space.vue', () => {
 
     expect(wrapper.findAll(`.${testSpacerCls}`)).toHaveLength(1)
     expect(wrapper.element.children).toHaveLength(3)
+  })
+
+  it('should render every component vnode spacer after hydration', async () => {
+    const showSpace = ref(false)
+    const spacer = h(() => h('i', { class: 'test-spacer' }))
+    const App = () =>
+      showSpace.value
+        ? h(Space, { spacer }, () => [1, 2, 3].map((item) => h('div', item)))
+        : null
+    const container = document.createElement('div')
+    container.innerHTML = await renderToString(h(App))
+    const app = createSSRApp(App)
+
+    app.mount(container)
+    showSpace.value = true
+    await nextTick()
+
+    expect(container.querySelectorAll('.test-spacer')).toHaveLength(2)
+    app.unmount()
   })
 
   it('fill', async () => {

--- a/packages/components/space/src/space.ts
+++ b/packages/components/space/src/space.ts
@@ -1,5 +1,6 @@
 import {
   Comment,
+  cloneVNode,
   createTextVNode,
   createVNode,
   defineComponent,
@@ -217,7 +218,7 @@ const Space = defineComponent({
                       // span element.
                       // otherwise, treat it as string.
                       isVNode(spacer)
-                        ? spacer
+                        ? cloneVNode(spacer)
                         : createTextVNode(spacer as string, PatchFlags.TEXT),
                     ],
                     PatchFlags.STYLE


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fix #24644 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing behavior between items in Vue components, ensuring spacer elements render correctly without being reused unexpectedly.
  * Fixed spacer rendering during server-side rendering and hydration when visibility changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->