### PR TITLE
fix(components): [select] match input wrapper transition

### DIFF
--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -36,7 +36,7 @@
     line-height: map.get($select-item-height, 'default');
     border-radius: getCssVar('border-radius-base');
     background-color: getCssVar('fill-color', 'blank');
-    transition: getCssVar('transition', 'duration');
+    transition: getCssVar('transition-box-shadow');
 
     // Keep the 3D transform to avoid Chromium inset box-shadow noise.
     transform: translateZ(0);


### PR DESCRIPTION
`.el-select__wrapper` uses `transition: var(--el-transition-duration)`, and since that token is a bare duration the shorthand resolves to `all 0.3s`. So the select background fades on a theme switch while `.el-input__wrapper`, which only transitions box-shadow, flips instantly, and the two controls look out of sync on the same form. The focus ring also runs at 0.3s on select against 0.2s on input.

Pointing the select wrapper at the same `--el-transition-box-shadow` token lines both up and drops the unintended `all`.

Closes #24707

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved select component animations by using the dedicated box-shadow transition setting for smoother visual effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->