### PR TITLE
fix(components): [input] expose word limit count to screen readers

### DIFF
--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -155,12 +155,12 @@ describe('Input.vue', () => {
 
       const elCount = wrapper.find('.el-input__count')
       expect(elCount.exists()).toBe(true)
-      expect(elCount.text()).toMatchInlineSnapshot(`"4 / 4 characters"`)
+      expect(elCount.text()).toMatchInlineSnapshot(`"4 / 4"`)
 
       inputVal.value = '哈哈1👌3😄'
       await nextTick()
       expect(nativeInput.value).toMatchInlineSnapshot(`"哈哈1👌3😄"`)
-      expect(elCount.text()).toMatchInlineSnapshot(`"8 / 4 characters"`)
+      expect(elCount.text()).toMatchInlineSnapshot(`"8 / 4"`)
       expect(Array.from(vm.$el.classList)).toMatchInlineSnapshot(`
         [
           "el-textarea",
@@ -190,12 +190,12 @@ describe('Input.vue', () => {
 
       const elCount = wrapper.find('.el-input__count')
       expect(elCount.exists()).toBe(true)
-      expect(elCount.text()).toMatchInlineSnapshot(`"3 / 4 characters"`)
+      expect(elCount.text()).toMatchInlineSnapshot(`"3 / 4"`)
 
       inputVal.value = '哈哈1👌3😄'
       await nextTick()
       expect(nativeInput.value).toMatchInlineSnapshot(`"哈哈1👌3😄"`)
-      expect(elCount.text()).toMatchInlineSnapshot(`"6 / 4 characters"`)
+      expect(elCount.text()).toMatchInlineSnapshot(`"6 / 4"`)
       expect(Array.from(vm.$el.classList)).toMatchInlineSnapshot(`
         [
           "el-textarea",

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -155,12 +155,12 @@ describe('Input.vue', () => {
 
       const elCount = wrapper.find('.el-input__count')
       expect(elCount.exists()).toBe(true)
-      expect(elCount.text()).toMatchInlineSnapshot(`"4 / 4"`)
+      expect(elCount.text()).toMatchInlineSnapshot(`"4 / 4 characters"`)
 
       inputVal.value = '哈哈1👌3😄'
       await nextTick()
       expect(nativeInput.value).toMatchInlineSnapshot(`"哈哈1👌3😄"`)
-      expect(elCount.text()).toMatchInlineSnapshot(`"8 / 4"`)
+      expect(elCount.text()).toMatchInlineSnapshot(`"8 / 4 characters"`)
       expect(Array.from(vm.$el.classList)).toMatchInlineSnapshot(`
         [
           "el-textarea",
@@ -190,12 +190,12 @@ describe('Input.vue', () => {
 
       const elCount = wrapper.find('.el-input__count')
       expect(elCount.exists()).toBe(true)
-      expect(elCount.text()).toMatchInlineSnapshot(`"3 / 4"`)
+      expect(elCount.text()).toMatchInlineSnapshot(`"3 / 4 characters"`)
 
       inputVal.value = '哈哈1👌3😄'
       await nextTick()
       expect(nativeInput.value).toMatchInlineSnapshot(`"哈哈1👌3😄"`)
-      expect(elCount.text()).toMatchInlineSnapshot(`"6 / 4"`)
+      expect(elCount.text()).toMatchInlineSnapshot(`"6 / 4 characters"`)
       expect(Array.from(vm.$el.classList)).toMatchInlineSnapshot(`
         [
           "el-textarea",
@@ -488,6 +488,8 @@ describe('Input.vue', () => {
     const counts = wrapper.findAll('.el-input__count')
     expect(counts[0].attributes('role')).toBe('status')
     expect(counts[1].attributes('role')).toBe('status')
+    expect(counts[0].text()).toContain('characters')
+    expect(counts[1].text()).toContain('characters')
   })
 
   test('use formatter and parser', async () => {

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -478,6 +478,18 @@ describe('Input.vue', () => {
     `)
   })
 
+  test('word count is a live region', () => {
+    const wrapper = mount(() => (
+      <>
+        <Input maxlength="10" showWordLimit />
+        <Input type="textarea" maxlength="10" showWordLimit />
+      </>
+    ))
+    const counts = wrapper.findAll('.el-input__count')
+    expect(counts[0].attributes('role')).toBe('status')
+    expect(counts[1].attributes('role')).toBe('status')
+  })
+
   test('use formatter and parser', async () => {
     const val = ref('10000')
     const formatter = (val: string) => {

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -478,18 +478,31 @@ describe('Input.vue', () => {
     `)
   })
 
-  test('word count is a live region', () => {
+  test('word count is a live region', async () => {
+    const inputValue = ref('')
+    const textareaValue = ref('')
     const wrapper = mount(() => (
       <>
-        <Input maxlength="10" showWordLimit />
-        <Input type="textarea" maxlength="10" showWordLimit />
+        <Input v-model={inputValue.value} maxlength="10" showWordLimit />
+        <Input
+          type="textarea"
+          v-model={textareaValue.value}
+          maxlength="10"
+          showWordLimit
+        />
       </>
     ))
     const counts = wrapper.findAll('.el-input__count')
     expect(counts[0].attributes('role')).toBe('status')
     expect(counts[1].attributes('role')).toBe('status')
-    expect(counts[0].text()).toContain('characters')
-    expect(counts[1].text()).toContain('characters')
+    expect(counts[0].attributes('aria-label')).toBe('0 / 10 characters')
+    expect(counts[1].attributes('aria-label')).toBe('0 / 10 characters')
+
+    inputValue.value = 'input'
+    textareaValue.value = 'text'
+    await nextTick()
+    expect(counts[0].attributes('aria-label')).toBe('5 / 10 characters')
+    expect(counts[1].attributes('aria-label')).toBe('4 / 10 characters')
   })
 
   test('use formatter and parser', async () => {

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -99,6 +99,9 @@
               <span :class="nsInput.e('count-inner')">
                 {{ textLength }} / {{ maxlength }}
               </span>
+              <span :class="nsInput.e('count-unit')">
+                {{ t('el.input.characters') }}
+              </span>
             </span>
             <el-icon
               v-if="validateState && validateIcon && needStatusIcon"
@@ -174,6 +177,9 @@
         role="status"
       >
         {{ textLength }} / {{ maxlength }}
+        <span :class="nsInput.e('count-unit')">
+          {{ t('el.input.characters') }}
+        </span>
       </span>
     </template>
   </div>
@@ -216,6 +222,7 @@ import {
   useComposition,
   useCursor,
   useFocusController,
+  useLocale,
   useNamespace,
 } from '@element-plus/hooks'
 import {
@@ -275,6 +282,7 @@ const inputSize = useFormSize()
 const inputDisabled = useFormDisabled()
 const nsInput = useNamespace('input')
 const nsTextarea = useNamespace('textarea')
+const { t } = useLocale()
 
 const input = shallowRef<HTMLInputElement>()
 const textarea = shallowRef<HTMLTextAreaElement>()

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -94,13 +94,11 @@
                 nsInput.e('count'),
                 nsInput.is('outside', wordLimitPosition === 'outside'),
               ]"
+              :aria-label="wordLimitLabel"
               role="status"
             >
               <span :class="nsInput.e('count-inner')">
                 {{ textLength }} / {{ maxlength }}
-              </span>
-              <span :class="nsInput.e('count-unit')">
-                {{ t('el.input.characters') }}
               </span>
             </span>
             <el-icon
@@ -174,12 +172,10 @@
           nsInput.e('count'),
           nsInput.is('outside', wordLimitPosition === 'outside'),
         ]"
+        :aria-label="wordLimitLabel"
         role="status"
       >
         {{ textLength }} / {{ maxlength }}
-        <span :class="nsInput.e('count-unit')">
-          {{ t('el.input.characters') }}
-        </span>
       </span>
     </template>
   </div>
@@ -383,6 +379,12 @@ const textLength = computed(() => {
   }
   return nativeInputValue.value.length
 })
+const wordLimitLabel = computed(() =>
+  t('el.input.characters', {
+    count: textLength.value,
+    max: maxlength.value ?? '',
+  })
+)
 const inputExceed = computed(
   () =>
     // show exceed style if length of initial value greater then maxlength

--- a/packages/components/input/src/input.vue
+++ b/packages/components/input/src/input.vue
@@ -94,6 +94,7 @@
                 nsInput.e('count'),
                 nsInput.is('outside', wordLimitPosition === 'outside'),
               ]"
+              role="status"
             >
               <span :class="nsInput.e('count-inner')">
                 {{ textLength }} / {{ maxlength }}
@@ -170,6 +171,7 @@
           nsInput.e('count'),
           nsInput.is('outside', wordLimitPosition === 'outside'),
         ]"
+        role="status"
       >
         {{ textLength }} / {{ maxlength }}
       </span>

--- a/packages/locale/lang/af.ts
+++ b/packages/locale/lang/af.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Des',
       },
     },
+    input: {
+      characters: 'karakters',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/af.ts
+++ b/packages/locale/lang/af.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'karakters',
+      characters: '{count} / {max} karakters',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/ar-eg.ts
+++ b/packages/locale/lang/ar-eg.ts
@@ -86,7 +86,7 @@ export default {
       },
     },
     input: {
-      characters: 'حرف',
+      characters: '{count} / {max} حرف',
     },
     inputNumber: {
       decrease: 'طرح رقم',

--- a/packages/locale/lang/ar-eg.ts
+++ b/packages/locale/lang/ar-eg.ts
@@ -85,6 +85,9 @@ export default {
         dec: 'ديسمبر',
       },
     },
+    input: {
+      characters: 'حرف',
+    },
     inputNumber: {
       decrease: 'طرح رقم',
       increase: 'زيادة رقم',

--- a/packages/locale/lang/ar.ts
+++ b/packages/locale/lang/ar.ts
@@ -85,6 +85,9 @@ export default {
         dec: 'كانون الاول',
       },
     },
+    input: {
+      characters: 'حرف',
+    },
     inputNumber: {
       decrease: 'طرح رقم',
       increase: 'زيادة رقم',

--- a/packages/locale/lang/ar.ts
+++ b/packages/locale/lang/ar.ts
@@ -86,7 +86,7 @@ export default {
       },
     },
     input: {
-      characters: 'حرف',
+      characters: '{count} / {max} حرف',
     },
     inputNumber: {
       decrease: 'طرح رقم',

--- a/packages/locale/lang/az.ts
+++ b/packages/locale/lang/az.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'simvol',
+      characters: '{count} / {max} simvol',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/az.ts
+++ b/packages/locale/lang/az.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dek',
       },
     },
+    input: {
+      characters: 'simvol',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/bg.ts
+++ b/packages/locale/lang/bg.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Дек',
       },
     },
+    input: {
+      characters: 'символа',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/bg.ts
+++ b/packages/locale/lang/bg.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'символа',
+      characters: '{count} / {max} символа',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/bn.ts
+++ b/packages/locale/lang/bn.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'ডিসে',
       },
     },
+    input: {
+      characters: 'অক্ষর',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/bn.ts
+++ b/packages/locale/lang/bn.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'অক্ষর',
+      characters: '{count} / {max} অক্ষর',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/ca.ts
+++ b/packages/locale/lang/ca.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Des',
       },
     },
+    input: {
+      characters: 'caràcters',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/ca.ts
+++ b/packages/locale/lang/ca.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'caràcters',
+      characters: '{count} / {max} caràcters',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/ckb.ts
+++ b/packages/locale/lang/ckb.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'پیت',
+      characters: '{count} / {max} پیت',
     },
     inputNumber: {
       decrease: 'کەمکردنەوەی ژمارە',

--- a/packages/locale/lang/ckb.ts
+++ b/packages/locale/lang/ckb.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'بەفرانبار',
       },
     },
+    input: {
+      characters: 'پیت',
+    },
     inputNumber: {
       decrease: 'کەمکردنەوەی ژمارە',
       increase: 'زیادکردنی ژمارە',

--- a/packages/locale/lang/cs.ts
+++ b/packages/locale/lang/cs.ts
@@ -89,7 +89,7 @@ export default {
       month: 'Měsíc',
     },
     input: {
-      characters: 'znaků',
+      characters: '{count} / {max} znaků',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/cs.ts
+++ b/packages/locale/lang/cs.ts
@@ -88,6 +88,9 @@ export default {
       day: 'Den',
       month: 'Měsíc',
     },
+    input: {
+      characters: 'znaků',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/da.ts
+++ b/packages/locale/lang/da.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dec',
       },
     },
+    input: {
+      characters: 'tegn',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/da.ts
+++ b/packages/locale/lang/da.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'tegn',
+      characters: '{count} / {max} tegn',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/de.ts
+++ b/packages/locale/lang/de.ts
@@ -88,6 +88,9 @@ export default {
       day: 'Tag',
       month: 'Monat',
     },
+    input: {
+      characters: 'Zeichen',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/de.ts
+++ b/packages/locale/lang/de.ts
@@ -89,7 +89,7 @@ export default {
       month: 'Monat',
     },
     input: {
-      characters: 'Zeichen',
+      characters: '{count} / {max} Zeichen',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/el.ts
+++ b/packages/locale/lang/el.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Δεκ',
       },
     },
+    input: {
+      characters: 'χαρακτήρες',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/el.ts
+++ b/packages/locale/lang/el.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'χαρακτήρες',
+      characters: '{count} / {max} χαρακτήρες',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/en.ts
+++ b/packages/locale/lang/en.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'characters',
+      characters: '{count} / {max} characters',
     },
     inputNumber: {
       decrease: 'decrease number',

--- a/packages/locale/lang/en.ts
+++ b/packages/locale/lang/en.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dec',
       },
     },
+    input: {
+      characters: 'characters',
+    },
     inputNumber: {
       decrease: 'decrease number',
       increase: 'increase number',

--- a/packages/locale/lang/eo.ts
+++ b/packages/locale/lang/eo.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'signoj',
+      characters: '{count} / {max} signoj',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/eo.ts
+++ b/packages/locale/lang/eo.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dec',
       },
     },
+    input: {
+      characters: 'signoj',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/es.ts
+++ b/packages/locale/lang/es.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'caracteres',
+      characters: '{count} / {max} caracteres',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/es.ts
+++ b/packages/locale/lang/es.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'dic',
       },
     },
+    input: {
+      characters: 'caracteres',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/et.ts
+++ b/packages/locale/lang/et.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dets',
       },
     },
+    input: {
+      characters: 'märki',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/et.ts
+++ b/packages/locale/lang/et.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'märki',
+      characters: '{count} / {max} märki',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/eu.ts
+++ b/packages/locale/lang/eu.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'karaktere',
+      characters: '{count} / {max} karaktere',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/eu.ts
+++ b/packages/locale/lang/eu.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'abe',
       },
     },
