### PR TITLE
feat(components): [message-box] add modal penetrable prop

### DIFF
--- a/docs/en-US/component/message-box.md
+++ b/docs/en-US/component/message-box.md
@@ -131,9 +131,9 @@ message-box/draggable
 
 ## Modal
 
-Setting `modal` to `false` will hide modal (overlay) of MessageBox.
+Setting `modal` to `false` hides the MessageBox overlay.
 
-Starting from version ^(2.14.4), `modalPenetrable` option is added, which can be penetrable.
+Starting from version ^(2.14.4), set `modalPenetrable` to `true` with `modal: false` to allow clicks to pass through to underlying page content while the MessageBox remains open.
 
 :::demo
 

--- a/docs/en-US/component/message-box.md
+++ b/docs/en-US/component/message-box.md
@@ -129,6 +129,18 @@ message-box/draggable
 
 :::
 
+## Modal
+
+Setting `modal` to `false` will hide modal (overlay) of MessageBox.
+
+Starting from version ^(2.14.4), `modalPenetrable` option is added, which can be penetrable.
+
+:::demo
+
+message-box/modal
+
+:::
+
 ## Global method
 
 If Element Plus is fully imported, it will add the following global methods for `app.config.globalProperties`: `$msgbox`, `$alert`, `$confirm` and `$prompt`. So in a Vue instance you can call `MessageBox` like what we did in this page. The parameters are:
