### PR TITLE
chore: ignore TypeScript v7 updates in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,10 @@
       "matchDepTypes": ["devDependencies"],
       "groupName": "all patch devDependencies",
       "groupSlug": "all-patch-dev-dependencies"
+    },
+    {
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
     }
   ],
   "ignoreDeps": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,7 +33,7 @@
     },
     {
       "matchPackageNames": ["typescript"],
-      "allowedVersions": "<7"
+      "allowedVersions": ">=6.0.0 <7.0.0"
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

Keep TypeScript updates limited to v6.x for now due to Vue ecosystem compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management settings to allow TypeScript updates from version 6.0.0 up to, but not including, version 7.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->