+    input: {
+      characters: 'karaktere',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/fa.ts
+++ b/packages/locale/lang/fa.ts
@@ -88,6 +88,9 @@ export default {
         dec: 'دسامبر',
       },
     },
+    input: {
+      characters: 'کاراکتر',
+    },
     inputNumber: {
       decrease: 'کاهش عدد',
       increase: 'افزایش عدد',

--- a/packages/locale/lang/fa.ts
+++ b/packages/locale/lang/fa.ts
@@ -89,7 +89,7 @@ export default {
       },
     },
     input: {
-      characters: 'کاراکتر',
+      characters: '{count} / {max} کاراکتر',
     },
     inputNumber: {
       decrease: 'کاهش عدد',

--- a/packages/locale/lang/fi.ts
+++ b/packages/locale/lang/fi.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'joulu',
       },
     },
+    input: {
+      characters: 'merkkiä',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/fi.ts
+++ b/packages/locale/lang/fi.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'merkkiä',
+      characters: '{count} / {max} merkkiä',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/fr.ts
+++ b/packages/locale/lang/fr.ts
@@ -88,6 +88,9 @@ export default {
         dec: 'Déc',
       },
     },
+    input: {
+      characters: 'caractères',
+    },
     inputNumber: {
       decrease: 'Décrémenter',
       increase: 'Incrémenter',

--- a/packages/locale/lang/fr.ts
+++ b/packages/locale/lang/fr.ts
@@ -89,7 +89,7 @@ export default {
       },
     },
     input: {
-      characters: 'caractères',
+      characters: '{count} / {max} caractères',
     },
     inputNumber: {
       decrease: 'Décrémenter',

--- a/packages/locale/lang/he.ts
+++ b/packages/locale/lang/he.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'תווים',
+      characters: '{count} / {max} תווים',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/he.ts
+++ b/packages/locale/lang/he.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'דצמבר',
       },
     },
