### PR TITLE
fix(components): [form-item] add alert role to validation message

### DIFF
--- a/packages/components/form/src/form-item.vue
+++ b/packages/components/form/src/form-item.vue
@@ -27,7 +27,7 @@
       <slot />
       <transition-group :name="`${ns.namespace.value}-zoom-in-top`">
         <slot v-if="shouldShowError" name="error" :error="validateMessage">
-          <div :class="validateClasses">
+          <div :class="validateClasses" role="alert">
             {{ validateMessage }}
           </div>
         </slot>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

close #24673

The validation message renders as a plain `div`, so screen readers stay silent when a field fails and the message appears. Added `role="alert"` to it, matching what `el-alert`, `el-message` and `el-notification` already do.

The issue also asks for `aria-live="polite"`. I left it out on purpose: `role="alert"` already implies `aria-live="assertive"` and `aria-atomic="true"`, so an explicit `polite` would only weaken the announcement. Happy to add it if you prefer polite here.
