### PR TITLE
fix(components): [dropdown, menu] don't trigger :focus-visible on hover

### DIFF
--- a/packages/components/menu/__tests__/menu.test.ts
+++ b/packages/components/menu/__tests__/menu.test.ts
@@ -304,6 +304,33 @@ describe('submenu', () => {
     await nextTick()
     expect(submenu.classes()).toContain('is-opened')
   })
+  test('should not trigger :focus-visible when focusing on mouseenter', async () => {
+    const wrapper = _mount(
+      `<el-menu mode="horizontal">
+        <el-sub-menu index="1" ref="submenu">
+          <template #title>导航一</template>
+          <el-menu-item index="1-1">选项1</el-menu-item>
+        </el-sub-menu>
+      </el-menu>`
+    )
+    await nextTick()
+    const submenu = wrapper.findComponent({ ref: 'submenu' })
+    const focusSpy = vi.spyOn(submenu.element as HTMLElement, 'focus')
+
+    vi.useFakeTimers()
+    await submenu.trigger('mouseenter')
+    vi.runAllTimers()
+    vi.useRealTimers()
+    await rAF()
+
+    // pointer-initiated focus must not paint the keyboard focus ring
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+    expect(focusSpy).toHaveBeenCalledWith({
+      preventScroll: true,
+      focusVisible: false,
+    })
+    focusSpy.mockRestore()
+  })
   test('default opened', async () => {
     const wrapper = _mount(
       `<el-menu :default-openeds="defaultOpeneds">

--- a/packages/components/menu/src/sub-menu.ts
+++ b/packages/components/menu/src/sub-menu.ts
@@ -295,7 +295,12 @@ export default defineComponent({
 
       if (event.type === 'mouseenter' && event.target) {
         nextTick(() => {
-          focusElement(event.target as HTMLElement, { preventScroll: true })
+          // `focusVisible: false` keeps the browser from painting the
+          // keyboard focus ring for this pointer-initiated focus
+          focusElement(event.target as HTMLElement, {
+            preventScroll: true,
+            focusVisible: false,
+          })
         })
       }
     }

--- a/packages/components/tooltip/__tests__/tooltip.test.tsx
+++ b/packages/components/tooltip/__tests__/tooltip.test.tsx
@@ -237,6 +237,35 @@ describe('<ElTooltip />', () => {
       expect(wrapper.emitted()).toHaveProperty('show')
     })
 
+    it('should not trigger :focus-visible when focusing the trigger on hover', async () => {
+      wrapper = createComponent(
+        {
+          trigger: 'hover',
+          focusOnTarget: true,
+        },
+        content
+      )
+      await nextTick()
+
+      const trigger$ = findTrigger()
+      const triggerEl = trigger$.find('.el-tooltip__trigger')
+      const focusSpy = vi.spyOn(triggerEl.element as HTMLElement, 'focus')
+
+      vi.useFakeTimers()
+      await triggerEl.trigger('mouseenter')
+      vi.runAllTimers()
+      vi.useRealTimers()
+      await rAF()
+
+      // pointer-initiated focus must not paint the keyboard focus ring
+      expect(focusSpy).toHaveBeenCalledTimes(1)
+      expect(focusSpy).toHaveBeenCalledWith({
+        preventScroll: true,
+        focusVisible: false,
+      })
+      focusSpy.mockRestore()
+    })
+
     it('should resync visibility when disabled toggles in controlled mode', async () => {
       wrapper = createComponent(
         {

--- a/packages/components/tooltip/src/trigger.vue
+++ b/packages/components/tooltip/src/trigger.vue
@@ -63,7 +63,12 @@ const onMouseenter = composeEventHandlers(
 
     if (props.focusOnTarget && e.target) {
       nextTick(() => {
-        focusElement(e.target as HTMLElement, { preventScroll: true })
+        // `focusVisible: false` keeps the browser from painting the
+        // keyboard focus ring for this pointer-initiated focus
+        focusElement(e.target as HTMLElement, {
+          preventScroll: true,
+          focusVisible: false,
+        })
       })
     }
   })

--- a/packages/utils/__tests__/dom/aria.test.ts
+++ b/packages/utils/__tests__/dom/aria.test.ts
@@ -102,5 +102,33 @@ describe('Aria Utils', () => {
       expect(() => focusElement(null)).not.toThrow()
       expect(() => focusElement(undefined)).not.toThrow()
     })
+
+    it('should forward the given options to the element', () => {
+      const input = CE('input')
+      document.body.appendChild(input)
+      const focusSpy = vi.spyOn(input, 'focus')
+      focusElement(input, { preventScroll: true, focusVisible: false })
+      expect(focusSpy).toHaveBeenCalledWith({
+        preventScroll: true,
+        focusVisible: false,
+      })
+      focusSpy.mockRestore()
+      document.body.removeChild(input)
+    })
+
+    it('should not opt out of :focus-visible on its own', () => {
+      const input = CE('input')
+      document.body.appendChild(input)
+      const focusSpy = vi.spyOn(input, 'focus')
+      focusElement(input)
+      expect(focusSpy).toHaveBeenCalledWith(undefined)
+      focusElement(input, { preventScroll: true })
+      expect(focusSpy).toHaveBeenLastCalledWith({ preventScroll: true })
+      expect(focusSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ focusVisible: expect.anything() })
+      )
+      focusSpy.mockRestore()
+      document.body.removeChild(input)
+    })
   })
 })


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

Hovering an `el-dropdown` trigger or an `el-sub-menu` programmatically calls `.focus()` on the hovered element so keyboard navigation can continue from there, and the browser then paints the `:focus-visible` ring even though the focus was pointer-initiated (#23253). It shows up all the more often because `focusElement` temporarily sets `tabindex="-1"` on elements that are not focusable on their own. This passes `focusVisible: false` at those two hover call sites. It is a standard `FocusOptions` member (Firefox 104+, Chromium 145+, and the reporter confirmed Chromium shipped it in 145), and browsers without support ignore the unknown key, so it degrades safely.

One thing worth a maintainer's opinion: I kept this at the two pointer-driven call sites rather than making `focusVisible: false` the default inside `focusElement` itself. There is a decent argument for the other way round — `focusElement` is what adds the temporary `tabindex="-1"` that provokes the ring, so suppressing it in the same place would also cover any future hover-driven caller. The reason I did not is that `focusElement` is used on keyboard paths too (`focus-trap`, restoring focus in tooltip content), where the ring must be drawn, and those would then have to ask for `focusVisible: true` explicitly, which inverts the responsibility. The helper keeps forwarding options verbatim, and a test in `aria.test.ts` pins that neutral contract so it fails if the default is ever changed. Happy to flip it if you prefer.

closes #23253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pointer-initiated focus behavior in submenus and tooltips.
  * Prevented keyboard-style focus rings from appearing when elements receive focus through mouse interactions.
  * Preserved scroll position when focusing interactive elements.

* **Tests**
  * Added coverage verifying focus behavior and option handling for menus, tooltips, and accessibility utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->