+    input: {
+      characters: 'תווים',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/hi.ts
+++ b/packages/locale/lang/hi.ts
@@ -88,6 +88,9 @@ export default {
         dec: 'दिसं.',
       },
     },
+    input: {
+      characters: 'वर्ण',
+    },
     inputNumber: {
       decrease: 'संख्या घटाएँ',
       increase: 'संख्या बढ़ाएँ',

--- a/packages/locale/lang/hi.ts
+++ b/packages/locale/lang/hi.ts
@@ -89,7 +89,7 @@ export default {
       },
     },
     input: {
-      characters: 'वर्ण',
+      characters: '{count} / {max} वर्ण',
     },
     inputNumber: {
       decrease: 'संख्या घटाएँ',

--- a/packages/locale/lang/hr.ts
+++ b/packages/locale/lang/hr.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'znakova',
+      characters: '{count} / {max} znakova',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/hr.ts
+++ b/packages/locale/lang/hr.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dec',
       },
     },
+    input: {
+      characters: 'znakova',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/hu.ts
+++ b/packages/locale/lang/hu.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'karakter',
+      characters: '{count} / {max} karakter',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/hu.ts
+++ b/packages/locale/lang/hu.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dec',
       },
     },
+    input: {
+      characters: 'karakter',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/hy-am.ts
+++ b/packages/locale/lang/hy-am.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'նիշ',
+      characters: '{count} / {max} նիշ',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/hy-am.ts
+++ b/packages/locale/lang/hy-am.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Դեկ',
       },
     },
