### PR TITLE
fix(components): [loading] avoid innerHTML and children conflict

### DIFF
--- a/packages/components/loading/__tests__/loading.test.tsx
+++ b/packages/components/loading/__tests__/loading.test.tsx
@@ -143,6 +143,26 @@ describe('Loading', () => {
     expect(wrapper.find('.custom-path').attributes().d).toEqual('M 30 15')
   })
 
+  test('switch between default and custom spinner', async () => {
+    const spinner = ref<string>()
+    const wrapper = _mount(() => (
+      <div v-loading={true} element-loading-spinner={spinner.value} />
+    ))
+
+    await nextTick()
+    expect(wrapper.find('svg circle.path').exists()).toBe(true)
+
+    spinner.value = '<path class="custom-spinner" d="M 30 15"/>'
+    await nextTick()
+    expect(wrapper.find('svg .custom-spinner').exists()).toBe(true)
+    expect(wrapper.find('svg circle.path').exists()).toBe(false)
+
+    spinner.value = undefined
+    await nextTick()
+    expect(wrapper.find('svg .custom-spinner').exists()).toBe(false)
+    expect(wrapper.find('svg circle.path').exists()).toBe(true)
+  })
+
   test('create service', async () => {
     loadingInstance = Loading()
     expect(document.querySelector('.el-loading-mask')).toBeTruthy()

--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -97,15 +97,17 @@ export function createLoadingComponent(
             viewBox: data.svgViewBox ? data.svgViewBox : '0 0 50 50',
             ...(svg ? { innerHTML: svg } : {}),
           },
-          [
-            h('circle', {
-              class: 'path',
-              cx: '25',
-              cy: '25',
-              r: '20',
-              fill: 'none',
-            }),
-          ]
+          svg
+            ? undefined
+            : [
+                h('circle', {
+                  class: 'path',
+                  cx: '25',
+                  cy: '25',
+                  r: '20',
+                  fill: 'none',
+                }),
+              ]
         )
 
         const spinnerText = data.text


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fix #24672 
relate https://github.com/vuejs/core/pull/15194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the loading spinner to display only the provided custom spinner or SVG content.
  * Prevented the default loading circle from appearing alongside custom loading visuals.
  * Restored the default spinner when custom content is cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->