### PR TITLE
fix(components): [table] avoid null theadRef access after header unmount

### DIFF
--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -3445,4 +3445,38 @@ describe('Table.vue', () => {
     filter.parentNode.removeChild(filter)
     wrapper.unmount()
   })
+
+  it('should not throw when unmounted with a pending fixed column style update', async () => {
+    // https://github.com/element-plus/element-plus/issues/24540
+    vi.useFakeTimers()
+    const wrapper = mount({
+      components: {
+        ElTable,
+        ElTableColumn,
+      },
+      template: `
+        <el-table :data="testData" table-layout="auto">
+          <el-table-column prop="name" label="片名" />
+          <el-table-column v-if="showExtra" prop="director" label="导演" />
+          <el-table-column prop="release" label="发行日期" fixed="right" />
+        </el-table>
+      `,
+      data() {
+        return {
+          testData: getTestData(),
+          showExtra: false,
+        }
+      },
+    })
+    await doubleWait()
+    // trigger a header re-render so another fixed column style update is
+    // scheduled while the previous one is still pending
+    await wrapper.setData({ showExtra: true })
+    await doubleWait()
+    wrapper.unmount()
+    // pending timers must be cleared on unmount and never touch the
+    // destroyed thead
+    expect(() => vi.runAllTimers()).not.toThrow()
+    vi.useRealTimers()
+  })
 })

--- a/packages/components/table/src/table-header/index.ts
+++ b/packages/components/table/src/table-header/index.ts
@@ -84,12 +84,16 @@ export default defineComponent({
 
     let delayId: ReturnType<typeof setTimeout> | undefined
     const updateFixedColumnStyle = () => {
+      if (delayId) {
+        clearTimeout(delayId)
+        delayId = undefined
+      }
       delayId = setTimeout(() => {
-        if (saveIndexSelection.size > 0) {
+        delayId = undefined
+        const thead = theadRef.value
+        if (thead && saveIndexSelection.size > 0) {
           saveIndexSelection.forEach((column, key) => {
-            const el = theadRef.value.querySelector(
-              `.${key.replace(/\s/g, '.')}`
-            )
+            const el = thead.querySelector(`.${key.replace(/\s/g, '.')}`)
             if (el) {
               const width = el.getBoundingClientRect().width
               column.width = width || column.width


### PR DESCRIPTION
close #24540

### What is the problem

With `table-layout="auto"` and a fixed column (e.g. `fixed="right"`), `ElTableHeader` schedules a `setTimeout` in `updateFixedColumnStyle` to measure fixed column widths. The timer id in `delayId` is overwritten on every call without clearing the previously scheduled timer, while `onBeforeUnmount` only clears the last one. The function is triggered both by the `saveIndexSelection` watcher (which fires on every header re-render) and by `onMounted`, so multiple timers can be pending at the same time.

If the header is unmounted before a leaked timer fires (v-if toggle, route change, dialog/tab close, etc.), the callback dereferences `theadRef.value` which is already `null`:

```
TypeError: Cannot read properties of null (reading 'querySelector')
```

### What is changed

- Clear the previously scheduled timer before scheduling a new one in `updateFixedColumnStyle`, so at most one timer is pending and `onBeforeUnmount` can reliably cancel it.
- Guard the callback against a `null` `theadRef.value` as a safety net.

### Test

Added a regression test that mounts a table with `table-layout="auto"` + `fixed="right"` under fake timers, schedules a second update via a header re-render, unmounts, and asserts running the remaining timers does not throw. It fails on the previous code with the exact error from the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table stability when columns change or the table is removed while fixed-column styling updates are pending.
  * Prevented errors caused by delayed table header updates after unmounting.

* **Tests**
  * Added regression coverage for safely handling pending table update timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->