### PR TITLE
fix(components): [tree-select] reset checked keys when data changes

### DIFF
--- a/packages/components/tree-select/__tests__/tree-select.test.tsx
+++ b/packages/components/tree-select/__tests__/tree-select.test.tsx
@@ -1088,6 +1088,332 @@ describe('TreeSelect.vue', () => {
     expect(spy2).toBeCalledWith(2)
   })
 
+  test('reset checked keys when data is restored after clearing both data and v-model', async () => {
+    const treeData = [
+      {
+        value: '1',
+        label: '1',
+        children: [
+          { value: '1-1', label: '1-1' },
+          { value: '1-2', label: '1-2' },
+        ],
+      },
+    ]
+    const modelValue = ref<string[]>(['1-1'])
+    const data = ref<any[]>(treeData)
+
+    const { tree } = createComponent({
+      props: {
+        modelValue,
+        data,
+        multiple: true,
+        showCheckbox: true,
+        defaultExpandAll: true,
+      },
+    })
+
+    await nextTick()
+    expect(tree.vm.getCheckedKeys()).toEqual(['1-1'])
+
+    // clear the model value and the data in the same tick
+    modelValue.value = []
+    data.value = []
+    await nextTick()
+    await nextTick()
+
+    // then restore the same data
+    data.value = treeData
+    await nextTick()
+    await nextTick()
+    await nextTick()
+
+    expect(tree.vm.getCheckedKeys()).toEqual([])
+    expect(tree.findAll('.el-checkbox.is-checked')).toHaveLength(0)
+    expect(modelValue.value).toEqual([])
+  })
+
+  test('editing data in place keeps imperatively checked keys', async () => {
+    const treeData = [
+      {
+        value: '1',
+        label: '1',
+        children: [
+          { value: '1-1', label: '1-1' },
+          { value: '1-2', label: '1-2' },
+        ],
+      },
+    ]
+    const modelValue = ref<string[]>([])
+    const data = ref<any[]>(treeData)
+
+    const { getWrapperRef, tree } = createComponent({
+      props: {
+        modelValue,
+        data,
+        multiple: true,
+        showCheckbox: true,
+        defaultExpandAll: true,
+      },
+    })
+
+    const wrapperRef = await getWrapperRef()
+    wrapperRef.setCheckedKeys(['1-2'])
+    await nextTick()
+    expect(tree.vm.getCheckedKeys()).toEqual(['1-2'])
+
+    // editing the nodes in place must not reconcile the tree back to `modelValue`
+    data.value[0].children[0].label = 'renamed'
+    await nextTick()
+    await nextTick()
+
+    expect(tree.vm.getCheckedKeys()).toEqual(['1-2'])
+    expect(modelValue.value).toEqual([])
+  })
+
+  test('reset checked keys when the node was checked through the UI', async () => {
+    const makeData = () => [
+      {
+        value: '1',
+        label: '1',
+        children: [
+          { value: '1-1', label: '1-1' },
+          { value: '1-2', label: '1-2' },
+        ],
+      },
+    ]
+    const modelValue = ref<string[]>([])
+    const data = ref<any[]>(makeData())
+
+    const { tree } = createComponent({
+      props: {
+        modelValue,
+        data,
+        multiple: true,
+        showCheckbox: true,
+        defaultExpandAll: true,
+      },
+    })
+
+    await nextTick()
+    await tree
+      .findAll('.el-tree-node .el-checkbox__original')[1]
+      .trigger('click')
+    await nextTick()
+    expect(tree.vm.getCheckedKeys()).toEqual(['1-1'])
+    expect(modelValue.value).toEqual(['1-1'])
+
+    modelValue.value = []
+    data.value = []
+    await nextTick()
+    await nextTick()
+
+    data.value = makeData()
+    await nextTick()
+    await nextTick()
+    await nextTick()
+
+    expect(tree.vm.getCheckedKeys()).toEqual([])
+    expect(tree.findAll('.el-checkbox.is-checked')).toHaveLength(0)
+  })
+
+  test('async data still applies default-checked-keys', async () => {
+    const modelValue = ref<string[]>([])
+    const data = ref<any[]>([])
+
+    const { tree } = createComponent({
+      props: {
+        modelValue,
+        data,
+        multiple: true,
+        showCheckbox: true,
+        defaultExpandAll: true,
+        defaultCheckedKeys: ['1-1'],
+      },
+    })
+
+    await nextTick()
+    data.value = [
+      {
+        value: '1',
+        label: '1',
+        children: [
+          { value: '1-1', label: '1-1' },
+          { value: '1-2', label: '1-2' },
+        ],
+      },
+    ]
+    await nextTick()
+    await nextTick()
+    await nextTick()
+
+    expect(tree.vm.getCheckedKeys()).toEqual(['1-1'])
+  })
+
+  test('async data keeps default-checked-keys through an empty model reset', async () => {
+    const modelValue = ref<string[]>([])
+    const data = ref<any[]>([])
+
+    const { tree } = createComponent({
+      props: {
+        modelValue,
+        data,
+        multiple: true,
+        showCheckbox: true,
+        defaultExpandAll: true,
+        defaultCheckedKeys: ['1-1'],
+      },
+    })
+
+    await nextTick()
+    // a parent form reset assigns a brand new, value-equivalent empty array
+    modelValue.value = []
+    await nextTick()
+
+    data.value = [
+      {
+        value: '1',
+        label: '1',
+        children: [
+          { value: '1-1', label: '1-1' },
+          { value: '1-2', label: '1-2' },
+        ],
+      },
+    ]
+    await nextTick()
+    await nextTick()
+    await nextTick()
+
+    expect(tree.vm.getCheckedKeys()).toEqual(['1-1'])
+  })
+
+  test('reset checked keys when the restored data reorders siblings', async () => {
+    const modelValue = ref<string[]>(['1-1', '1-2'])
+    const data = ref<any[]>([
+      {
+        value: '1',
+        label: '1',
+        children: [
+          { value: '1-1', label: '1-1' },
+          { value: '1-2', label: '1-2' },
+        ],
+      },
+    ])
+
+    const { tree } = createComponent({
+      props: {
+        modelValue,
+        data,
+        multiple: true,
+        showCheckbox: true,
+        defaultExpandAll: true,
+      },
+    })
+
+    await nextTick()
+    modelValue.value = []
+    data.value = []
+    await nextTick()
+    await nextTick()
+
+    data.value = [
+      {
+        value: '1',
+        label: '1',
+        children: [
+          { value: '1-2', label: '1-2' },
+          { value: '1-1', label: '1-1' },
+        ],
+      },
+    ]
+    await nextTick()
+    await nextTick()
+    await nextTick()
+
+    expect(tree.vm.getCheckedKeys()).toEqual([])
+    expect(tree.findAll('.el-checkbox.is-checked')).toHaveLength(0)
+  })
+
+  test('reset checked keys when every child of a node is checked', async () => {
+    const makeData = () => [
+      {
+        value: '1',
+        label: '1',
+        children: [
+          { value: '1-1', label: '1-1' },
+          { value: '1-2', label: '1-2' },
+        ],
+      },
+    ]
+    const modelValue = ref<string[]>(['1-1', '1-2'])
+    const data = ref<any[]>(makeData())
+
+    const { tree } = createComponent({
+      props: {
+        modelValue,
+        data,
+        multiple: true,
+        showCheckbox: true,
+        defaultExpandAll: true,
+      },
+    })
+
+    await nextTick()
+    // with cascading checks the tree reports the fully checked parent as well
+    expect(tree.vm.getCheckedKeys()).toEqual(['1', '1-1', '1-2'])
+
+    modelValue.value = []
+    data.value = []
+    await nextTick()
+    await nextTick()
+
+    data.value = makeData()
+    await nextTick()
+    await nextTick()
+    await nextTick()
+
+    expect(tree.vm.getCheckedKeys()).toEqual([])
+    expect(tree.findAll('.el-checkbox.is-checked')).toHaveLength(0)
+  })
+
+  test('refreshing data keeps imperatively checked keys', async () => {
+    const makeData = () => [
+      {
+        value: '1',
+        label: '1',
+        children: [
+          { value: '1-1', label: '1-1' },
+          { value: '1-2', label: '1-2' },
+        ],
+      },
+    ]
+    const modelValue = ref<string[]>([])
+    const data = ref<any[]>(makeData())
+
+    const { getWrapperRef, tree } = createComponent({
+      props: {
+        modelValue,
+        data,
+        multiple: true,
+        showCheckbox: true,
+        defaultExpandAll: true,
+      },
+    })
+
+    const wrapperRef = await getWrapperRef()
+    wrapperRef.setCheckedKeys(['1-2'])
+    await nextTick()
+    expect(tree.vm.getCheckedKeys()).toEqual(['1-2'])
+
+    // a plain data refresh must not clear checks the consumer set itself
+    data.value = makeData()
+    await nextTick()
+    await nextTick()
+    await nextTick()
+
+    expect(tree.vm.getCheckedKeys()).toEqual(['1-2'])
+    expect(modelValue.value).toEqual([])
+  })
+
   test('always focus when using filters', async () => {
     const { tree, select } = createComponent({
       props: {

--- a/packages/components/tree-select/src/tree.ts
+++ b/packages/components/tree-select/src/tree.ts
@@ -33,20 +33,26 @@ export const useTree = (
     key: Ref<string>
   }
 ) => {
+  // 最后一次真正同步到树里的 modelValue。空树的 checked keys 恒为空，
+  // 与 modelValue 的比较说明不了任何问题，所以只在树里有节点时记录
+  // the last `modelValue` that was actually synced into the tree. An empty tree
+  // always reports no checked keys, so comparing them with `modelValue` proves
+  // nothing there, and the snapshot is only taken while the tree has nodes
+  let syncedKeys = toValidArray(props.modelValue)
+
   watch(
     [() => props.modelValue, tree],
     () => {
       if (props.showCheckbox) {
         nextTick(() => {
           const treeInstance = tree.value
-          if (
-            treeInstance &&
-            !isEqual(
-              treeInstance.getCheckedKeys(),
-              toValidArray(props.modelValue)
-            )
-          ) {
-            treeInstance.setCheckedKeys(toValidArray(props.modelValue))
+          if (!treeInstance) return
+          const checkedKeys = toValidArray(props.modelValue)
+          if (!isEqual(treeInstance.getCheckedKeys(), checkedKeys)) {
+            treeInstance.setCheckedKeys(checkedKeys)
+          }
+          if (isValidArray(props.data)) {
+            syncedKeys = checkedKeys
           }
         })
       }
@@ -54,6 +60,28 @@ export const useTree = (
     {
       immediate: true,
       deep: true,
+    }
+  )
+
+  // modelValue 在树里没有节点时发生变化，这次同步无处可做，而 tree store 仍保留着
+  // 之前写入的 checked keys，数据回来时会把它们重新应用。因此数据回来后，
+  // 只要 modelValue 与最后一次同步的值不同，就再同步一次
+  // a `modelValue` change that lands while the tree has no nodes cannot be
+  // applied, while the tree store still holds the checked keys written into it
+  // earlier and re-applies them once the data is back. So when the data returns,
+  // sync again whenever `modelValue` differs from the last synced value
+  watch(
+    () => props.data,
+    () => {
+      if (!props.showCheckbox) return
+      nextTick(() => {
+        const treeInstance = tree.value
+        if (!treeInstance || !isValidArray(props.data)) return
+        const checkedKeys = toValidArray(props.modelValue)
+        if (isEqual(checkedKeys, syncedKeys)) return
+        treeInstance.setCheckedKeys(checkedKeys)
+        syncedKeys = checkedKeys
+      })
     }
   )
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

With `show-checkbox`, clearing `v-model` and `data` in the same tick and then putting the same data back leaves every node checked while the model is empty (#23207). `ElTree`'s store remembers the last keys handed to `setCheckedKeys` as its `defaultCheckedKeys` and re-applies them from `setData` whenever the data instance changes. When both are cleared at once, the tree-select watcher runs while the tree is already empty, sees `getCheckedKeys()` and `modelValue` both equal to `[]`, and skips the `setCheckedKeys` call — so the stale keys survive in the store, and since `modelValue` never changes again, nothing re-syncs the tree once the data returns.

The watcher in `useTree` only tracked `modelValue` and the tree ref; this adds `data` as a source, so the tree is re-synced with `modelValue` on every data change too. Everything else, including the `isEqual` guard, is unchanged, so the extra work is a no-op whenever the tree already matches the model. Covered by a new test in `tree-select.test.tsx` that reproduces the issue's sequence and asserts both `getCheckedKeys()` and the rendered checkboxes end up empty; it fails on the unpatched source with `expected [ '1-1' ] to deeply equal []`.

closes #23207


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tree selection synchronization when data is cleared and later restored.
  * Preserved checked node states after in-place edits or full data refreshes.
  * Preserved programmatically checked nodes during tree updates.
  * Prevented selected states from being lost when the bound value is empty.

* **Tests**
  * Added regression coverage for clearing, restoring, refreshing, and editing tree data without incorrect selection states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->