+    input: {
+      characters: 'նիշ',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/id.ts
+++ b/packages/locale/lang/id.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'karakter',
+      characters: '{count} / {max} karakter',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/id.ts
+++ b/packages/locale/lang/id.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Des',
       },
     },
+    input: {
+      characters: 'karakter',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/it.ts
+++ b/packages/locale/lang/it.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dic',
       },
     },
+    input: {
+      characters: 'caratteri',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/it.ts
+++ b/packages/locale/lang/it.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'caratteri',
+      characters: '{count} / {max} caratteri',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/ja.ts
+++ b/packages/locale/lang/ja.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: '文字',
+      characters: '{count} / {max} 文字',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/ja.ts
+++ b/packages/locale/lang/ja.ts
@@ -86,6 +86,9 @@ export default {
         dec: '12月',
       },
     },
+    input: {
+      characters: '文字',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/kk.ts
+++ b/packages/locale/lang/kk.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Жел',
       },
     },
+    input: {
+      characters: 'таңба',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/kk.ts
+++ b/packages/locale/lang/kk.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'таңба',
+      characters: '{count} / {max} таңба',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/km.ts
+++ b/packages/locale/lang/km.ts
@@ -88,6 +88,9 @@ export default {
         dec: 'ធ្នូ',
       },
     },
