### PR TITLE
fix(components): [scrollbar] update after transitions

### DIFF
--- a/packages/components/scrollbar/__tests__/scrollbar.test.tsx
+++ b/packages/components/scrollbar/__tests__/scrollbar.test.tsx
@@ -75,6 +75,47 @@ describe('ScrollBar', () => {
     scrollWidthRestore()
   })
 
+  test('updates after a descendant transition changes scrollable overflow', async () => {
+    const outerWidth = 204
+    let innerWidth = 500
+    const wrapper = mount({
+      setup() {
+        return () => (
+          <Scrollbar ref="scrollbar" always>
+            <div class="slide-track" />
+          </Scrollbar>
+        )
+      },
+    })
+    const scrollbar = wrapper.findComponent({ ref: 'scrollbar' }).vm
+    const scrollDom = wrapper.find('.el-scrollbar__wrap').element
+    const offsetWidthRestore = defineGetter(
+      scrollDom,
+      'offsetWidth',
+      outerWidth
+    )
+    const scrollWidthRestore = defineGetter(
+      scrollDom,
+      'scrollWidth',
+      () => innerWidth
+    )
+
+    scrollbar.update()
+    await nextTick()
+    expect(wrapper.find('.is-horizontal div').attributes('style')).toContain(
+      'width: 80px;'
+    )
+
+    innerWidth = outerWidth - 4
+    await wrapper.find('.slide-track').trigger('transitionend')
+    expect(
+      wrapper.find('.is-horizontal div').attributes('style')
+    ).not.toContain('width:')
+
+    offsetWidthRestore()
+    scrollWidthRestore()
+  })
+
   test('both vertical and horizontal', async () => {
     const outerHeight = 204
     const innerHeight = 500

--- a/packages/components/scrollbar/src/scrollbar.vue
+++ b/packages/components/scrollbar/src/scrollbar.vue
@@ -6,6 +6,7 @@
       :style="wrapStyle"
       :tabindex="tabindex"
       @scroll="handleScroll"
+      @transitionend="update"
     >
       <component
         :is="tag"


### PR DESCRIPTION
## What

Refresh the custom scrollbar measurements when a transition inside the scrollable wrapper finishes.

## Why

CSS transforms can change a descendant's scrollable overflow without changing its border-box size. In that case, the existing resize observers do not run, so a horizontal thumb measured during the transition can remain visible after the content is no longer scrollable.

The wrapper now handles the bubbled `transitionend` event and reuses the existing `update()` path. The regression test changes the measured scroll width at transition completion and verifies that the stale horizontal thumb size is cleared.

Closes #24507

## Test

- `pnpm test packages/components/scrollbar/__tests__/scrollbar.test.tsx`
- `pnpm exec eslint packages/components/scrollbar/src/scrollbar.vue packages/components/scrollbar/__tests__/scrollbar.test.tsx`
- `printf '%s\n' 'fix(components): [scrollbar] update after transitions' | pnpm run lint:commit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scrollbars now recalculate correctly when content changes size during a transition.
  * Horizontal scroll indicators are removed when content no longer overflows its container.

* **Tests**
  * Added coverage for scrollbar updates after descendant transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->