### PR TITLE
fix(components): [form] improve error message text contrast

### DIFF
--- a/packages/theme-chalk/src/form-item.scss
+++ b/packages/theme-chalk/src/form-item.scss
@@ -152,7 +152,7 @@ $form-item-label-top-margin-bottom: map.merge(
   }
 
   @include e(error) {
-    color: getCssVar('color-danger');
+    color: getCssVar('color-danger', 'dark-2');
     font-size: 12px;
     line-height: 1;
     padding-top: #{map.get($form-item-error-padding-top, 'default')};


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

close #24676

The form validation message uses `--el-color-danger` (`#f56c6c`). On the default white background that is 2.9:1 at 12px, under the 3:1 minimum the report asks for.

`--el-color-danger-dark-2` is generated from the same danger base, so a SCSS theme override still feeds it, and it already flips per theme: `#c45656` in light mode and `#f78989` in dark mode. Contrast goes from 2.9:1 to 4.4:1 on white, and from 6.4:1 to 7.8:1 on the dark background. Only the message text moves. The required asterisk, the validate icon and the error border keep the plain danger color, because the report is about the text.