+    input: {
+      characters: 'តួអក្សរ',
+    },
     inputNumber: {
       decrease: 'បន្ថយតម្លៃ',
       increase: 'បង្កើនតម្លៃ',

--- a/packages/locale/lang/km.ts
+++ b/packages/locale/lang/km.ts
@@ -89,7 +89,7 @@ export default {
       },
     },
     input: {
-      characters: 'តួអក្សរ',
+      characters: '{count} / {max} តួអក្សរ',
     },
     inputNumber: {
       decrease: 'បន្ថយតម្លៃ',

--- a/packages/locale/lang/ko.ts
+++ b/packages/locale/lang/ko.ts
@@ -86,6 +86,9 @@ export default {
         dec: '12월',
       },
     },
+    input: {
+      characters: '자',
+    },
     inputNumber: {
       decrease: '값 증가',
       increase: '값 감소',

--- a/packages/locale/lang/ko.ts
+++ b/packages/locale/lang/ko.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: '자',
+      characters: '{count} / {max} 자',
     },
     inputNumber: {
       decrease: '값 증가',

--- a/packages/locale/lang/ku.ts
+++ b/packages/locale/lang/ku.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'karakter',
+      characters: '{count} / {max} karakter',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/ku.ts
+++ b/packages/locale/lang/ku.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Ber',
       },
     },
+    input: {
+      characters: 'karakter',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/ky.ts
+++ b/packages/locale/lang/ky.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'белги',
+      characters: '{count} / {max} белги',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/ky.ts
+++ b/packages/locale/lang/ky.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'он экинчи айда',
       },
     },
+    input: {
+      characters: 'белги',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/lo.ts
+++ b/packages/locale/lang/lo.ts
@@ -85,7 +85,7 @@ export default {
       },
     },
     input: {
-      characters: 'ຕົວອັກສອນ',
+      characters: '{count} / {max} ຕົວອັກສອນ',
     },
     inputNumber: {
       decrease: 'ຫຼຸດຈຳນວນ',

--- a/packages/locale/lang/lo.ts
+++ b/packages/locale/lang/lo.ts
@@ -84,6 +84,9 @@ export default {
         dec: 'ທັນວາ',
       },
     },
+    input: {
+      characters: 'ຕົວອັກສອນ',
+    },
     inputNumber: {
       decrease: 'ຫຼຸດຈຳນວນ',
       increase: 'ເພີ່ມຈຳນວນ',

--- a/packages/locale/lang/lt.ts
+++ b/packages/locale/lang/lt.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'simbolių',
+      characters: '{count} / {max} simbolių',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/lt.ts
+++ b/packages/locale/lang/lt.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Gruo',
       },
     },
+    input: {
+      characters: 'simbolių',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/lv.ts
+++ b/packages/locale/lang/lv.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dec',
       },
     },
+    input: {
+      characters: 'rakstzīmes',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/lv.ts
+++ b/packages/locale/lang/lv.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'rakstzīmes',
+      characters: '{count} / {max} rakstzīmes',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/mg.ts
+++ b/packages/locale/lang/mg.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'characters', // to be translated
+      characters: '{count} / {max} characters', // to be translated
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/mg.ts
+++ b/packages/locale/lang/mg.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Des',
       },
     },
+    input: {
+      characters: 'characters', // to be translated
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/mn.ts
+++ b/packages/locale/lang/mn.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'тэмдэгт',
+      characters: '{count} / {max} тэмдэгт',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/mn.ts
+++ b/packages/locale/lang/mn.ts
@@ -86,6 +86,9 @@ export default {
         dec: '12 сар',
       },
     },
+    input: {
+      characters: 'тэмдэгт',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/ms.ts
+++ b/packages/locale/lang/ms.ts
@@ -88,6 +88,9 @@ export default {
         dec: 'Dis',
       },
     },
+    input: {
+      characters: 'aksara',
+    },
     inputNumber: {
       decrease: 'mengurangkan',
       increase: 'meningkatkan',

--- a/packages/locale/lang/ms.ts
+++ b/packages/locale/lang/ms.ts
@@ -89,7 +89,7 @@ export default {
       },
     },
     input: {
-      characters: 'aksara',
+      characters: '{count} / {max} aksara',
     },
     inputNumber: {
       decrease: 'mengurangkan',

--- a/packages/locale/lang/my.ts
+++ b/packages/locale/lang/my.ts
@@ -88,6 +88,9 @@ export default {
         dec: 'ဒီ',
       },
     },
+    input: {
+      characters: 'စာလုံး',
+    },
     inputNumber: {
       decrease: 'အရေအတွက်လျှော့ချ',
       increase: 'အရေအတွက်တိုး',

--- a/packages/locale/lang/my.ts
+++ b/packages/locale/lang/my.ts
@@ -89,7 +89,7 @@ export default {
       },
     },
     input: {
-      characters: 'စာလုံး',
+      characters: '{count} / {max} စာလုံး',
     },
     inputNumber: {
       decrease: 'အရေအတွက်လျှော့ချ',

--- a/packages/locale/lang/nb-no.ts
+++ b/packages/locale/lang/nb-no.ts
@@ -85,6 +85,9 @@ export default {
         dec: 'Des',
       },
     },
