### PR TITLE
fix(components): [input] add background-color transition to wrapper for consistent theme switch

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -236,7 +236,10 @@
       map.get($input, 'border-radius')
     );
     cursor: text;
-    transition: getCssVar('transition-box-shadow');
+    transition:
+      getCssVar('transition-box-shadow'),
+      background-color getCssVar('transition-duration-fast')
+        getCssVar('transition-function-ease-in-out-bezier');
 
     // Keep the 3D transform to avoid Chromium inset box-shadow noise.
     transform: translateZ(0);


### PR DESCRIPTION
### Description

When switching between dark and light theme, `el-input` and `el-select` background colors transition at different speeds:
- `el-input` — `transition: var(--el-transition-box-shadow)` → only box-shadow is animated, background-color snaps instantly
- `el-select` — `transition: var(--el-transition-duration)` → all properties animate smoothly over ~0.3s

This fix adds `background-color` to the `el-input__wrapper` transition so both controls stay visually in sync when the theme changes.

### Changes

- `packages/theme-chalk/src/input.scss`: Added `background-color` transition to `el-input__wrapper` using the same duration and easing as the existing `box-shadow` transition.

Closes #24707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved input field transitions to smoothly animate both the shadow and background color.
  * Updated the animation timing for a more responsive, polished feel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->