### PR TITLE
fix(components): [splitter] preserve panel sizes across collapse and resize

### DIFF
--- a/docs/en-US/component/splitter.md
+++ b/docs/en-US/component/splitter.md
@@ -57,6 +57,29 @@ splitter/size
 
 :::
 
+### Size units
+
+The unit a `size` is written in decides what the panel aims for when the
+container is resized, so pick the one that matches your intent:
+
+| `size`        | Panel aims for                                                                     |
+| ------------- | ---------------------------------------------------------------------------------- |
+| `"200px"`     | 200px, keeping that width as the container resizes. The rest goes to other panels. |
+| `:size="200"` | 200px to begin with, then its share of the container proportionally.               |
+| `"25%"`       | A quarter of the container.                                                        |
+| omitted       | Whatever the sized panels leave over, split evenly with the other omitted panels.  |
+
+A panel sized in `px` keeps its width through collapse and expand too, and
+dragging it sets a new one.
+
+These are targets rather than guarantees. `min` and `max` take precedence, a
+panel can be collapsed to zero whatever its size says, and when the `px` panels
+together are wider than the container they shrink in proportion rather than
+pushing the other panels out.
+
+`min` and `max` read their units the usual way: a percentage tracks the
+container, while a number or a `px` string is a literal pixel limit.
+
 ## Lazy ^(2.11.0)
 
 When `lazy` is enabled, the panel size will not update in real time during dragging, but only after the drag ends.

--- a/packages/components/splitter/__tests__/splitter.test.tsx
+++ b/packages/components/splitter/__tests__/splitter.test.tsx
@@ -179,6 +179,1385 @@ describe('Splitter', () => {
     expect(panels[0].attributes('style')).toContain('flex-basis: 150px;')
   })
 