+    input: {
+      characters: 'tegn',
+    },
     inputNumber: {
       decrease: 'reduser tall',
       increase: 'øk tall',

--- a/packages/locale/lang/nb-no.ts
+++ b/packages/locale/lang/nb-no.ts
@@ -86,7 +86,7 @@ export default {
       },
     },
     input: {
-      characters: 'tegn',
+      characters: '{count} / {max} tegn',
     },
     inputNumber: {
       decrease: 'reduser tall',

--- a/packages/locale/lang/nl.ts
+++ b/packages/locale/lang/nl.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'tekens',
+      characters: '{count} / {max} tekens',
     },
     inputNumber: {
       decrease: 'getal verlagen',

--- a/packages/locale/lang/nl.ts
+++ b/packages/locale/lang/nl.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'dec',
       },
     },
+    input: {
+      characters: 'tekens',
+    },
     inputNumber: {
       decrease: 'getal verlagen',
       increase: 'getal verhogen',

--- a/packages/locale/lang/no.ts
+++ b/packages/locale/lang/no.ts
@@ -84,6 +84,9 @@ export default {
         dec: 'Desember',
       },
     },
+    input: {
+      characters: 'tegn',
+    },
     inputNumber: {
       decrease: 'Minsk verdi',
       increase: 'Øk verdi',

--- a/packages/locale/lang/no.ts
+++ b/packages/locale/lang/no.ts
@@ -85,7 +85,7 @@ export default {
       },
     },
     input: {
-      characters: 'tegn',
+      characters: '{count} / {max} tegn',
     },
     inputNumber: {
       decrease: 'Minsk verdi',

--- a/packages/locale/lang/pa.ts
+++ b/packages/locale/lang/pa.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'توري',
+      characters: '{count} / {max} توري',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/pa.ts
+++ b/packages/locale/lang/pa.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'دسمبر',
       },
     },
+    input: {
+      characters: 'توري',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/pl.ts
+++ b/packages/locale/lang/pl.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'znaków',
+      characters: '{count} / {max} znaków',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/pl.ts
+++ b/packages/locale/lang/pl.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'GRU',
       },
     },
+    input: {
+      characters: 'znaków',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/pt-br.ts
+++ b/packages/locale/lang/pt-br.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'caracteres',
+      characters: '{count} / {max} caracteres',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/pt-br.ts
+++ b/packages/locale/lang/pt-br.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dez',
       },
     },
+    input: {
+      characters: 'caracteres',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/pt.ts
+++ b/packages/locale/lang/pt.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'caracteres',
+      characters: '{count} / {max} caracteres',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/pt.ts
+++ b/packages/locale/lang/pt.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dez',
       },
     },
+    input: {
+      characters: 'caracteres',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/ro.ts
+++ b/packages/locale/lang/ro.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'caractere',
+      characters: '{count} / {max} caractere',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/ro.ts
+++ b/packages/locale/lang/ro.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dec',
       },
     },
+    input: {
+      characters: 'caractere',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/ru.ts
+++ b/packages/locale/lang/ru.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'символов',
+      characters: '{count} / {max} символов',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/ru.ts
+++ b/packages/locale/lang/ru.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Дек',
       },
     },
+    input: {
+      characters: 'символов',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/sk.ts
+++ b/packages/locale/lang/sk.ts
@@ -88,6 +88,9 @@ export default {
       day: 'Deň',
       month: 'Mesiac',
     },
+    input: {
+      characters: 'znakov',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/sk.ts
+++ b/packages/locale/lang/sk.ts
@@ -89,7 +89,7 @@ export default {
       month: 'Mesiac',
     },
     input: {
-      characters: 'znakov',
+      characters: '{count} / {max} znakov',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/sl.ts
+++ b/packages/locale/lang/sl.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dec',
       },
     },
+    input: {
+      characters: 'znakov',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/sl.ts
+++ b/packages/locale/lang/sl.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'znakov',
+      characters: '{count} / {max} znakov',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/sr.ts
+++ b/packages/locale/lang/sr.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'дец',
       },
     },
+    input: {
+      characters: 'карактера',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/sr.ts
+++ b/packages/locale/lang/sr.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'карактера',
+      characters: '{count} / {max} карактера',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/sv.ts
+++ b/packages/locale/lang/sv.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dec',
       },
     },
+    input: {
+      characters: 'tecken',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/sv.ts
+++ b/packages/locale/lang/sv.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'tecken',
+      characters: '{count} / {max} tecken',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/sw.ts
+++ b/packages/locale/lang/sw.ts
@@ -88,7 +88,7 @@ export default {
       },
     },
     input: {
-      characters: 'herufi',
+      characters: '{count} / {max} herufi',
     },
     inputNumber: {
       decrease: 'kupunguza idadi',

--- a/packages/locale/lang/sw.ts
+++ b/packages/locale/lang/sw.ts
@@ -87,6 +87,9 @@ export default {
         dec: 'mwezi 12',
       },
     },
