### PR TITLE
fix(components): [splitter] incorrect size after resize on collapse

### DIFF
--- a/packages/components/splitter/__tests__/splitter.test.tsx
+++ b/packages/components/splitter/__tests__/splitter.test.tsx
@@ -179,6 +179,579 @@ describe('Splitter', () => {
     expect(panels[0].attributes('style')).toContain('flex-basis: 150px;')
   })
 
+  it('should restore proportional size after container resize between collapse and expand', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel collapsible>Left Panel</ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    // default 50/50 split
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+
+    // Collapse the left panel while container is still 1000px
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Container shrinks while the panel is collapsed
+    containerWidth.value = 800
+    await nextTick()
+
+    // Expand the left panel back - it should restore to 50% of the *new*
+    // container size (400px), not the stale 500px captured before collapse
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 400px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should keep a fixed pixel size pinned after container resize between collapse and expand', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size={150} collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 150px;')
+
+    // Collapse the fixed-size panel while container is still 1000px
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Container shrinks while the panel is collapsed
+    containerWidth.value = 800
+    await nextTick()
+
+    // Expand - a fixed pixel size should stay pinned at 150px, not be
+    // rescaled as if it were a 15% proportional share of the new width
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 150px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should keep a numeric string pixel size pinned after container resize between collapse and expand', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="150" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 150px;')
+
+    // Collapse the fixed-size panel (passed as a plain numeric string, as
+    // Vue templates would pass `size="150"`) while container is still 1000px
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Container shrinks while the panel is collapsed
+    containerWidth.value = 800
+    await nextTick()
+
+    // Expand - a numeric string pixel size should stay pinned at 150px too
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 150px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should not mistake an internally-generated numeric size for an authored fixed size', async () => {
+    const containerWidth = ref(800)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel collapsible>Left Panel</ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    // Round-trip a collapse/expand at 800px - this leaves the internal
+    // `size` as the raw number 400, even though both panels were declared
+    // proportionally (no `size` prop at all)
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    await endCollapseButton.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+
+    // Container grows - since both panels are still proportional, this
+    // scales evenly to 500/500
+    containerWidth.value = 1000
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+
+    // Collapse again, then shrink the container back down while collapsed
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    containerWidth.value = 800
+    await nextTick()
+
+    // Expanding should still land on an even 50/50 split (400/400), not
+    // treat the leftover raw-number internal state as an authored fixed size
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 400px;')
+
+    mockSize.mockRestore()
+  })
+
+  it("should restore a collapsed-to-zero panel's fixed min after container resize", async () => {
+    const containerWidth = ref(400)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="0%" min={100} collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Middle Panel</ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const endIcons = wrapper.findAll(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    // Left panel is inherently 0 (declared as "0%"), with a fixed 100px min
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Collapse Right onto Middle first - this is the first-ever onCollapse
+    // call, so it populates the cache for every panel (including the
+    // already-zero left one) while the container is still 400px. Middle
+    // keeps a positive size so Left's own expand icon stays available.
+    await endIcons[1]!.trigger('click')
+    await nextTick()
+
+    // Container shrinks while the left panel is still at 0
+    containerWidth.value = 200
+    await nextTick()
+
+    // Expand the left panel - it should restore to its literal 100px min,
+    // not a min/400 ratio rescaled against the new 200px container (50px)
+    const leftEndIcon = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+    await leftEndIcon.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 100px;')
+
+    // Collapse it back to 0, resize again, and expand once more - the fixed
+    // min classification must survive a *later* re-collapse too, not just
+    // the very first expand-from-zero
+    const leftStartIcon = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    await leftStartIcon.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    containerWidth.value = 400
+    await nextTick()
+
+    const leftEndIconAgain = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+    await leftEndIconAgain.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 100px;')
+
+    mockSize.mockRestore()
+  })
+
+  it("should expand an initially collapsed end panel to its own cached min, not the bar's other side", async () => {
+    const containerWidth = ref(400)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel collapsible>Left Panel</ElSplitterPanel>
+          <ElSplitterPanel size="0%" min={100} collapsible>
+            Right Panel
+          </ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+
+    // Left fills the whole container since Right is declared as "0%"
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 0px;')
+
+    // The only bar here has just one collapse icon (Right is already 0), and
+    // clicking it is the very first onCollapse call ever - it must populate
+    // the cache from the *right* panel's fixed min, not the left panel
+    const collapseIcon = wrapper.find('.el-splitter-bar__collapse-icon')
+    await collapseIcon.trigger('click')
+    await nextTick()
+
+    expect(panels[1].attributes('style')).toContain('flex-basis: 100px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should keep a fixed pixel size pinned when collapsing the end panel', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel collapsible>Left Panel</ElSplitterPanel>
+          <ElSplitterPanel size={150} collapsible>
+            Right Panel
+          </ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+
+    expect(panels[1].attributes('style')).toContain('flex-basis: 150px;')
+
+    // Collapse the fixed-size *end* panel while container is still 1000px
+    await endCollapseButton.trigger('click')
+    await nextTick()
+    expect(panels[1].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Container shrinks while the panel is collapsed
+    containerWidth.value = 800
+    await nextTick()
+
+    // Expand - the end panel's fixed size must stay pinned at 150px, not be
+    // classified using the left (auto-fill) panel's size
+    await startCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[1].attributes('style')).toContain('flex-basis: 150px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should not restore a proportional panel below its fixed min after container resize', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="30%" min={300} collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    // The panel sits exactly on its fixed 300px min
+    expect(panels[0].attributes('style')).toContain('flex-basis: 300px;')
+
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Container shrinks while the panel is collapsed
+    containerWidth.value = 800
+    await nextTick()
+
+    // Expanding must not drop below the min that dragging enforces - the
+    // cached 30% ratio alone would restore 240px against the new width
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 300px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 500px;')
+
+    mockSize.mockRestore()
+  })
+
+  it("should not restore over a neighbour's fixed min after container resize", async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="70%" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel min={400} collapsible>
+            Right Panel
+          </ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 700px;')
+
+    await startCollapseButton.trigger('click')
+    await nextTick()
+
+    // Container shrinks while the panel is collapsed
+    containerWidth.value = 800
+    await nextTick()
+
+    // Restoring 70% of 800px would leave the neighbour at 240px, under the
+    // 400px min that dragging enforces - the neighbour's limit wins, exactly
+    // as it does in onMoving
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 400px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should keep a two-way bound proportional size proportional across collapse cycles', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+    const size = ref<string | number>('50%')
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel v-model:size={size.value} collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+
+    // A collapse/expand round trip writes an internal pixel snapshot back
+    // through `update:size`, so the bound value is now the raw number 500
+    // even though the panel was declared as "50%"
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    await endCollapseButton.trigger('click')
+    await nextTick()
+    expect(size.value).toBe(500)
+
+    // Container shrinks - the panel is still proportional, so it tracks
+    containerWidth.value = 800
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+
+    // Collapse it, grow the container back while collapsed, then expand
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    containerWidth.value = 1000
+    await nextTick()
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    // The echoed-back number must not be mistaken for an authored fixed
+    // size: the panel restores to 50% of the current container (500px),
+    // not the 400px it happened to occupy when it was collapsed
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 500px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should restore a middle panel collapsed from one bar when expanded from the other', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="20%" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel size="30%" collapsible>
+            Middle Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel size="50%" collapsible>
+            Right Panel
+          </ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const endIcons = wrapper.findAll(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[1].attributes('style')).toContain('flex-basis: 300px;')
+
+    // Collapse the middle panel onto the left one, using the *first* bar
+    await endIcons[0]!.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Expand it again from the *second* bar - with the middle panel at 0 the
+    // only remaining end icon is that bar's. The remembered size belongs to
+    // the middle panel itself, so it comes back at 300px and eats into the
+    // right panel, rather than restoring the right panel's cached 500px
+    const secondBarEndIcon = wrapper.findAll(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+    expect(secondBarEndIcon).toHaveLength(1)
+    await secondBarEndIcon[0]!.trigger('click')
+    await nextTick()
+
+    expect(panels[1].attributes('style')).toContain('flex-basis: 300px;')
+    expect(panels[2].attributes('style')).toContain('flex-basis: 200px;')
+
+    mockSize.mockRestore()
+  })
+
   it('should emit resize events', async () => {
     const onResizeStart = vi.fn()
     const onResize = vi.fn()

--- a/packages/components/splitter/src/hooks/index.ts
+++ b/packages/components/splitter/src/hooks/index.ts
@@ -1,3 +1,11 @@
 export { useContainer } from './useContainer'
 export { useResize } from './useResize'
-export { useSize, isPct, isPx, getPct, getPx } from './useSize'
+export {
+  useSize,
+  isPct,
+  isPx,
+  isFixedSize,
+  isZeroSize,
+  getPct,
+  getPx,
+} from './useSize'

--- a/packages/components/splitter/src/hooks/useResize.ts
+++ b/packages/components/splitter/src/hooks/useResize.ts
@@ -1,6 +1,6 @@
 import { computed, ref, watch } from 'vue'
 import { clamp } from 'lodash-unified'
-import { getPct, getPx, isPct, isPx } from './useSize'
+import { getPct, getPx, isFixedSize, isPct, isPx } from './useSize'
 import { NOOP } from '@element-plus/utils'
 
 import type { ComputedRef, Ref } from 'vue'
@@ -128,13 +128,53 @@ export function useResize(
     cachePxSizes = []
   }
 
-  const cacheCollapsedSize: number[] = []
+  // A panel's declared size mode (fixed pixel vs proportional) is read from
+  // `panel.isFixedSize`, which is derived purely from its `size` prop and is
+  // NOT affected by `panel.size` itself being overwritten with a live raw px
+  // number while dragging/collapsing (see split-panel.vue).
+  const px2ptg = (px: number) =>
+    containerSize.value ? px / containerSize.value : 0
+  const ptg2pxSize = (ptg: number) => ptg * containerSize.value
+
+  interface CachedSize {
+    value: number
+    isRatio: boolean
+  }
+
+  const toCachedSize = (
+    px: number,
+    isFixed: boolean | undefined
+  ): CachedSize =>
+    isFixed
+      ? { value: px, isRatio: false }
+      : { value: px2ptg(px), isRatio: true }
+
+  const cachedSizeToPx = (cached: CachedSize | undefined) =>
+    cached ? (cached.isRatio ? ptg2pxSize(cached.value) : cached.value) : 0
+
+  // A panel whose *declared* size always resolves to 0 (e.g. "0%") has no
+  // meaningful size of its own to remember - `min` is the real floor, so
+  // classify by min's units instead of the (irrelevantly proportional) size.
+  const isFixedForCache = (
+    panel: PanelItemState | undefined,
+    minLimit: string | number | undefined
+  ) => (panel?.isZeroSize ? isFixedSize(minLimit) : !!panel?.isFixedSize)
+
+  // Keyed by *panel* index, not bar index: a middle panel can be collapsed
+  // from one bar and expanded from the other, so its remembered size has to
+  // belong to the panel itself rather than to whichever bar collapsed it.
+  const cacheCollapsedSize: (CachedSize | undefined)[] = []
   const onCollapse = (index: number, type: 'start' | 'end') => {
     if (!cacheCollapsedSize.length) {
       cacheCollapsedSize.push(
-        ...pxSizes.value.map((size, i) =>
-          size <= 0 ? getLimitSize(limitSizes.value[i]?.[0], 0) : size
-        )
+        ...pxSizes.value.map((size, i) => {
+          const minLimit = limitSizes.value[i]?.[0]
+          const validSize = size <= 0 ? getLimitSize(minLimit, 0) : size
+          return toCachedSize(
+            validSize,
+            isFixedForCache(panels.value[i], minLimit)
+          )
+        })
       )
     }
 
@@ -149,19 +189,54 @@ export function useResize(
     if (currentSize !== 0 && targetSize !== 0) {
       currentSizes[currentIndex] = 0
       currentSizes[targetIndex]! += currentSize
-      cacheCollapsedSize[index] = currentSize
+      cacheCollapsedSize[currentIndex] = toCachedSize(
+        currentSize,
+        isFixedForCache(
+          panels.value[currentIndex],
+          limitSizes.value[currentIndex]?.[0]
+        )
+      )
     } else {
+      // Whichever of the pair sits at 0 is the one being expanded; restore it
+      // from its own cache entry and give the remainder to its neighbour.
+      const collapsedIndex = currentSize === 0 ? currentIndex : targetIndex
       const totalSize = currentSize + targetSize
 
-      const targetCacheCollapsedSize = clamp(
-        cacheCollapsedSize[index],
+      const restoredSize = clamp(
+        cachedSizeToPx(cacheCollapsedSize[collapsedIndex]),
         0,
         totalSize
       )
-      const currentCacheCollapsedSize = totalSize - targetCacheCollapsedSize
 
-      currentSizes[targetIndex] = targetCacheCollapsedSize
-      currentSizes[currentIndex] = currentCacheCollapsedSize
+      // Restoring has to respect the same limits dragging enforces - a cached
+      // ratio can otherwise land outside them once the container was resized
+      // while the panel sat collapsed. Applied in the same order as onMoving
+      // (start min, end min, start max, end max) so conflicting limits resolve
+      // identically whether the size came from a drag or from an expand.
+      const startIndex = index
+      const endIndex = index + 1
+      const startMinSize = getLimitSize(limitSizes.value[startIndex]?.[0], 0)
+      const endMinSize = getLimitSize(limitSizes.value[endIndex]?.[0], 0)
+      const startMaxSize = getLimitSize(
+        limitSizes.value[startIndex]?.[1],
+        containerSize.value || 0
+      )
+      const endMaxSize = getLimitSize(
+        limitSizes.value[endIndex]?.[1],
+        containerSize.value || 0
+      )
+
+      let startSize =
+        collapsedIndex === startIndex ? restoredSize : totalSize - restoredSize
+
+      startSize = Math.max(startSize, Number(startMinSize))
+      startSize = Math.min(startSize, totalSize - Number(endMinSize))
+      startSize = Math.min(startSize, Number(startMaxSize))
+      startSize = Math.max(startSize, totalSize - Number(endMaxSize))
+      startSize = clamp(startSize, 0, totalSize)
+
+      currentSizes[startIndex] = startSize
+      currentSizes[endIndex] = totalSize - startSize
     }
 
     panels.value.forEach((panel, index) => {

--- a/packages/components/splitter/src/hooks/useSize.ts
+++ b/packages/components/splitter/src/hooks/useSize.ts
@@ -24,6 +24,32 @@ export function isPx(
   return isString(itemSize) && itemSize.endsWith('px')
 }
 
+// Mirrors the itemSize parsing below: a '%' string or empty/undefined value is
+// proportional (auto-fill or ratio-based), everything else that resolves to a
+// number (a literal number, an "Npx" string, or a bare numeric string such as
+// the Vue template `size="150"`) is pinned to that literal pixel value.
+export function isFixedSize(itemSize: string | number | undefined): boolean {
+  if (itemSize === undefined || itemSize === '' || isPct(itemSize)) {
+    return false
+  }
+  return (
+    isPx(itemSize) ||
+    typeof itemSize === 'number' ||
+    !Number.isNaN(Number(itemSize))
+  )
+}
+
+// Whether a *declared* size prop always resolves to exactly 0 (e.g. "0%",
+// "0px", or 0), regardless of container size - unlike undefined/'' (auto-fill),
+// which depends on siblings and isn't deterministically zero.
+export function isZeroSize(itemSize: string | number | undefined): boolean {
+  if (itemSize === undefined || itemSize === '') return false
+  if (isPct(itemSize)) return getPct(itemSize) === 0
+  if (isPx(itemSize)) return getPx(itemSize) === 0
+  const num = Number(itemSize)
+  return !Number.isNaN(num) && num === 0
+}
+
 export function useSize(
   panels: Ref<PanelItemState[]>,
   containerSize: ComputedRef<number>

--- a/packages/components/splitter/src/split-panel.vue
+++ b/packages/components/splitter/src/split-panel.vue
@@ -15,7 +15,7 @@ import { throwError } from '@element-plus/utils'
 import { getCollapsible, isCollapsible } from './hooks/usePanel'
 import SplitBar from './split-bar.vue'
 import { splitterPanelEmits } from './split-panel'
-import { getPct, getPx, isPct, isPx } from './hooks'
+import { getPct, getPx, isFixedSize, isPct, isPx, isZeroSize } from './hooks'
 import { splitterRootContextKey } from './type'
 
 import type { SplitterPanelProps } from './split-panel'
@@ -112,11 +112,24 @@ function sizeToPx(str: string | number | undefined) {
   return str ?? 0
 }
 
+// `v-model:size` writes the internal pixel snapshots emitted below straight
+// back into `props.size`, which would make an authored "50%" look like an
+// authored `500`. Track what was actually declared by ignoring the values we
+// emitted ourselves, so the panel's size mode survives a collapse cycle.
+let lastEmittedSize: number | undefined
+const declaredSize = ref<string | number | undefined>(props.size)
+
 // Two-way binding for size
 let isSizeUpdating = false
 watch(
   () => props.size,
   () => {
+    if (props.size === lastEmittedSize) {
+      lastEmittedSize = undefined
+    } else {
+      declaredSize.value = props.size
+    }
+
     if (!isSizeUpdating && panel.value) {
       if (!containerSize.value) {
         panel.value.size = props.size
@@ -131,6 +144,7 @@ watch(
       const finalSize = Math.min(Math.max(size, minSize || 0), maxSize || size)
 
       if (finalSize !== size) {
+        lastEmittedSize = finalSize
         emits('update:size', finalSize)
       }
 
@@ -144,6 +158,7 @@ watch(
   (val) => {
     if (val !== props.size) {
       isSizeUpdating = true
+      lastEmittedSize = val as number
       emits('update:size', val as number)
       nextTick(() => (isSizeUpdating = false))
     }
@@ -165,6 +180,11 @@ const _panel = reactive({
   setIndex,
   ...props,
   collapsible: computed(() => getCollapsible(props.collapsible)),
+  // Tied to the declared size (not the internal `size` below, which useResize
+  // overwrites with a live raw px number while dragging/collapsing) so a
+  // panel's declared size mode survives those internal mutations.
+  isFixedSize: computed(() => isFixedSize(declaredSize.value)),
+  isZeroSize: computed(() => isZeroSize(declaredSize.value)),
 })
 
 registerPanel(_panel)

--- a/packages/components/splitter/src/type.ts
+++ b/packages/components/splitter/src/type.ts
@@ -10,6 +10,14 @@ export type PanelItemState = UnwrapRef<{
   min?: number | string
   resizable: boolean
   size?: number | string
+  // Whether the panel's *declared* size prop is a fixed pixel value, kept
+  // separate from `size` (which useResize also overwrites with a live raw
+  // px number while dragging/collapsing) so that value doesn't get mistaken
+  // for an authored fixed size once it's just an internal snapshot.
+  isFixedSize?: boolean
+  // Whether the declared size prop always resolves to exactly 0 (e.g. "0%"),
+  // in which case `min` - not `size` - is the meaningful floor to restore to.
+  isZeroSize?: boolean
   setIndex: (val: number) => void
 }>
 


### PR DESCRIPTION
## Problem

`el-splitter-panel`'s collapse/expand cache (`cacheCollapsedSize` in `useResize.ts`) stored the panel size as a raw pixel value. If the container was resized while a panel was collapsed, expanding it later restored the stale pixel amount instead of the correct proportional size.

Repro (from #23015): container 1000px, two 50/50 panels.
1. Collapse panel A → cache stores 500px
2. Container resizes to 800px → panel A stays 0px, panel B fills 800px
3. Expand panel A → restores to 500px (wrong, should be 400px / 50% of the new 800px container)

This is the same root cause reported in #22944 (panel widths change unexpectedly after a collapse/expand cycle once the container is resized).

## Fix

Cache the collapsed size as a ratio of `containerSize` instead of a raw pixel value, converting back to pixels against the *current* container size when expanding. This keeps the collapse/expand cache resolution-independent.

## Testing

- Added a regression test (`should restore proportional size after container resize between collapse and expand`) that reproduces the exact scenario from #23015 and fails without the fix (`500px` instead of the expected `400px`).
- All existing splitter tests continue to pass.

Fixes #23015
Fixes #22944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed splitter panels restoring to incorrect sizes after the container is resized while collapsed.
  * Preserved proportional panel dimensions when restored.
  * Preserved fixed pixel sizes, including numeric and numeric-string values, when collapsing and restoring panels.
  * Fixed restoration of fixed-size end panels without incorrectly relying on adjacent auto-sized panels.
  * Ensured panels with zero size restore from their minimum configured size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->