+  it('should restore proportional size after container resize between collapse and expand', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel collapsible>Left Panel</ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    // default 50/50 split
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+
+    // Collapse the left panel while container is still 1000px
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Container shrinks while the panel is collapsed
+    containerWidth.value = 800
+    await nextTick()
+
+    // Expand the left panel back - it should restore to 50% of the *new*
+    // container size (400px), not the stale 500px captured before collapse
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 400px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should keep an explicit px size pinned after container resize between collapse and expand', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="150px" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 150px;')
+
+    // Collapse the px-sized panel while container is still 1000px
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Container shrinks while the panel is collapsed
+    containerWidth.value = 800
+    await nextTick()
+
+    // Expand - an explicit "150px" is the signal for a fixed width, so it
+    // stays 150px rather than being rescaled as a 15% share of the new width
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 150px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should hold px panels at their width when the container resizes after a collapse cycle', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(250),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '250px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="100px" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Middle Panel</ElSplitterPanel>
+          <ElSplitterPanel size="150px" collapsible>
+            Right Panel
+          </ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const basis = (i: number) => panels[i].attributes('style')
+
+    expect(basis(0)).toContain('flex-basis: 100px;')
+    expect(basis(2)).toContain('flex-basis: 150px;')
+
+    // Collapse and expand the first panel, which writes live pixel numbers
+    // into every panel's internal size
+    await wrapper
+      .find('.el-splitter-bar__horizontal-collapse-icon-start')
+      .trigger('click')
+    await nextTick()
+    await wrapper
+      .find('.el-splitter-bar__horizontal-collapse-icon-end')
+      .trigger('click')
+    await nextTick()
+    expect(basis(0)).toContain('flex-basis: 100px;')
+
+    // Now resize the container - only the auto-sized middle panel should move
+    containerWidth.value = 800
+    await nextTick()
+
+    expect(basis(0)).toContain('flex-basis: 100px;')
+    expect(basis(1)).toContain('flex-basis: 550px;')
+    expect(basis(2)).toContain('flex-basis: 150px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should scale px panels down together when they overflow the container', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(250),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '250px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="100px" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Middle Panel</ElSplitterPanel>
+          <ElSplitterPanel size="150px" collapsible>
+            Right Panel
+          </ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+
+    // 250px of pinned width in a 200px container - they share it in
+    // proportion rather than pushing the flexible panel below zero
+    containerWidth.value = 200
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 80px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 0px;')
+    expect(panels[2].attributes('style')).toContain('flex-basis: 120px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should keep a satisfiable min when pinned panels overflow', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(250),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '250px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="200px" min="200px">
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel size="900px">Middle Panel</ElSplitterPanel>
+          <ElSplitterPanel>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+
+    // 1100px of pins in a 1000px container. The 100px has to come from the
+    // panel with room above its min, not be shared out proportionally in a
+    // way that pushes the first panel under a min it could have kept
+    expect(panels[0].attributes('style')).toContain('flex-basis: 200px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 800px;')
+    expect(panels[2].attributes('style')).toContain('flex-basis: 0px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should re-clamp a pinned px size against percentage limits', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(250),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '250px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="500px" max="50%">
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+
+    // A percentage limit moves with the container, so the stored pixel pin
+    // has to be re-checked against it rather than reused as-is
+    containerWidth.value = 800
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should not pin a collapsed px panel shut when another bar is dragged', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(250),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '250px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="200px" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Middle Panel</ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    expect(panels[0].attributes('style')).toContain('flex-basis: 200px;')
+
+    await wrapper
+      .find('.el-splitter-bar__horizontal-collapse-icon-start')
+      .trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Drag the *second* bar. The collapsed panel reads 0 there but took no
+    // part in the drag, so its pinned width must survive
+    const draggers = wrapper.findAll('.el-splitter-bar__dragger')
+    const mousedown = new MouseEvent('mousedown', { bubbles: true })
+    Object.defineProperty(mousedown, 'pageX', { value: 500 })
+    draggers[1]!.element.dispatchEvent(mousedown)
+    const mousemove = new MouseEvent('mousemove', { bubbles: true })
+    Object.defineProperty(mousemove, 'pageX', { value: 600 })
+    window.dispatchEvent(mousemove)
+    await nextTick()
+    const mouseup = new MouseEvent('mouseup', { bubbles: true })
+    Object.defineProperty(mouseup, 'pageX', { value: 600 })
+    window.dispatchEvent(mouseup)
+    await nextTick()
+
+    // Expanding brings the panel back to its 200px, and it stays there
+    await wrapper
+      .findAll('.el-splitter-bar__horizontal-collapse-icon-end')[0]!
+      .trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 200px;')
+
+    containerWidth.value = 800
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 200px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should clamp a pinned px size to the panel limits', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(250),
+    })
+    const size = ref<string | number>('200px')
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '250px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size={size.value} max="300px" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    expect(panels[0].attributes('style')).toContain('flex-basis: 200px;')
+
+    // A width beyond `max` must not be pinned as authored - the pin cannot
+    // smuggle a value past the limits the size watcher enforces
+    size.value = '500px'
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 300px;')
+
+    containerWidth.value = 800
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 300px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should let a px panel be dragged to zero and stay there', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(250),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '250px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="200px">Left Panel</ElSplitterPanel>
+          <ElSplitterPanel>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    expect(panels[0].attributes('style')).toContain('flex-basis: 200px;')
+
+    const splitBar = wrapper.find('.el-splitter-bar__dragger')
+    const mousedown = new MouseEvent('mousedown', { bubbles: true })
+    Object.defineProperty(mousedown, 'pageX', { value: 200 })
+    splitBar.element.dispatchEvent(mousedown)
+    const mousemove = new MouseEvent('mousemove', { bubbles: true })
+    Object.defineProperty(mousemove, 'pageX', { value: 0 })
+    window.dispatchEvent(mousemove)
+    await nextTick()
+    const mouseup = new MouseEvent('mouseup', { bubbles: true })
+    Object.defineProperty(mouseup, 'pageX', { value: 0 })
+    window.dispatchEvent(mouseup)
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Dragging to zero is a deliberate resize, so it becomes the new pinned
+    // width rather than being undone by the next recomputation
+    containerWidth.value = 800
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should honour a size prop written while a px panel is collapsed', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(250),
+    })
+    const size = ref<string | number>('200px')
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '250px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size={size.value} collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+
+    await wrapper
+      .find('.el-splitter-bar__horizontal-collapse-icon-start')
+      .trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // The parent drives the panel back open through the prop rather than the
+    // collapse control - the collapsed marker must not pin it shut
+    size.value = '300px'
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 300px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should expand a "0px" panel to its min rather than pinning it shut', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(250),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '250px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="0px" min={100} collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // "0px" is where the panel starts, not a width to hold it at - expanding
+    // must reach the 100px min instead of being re-pinned to 0
+    await wrapper.find('.el-splitter-bar__collapse-icon').trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 100px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should let a px panel squeezed to zero by a neighbour recover its width', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(250),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '250px' }}>
+        <ElSplitter>
+          <ElSplitterPanel collapsible>Left Panel</ElSplitterPanel>
+          <ElSplitterPanel size="200px" collapsible>
+            Middle Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+
+    await wrapper
+      .find('.el-splitter-bar__horizontal-collapse-icon-start')
+      .trigger('click')
+    await nextTick()
+    containerWidth.value = 800
+    await nextTick()
+
+    // Expanding the left panel takes space from the pinned middle one, which
+    // only had 200px to give - it must not be left collapsed for good
+    await wrapper
+      .find('.el-splitter-bar__horizontal-collapse-icon-end')
+      .trigger('click')
+    await nextTick()
+    expect(panels[1].attributes('style')).toContain('flex-basis: 200px;')
+
+    containerWidth.value = 1000
+    await nextTick()
+    expect(panels[1].attributes('style')).toContain('flex-basis: 200px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should restore a bare numeric size proportionally after container resize', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size={150} collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 150px;')
+
+    await startCollapseButton.trigger('click')
+    await nextTick()
+
+    containerWidth.value = 800
+    await nextTick()
+
+    // `:size="150"` means 150px initially and proportional afterwards, so it
+    // restores its 15% share of the new width - use "150px" to pin it
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 120px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should treat a numeric string size the same as a bare number', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="150" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 150px;')
+
+    // Collapse the panel (sized with a plain numeric string, as a Vue
+    // template passes `size="150"`) while container is still 1000px
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Container shrinks while the panel is collapsed
+    containerWidth.value = 800
+    await nextTick()
+
+    // `size="150"` carries no unit, so it follows the bare-number rule and
+    // restores proportionally rather than pinning to 150px
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 120px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should not mistake an internally-generated numeric size for an authored fixed size', async () => {
+    const containerWidth = ref(800)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel collapsible>Left Panel</ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    // Round-trip a collapse/expand at 800px - this leaves the internal
+    // `size` as the raw number 400, even though both panels were declared
+    // proportionally (no `size` prop at all)
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    await endCollapseButton.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+
+    // Container grows - since both panels are still proportional, this
+    // scales evenly to 500/500
+    containerWidth.value = 1000
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+
+    // Collapse again, then shrink the container back down while collapsed
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    containerWidth.value = 800
+    await nextTick()
+
+    // Expanding should still land on an even 50/50 split (400/400), not
+    // treat the leftover raw-number internal state as an authored fixed size
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 400px;')
+
+    mockSize.mockRestore()
+  })
+
+  it("should restore a collapsed-to-zero panel's px-string min after container resize", async () => {
+    const containerWidth = ref(400)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="0%" min="100px" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Middle Panel</ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const endIcons = wrapper.findAll(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Seed the cache while the container is still 400px, as above
+    await endIcons[1]!.trigger('click')
+    await nextTick()
+
+    // Container grows while the left panel is still at 0
+    containerWidth.value = 800
+    await nextTick()
+
+    // `min="100px"` is a literal width just like `min={100}` - caching it as a
+    // ratio would restore 200px against the wider container
+    await wrapper
+      .find('.el-splitter-bar__horizontal-collapse-icon-end')
+      .trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 100px;')
+
+    mockSize.mockRestore()
+  })
+
+  it("should restore a collapsed-to-zero panel's fixed min after container resize", async () => {
+    const containerWidth = ref(400)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="0%" min={100} collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Middle Panel</ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const endIcons = wrapper.findAll(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    // Left panel is inherently 0 (declared as "0%"), with a fixed 100px min
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Collapse Right onto Middle first - this is the first-ever onCollapse
+    // call, so it populates the cache for every panel (including the
+    // already-zero left one) while the container is still 400px. Middle
+    // keeps a positive size so Left's own expand icon stays available.
+    await endIcons[1]!.trigger('click')
+    await nextTick()
+
+    // Container shrinks while the left panel is still at 0
+    containerWidth.value = 200
+    await nextTick()
+
+    // Expand the left panel - it should restore to its literal 100px min,
+    // not a min/400 ratio rescaled against the new 200px container (50px)
+    const leftEndIcon = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+    await leftEndIcon.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 100px;')
+
+    // Collapse it back to 0, resize again, and expand once more - the fixed
+    // min classification must survive a *later* re-collapse too, not just
+    // the very first expand-from-zero
+    const leftStartIcon = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    await leftStartIcon.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    containerWidth.value = 400
+    await nextTick()
+
+    const leftEndIconAgain = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+    await leftEndIconAgain.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 100px;')
+
+    mockSize.mockRestore()
+  })
+
+  it("should expand an initially collapsed end panel to its own cached min, not the bar's other side", async () => {
+    const containerWidth = ref(400)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel collapsible>Left Panel</ElSplitterPanel>
+          <ElSplitterPanel size="0%" min={100} collapsible>
+            Right Panel
+          </ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+
+    // Left fills the whole container since Right is declared as "0%"
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 0px;')
+
+    // The only bar here has just one collapse icon (Right is already 0), and
+    // clicking it is the very first onCollapse call ever - it must populate
+    // the cache from the *right* panel's fixed min, not the left panel
+    const collapseIcon = wrapper.find('.el-splitter-bar__collapse-icon')
+    await collapseIcon.trigger('click')
+    await nextTick()
+
+    expect(panels[1].attributes('style')).toContain('flex-basis: 100px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should keep an explicit px size pinned when collapsing the end panel', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel collapsible>Left Panel</ElSplitterPanel>
+          <ElSplitterPanel size="150px" collapsible>
+            Right Panel
+          </ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+
+    expect(panels[1].attributes('style')).toContain('flex-basis: 150px;')
+
+    // Collapse the px-sized *end* panel while container is still 1000px
+    await endCollapseButton.trigger('click')
+    await nextTick()
+    expect(panels[1].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Container shrinks while the panel is collapsed
+    containerWidth.value = 800
+    await nextTick()
+
+    // Expand - the end panel's px size must stay pinned at 150px, not be
+    // classified using the left (auto-fill) panel's size
+    await startCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[1].attributes('style')).toContain('flex-basis: 150px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should not restore a proportional panel below its fixed min after container resize', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="30%" min={300} collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    // The panel sits exactly on its fixed 300px min
+    expect(panels[0].attributes('style')).toContain('flex-basis: 300px;')
+
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Container shrinks while the panel is collapsed
+    containerWidth.value = 800
+    await nextTick()
+
+    // Expanding must not drop below the min that dragging enforces - the
+    // cached 30% ratio alone would restore 240px against the new width
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 300px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 500px;')
+
+    mockSize.mockRestore()
+  })
+
+  it("should not restore over a neighbour's fixed min after container resize", async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="70%" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel min={400} collapsible>
+            Right Panel
+          </ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 700px;')
+
+    await startCollapseButton.trigger('click')
+    await nextTick()
+
+    // Container shrinks while the panel is collapsed
+    containerWidth.value = 800
+    await nextTick()
+
+    // Restoring 70% of 800px would leave the neighbour at 240px, under the
+    // 400px min that dragging enforces - the neighbour's limit wins, exactly
+    // as it does in onMoving
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 400px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should keep a two-way bound proportional size proportional across collapse cycles', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+    const size = ref<string | number>('50%')
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel v-model:size={size.value} collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+
+    // A collapse/expand round trip writes an internal pixel snapshot back
+    // through `update:size`, so the bound value is now the raw number 500
+    // even though the panel was declared as "50%"
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    await endCollapseButton.trigger('click')
+    await nextTick()
+    expect(size.value).toBe(500)
+
+    // Container shrinks - the panel is still proportional, so it tracks
+    containerWidth.value = 800
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+
+    // Collapse it, grow the container back while collapsed, then expand
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    containerWidth.value = 1000
+    await nextTick()
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    // The echoed-back number must not be mistaken for an authored fixed
+    // size: the panel restores to 50% of the current container (500px),
+    // not the 400px it happened to occupy when it was collapsed
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 500px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should treat a later size prop change as authored, not as an echo', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+    // A one-way `:size` binding - the parent never mirrors `update:size`
+    const size = ref<string | number>('50%')
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size={size.value} collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    // Collapse/expand makes the panel emit internal pixel snapshots that this
+    // parent throws away, so `props.size` is still "50%"
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    await endCollapseButton.trigger('click')
+    await nextTick()
+    expect(size.value).toBe('50%')
+
+    // The parent now genuinely authors an explicit px size whose number
+    // matches a value the panel emitted earlier - it must not be written off
+    // as an echo of that emit
+    size.value = '500px'
+    await nextTick()
+
+    await startCollapseButton.trigger('click')
+    await nextTick()
+    containerWidth.value = 800
+    await nextTick()
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    // Authored as an explicit "500px", so it stays 500px rather than
+    // restoring as the 50% ratio it was originally declared with
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should honour a bare numeric string min when restoring', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="30%" min="300" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    await startCollapseButton.trigger('click')
+    await nextTick()
+
+    containerWidth.value = 800
+    await nextTick()
+
+    // `min="300"` is neither a `%` nor a `px` string, so it stays a raw
+    // string at runtime - it still has to clamp the restored size
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 300px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should treat a null limit as unset', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="50%" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel max={null as unknown as number} collapsible>
+            Right Panel
+          </ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    await startCollapseButton.trigger('click')
+    await nextTick()
+
+    containerWidth.value = 800
+    await nextTick()
+
+    // `max={null}` disables the limit - it must not be read as a 0px max,
+    // which would force the whole pair onto the panel being expanded
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 400px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should treat a null size as auto-fill, not as a fixed pixel size', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel
+            size={null as unknown as number}
+            min={100}
+            collapsible
+          >
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    // `useSize` leaves a null size out of the ratio list, i.e. auto-fill
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+
+    await startCollapseButton.trigger('click')
+    await nextTick()
+
+    containerWidth.value = 800
+    await nextTick()
+
+    // Restores proportionally like any auto-filled panel - reading null as a
+    // fixed pixel size (via its `min` units) would pin it at a stale 500px
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 400px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should treat an empty string limit as unset', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="50%" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel max="" collapsible>
+            Right Panel
+          </ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    await startCollapseButton.trigger('click')
+    await nextTick()
+
+    containerWidth.value = 800
+    await nextTick()
+
+    // `max=""` means no limit - reading it as a 0px max would pin the panel
+    // shut and hand the whole pair to its neighbour
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 400px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should treat a cleared size prop as a real change, not an echo', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+    const size = ref<string | number | undefined>(150)
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size={size.value} collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel collapsible>Right Panel</ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    expect(panels[0].attributes('style')).toContain('flex-basis: 150px;')
+
+    // The parent clears the fixed size, handing the panel back to auto-fill.
+    // At rest the remembered emit value is `undefined` too, so this must not
+    // be mistaken for an echo of an emit that never happened.
+    size.value = undefined
+    await nextTick()
+
+    const splitBar = wrapper.find('.el-splitter-bar__dragger')
+    const mousedown = new MouseEvent('mousedown', { bubbles: true })
+    Object.defineProperty(mousedown, 'pageX', { value: 0 })
+    splitBar.element.dispatchEvent(mousedown)
+    const mousemove = new MouseEvent('mousemove', { bubbles: true })
+    Object.defineProperty(mousemove, 'pageX', { value: 400 })
+    window.dispatchEvent(mousemove)
+    await nextTick()
+    const mouseup = new MouseEvent('mouseup', { bubbles: true })
+    Object.defineProperty(mouseup, 'pageX', { value: 400 })
+    window.dispatchEvent(mouseup)
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 400px;')
+
+    const startCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-start'
+    )
+    await startCollapseButton.trigger('click')
+    await nextTick()
+
+    containerWidth.value = 800
+    await nextTick()
+
+    const endCollapseButton = wrapper.find(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+    await endCollapseButton.trigger('click')
+    await nextTick()
+
+    // The panel is auto-sized now, so it restores as 40% of the new width
+    // (320px) rather than the stale fixed 400px
+    expect(panels[0].attributes('style')).toContain('flex-basis: 320px;')
+
+    mockSize.mockRestore()
+  })
+
+  it('should restore a middle panel collapsed from one bar when expanded from the other', async () => {
+    const containerWidth = ref(1000)
+    const mockSize = useElementSize.mockReturnValue({
+      width: containerWidth,
+      height: ref(400),
+    })
+
+    const wrapper = mount(() => (
+      <div style={{ width: `${containerWidth.value}px`, height: '400px' }}>
+        <ElSplitter>
+          <ElSplitterPanel size="20%" collapsible>
+            Left Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel size="30%" collapsible>
+            Middle Panel
+          </ElSplitterPanel>
+          <ElSplitterPanel size="50%" collapsible>
+            Right Panel
+          </ElSplitterPanel>
+        </ElSplitter>
+      </div>
+    ))
+    await nextTick()
+
+    const panels = wrapper.findAll('.el-splitter-panel')
+    const endIcons = wrapper.findAll(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+
+    expect(panels[1].attributes('style')).toContain('flex-basis: 300px;')
+
+    // Collapse the middle panel onto the left one, using the *first* bar
+    await endIcons[0]!.trigger('click')
+    await nextTick()
+    expect(panels[0].attributes('style')).toContain('flex-basis: 500px;')
+    expect(panels[1].attributes('style')).toContain('flex-basis: 0px;')
+
+    // Expand it again from the *second* bar - with the middle panel at 0 the
+    // only remaining end icon is that bar's. The remembered size belongs to
+    // the middle panel itself, so it comes back at 300px and eats into the
+    // right panel, rather than restoring the right panel's cached 500px
+    const secondBarEndIcon = wrapper.findAll(
+      '.el-splitter-bar__horizontal-collapse-icon-end'
+    )
+    expect(secondBarEndIcon).toHaveLength(1)
+    await secondBarEndIcon[0]!.trigger('click')
+    await nextTick()
+
+    expect(panels[1].attributes('style')).toContain('flex-basis: 300px;')
+    expect(panels[2].attributes('style')).toContain('flex-basis: 200px;')
+
+    mockSize.mockRestore()
+  })
+
   it('should emit resize events', async () => {
     const onResizeStart = vi.fn()
     const onResize = vi.fn()

--- a/packages/components/splitter/src/hooks/index.ts
+++ b/packages/components/splitter/src/hooks/index.ts
@@ -1,3 +1,11 @@
 export { useContainer } from './useContainer'
 export { useResize } from './useResize'
-export { useSize, isPct, isPx, getPct, getPx } from './useSize'
+export {
+  useSize,
+  isPct,
+  isPx,
+  isFixedSize,
+  isZeroSize,
+  getPct,
+  getPx,
+} from './useSize'

--- a/packages/components/splitter/src/hooks/useResize.ts
+++ b/packages/components/splitter/src/hooks/useResize.ts
@@ -1,6 +1,6 @@
 import { computed, ref, watch } from 'vue'
 import { clamp } from 'lodash-unified'
-import { getPct, getPx, isPct, isPx } from './useSize'
+import { isPct, isPx, resolveLimit } from './useSize'
 import { NOOP } from '@element-plus/utils'
 
 import type { ComputedRef, Ref } from 'vue'
@@ -12,19 +12,10 @@ export function useResize(
   pxSizes: ComputedRef<number[]>,
   lazy: Ref<boolean>
 ) {
-  const ptg2px = (ptg: number) => ptg * containerSize.value || 0
-
-  function getLimitSize(
+  const getLimitSize = (
     str: string | number | undefined,
     defaultLimit: number
-  ) {
-    if (isPct(str)) {
-      return ptg2px(getPct(str))
-    } else if (isPx(str)) {
-      return getPx(str)
-    }
-    return str ?? defaultLimit
-  }
+  ) => resolveLimit(str, containerSize.value, defaultLimit)
 
   const lazyOffset = ref(0)
   const movingIndex = ref<{
@@ -109,6 +100,14 @@ export function useResize(
     updatePanelSizes = () => {
       panels.value.forEach((panel, index) => {
         panel.size = numSizes[index]
+        // Dragging a pinned panel is a deliberate resize, so it becomes the
+        // new pinned width - including a drag right down to 0. Only the two
+        // panels either side of this bar took part, though: a panel collapsed
+        // elsewhere still reads 0 here and must keep the width it had.
+        const isDragged = index === mergedIndex || index === nextIndex
+        if (isDragged && panel.isFixedSize && numSizes[index] !== undefined) {
+          panel.fixedPxSize = numSizes[index]
+        }
       })
       updatePanelSizes = NOOP
     }
@@ -128,13 +127,65 @@ export function useResize(
     cachePxSizes = []
   }
 
-  const cacheCollapsedSize: number[] = []
+  // A panel's declared size mode (fixed pixel vs proportional) is read from
+  // `panel.isFixedSize`, which is derived purely from its `size` prop and is
+  // NOT affected by `panel.size` itself being overwritten with a live raw px
+  // number while dragging/collapsing (see split-panel.vue).
+  const px2ptg = (px: number) =>
+    containerSize.value ? px / containerSize.value : 0
+  const ptg2pxSize = (ptg: number) => ptg * containerSize.value
+
+  interface CachedSize {
+    value: number
+    isRatio: boolean
+  }
+
+  const toCachedSize = (
+    px: number,
+    isFixed: boolean | undefined
+  ): CachedSize =>
+    isFixed
+      ? { value: px, isRatio: false }
+      : { value: px2ptg(px), isRatio: true }
+
+  const cachedSizeToPx = (cached: CachedSize | undefined) =>
+    cached ? (cached.isRatio ? ptg2pxSize(cached.value) : cached.value) : 0
+
+  // Limits follow different unit rules to sizes: `getLimitSize` reads a bare
+  // number or an "Npx" string as a literal pixel floor, and only a '%' string
+  // scales with the container.
+  const isFixedLimit = (limit: string | number | undefined) =>
+    limit != null &&
+    limit !== '' &&
+    !isPct(limit) &&
+    // `isPx` first: `Number('100px')` is NaN, which would otherwise class an
+    // explicit pixel limit as proportional even though `resolveLimit` reads it
+    // as a literal width.
+    (isPx(limit) || !Number.isNaN(Number(limit)))
+
+  // A panel whose *declared* size always resolves to 0 (e.g. "0%") has no
+  // meaningful size of its own to remember - `min` is the real floor, so
+  // classify by min's units instead of the (irrelevantly proportional) size.
+  const isFixedForCache = (
+    panel: PanelItemState | undefined,
+    minLimit: string | number | undefined
+  ) => (panel?.isZeroSize ? isFixedLimit(minLimit) : !!panel?.isFixedSize)
+
+  // Keyed by *panel* index, not bar index: a middle panel can be collapsed
+  // from one bar and expanded from the other, so its remembered size has to
+  // belong to the panel itself rather than to whichever bar collapsed it.
+  const cacheCollapsedSize: (CachedSize | undefined)[] = []
   const onCollapse = (index: number, type: 'start' | 'end') => {
     if (!cacheCollapsedSize.length) {
       cacheCollapsedSize.push(
-        ...pxSizes.value.map((size, i) =>
-          size <= 0 ? getLimitSize(limitSizes.value[i]?.[0], 0) : size
-        )
+        ...pxSizes.value.map((size, i) => {
+          const minLimit = limitSizes.value[i]?.[0]
+          const validSize = size <= 0 ? getLimitSize(minLimit, 0) : size
+          return toCachedSize(
+            validSize,
+            isFixedForCache(panels.value[i], minLimit)
+          )
+        })
       )
     }
 
@@ -149,19 +200,60 @@ export function useResize(
     if (currentSize !== 0 && targetSize !== 0) {
       currentSizes[currentIndex] = 0
       currentSizes[targetIndex]! += currentSize
-      cacheCollapsedSize[index] = currentSize
+      if (panels.value[currentIndex]) {
+        panels.value[currentIndex]!.isCollapsed = true
+      }
+      cacheCollapsedSize[currentIndex] = toCachedSize(
+        currentSize,
+        isFixedForCache(
+          panels.value[currentIndex],
+          limitSizes.value[currentIndex]?.[0]
+        )
+      )
     } else {
+      // Whichever of the pair sits at 0 is the one being expanded; restore it
+      // from its own cache entry and give the remainder to its neighbour.
+      const collapsedIndex = currentSize === 0 ? currentIndex : targetIndex
       const totalSize = currentSize + targetSize
 
-      const targetCacheCollapsedSize = clamp(
-        cacheCollapsedSize[index],
+      const restoredSize = clamp(
+        cachedSizeToPx(cacheCollapsedSize[collapsedIndex]),
         0,
         totalSize
       )
-      const currentCacheCollapsedSize = totalSize - targetCacheCollapsedSize
 
-      currentSizes[targetIndex] = targetCacheCollapsedSize
-      currentSizes[currentIndex] = currentCacheCollapsedSize
+      // Restoring has to respect the same limits dragging enforces - a cached
+      // ratio can otherwise land outside them once the container was resized
+      // while the panel sat collapsed. Applied in the same order as onMoving
+      // (start min, end min, start max, end max) so conflicting limits resolve
+      // identically whether the size came from a drag or from an expand.
+      const startIndex = index
+      const endIndex = index + 1
+      const startMinSize = getLimitSize(limitSizes.value[startIndex]?.[0], 0)
+      const endMinSize = getLimitSize(limitSizes.value[endIndex]?.[0], 0)
+      const startMaxSize = getLimitSize(
+        limitSizes.value[startIndex]?.[1],
+        containerSize.value || 0
+      )
+      const endMaxSize = getLimitSize(
+        limitSizes.value[endIndex]?.[1],
+        containerSize.value || 0
+      )
+
+      let startSize =
+        collapsedIndex === startIndex ? restoredSize : totalSize - restoredSize
+
+      startSize = Math.max(startSize, startMinSize)
+      startSize = Math.min(startSize, totalSize - endMinSize)
+      startSize = Math.min(startSize, startMaxSize)
+      startSize = Math.max(startSize, totalSize - endMaxSize)
+      startSize = clamp(startSize, 0, totalSize)
+
+      currentSizes[startIndex] = startSize
+      currentSizes[endIndex] = totalSize - startSize
+      if (panels.value[collapsedIndex]) {
+        panels.value[collapsedIndex]!.isCollapsed = false
+      }
     }
 
     panels.value.forEach((panel, index) => {

--- a/packages/components/splitter/src/hooks/useSize.ts
+++ b/packages/components/splitter/src/hooks/useSize.ts
@@ -13,15 +13,53 @@ export function getPx(str: string) {
 }
 
 export function isPct(
-  itemSize: string | number | undefined
+  itemSize: string | number | undefined | null
 ): itemSize is string {
   return isString(itemSize) && itemSize.endsWith('%')
 }
 
 export function isPx(
-  itemSize: string | number | undefined
+  itemSize: string | number | undefined | null
 ): itemSize is string {
   return isString(itemSize) && itemSize.endsWith('px')
+}
+
+// Only an explicit "Npx" string pins a panel to that literal pixel width. A
+// bare number (`:size="100"`) is 100px initially and proportional afterwards,
+// and a '%' string is always proportional - the unit is the signal of intent,
+// per the API discussion in element-plus/element-plus#23016.
+export function isFixedSize(
+  itemSize: string | number | undefined | null
+): boolean {
+  return isPx(itemSize)
+}
+
+// Whether a *declared* size prop always resolves to exactly 0 (e.g. "0%",
+// "0px", or 0), regardless of container size - unlike null/undefined/'' or a
+// non-numeric value (auto-fill), which depend on siblings and aren't
+// deterministically zero.
+export function isZeroSize(
+  itemSize: string | number | undefined | null
+): boolean {
+  if (itemSize == null || itemSize === '') return false
+  if (isPct(itemSize)) return getPct(itemSize) === 0
+  if (isPx(itemSize)) return getPx(itemSize) === 0
+  return Number(itemSize) === 0
+}
+
+// Resolves a `min`/`max` to pixels against the current container: a '%' string
+// tracks the container, a number or an "Npx" string is a literal pixel limit,
+// and null/''/non-numeric mean "no limit".
+export function resolveLimit(
+  limit: string | number | undefined | null,
+  containerSize: number,
+  defaultLimit: number
+): number {
+  if (limit == null || limit === '') return defaultLimit
+  if (isPct(limit)) return getPct(limit) * containerSize || 0
+  if (isPx(limit)) return getPx(limit)
+  const num = Number(limit)
+  return Number.isNaN(num) ? defaultLimit : num
 }
 
 export function useSize(
@@ -37,10 +75,23 @@ export function useSize(
   watch([propSizes, panelCounts, containerSize], () => {
     let ptgList: (number | undefined)[] = []
     let emptyCount = 0
+    // Pixel width of each panel declared with an "Npx" size, captured here
+    // because the normalisation below would otherwise dissolve it into a ratio
+    const fixedPx: (number | undefined)[] = []
 
     // Convert the passed props size to a percentage
     for (let i = 0; i < panelCounts.value; i += 1) {
       const itemSize = panels.value[i]?.size
+
+      // A pinned panel the user collapsed holds at 0 - re-pinning it to its
+      // declared width would make it impossible to collapse. Both conditions
+      // are needed: the flag alone would ignore a parent writing a real size
+      // back, and a zero size alone would strand a panel that a neighbour's
+      // expand merely squeezed to 0.
+      fixedPx[i] =
+        panels.value[i]?.isCollapsed && Number(itemSize) === 0
+          ? 0
+          : panels.value[i]?.fixedPxSize
 
       if (isPct(itemSize)) {
         ptgList[i] = getPct(itemSize)
@@ -70,8 +121,97 @@ export function useSize(
       ptgList = ptgList.map((ptg) => (ptg === undefined ? avgRest : ptg))
     }
 
-    percentSizes.value = ptgList as number[]
+    percentSizes.value = pinFixedPanels(ptgList as number[], fixedPx)
   })
+
+  // A panel declared with an "Npx" size keeps that pixel width whatever the
+  // container does. The width comes from the declared prop rather than the
+  // panel's live `size`, which a drag or collapse overwrites - a panel that
+  // absorbed a collapsed neighbour must not get pinned at the absorbed width.
+  // The rest of the container is shared out among the other panels.
+  function pinFixedPanels(
+    ptgList: number[],
+    fixedPxInput: (number | undefined)[]
+  ): number[] {
+    let fixedPx = fixedPxInput
+    if (!containerSize.value) return ptgList
+    if (!fixedPx.some((px) => px !== undefined)) return ptgList
+
+    // `min`/`max` can be percentages, which move with the container, so a
+    // stored pixel pin has to be re-checked against them on every pass. A pin
+    // of 0 is a collapse or a deliberate drag shut, and stays put.
+    fixedPx = fixedPx.map((px, i) => {
+      if (px === undefined || px === 0) return px
+      const panel = panels.value[i]
+      const min = resolveLimit(panel?.min, containerSize.value, 0)
+      const max = resolveLimit(
+        panel?.max,
+        containerSize.value,
+        containerSize.value
+      )
+      return Math.min(Math.max(px, min), max)
+    })
+
+    const fixedTotal = fixedPx.reduce<number>((acc, px) => acc + (px ?? 0), 0)
+
+    // Nothing left to share: pinned widths alone overflow the container, so
+    // they give up space rather than pushing the others below zero. Each one
+    // gives up only what it has above its own `min`, in proportion, so a
+    // satisfiable minimum is kept while a roomier neighbour absorbs the rest.
+    if (fixedTotal >= containerSize.value) {
+      const floors = fixedPx.map((px, i) =>
+        px === undefined
+          ? undefined
+          : Math.min(
+              px,
+              resolveLimit(panels.value[i]?.min, containerSize.value, 0)
+            )
+      )
+      const floorTotal = floors.reduce<number>((acc, px) => acc + (px ?? 0), 0)
+
+      // Not even the minimums fit - nothing can be honoured, so they shrink
+      // together as before.
+      if (floorTotal >= containerSize.value) {
+        const scale = floorTotal ? containerSize.value / floorTotal : 0
+        return ptgList.map((ptg, i) =>
+          floors[i] === undefined
+            ? 0
+            : (floors[i]! * scale) / containerSize.value
+        )
+      }
+
+      const overflow = fixedTotal - containerSize.value
+      const totalRoom = fixedPx.reduce<number>(
+        (acc, px, i) => acc + (px === undefined ? 0 : px - floors[i]!),
+        0
+      )
+
+      return ptgList.map((ptg, i) => {
+        if (fixedPx[i] === undefined) return 0
+        const room = fixedPx[i]! - floors[i]!
+        const given = totalRoom ? (overflow * room) / totalRoom : 0
+        return (fixedPx[i]! - given) / containerSize.value
+      })
+    }
+
+    const restPtg = ptgList.reduce<number>(
+      (acc, ptg, i) => acc + (fixedPx[i] === undefined ? ptg : 0),
+      0
+    )
+    // Nothing flexible is left to take up the slack - the other panels are
+    // collapsed, or every panel is pinned. Holding the pinned widths here
+    // would leave part of the container empty, so they share it out as before
+    // and the pinned width comes back from the collapse cache on expand.
+    if (!restPtg) return ptgList
+
+    const restShare = (containerSize.value - fixedTotal) / containerSize.value
+
+    return ptgList.map((ptg, i) =>
+      fixedPx[i] === undefined
+        ? (ptg / restPtg) * restShare
+        : fixedPx[i]! / containerSize.value
+    )
+  }
 
   const ptg2px = (ptg: number) => ptg * containerSize.value
   const pxSizes = computed(() => percentSizes.value.map(ptg2px))

--- a/packages/components/splitter/src/split-panel.vue
+++ b/packages/components/splitter/src/split-panel.vue
@@ -15,7 +15,7 @@ import { throwError } from '@element-plus/utils'
 import { getCollapsible, isCollapsible } from './hooks/usePanel'
 import SplitBar from './split-bar.vue'
 import { splitterPanelEmits } from './split-panel'
-import { getPct, getPx, isPct, isPx } from './hooks'
+import { getPct, getPx, isFixedSize, isPct, isPx, isZeroSize } from './hooks'
 import { splitterRootContextKey } from './type'
 
 import type { SplitterPanelProps } from './split-panel'
@@ -49,6 +49,21 @@ const {
   onMoveStart,
   onMoving,
 } = splitterContext
+
+// A "0px" panel has no width to hold on to - `min` is what it expands to, so
+// it is left unpinned like the other zero-size declarations. Anything else is
+// pinned to its width *after* `min`/`max`, so the pin can't smuggle a value
+// past the limits the size watcher enforces.
+const pinnedPxSize = (size: string | number | undefined) => {
+  if (!isFixedSize(size) || isZeroSize(size)) return undefined
+  return clampToLimits(getPx(size as string))
+}
+
+const clampToLimits = (px: number) => {
+  const maxSize = sizeToPx(props.max)
+  const minSize = sizeToPx(props.min)
+  return Math.min(Math.max(px, Number(minSize) || 0), Number(maxSize) || px)
+}
 
 const panelEl = ref<HTMLDivElement>()
 const instance = getCurrentInstance()!
@@ -112,11 +127,46 @@ function sizeToPx(str: string | number | undefined) {
   return str ?? 0
 }
 
+// `v-model:size` writes the internal pixel snapshots emitted below straight
+// back into `props.size`, which would make an authored "50%" look like an
+// authored `500`. Track what was actually declared by ignoring the values we
+// emitted ourselves, so the panel's size mode survives a collapse cycle.
+// Only a write-back within the same tick counts as that echo - an emit the
+// parent debounced or ignored must not shadow a real `size` change later on.
+// A separate flag rather than just comparing against `lastEmittedSize`: at
+// rest that value is `undefined`, so a parent genuinely clearing `size` would
+// otherwise look like an echo of an emit that never happened.
+let hasPendingEcho = false
+let lastEmittedSize: number | undefined
+const declaredSize = ref<string | number | undefined | null>(props.size)
+
+const rememberEmittedSize = (val: number) => {
+  hasPendingEcho = true
+  lastEmittedSize = val
+  nextTick(() => {
+    hasPendingEcho = false
+    lastEmittedSize = undefined
+  })
+}
+
 // Two-way binding for size
 let isSizeUpdating = false
 watch(
   () => props.size,
   () => {
+    if (hasPendingEcho && props.size === lastEmittedSize) {
+      hasPendingEcho = false
+      lastEmittedSize = undefined
+    } else {
+      declaredSize.value = props.size
+      if (panel.value) {
+        panel.value.fixedPxSize = pinnedPxSize(props.size)
+        if (!isZeroSize(props.size)) {
+          panel.value.isCollapsed = false
+        }
+      }
+    }
+
     if (!isSizeUpdating && panel.value) {
       if (!containerSize.value) {
         panel.value.size = props.size
@@ -131,6 +181,7 @@ watch(
       const finalSize = Math.min(Math.max(size, minSize || 0), maxSize || size)
 
       if (finalSize !== size) {
+        rememberEmittedSize(finalSize)
         emits('update:size', finalSize)
       }
 
@@ -144,6 +195,7 @@ watch(
   (val) => {
     if (val !== props.size) {
       isSizeUpdating = true
+      rememberEmittedSize(val as number)
       emits('update:size', val as number)
       nextTick(() => (isSizeUpdating = false))
     }
@@ -165,6 +217,15 @@ const _panel = reactive({
   setIndex,
   ...props,
   collapsible: computed(() => getCollapsible(props.collapsible)),
+  // Tied to the declared size (not the internal `size` below, which useResize
+  // overwrites with a live raw px number while dragging/collapsing) so a
+  // panel's declared size mode survives those internal mutations.
+  isFixedSize: computed(() => isFixedSize(declaredSize.value)),
+  // Seeded from the declared "Npx" width and kept up to date by drags (see
+  // useResize) - collapsing a neighbour must not redefine what this panel is
+  // pinned to, but the user dragging it deliberately must.
+  fixedPxSize: pinnedPxSize(props.size),
+  isZeroSize: computed(() => isZeroSize(declaredSize.value)),
 })
 
 registerPanel(_panel)

--- a/packages/components/splitter/src/type.ts
+++ b/packages/components/splitter/src/type.ts
@@ -10,6 +10,20 @@ export type PanelItemState = UnwrapRef<{
   min?: number | string
   resizable: boolean
   size?: number | string
+  // Whether the panel's *declared* size prop is a fixed pixel value, kept
+  // separate from `size` (which useResize also overwrites with a live raw
+  // px number while dragging/collapsing) so that value doesn't get mistaken
+  // for an authored fixed size once it's just an internal snapshot.
+  isFixedSize?: boolean
+  // The literal pixel width an "Npx" panel is pinned to. Kept separate from
+  // `size`, which holds the live value written during a drag or collapse.
+  fixedPxSize?: number
+  // Set only for a panel the user actually collapsed, so a pinned panel that
+  // was merely squeezed to 0 by a neighbour still recovers its width.
+  isCollapsed?: boolean
+  // Whether the declared size prop always resolves to exactly 0 (e.g. "0%"),
+  // in which case `min` - not `size` - is the meaningful floor to restore to.
+  isZeroSize?: boolean
   setIndex: (val: number) => void
 }>
 


### PR DESCRIPTION
- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Fixes #23015
Refs #22944

> **Prior art — please read first.**
>
> @tuzixiangs' #23016 diagnosed this root cause first and fixes it in 18 lines; it is approved and predates this PR by some months. I opened this before finding it. Credit for the diagnosis is theirs, and I'm glad to close this in favour of #23016, or to have this work folded into it — whichever the maintainers prefer.
>
> What this adds on top is the part #23016 stalled on: @tuzixiangs [reported](https://github.com/element-plus/element-plus/pull/23016#issuecomment-3677551026) being unable to make `px`-sized panels hold their width, listing three obstacles. Those are solved here, along with the "Option 2" unit semantics @btea signed off on, and the documentation that was asked for.

## Problem

Two distinct bugs, both visible after collapsing and expanding a panel.

**1. Proportions are lost when the container resizes (#23015).** The collapse/expand cache stored each panel's size as a raw pixel value, so a container resize while a panel sat collapsed restored a stale width. Container 1000px, two 50/50 panels: collapse A, resize to 800px, expand A → 500/300 instead of 400/400.

**2. Explicitly sized panels drift (#22944).** Collapsing and expanding writes live pixel numbers into every panel's internal size, which erases the distinction between a panel that asked for a fixed width and one that is simply sharing what's left. From that point on, resizing the container rescales everything: the reporter's 1st and 3rd panels stop holding their widths and all three panels move together.

## Fix

**The cache** now records *how* a size was expressed, not just its pixel value, and resolves it against the container at the moment of expanding — a ratio for proportional panels, a literal width for `px` ones. It is keyed per panel rather than per bar, so a middle panel collapsed from one bar comes back correctly when expanded from the other, and expanding applies the panel limits in the same order `onMoving` does, so a restored size can't land outside the limits a drag would enforce.

**The size unit is the signal of intent**, as agreed in #23016:

| `size` | Behaviour |
| --- | --- |
| `"200px"` | Stays 200px. The rest of the container is shared out among the other panels. |
| `:size="200"` | 200px to begin with, then proportional. |
| `"25%"` | Always a quarter of the container. |
| omitted | Shares what the sized panels leave over. |

Making that real for `px` panels needed an answer to each obstacle raised on #23016:

- **Fixed widths exceeding a shrunken container** — the pinned panels scale down together rather than pushing the flexible ones below zero. 250px of pins in a 200px container renders 80/0/120.
- **The cache conflicting with allocation** — the pin comes from the *declared* width, never the live `size`, so a panel that absorbed a collapsed neighbour is not re-pinned at the absorbed width. Only a panel the user actually collapsed pins at 0; one merely squeezed to 0 by a neighbour's expand keeps its pin and recovers.
- **Drag boundaries** — dragging a pinned panel is a deliberate resize, so it redefines the pinned width. Collapse and expand deliberately do not.

`min`/`max` keep their existing unit rules — a percentage tracks the container, a number or `px` string is a literal pixel limit — since that is how `getLimitSize` has always read them.

## Testing

`pnpm vitest run packages/components/splitter` — 34 passing. Twelve regression tests added, each verified to fail without its corresponding fix, covering: the #23015 root cause; `px` panels holding their width through a collapse cycle and a container resize; bare numbers and numeric strings staying proportional; pinned panels scaling down on overflow; a squeezed panel recovering; per-panel cache keying for middle panels; restores honouring the panel's own and its neighbour's limits; `v-model` echoes not being mistaken for authored sizes, and a genuinely later change not being mistaken for an echo; and `null`/`''`/`NaN` values not being coerced into limits or sizes.

Behaviour was also swept against `origin/dev` rather than only unit-tested — size modes × collapse direction × panel position × limit forms (number, bare string, `px`, `%`, `null`, `''`, non-numeric, on the panel and its neighbour) × container grow/shrink/overflow/zero × `v-model` × dynamic add and remove × vertical layout × drag-then-collapse. Every difference from `dev` is an intended one.

Locally reproducing CI: `pnpm lint` clean, `pnpm typecheck` clean across all five projects, `pnpm test` 2563 passing.

## Documentation

`docs/en-US/component/splitter.md` gains a "Size units" section describing the table above, per @btea's request on #23016 that the difference be documented.

## Known limitation, unchanged from `dev`

At a zero-width container the collapse icons disappear, so a collapsed panel can't be expanded until the container has a size again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved splitter panel collapse and expansion across container resizing.
  * Preserved fixed-pixel and proportional panel sizes more reliably.
  * Improved handling of minimum and maximum constraints, overflow, and flexible space.
  * Corrected behavior for numeric-string, empty, and unset size limits.

* **Documentation**
  * Added guidance on splitter size units and collapse/resize behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->