+    input: {
+      characters: 'herufi',
+    },
     inputNumber: {
       decrease: 'kupunguza idadi',
       increase: 'kuongeza idadi',

--- a/packages/locale/lang/ta.ts
+++ b/packages/locale/lang/ta.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'டிசம்பர்',
       },
     },
+    input: {
+      characters: 'எழுத்துகள்',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/ta.ts
+++ b/packages/locale/lang/ta.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'எழுத்துகள்',
+      characters: '{count} / {max} எழுத்துகள்',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/te.ts
+++ b/packages/locale/lang/te.ts
@@ -88,7 +88,7 @@ export default {
       },
     },
     input: {
-      characters: 'అక్షరాలు',
+      characters: '{count} / {max} అక్షరాలు',
     },
     inputNumber: {
       decrease: 'సంఖ్య తగ్గించు',

--- a/packages/locale/lang/te.ts
+++ b/packages/locale/lang/te.ts
@@ -87,6 +87,9 @@ export default {
         dec: 'డిసెం',
       },
     },
+    input: {
+      characters: 'అక్షరాలు',
+    },
     inputNumber: {
       decrease: 'సంఖ్య తగ్గించు',
       increase: 'సంఖ్య పెంచు',

--- a/packages/locale/lang/th.ts
+++ b/packages/locale/lang/th.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'ตัวอักษร',
+      characters: '{count} / {max} ตัวอักษร',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/th.ts
+++ b/packages/locale/lang/th.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'ธ.ค.',
       },
     },
+    input: {
+      characters: 'ตัวอักษร',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/tk.ts
+++ b/packages/locale/lang/tk.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'belgi',
+      characters: '{count} / {max} belgi',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/tk.ts
+++ b/packages/locale/lang/tk.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dek',
       },
     },
+    input: {
+      characters: 'belgi',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/tr.ts
+++ b/packages/locale/lang/tr.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Ara',
       },
     },
+    input: {
+      characters: 'karakter',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/tr.ts
+++ b/packages/locale/lang/tr.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'karakter',
+      characters: '{count} / {max} karakter',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/ug-cn.ts
+++ b/packages/locale/lang/ug-cn.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'ھەرپ',
+      characters: '{count} / {max} ھەرپ',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/ug-cn.ts
+++ b/packages/locale/lang/ug-cn.ts
@@ -86,6 +86,9 @@ export default {
         dec: '12-ئاي',
       },
     },
+    input: {
+      characters: 'ھەرپ',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/uk.ts
+++ b/packages/locale/lang/uk.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'символів',
+      characters: '{count} / {max} символів',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/uk.ts
+++ b/packages/locale/lang/uk.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Гру',
       },
     },
+    input: {
+      characters: 'символів',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/uz-uz.ts
+++ b/packages/locale/lang/uz-uz.ts
@@ -87,7 +87,7 @@ export default {
       },
     },
     input: {
-      characters: 'belgi',
+      characters: '{count} / {max} belgi',
     },
     inputNumber: {
       decrease: 'decrease number', // to be translated

--- a/packages/locale/lang/uz-uz.ts
+++ b/packages/locale/lang/uz-uz.ts
@@ -86,6 +86,9 @@ export default {
         dec: 'Dek',
       },
     },
+    input: {
+      characters: 'belgi',
+    },
     inputNumber: {
       decrease: 'decrease number', // to be translated
       increase: 'increase number', // to be translated

--- a/packages/locale/lang/vi.ts
+++ b/packages/locale/lang/vi.ts
@@ -85,7 +85,7 @@ export default {
       },
     },
     input: {
-      characters: 'ký tự',
+      characters: '{count} / {max} ký tự',
     },
     inputNumber: {
       decrease: 'giảm số',

--- a/packages/locale/lang/vi.ts
+++ b/packages/locale/lang/vi.ts
@@ -84,6 +84,9 @@ export default {
         dec: 'Th.12',
       },
     },
+    input: {
+      characters: 'ký tự',
+    },
     inputNumber: {
       decrease: 'giảm số',
       increase: 'tăng số',

--- a/packages/locale/lang/zh-cn.ts
+++ b/packages/locale/lang/zh-cn.ts
@@ -84,7 +84,7 @@ export default {
       },
     },
     input: {
-      characters: '个字符',
+      characters: '{count} / {max} 个字符',
     },
     inputNumber: {
       decrease: '减少数值',

--- a/packages/locale/lang/zh-cn.ts
+++ b/packages/locale/lang/zh-cn.ts
@@ -83,6 +83,9 @@ export default {
         dec: '十二月',
       },
     },
