### PR TITLE
chore: refactor imports and enable dark mode

### DIFF
--- a/play/main.ts
+++ b/play/main.ts
@@ -1,9 +1,13 @@
 import { Component, createApp } from 'vue'
+import { useDark } from '@vueuse/core'
+
 import '@element-plus/theme-chalk/src/var.scss'
 import '@element-plus/theme-chalk/src/dark/css-vars.scss'
-import '@element-plus/theme-chalk/src/notification.scss'
-import '@element-plus/theme-chalk/src/message-box.scss'
-import '@element-plus/theme-chalk/src/message.scss'
+import '@element-plus/components/notification/style'
+import '@element-plus/components/message-box/style'
+import '@element-plus/components/message/style'
+
+useDark()
 
 // #21498
 window.addEventListener('error', (e: ErrorEvent) => {


### PR DESCRIPTION
1. The newly added `progress` for notification doesn't seem to have the corresponding styles in Play yet.
2. Making Play's theme follow the system setting might be a bit more developer-friendly for those who frequently use Dark Mode, like me. 🙈

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode initialization for a more consistent visual experience.
  * Updated notification, message box, and message styling to use component-specific styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->