@@ -180,6 +192,7 @@ The corresponding methods are: `ElMessageBox`, `ElMessageBox.alert`, `ElMessageB
 | customClass                       | custom class name for MessageBox                                                                                                         | ^[string]                                                                                                                | ''                                               |
 | customStyle                       | custom inline style for MessageBox                                                                                                       | ^[CSSProperties]                                                                                                         | {}                                               |
 | modal                             | whether a mask is displayed                                                                                                              | ^[boolean]                                                                                                               | true                                             |
+| modal-penetrable ^(2.14.4)        | whether the mask is penetrable. The modal attribute must be `false`.                                                                     | ^[boolean]                                                                                                               | false                                            |
 | modalClass                        | custom class names for mask                                                                                                              | string                                                                                                                   | —                                                |
 | callback                          | MessageBox closing callback if you don't prefer Promise                                                                                  | ^[Function]`(value: string, action: Action) => any \| (action: Action) => any`                                           | null                                             |
 | showClose                         | whether to show close icon of MessageBox                                                                                                 | ^[boolean]                                                                                                               | true                                             |

--- a/docs/examples/message-box/modal.vue
+++ b/docs/examples/message-box/modal.vue
@@ -1,0 +1,14 @@
+<template>
+  <el-button plain @click="open"> Click to open the Message Box </el-button>
+</template>
+
+<script lang="ts" setup>
+import { ElMessageBox } from 'element-plus'
+
+const open = () => {
+  ElMessageBox.alert('This is a message', 'Title', {
+    modal: false,
+    modalPenetrable: true,
+  })
+}
+</script>

--- a/packages/components/message-box/__tests__/message-box.test.ts
+++ b/packages/components/message-box/__tests__/message-box.test.ts
@@ -532,4 +532,58 @@ describe('MessageBox', () => {
     expect(cancelBtn).not.toBeNull()
     expect(confirmBtn).not.toBeNull()
   })
+
+  describe('modal penetrable', () => {
+    test('should not close message box when mask is penetrable', async () => {
+      const onClick = vi.fn()
+      const button = document.createElement('button')
+      button.addEventListener('click', onClick)
+      document.body.appendChild(button)
+
+      MessageBox({
+        title: '消息',
+        message: '这是一段内容',
+        modal: false,
+        modalPenetrable: true,
+      })
+      await rAF()
+
+      const overlay = document.querySelector('.el-modal-message-box')!
+      expect(overlay.classList.contains('is-penetrable')).toBe(true)
+
+      // clicking the mask should not close the message box
+      ;(overlay as HTMLElement).click()
+      await rAF()
+      expect(document.querySelector('.el-message-box')).not.toBeNull()
+
+      // the element behind the mask should still be clickable
+      button.click()
+      expect(onClick).toHaveBeenCalled()
+
+      button.remove()
+    })
+
+    test('should bring the clicked penetrable message box to front', async () => {
+      MessageBox({ message: 'first', modal: false, modalPenetrable: true })
+      MessageBox({ message: 'second', modal: false, modalPenetrable: true })
+      await rAF()
+
+      const overlays = document.querySelectorAll('.el-modal-message-box')
+      const msgboxes = document.querySelectorAll('.el-message-box')
+      expect(overlays).toHaveLength(2)
+      expect(msgboxes).toHaveLength(2)
+
+      const getZIndex = (index: number) =>
+        Number((overlays[index] as HTMLElement).style.zIndex)
+      // the second one should have a higher z-index initially
+      expect(getZIndex(1)).toBeGreaterThan(getZIndex(0))
+
+      // mousedown on the first message box should bring it to front
+      ;(msgboxes[0] as HTMLElement).dispatchEvent(
+        new MouseEvent('mousedown', { bubbles: true })
+      )
+      await rAF()
+      expect(getZIndex(0)).toBeGreaterThan(getZIndex(1))
+    })
+  })
 })

--- a/packages/components/message-box/src/index.vue
+++ b/packages/components/message-box/src/index.vue
@@ -3,7 +3,12 @@
     <el-overlay
       v-show="visible"
       :z-index="zIndex"
-      :overlay-class="[ns.is('message-box'), modalClass]"
+      :overlay-class="[
+        ns.is('message-box'),
+        `${ns.namespace.value}-modal-message-box`,
+        ns.is('penetrable', penetrable),
+        modalClass,
+      ]"
       :mask="modal"
     >
       <div
@@ -35,6 +40,7 @@
             :style="customStyle"
             tabindex="-1"
             @click.stop=""
+            @mousedown="bringToFront"
           >
             <div
               v-if="title !== null && title !== undefined"
@@ -222,6 +228,10 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
+    modalPenetrable: {
+      type: Boolean,
+      default: false,
+    },
     lockScroll: {
       type: Boolean,
       default: true,
@@ -385,6 +395,14 @@ export default defineComponent({
     const overflow = computed(() => props.overflow)
     const { isDragging } = useDraggable(rootRef, headerRef, draggable, overflow)
 
+    const penetrable = computed(() => props.modalPenetrable && !props.modal)
+
+    function bringToFront() {
+      if (!visible.value || !penetrable.value) return
+
+      state.zIndex = nextZIndex()
+    }
+
     onMounted(async () => {
       await nextTick()
       if (props.closeOnHashChange) {
@@ -515,6 +533,8 @@ export default defineComponent({
       handleWrapperClick,
       handleInputEnter,
       handleAction,
+      bringToFront,
+      penetrable,
       t,
     }
   },

--- a/packages/components/message-box/src/message-box.type.ts
+++ b/packages/components/message-box/src/message-box.type.ts
@@ -98,6 +98,9 @@ export interface ElMessageBoxOptions {
   /** Whether a mask is displayed */
   modal?: boolean
 
+  /** Whether the mask is penetrable. The modal attribute must be `false`. */
+  modalPenetrable?: boolean
+
   /** modal class name for MessageBox */
   modalClass?: string
 

--- a/packages/theme-chalk/src/message-box.scss
+++ b/packages/theme-chalk/src/message-box.scss
@@ -195,6 +195,16 @@
   }
 }
 
+.#{$namespace}-modal-message-box {
+  &.is-penetrable {
+    pointer-events: none;
+
+    .#{$namespace}-message-box {
+      pointer-events: auto;
+    }
+  }
+}
+
 .fade-in-linear-enter-active {
   .#{$namespace}-overlay-message-box {
     animation: msgbox-fade-in getCssVar('transition-duration');


### PR DESCRIPTION
Fixed #24661

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional penetrable mode for non-modal Message Boxes.
  * Enables interaction with elements behind the Message Box while keeping the box interactive.
  * Clicking a Message Box brings it to the front when multiple boxes are open.

* **Bug Fixes**
  * Prevented background mask clicks from unintentionally closing penetrable Message Boxes.

* **Documentation**
  * Added API guidance, usage constraints, and an example for configuring penetrable Message Boxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->