### PR TITLE
feat(components): [select] show tooltip when tag text is truncated

### DIFF
--- a/docs/en-US/component/select-v2.md
+++ b/docs/en-US/component/select-v2.md
@@ -285,7 +285,7 @@ select-v2/custom-width
 | placement                             | position of dropdown                                                                                                                                                                             | ^[enum]`'top' \| 'top-start' \| 'top-end' \| 'bottom' \| 'bottom-start' \| 'bottom-end' \| 'left' \| 'left-start' \| 'left-end' \| 'right' \| 'right-start' \| 'right-end'` | bottom-start                                   |
 | fallback-placements ^(2.5.6)          | list of possible positions for dropdown [popper.js](https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements)                                                                            | ^[array]`Placement[]`                                                                                                                                                       | ['bottom-start', 'top-start', 'right', 'left'] |
 | collapse-tags-tooltip ^(2.3.0)        | whether show all selected tags when mouse hover text of collapse-tags. To use this, `collapse-tags` must be true                                                                                 | ^[boolean]                                                                                                                                                                  | false                                          |
-| [tag-tooltip](#tag-tooltip) ^(2.13.3) | configuration object for the collapse-tags tooltip. To use this, `collapse-tags` and `collapse-tags-tooltip` must be true                                                                        | ^[object]`TagTooltipProps`                                                                                                                                                  | {}                                             |
+| [tag-tooltip](#tag-tooltip) ^(2.13.3) | configuration object for the tag tooltips, see [tag-tooltip](#tag-tooltip)                                                                                                                       | ^[object]`TagTooltipProps`                                                                                                                                                  | {}                                             |
 | max-collapse-tags ^(2.3.0)            | The max tags number to be shown. To use this, `collapse-tags` must be true                                                                                                                       | ^[number]                                                                                                                                                                   | 1                                              |
 | tag-type ^(2.5.0)                     | tag type                                                                                                                                                                                         | ^[enum]`'' \| 'success' \| 'info' \| 'warning' \| 'danger'`                                                                                                                 | info                                           |
 | tag-effect ^(2.7.7)                   | tag effect                                                                                                                                                                                       | ^[enum]`'' \| 'light' \| 'dark' \| 'plain'`                                                                                                                                 | light                                          |
@@ -305,6 +305,15 @@ select-v2/custom-width
 | disabled  | specify which key of node object is used as the node's disabled | ^[string] | disabled |
 
 ### tag-tooltip ^(2.13.3)
+
+:::tip Which Tooltips Are Affected
+
+This configuration applies to both tag tooltips:
+
+1. The collapse-tags tooltip which shows the hidden tags, it requires `collapse-tags` and `collapse-tags-tooltip` to be true.
+2. The tooltip which shows the complete text of a tag whose text is truncated ^(2.14.4), it appears when hovering that tag and is enabled by default. Its default `placement` is `top` and its default `fallback-placements` is `['top', 'bottom', 'right', 'left']`.
+
+:::
 
 :::tip Fallback Mechanism
 

--- a/docs/en-US/component/select.md
+++ b/docs/en-US/component/select.md
@@ -213,7 +213,7 @@ select/custom-label
 | clearable                             | whether select can be cleared                                                                                                            | ^[boolean]                                                                                                                                                                  | false                                          |
 | collapse-tags                         | whether to collapse tags to a text when multiple selecting                                                                               | ^[boolean]                                                                                                                                                                  | false                                          |
 | collapse-tags-tooltip ^(2.3.0)        | whether show all selected tags when mouse hover text of collapse-tags. To use this, `collapse-tags` must be true                         | ^[boolean]                                                                                                                                                                  | false                                          |
-| [tag-tooltip](#tag-tooltip) ^(2.13.3) | configuration object for the collapse-tags tooltip. To use this, `collapse-tags` and `collapse-tags-tooltip` must be true                | ^[object]`TagTooltipProps`                                                                                                                                                  | {}                                             |
+| [tag-tooltip](#tag-tooltip) ^(2.13.3) | configuration object for the tag tooltips, see [tag-tooltip](#tag-tooltip)                                                               | ^[object]`TagTooltipProps`                                                                                                                                                  | {}                                             |
 | multiple-limit                        | maximum number of options user can select when `multiple` is `true`. No limit when set to 0                                              | ^[number]                                                                                                                                                                   | 0                                              |
 | id                                    | native input id input                                                                                                                    | ^[string]                                                                                                                                                                   | —                                              |
 | name                                  | the name attribute of select input                                                                                                       | ^[string]                                                                                                                                                                   | —                                              |
@@ -273,6 +273,15 @@ select/custom-label
 | disabled          | specify which key of node object is used as the node's disabled | ^[string] | disabled |
 
 ### tag-tooltip ^(2.13.3)
+
+:::tip Which Tooltips Are Affected
+
+This configuration applies to both tag tooltips:
+
+1. The collapse-tags tooltip which shows the hidden tags, it requires `collapse-tags` and `collapse-tags-tooltip` to be true.
+2. The tooltip which shows the complete text of a tag whose text is truncated ^(2.14.4), it appears when hovering that tag and is enabled by default. Its default `placement` is `top` and its default `fallback-placements` is `['top', 'bottom', 'right', 'left']`.
+
+:::
 
 :::tip Fallback Mechanism
 

--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -2314,6 +2314,76 @@ describe('Select', () => {
     mockSelectWidth.mockRestore()
   })
 
+  it('multiple select with truncated tag text', async () => {
+    vi.useFakeTimers()
+    const longLabel = '一个比较长文本的标签一个比较长文本的标签'
+    const wrapper = createSelect({
+      data() {
+        return {
+          multiple: true,
+          value: [],
+          tagTooltip: {
+            popperClass: 'custom-tag-tooltip',
+            showAfter: 100,
+            hideAfter: 300,
+          },
+          options: [
+            {
+              value: '选项1',
+              label: longLabel,
+            },
+            {
+              value: '选项2',
+              label: '双皮奶',
+            },
+          ],
+        }
+      },
+    })
+    await nextTick()
+    await wrapper.find(`.${WRAPPER_CLASS_NAME}`).trigger('click')
+    const options = getOptions()
+    options[0].click()
+    await nextTick()
+
+    const select = wrapper.findComponent(Select)
+    const selectVm = select.vm as any
+    const tagItem = wrapper.find('.el-select__selected-item')
+    const textEl = tagItem.find('.el-select__tags-text').element
+    const clientWidthSpy = vi.spyOn(textEl, 'clientWidth', 'get')
+    const scrollWidthSpy = vi.spyOn(textEl, 'scrollWidth', 'get')
+
+    // the tag text is not truncated, no tooltip at all
+    clientWidthSpy.mockReturnValue(100)
+    scrollWidthSpy.mockReturnValue(100)
+    await tagItem.trigger('mouseenter')
+    vi.runAllTimers()
+    await nextTick()
+    expect(selectVm.tagTextTooltipVisible).toBe(false)
+
+    scrollWidthSpy.mockReturnValue(200)
+    await tagItem.trigger('mouseenter')
+    // `showAfter` of `tag-tooltip` should be respected
+    expect(selectVm.tagTextTooltipVisible).toBe(false)
+    vi.advanceTimersByTime(100)
+    await nextTick()
+    expect(selectVm.tagTextTooltipVisible).toBe(true)
+
+    const tooltip = document.querySelector('.custom-tag-tooltip')
+    expect(tooltip?.textContent?.trim()).toBe(longLabel)
+
+    await tagItem.trigger('mouseleave')
+    // `hideAfter` of `tag-tooltip` should be respected
+    expect(selectVm.tagTextTooltipVisible).toBe(true)
+    vi.advanceTimersByTime(300)
+    await nextTick()
+    expect(selectVm.tagTextTooltipVisible).toBe(false)
+
+    clientWidthSpy.mockRestore()
+    scrollWidthSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
   describe('scrollbarAlwaysOn flag control the scrollbar whether always displayed', () => {
     it('The default scrollbar is not always displayed', async () => {
       const wrapper = createSelect()

--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -2379,6 +2379,17 @@ describe('Select', () => {
     await nextTick()
     expect(selectVm.tagTextTooltipVisible).toBe(false)
 
+    // pending `showAfter` should be cancelled when the tag list changes
+    scrollWidthSpy.mockReturnValue(200)
+    await tagItem.trigger('mouseenter')
+    expect(selectVm.tagTextTooltipVisible).toBe(false)
+    await wrapper.find('.el-tag__close').trigger('click')
+    await nextTick()
+    expect(selectVm.tagTextTooltipVisible).toBe(false)
+    vi.advanceTimersByTime(100)
+    await nextTick()
+    expect(selectVm.tagTextTooltipVisible).toBe(false)
+
     clientWidthSpy.mockRestore()
     scrollWidthSpy.mockRestore()
     vi.useRealTimers()

--- a/packages/components/select-v2/src/defaults.ts
+++ b/packages/components/select-v2/src/defaults.ts
@@ -95,7 +95,7 @@ export const selectV2Props = buildProps({
    */
   collapseTagsTooltip: Boolean,
   /**
-   * @description configuration object for the collapse-tags tooltip. To use this, `collapse-tags` and `collapse-tags-tooltip` must be true
+   * @description configuration object for the tag tooltips, including the collapse-tags tooltip (to use that, `collapse-tags` and `collapse-tags-tooltip` must be true) and the tooltip which shows the complete text of a truncated tag
    */
   tagTooltip: {
     type: definePropType<TagTooltipProps>(Object),

--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -68,6 +68,8 @@
                 v-for="item in showTagList"
                 :key="getValueKey(getValue(item))"
                 :class="nsSelect.e('selected-item')"
+                @mouseenter="handleTagMouseEnter($event, item)"
+                @mouseleave="handleTagMouseLeave"
               >
                 <el-tag
                   :closable="!selectDisabled && !getDisabled(item)"
@@ -90,6 +92,43 @@
                   </span>
                 </el-tag>
               </div>
+
+              <el-tooltip
+                v-if="hoveringTag"
+                virtual-triggering
+                :virtual-ref="hoveringTagRef"
+                :visible="tagTextTooltipVisible"
+                :fallback-placements="
+                  tagTooltip?.fallbackPlacements ?? [
+                    'top',
+                    'bottom',
+                    'right',
+                    'left',
+                  ]
+                "
+                :effect="tagTooltip?.effect ?? effect"
+                :placement="tagTooltip?.placement ?? 'top'"
+                :popper-class="tagTooltip?.popperClass ?? popperClass"
+                :popper-style="tagTooltip?.popperStyle ?? popperStyle"
+                :teleported="tagTooltip?.teleported ?? teleported"
+                :append-to="tagTooltip?.appendTo ?? appendTo"
+                :popper-options="tagTooltip?.popperOptions ?? popperOptions"
+                :transition="tagTooltip?.transition"
+                :offset="tagTooltip?.offset"
+                :persistent="false"
+              >
+                <template #content>
+                  <slot
+                    v-if="hoveringTag"
+                    name="label"
+                    :index="getIndex(hoveringTag)"
+                    :label="getLabel(hoveringTag)"
+                    :value="getValue(hoveringTag)"
+                  >
+                    {{ getLabel(hoveringTag) }}
+                  </slot>
+                </template>
+              </el-tooltip>
 
               <el-tooltip
                 v-if="

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -437,23 +437,26 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
 
   // the tag text tooltip is controlled, so the delayed toggle of
   // `tagTooltip` has to be applied here instead of the tooltip itself
-  const { onOpen: openTagTextTooltip, onClose: closeTagTextTooltip } =
-    useDelayedToggle({
-      showAfter: computed(
-        () =>
-          props.tagTooltip?.showAfter ?? useDelayedTogglePropsDefaults.showAfter
-      ),
-      hideAfter: computed(
-        () =>
-          props.tagTooltip?.hideAfter ?? useDelayedTogglePropsDefaults.hideAfter
-      ),
-      autoClose: computed(
-        () =>
-          props.tagTooltip?.autoClose ?? useDelayedTogglePropsDefaults.autoClose
-      ),
-      open: () => (tagTextTooltipVisible.value = true),
-      close: () => (tagTextTooltipVisible.value = false),
-    })
+  const {
+    onOpen: openTagTextTooltip,
+    onClose: closeTagTextTooltip,
+    cancel: cancelTagTextTooltip,
+  } = useDelayedToggle({
+    showAfter: computed(
+      () =>
+        props.tagTooltip?.showAfter ?? useDelayedTogglePropsDefaults.showAfter
+    ),
+    hideAfter: computed(
+      () =>
+        props.tagTooltip?.hideAfter ?? useDelayedTogglePropsDefaults.hideAfter
+    ),
+    autoClose: computed(
+      () =>
+        props.tagTooltip?.autoClose ?? useDelayedTogglePropsDefaults.autoClose
+    ),
+    open: () => (tagTextTooltipVisible.value = true),
+    close: () => (tagTextTooltipVisible.value = false),
+  })
 
   const handleTagMouseEnter = (event: MouseEvent, item: Option) => {
     const tagEl = event.currentTarget as HTMLElement
@@ -473,6 +476,7 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
 
   // the hovered tag may be removed or collapsed, destroy the tooltip at once
   watch(showTagList, () => {
+    cancelTagTextTooltip()
     tagTextTooltipVisible.value = false
     hoveringTag.value = undefined
   })

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -25,6 +25,8 @@ import {
 } from '@element-plus/utils'
 import {
   useComposition,
+  useDelayedToggle,
+  useDelayedTogglePropsDefaults,
   useEmptyValues,
   useFocusController,
   useLocale,
@@ -425,6 +427,54 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     return props.collapseTags
       ? states.cachedOptions.slice(props.maxCollapseTags)
       : []
+  })
+
+  // the tag whose text is truncated and currently hovered,
+  // it is used as the reference of the tag text tooltip
+  const hoveringTag = ref<Option>()
+  const hoveringTagRef = ref<HTMLElement>()
+  const tagTextTooltipVisible = ref(false)
+
+  // the tag text tooltip is controlled, so the delayed toggle of
+  // `tagTooltip` has to be applied here instead of the tooltip itself
+  const { onOpen: openTagTextTooltip, onClose: closeTagTextTooltip } =
+    useDelayedToggle({
+      showAfter: computed(
+        () =>
+          props.tagTooltip?.showAfter ?? useDelayedTogglePropsDefaults.showAfter
+      ),
+      hideAfter: computed(
+        () =>
+          props.tagTooltip?.hideAfter ?? useDelayedTogglePropsDefaults.hideAfter
+      ),
+      autoClose: computed(
+        () =>
+          props.tagTooltip?.autoClose ?? useDelayedTogglePropsDefaults.autoClose
+      ),
+      open: () => (tagTextTooltipVisible.value = true),
+      close: () => (tagTextTooltipVisible.value = false),
+    })
+
+  const handleTagMouseEnter = (event: MouseEvent, item: Option) => {
+    const tagEl = event.currentTarget as HTMLElement
+    const textEl = tagEl.querySelector<HTMLElement>(
+      `.${nsSelect.e('tags-text')}`
+    )
+    // only show the tooltip when the tag text is ellipsis
+    if (!textEl || textEl.scrollWidth <= textEl.clientWidth) return
+    hoveringTagRef.value = tagEl
+    hoveringTag.value = item
+    openTagTextTooltip(event)
+  }
+
+  const handleTagMouseLeave = (event?: MouseEvent) => {
+    closeTagTextTooltip(event)
+  }
+
+  // the hovered tag may be removed or collapsed, destroy the tooltip at once
+  watch(showTagList, () => {
+    tagTextTooltipVisible.value = false
+    hoveringTag.value = undefined
   })
 
   // hooks
@@ -1064,10 +1114,15 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     validateIcon,
     showTagList,
     collapseTagList,
+    hoveringTag,
+    hoveringTagRef,
+    tagTextTooltipVisible,
 
     // methods exports
     debouncedOnInputChange,
     deleteTag,
+    handleTagMouseEnter,
+    handleTagMouseLeave,
     getLabel,
     getValue,
     getDisabled,

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -1686,6 +1686,77 @@ describe('Select', () => {
     expect(tags.length).toBe(3)
   })
 
+  test('multiple select with truncated tag text', async () => {
+    vi.useFakeTimers()
+    const longLabel = '一个比较长文本的标签一个比较长文本的标签'
+    wrapper = _mount(
+      `
+      <el-select v-model="selectedList" multiple placeholder="请选择" :tag-tooltip="tagTooltip">
+        <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value">
+        </el-option>
+      </el-select>
+    `,
+      () => ({
+        options: [
+          {
+            value: '选项1',
+            label: longLabel,
+          },
+          {
+            value: '选项2',
+            label: '双皮奶',
+          },
+        ],
+        selectedList: [],
+        tagTooltip: {
+          popperClass: 'custom-tag-tooltip',
+          showAfter: 100,
+          hideAfter: 300,
+        },
+      })
+    )
+    await wrapper.find(`.${WRAPPER_CLASS_NAME}`).trigger('click')
+    const options = getOptions()
+    options[0].click()
+    await nextTick()
+
+    const select = wrapper.findComponent(Select)
+    const tagItem = wrapper.find('.el-select__selected-item')
+    const textEl = tagItem.find('.el-select__tags-text').element
+    const clientWidthSpy = vi.spyOn(textEl, 'clientWidth', 'get')
+    const scrollWidthSpy = vi.spyOn(textEl, 'scrollWidth', 'get')
+
+    // the tag text is not truncated, no tooltip at all
+    clientWidthSpy.mockReturnValue(100)
+    scrollWidthSpy.mockReturnValue(100)
+    await tagItem.trigger('mouseenter')
+    vi.runAllTimers()
+    await nextTick()
+    expect(select.vm.tagTextTooltipVisible).toBe(false)
+
+    scrollWidthSpy.mockReturnValue(200)
+    await tagItem.trigger('mouseenter')
+    // `showAfter` of `tag-tooltip` should be respected
+    expect(select.vm.tagTextTooltipVisible).toBe(false)
+    vi.advanceTimersByTime(100)
+    await nextTick()
+    expect(select.vm.tagTextTooltipVisible).toBe(true)
+
+    const tooltip = document.querySelector('.custom-tag-tooltip')
+    expect(tooltip?.textContent?.trim()).toBe(longLabel)
+
+    await tagItem.trigger('mouseleave')
+    // `hideAfter` of `tag-tooltip` should be respected
+    expect(select.vm.tagTextTooltipVisible).toBe(true)
+    vi.advanceTimersByTime(300)
+    await nextTick()
+    expect(select.vm.tagTextTooltipVisible).toBe(false)
+
+    clientWidthSpy.mockRestore()
+    scrollWidthSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
   test('multiple remove-tag', async () => {
     const handleRemoveTag = vi.fn()
 

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -1752,6 +1752,17 @@ describe('Select', () => {
     await nextTick()
     expect(select.vm.tagTextTooltipVisible).toBe(false)
 
+    // pending `showAfter` should be cancelled when the tag list changes
+    scrollWidthSpy.mockReturnValue(200)
+    await tagItem.trigger('mouseenter')
+    expect(select.vm.tagTextTooltipVisible).toBe(false)
+    await wrapper.find('.el-tag__close').trigger('click')
+    await nextTick()
+    expect(select.vm.tagTextTooltipVisible).toBe(false)
+    vi.advanceTimersByTime(100)
+    await nextTick()
+    expect(select.vm.tagTextTooltipVisible).toBe(false)
+
     clientWidthSpy.mockRestore()
     scrollWidthSpy.mockRestore()
     vi.useRealTimers()

--- a/packages/components/select/src/select.ts
+++ b/packages/components/select/src/select.ts
@@ -209,7 +209,7 @@ export const selectProps = buildProps({
    */
   collapseTagsTooltip: Boolean,
   /**
-   * @description configuration object for the collapse-tags tooltip. To use this, `collapse-tags` and `collapse-tags-tooltip` must be true
+   * @description configuration object for the tag tooltips, including the collapse-tags tooltip (to use that, `collapse-tags` and `collapse-tags-tooltip` must be true) and the tooltip which shows the complete text of a truncated tag
    */
   tagTooltip: {
     type: definePropType<TagTooltipProps>(Object),

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -68,6 +68,8 @@
                 v-for="item in showTagList"
                 :key="getValueKey(item)"
                 :class="nsSelect.e('selected-item')"
+                @mouseenter="handleTagMouseEnter($event, item)"
+                @mouseleave="handleTagMouseLeave"
               >
                 <el-tag
                   :closable="!selectDisabled && !item.isDisabled"
@@ -90,6 +92,43 @@
                   </span>
                 </el-tag>
               </div>
+
+              <el-tooltip
+                v-if="hoveringTag"
+                virtual-triggering
+                :virtual-ref="hoveringTagRef"
+                :visible="tagTextTooltipVisible"
+                :fallback-placements="
+                  tagTooltip?.fallbackPlacements ?? [
+                    'top',
+                    'bottom',
+                    'right',
+                    'left',
+                  ]
+                "
+                :effect="tagTooltip?.effect ?? effect"
+                :placement="tagTooltip?.placement ?? 'top'"
+                :popper-class="tagTooltip?.popperClass ?? popperClass"
+                :popper-style="tagTooltip?.popperStyle ?? popperStyle"
+                :teleported="tagTooltip?.teleported ?? teleported"
+                :append-to="tagTooltip?.appendTo ?? appendTo"
+                :popper-options="tagTooltip?.popperOptions ?? popperOptions"
+                :transition="tagTooltip?.transition"
+                :offset="tagTooltip?.offset"
+                :persistent="false"
+              >
+                <template #content>
+                  <slot
+                    v-if="hoveringTag"
+                    name="label"
+                    :index="hoveringTag.index"
+                    :label="hoveringTag.currentLabel"
+                    :value="hoveringTag.value"
+                  >
+                    {{ hoveringTag.currentLabel }}
+                  </slot>
+                </template>
+              </el-tooltip>
 
               <el-tooltip
                 v-if="collapseTags && states.selected.length > maxCollapseTags"

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -783,23 +783,26 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
 
   // the tag text tooltip is controlled, so the delayed toggle of
   // `tagTooltip` has to be applied here instead of the tooltip itself
-  const { onOpen: openTagTextTooltip, onClose: closeTagTextTooltip } =
-    useDelayedToggle({
-      showAfter: computed(
-        () =>
-          props.tagTooltip?.showAfter ?? useDelayedTogglePropsDefaults.showAfter
-      ),
-      hideAfter: computed(
-        () =>
-          props.tagTooltip?.hideAfter ?? useDelayedTogglePropsDefaults.hideAfter
-      ),
-      autoClose: computed(
-        () =>
-          props.tagTooltip?.autoClose ?? useDelayedTogglePropsDefaults.autoClose
-      ),
-      open: () => (tagTextTooltipVisible.value = true),
-      close: () => (tagTextTooltipVisible.value = false),
-    })
+  const {
+    onOpen: openTagTextTooltip,
+    onClose: closeTagTextTooltip,
+    cancel: cancelTagTextTooltip,
+  } = useDelayedToggle({
+    showAfter: computed(
+      () =>
+        props.tagTooltip?.showAfter ?? useDelayedTogglePropsDefaults.showAfter
+    ),
+    hideAfter: computed(
+      () =>
+        props.tagTooltip?.hideAfter ?? useDelayedTogglePropsDefaults.hideAfter
+    ),
+    autoClose: computed(
+      () =>
+        props.tagTooltip?.autoClose ?? useDelayedTogglePropsDefaults.autoClose
+    ),
+    open: () => (tagTextTooltipVisible.value = true),
+    close: () => (tagTextTooltipVisible.value = false),
+  })
 
   const handleTagMouseEnter = (event: MouseEvent, item: OptionBasic) => {
     const tagEl = event.currentTarget as HTMLElement
@@ -819,6 +822,7 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
 
   // the hovered tag may be removed or collapsed, destroy the tooltip at once
   watch(showTagList, () => {
+    cancelTagTextTooltip()
     tagTextTooltipVisible.value = false
     hoveringTag.value = undefined
   })

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -34,6 +34,8 @@ import {
 } from '@element-plus/constants'
 import {
   useComposition,
+  useDelayedToggle,
+  useDelayedTogglePropsDefaults,
   useEmptyValues,
   useFocusController,
   useId,
@@ -773,6 +775,54 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
       : []
   })
 
+  // the tag whose text is truncated and currently hovered,
+  // it is used as the reference of the tag text tooltip
+  const hoveringTag = ref<OptionBasic>()
+  const hoveringTagRef = ref<HTMLElement>()
+  const tagTextTooltipVisible = ref(false)
+
+  // the tag text tooltip is controlled, so the delayed toggle of
+  // `tagTooltip` has to be applied here instead of the tooltip itself
+  const { onOpen: openTagTextTooltip, onClose: closeTagTextTooltip } =
+    useDelayedToggle({
+      showAfter: computed(
+        () =>
+          props.tagTooltip?.showAfter ?? useDelayedTogglePropsDefaults.showAfter
+      ),
+      hideAfter: computed(
+        () =>
+          props.tagTooltip?.hideAfter ?? useDelayedTogglePropsDefaults.hideAfter
+      ),
+      autoClose: computed(
+        () =>
+          props.tagTooltip?.autoClose ?? useDelayedTogglePropsDefaults.autoClose
+      ),
+      open: () => (tagTextTooltipVisible.value = true),
+      close: () => (tagTextTooltipVisible.value = false),
+    })
+
+  const handleTagMouseEnter = (event: MouseEvent, item: OptionBasic) => {
+    const tagEl = event.currentTarget as HTMLElement
+    const textEl = tagEl.querySelector<HTMLElement>(
+      `.${nsSelect.e('tags-text')}`
+    )
+    // only show the tooltip when the tag text is ellipsis
+    if (!textEl || textEl.scrollWidth <= textEl.clientWidth) return
+    hoveringTagRef.value = tagEl
+    hoveringTag.value = item
+    openTagTextTooltip(event)
+  }
+
+  const handleTagMouseLeave = (event?: MouseEvent) => {
+    closeTagTextTooltip(event)
+  }
+
+  // the hovered tag may be removed or collapsed, destroy the tooltip at once
+  watch(showTagList, () => {
+    tagTextTooltipVisible.value = false
+    hoveringTag.value = undefined
+  })
+
   const navigateOptions = (direction: 'prev' | 'next') => {
     if (!expanded.value) {
       expanded.value = true
@@ -997,6 +1047,11 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
     dropdownMenuVisible,
     showTagList,
     collapseTagList,
+    hoveringTag,
+    hoveringTagRef,
+    tagTextTooltipVisible,
+    handleTagMouseEnter,
+    handleTagMouseLeave,
     popupScroll,
     getOption,
     endReached,

--- a/packages/hooks/__tests__/use-delayed-toggle.test.ts
+++ b/packages/hooks/__tests__/use-delayed-toggle.test.ts
@@ -180,4 +180,37 @@ describe('use-delayed-toggle', () => {
     expect(cbOpen).toHaveBeenCalledTimes(1)
     expect(cbClose).toHaveBeenCalledTimes(1)
   })
+
+  it('should cancel pending timers', () => {
+    const cbOpen = vi.fn()
+    const cbClose = vi.fn()
+    const { onOpen, onClose, cancel } = useDelayedToggle({
+      open: cbOpen,
+      close: cbClose,
+      showAfter: ref(100),
+      hideAfter: ref(100),
+      autoClose: ref(100),
+    })
+
+    onOpen()
+    cancel()
+    vi.runAllTimers()
+    expect(cbOpen).not.toHaveBeenCalled()
+    expect(cbClose).not.toHaveBeenCalled()
+
+    onOpen()
+    vi.advanceTimersByTime(100)
+    expect(cbOpen).toHaveBeenCalledTimes(1)
+    expect(cbClose).not.toHaveBeenCalled()
+
+    cancel()
+    vi.runAllTimers()
+    expect(cbOpen).toHaveBeenCalledTimes(1)
+    expect(cbClose).not.toHaveBeenCalled()
+
+    onClose()
+    cancel()
+    vi.runAllTimers()
+    expect(cbClose).not.toHaveBeenCalled()
+  })
 })

--- a/packages/hooks/use-delayed-toggle/index.ts
+++ b/packages/hooks/use-delayed-toggle/index.ts
@@ -64,7 +64,7 @@ export const useDelayedToggle = ({
   open,
   close,
 }: DelayedToggle) => {
-  const { registerTimeout } = useTimeout()
+  const { registerTimeout, cancelTimeout } = useTimeout()
   const {
     registerTimeout: registerTimeoutForAutoClose,
     cancelTimeout: cancelTimeoutForAutoClose,
@@ -90,8 +90,14 @@ export const useDelayedToggle = ({
     }, delay)
   }
 
+  const cancel = () => {
+    cancelTimeout()
+    cancelTimeoutForAutoClose()
+  }
+
   return {
     onOpen,
     onClose,
+    cancel,
   }
 }


### PR DESCRIPTION
- Show the complete text in a tooltip when hovering a selected tag whose text is truncated by ellipsis, for both select and select-v2
- The tooltip inherits the `tag-tooltip` configuration, including its delayed toggle options

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tooltips for truncated tag labels in single-select and virtualized Select components.
  * Tooltips display the full tag text with configurable placement, styling, and show/hide delays.

* **Bug Fixes**
  * Prevented tooltips from appearing when labels fit within available space.
  * Canceled pending tooltip actions when tags are removed or hover state changes.

* **Documentation**
  * Clarified `tag-tooltip` behavior for collapsed and truncated tags, including default and fallback placement settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->