### PR TITLE
fix(components): [menu] keep nested sub-menus open with unique-opened

### DIFF
--- a/packages/components/menu/__tests__/menu.test.ts
+++ b/packages/components/menu/__tests__/menu.test.ts
@@ -591,4 +591,80 @@ describe('other', () => {
     styleSpy.mockRestore()
     menuItemSpy.mockRestore()
   })
+
+  describe('nested sub-menu opened state, issue 23210', () => {
+    const nestedMenu = (attrs: string) => `<el-menu ${attrs}>
+      <el-sub-menu index="1" ref="one">
+        <template #title>Navigator One</template>
+        <el-menu-item index="1-1">Item One</el-menu-item>
+        <el-sub-menu index="1-4" ref="four">
+          <template #title>Item Four</template>
+          <el-menu-item index="1-4-1" ref="fourItem">Item Four One</el-menu-item>
+        </el-sub-menu>
+      </el-sub-menu>
+      <el-sub-menu index="2" ref="two">
+        <template #title>Navigator Two</template>
+        <el-menu-item index="2-1">Item Two</el-menu-item>
+      </el-sub-menu>
+    </el-menu>`
+
+    const setup = (attrs: string) => {
+      const wrapper = _mount(nestedMenu(attrs))
+      const one = wrapper.findComponent({ ref: 'one' })
+      const four = wrapper.findComponent({ ref: 'four' })
+      const two = wrapper.findComponent({ ref: 'two' })
+      const clickTitle = async (submenu: typeof one) => {
+        submenu.vm.$el.querySelector('.el-sub-menu__title').click()
+        await nextTick()
+      }
+      return { wrapper, one, four, two, clickTitle }
+    }
+
+    test('re-expanding a parent restores its nested sub-menu', async () => {
+      const { one, four, clickTitle } = setup('')
+
+      await clickTitle(one)
+      await clickTitle(four)
+      expect(one.classes()).toContain('is-opened')
+      expect(four.classes()).toContain('is-opened')
+
+      await clickTitle(one)
+      expect(one.classes()).not.toContain('is-opened')
+      expect(four.classes()).toContain('is-opened')
+
+      await clickTitle(one)
+      expect(one.classes()).toContain('is-opened')
+      expect(four.classes()).toContain('is-opened')
+    })
+
+    test('re-expanding a parent restores its nested sub-menu with unique-opened', async () => {
+      const { one, four, clickTitle } = setup('unique-opened')
+
+      await clickTitle(one)
+      await clickTitle(four)
+      expect(one.classes()).toContain('is-opened')
+      expect(four.classes()).toContain('is-opened')
+
+      await clickTitle(one)
+      expect(one.classes()).not.toContain('is-opened')
+      expect(four.classes()).toContain('is-opened')
+
+      await clickTitle(one)
+      expect(one.classes()).toContain('is-opened')
+      expect(four.classes()).toContain('is-opened')
+    })
+
+    test('unique-opened still collapses the whole sibling branch', async () => {
+      const { one, four, two, clickTitle } = setup('unique-opened')
+
+      await clickTitle(one)
+      await clickTitle(four)
+      expect(two.classes()).not.toContain('is-opened')
+
+      await clickTitle(two)
+      expect(two.classes()).toContain('is-opened')
+      expect(one.classes()).not.toContain('is-opened')
+      expect(four.classes()).not.toContain('is-opened')
+    })
+  })
 })

--- a/packages/components/menu/src/menu.ts
+++ b/packages/components/menu/src/menu.ts
@@ -265,8 +265,13 @@ export default defineComponent({
       // 将不在该菜单路径下的其余菜单收起
       // collapse all menu that are not under current menu item
       if (props.uniqueOpened) {
-        openedMenus.value = openedMenus.value.filter((index: string) =>
-          indexPath.includes(index)
+        openedMenus.value = openedMenus.value.filter(
+          (openedIndex: string) =>
+            indexPath.includes(openedIndex) ||
+            // 保留该菜单下已展开的子菜单，重新展开父菜单时可恢复
+            // keep the already opened descendants of the menu being opened,
+            // so re-expanding a parent restores its previously opened children
+            subMenus.value[openedIndex]?.indexPath.includes(index)
         )
       }
       openedMenus.value.push(index)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

When a menu is three levels deep, `unique-opened` loses nested state. `openMenu` collapses "everything else" by keeping only the entries that appear in the opened menu's own `indexPath`, which also throws away sub-menus nested below the menu being opened. Collapsing a parent and expanding it again therefore forgets which of its children were open, while the identical sequence without `unique-opened` restores them. This patch keeps an opened entry when its own `indexPath` contains the index being opened, so `unique-opened` still collapses sibling and unrelated branches only, and both modes now behave the same. Regression tests cover both modes.

One question for maintainers: this deliberately fixes only the `unique-opened` side and leaves `close()` untouched, so collapsing a parent still leaves its nested sub-menus in `openedMenus` — with the visible side effect that a child sub-menu under a collapsed parent keeps its `is-opened` class. The behaviour the patch preserves is that an open child is remembered and comes back when its parent is expanded again, in both modes. Would you rather have `close()` drop descendants outright instead? That would clear the stale `is-opened` flag as well, but it also changes the default non-`unique-opened` behaviour people currently rely on, since collapsing a parent would then forget its open children in both modes. Happy to switch if that is the direction you prefer.

closes #23210


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved nested submenu behavior when reopening parent menus.
  - Preserves previously open descendant submenus, including when unique-open mode is enabled.
  - Opening a sibling submenu still closes the previously active branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->