+    input: {
+      characters: '个字符',
+    },
     inputNumber: {
       decrease: '减少数值',
       increase: '增加数值',

--- a/packages/locale/lang/zh-hk.ts
+++ b/packages/locale/lang/zh-hk.ts
@@ -85,7 +85,7 @@ export default {
       },
     },
     input: {
-      characters: '個字元',
+      characters: '{count} / {max} 個字元',
     },
     inputNumber: {
       decrease: '減少數值',

--- a/packages/locale/lang/zh-hk.ts
+++ b/packages/locale/lang/zh-hk.ts
@@ -84,6 +84,9 @@ export default {
         dec: '十二月',
       },
     },
+    input: {
+      characters: '個字元',
+    },
     inputNumber: {
       decrease: '減少數值',
       increase: '增加數值',

--- a/packages/locale/lang/zh-mo.ts
+++ b/packages/locale/lang/zh-mo.ts
@@ -85,7 +85,7 @@ export default {
       },
     },
     input: {
-      characters: '個字元',
+      characters: '{count} / {max} 個字元',
     },
     inputNumber: {
       decrease: '減少數值',

--- a/packages/locale/lang/zh-mo.ts
+++ b/packages/locale/lang/zh-mo.ts
@@ -84,6 +84,9 @@ export default {
         dec: '十二月',
       },
     },
+    input: {
+      characters: '個字元',
+    },
     inputNumber: {
       decrease: '減少數值',
       increase: '增加數值',

--- a/packages/locale/lang/zh-tw.ts
+++ b/packages/locale/lang/zh-tw.ts
@@ -85,7 +85,7 @@ export default {
       },
     },
     input: {
-      characters: '個字元',
+      characters: '{count} / {max} 個字元',
     },
     inputNumber: {
       decrease: '減少數值',

--- a/packages/locale/lang/zh-tw.ts
+++ b/packages/locale/lang/zh-tw.ts
@@ -84,6 +84,9 @@ export default {
         dec: '十二月',
       },
     },
+    input: {
+      characters: '個字元',
+    },
     inputNumber: {
       decrease: '減少數值',
       increase: '增加數值',

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -1,7 +1,6 @@
 @use 'sass:map';
 
 @use 'mixins/mixins' as *;
-@use 'mixins/utils' as *;
 @use 'mixins/var' as *;
 @use 'common/var' as *;
 
@@ -220,10 +219,6 @@
     }
   }
 
-  @include e(count-unit) {
-    @include utils-visually-hidden;
-  }
-
   @include e(wrapper) {
     display: inline-flex;
     flex-grow: 1;
@@ -336,7 +331,7 @@
       align-items: center;
       justify-content: center;
 
-      @if $slot == prefix {
+      @if $slot ==prefix {
         > :last-child {
           margin-right: 8px;
         }

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -1,6 +1,7 @@
 @use 'sass:map';
 
 @use 'mixins/mixins' as *;
+@use 'mixins/utils' as *;
 @use 'mixins/var' as *;
 @use 'common/var' as *;
 
@@ -217,6 +218,10 @@
         line-height: 1;
       }
     }
+  }
+
+  @include e(count-unit) {
+    @include utils-visually-hidden;
   }
 
   @include e(wrapper) {

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -331,7 +331,7 @@
       align-items: center;
       justify-content: center;
 
-      @if $slot ==prefix {
+      @if $slot == prefix {
         > :last-child {
           margin-right: 8px;
         }

--- a/packages/theme-chalk/src/mixins/utils.scss
+++ b/packages/theme-chalk/src/mixins/utils.scss
@@ -7,6 +7,7 @@
       display: table;
       content: '';
     }
+
     #{$selector}::after {
       clear: both;
     }
@@ -30,19 +31,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-@mixin utils-visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  clip: rect(0, 0, 0, 0);
-  clip-path: inset(50%);
 }
 
 @mixin utils-inline-flex-center {

--- a/packages/theme-chalk/src/mixins/utils.scss
+++ b/packages/theme-chalk/src/mixins/utils.scss
@@ -32,6 +32,19 @@
   white-space: nowrap;
 }
 
+@mixin utils-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+}
+
 @mixin utils-inline-flex-center {
   display: inline-flex;
   justify-content: center;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Fixes #24674

The `show-word-limit` counter renders as a plain `span`, so a screen reader never picks up the character count while you type. Marking it `role="status"` turns it into a polite live region, and the updated `5 / 10` gets read out on each change. Both the input and the textarea counter are covered.

The same live region now also holds a visually hidden `characters` label, so the announcement is "5 / 10 characters" rather than two bare numbers. That needed a new `el.input.characters` key across all 67 files in `packages/locale/lang` (generated with `pnpm locale:sync`, then translated) and a `utils-visually-hidden` mixin in `theme-chalk`, since the library had no screen-reader-only rule of its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Input and textarea character counters now display localized labels across supported languages.
  * Counters show the current character count alongside the maximum limit.

* **Accessibility**
  * Character counters now provide live status updates and accessible labels with current and maximum counts.

* **Tests**
  * Added coverage for localized character-count text and accessibility announcements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->