### PR TITLE
fix(components): [table-column] recognize custom column components

### DIFF
--- a/docs/en-US/component/table.md
+++ b/docs/en-US/component/table.md
@@ -105,6 +105,19 @@ table/grouping-header
 
 :::
 
+:::tip
+
+The default slot of `el-table-column` is shared by the cell content and the sub
+columns, so only `el-table-column` itself is picked up as a sub column. When the
+columns are built by your own (possibly recursive) component, mark that component
+with `__isTableColumn` ^(2.14.5) so it is recognized as a column provider as well:
+
+```ts
+defineOptions({ __isTableColumn: true })
+```
+
+:::
+
 ## Table with fixed group header
 
 fixed group head is supported

--- a/packages/components/table/__tests__/table-column.test.ts
+++ b/packages/components/table/__tests__/table-column.test.ts
@@ -1143,6 +1143,81 @@ describe('table column', () => {
       wrapper.unmount()
     })
 
+    it('should works with a custom recursive column component', async () => {
+      // A user land component that builds the column tree from a config
+      // object. `__isTableColumn` marks it as a column provider so that it is
+      // rendered into the hidden columns, see #22230.
+      const RecursiveColumn = {
+        name: 'RecursiveColumn',
+        __isTableColumn: true,
+        components: {
+          ElTableColumn,
+        },
+        props: {
+          columns: {
+            type: Array,
+            default: () => [],
+          },
+        },
+        template: `
+          <el-table-column
+            v-for="col in columns"
+            :key="col.prop || col.label"
+            :prop="col.prop"
+            :label="col.label"
+          >
+            <recursive-column v-if="col.children" :columns="col.children" />
+          </el-table-column>
+        `,
+      }
+      const wrapper = mount({
+        components: {
+          ElTable,
+          RecursiveColumn,
+        },
+        template: `
+          <el-table :data="testData">
+            <recursive-column :columns="columns" />
+          </el-table>
+        `,
+
+        created() {
+          this.testData = null
+          this.columns = [
+            { prop: 'name', label: 'name' },
+            {
+              label: 'group',
+              children: [
+                { prop: 'release', label: 'release' },
+                {
+                  label: "group's group",
+                  children: [
+                    { prop: 'director', label: 'director' },
+                    { prop: 'runtime', label: 'runtime' },
+                  ],
+                },
+              ],
+            },
+          ]
+        },
+      })
+
+      await doubleWait()
+      const trs = wrapper.findAll('.el-table__header tr')
+      expect(trs.length).toEqual(3)
+      expect(trs[0].findAll('th .cell').length).toEqual(2)
+      expect(trs[1].findAll('th .cell').length).toEqual(2)
+      expect(trs[2].findAll('th .cell').length).toEqual(2)
+
+      expect(trs[0].find('th:first-child').attributes('rowspan')).toEqual('3')
+      expect(trs[0].find('th:nth-child(2)').attributes('colspan')).toEqual('3')
+      expect(trs[1].find('th:first-child').attributes('rowspan')).toEqual('2')
+      expect(trs[1].find('th:nth-child(2)').attributes('colspan')).toEqual('2')
+
+      expect(wrapper.find('.el-table__header').text()).toContain('director')
+      wrapper.unmount()
+    })
+
     it('should work with fixed', async () => {
       const wrapper = mount({
         components: {

--- a/packages/components/table/src/table-column/index.vue
+++ b/packages/components/table/src/table-column/index.vue
@@ -26,6 +26,9 @@ import type { DefaultRow } from '../table/defaults'
 
 defineOptions({
   name: 'ElTableColumn',
+  // Allows user land components to be recognized as column providers as well,
+  // see the `__isTableColumn` check in `TableColumnRenderer` below.
+  __isTableColumn: true,
 })
 
 const props = withDefaults(defineProps<TableColumnProps<T>>(), {
@@ -209,6 +212,7 @@ const TableColumnRenderer = () => {
       for (const childNode of renderDefault) {
         if (
           (childNode.type as any)?.name === 'ElTableColumn' ||
+          (childNode.type as any)?.__isTableColumn ||
           childNode.shapeFlag & 2
         ) {
           children.push(childNode)


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

`el-table-column` shares its default slot between the cell content and the sub columns, so `TableColumnRenderer` only forwards vnodes that are an `el-table-column` (or a functional component) into the hidden columns, and treats everything else as cell content and drops it. A user land component that builds the column tree from a config object — a very common pattern, and the one reported in #22230 — is therefore discarded as soon as it appears below the first level, so the nested columns never mount, never register, and a grouped header collapses into a single row. This adds an opt-in marker: a component whose options carry `__isTableColumn` is forwarded too, following the `__isTeleport` / `__isKeepAlive` convention Vue uses for its own component types. Components without the marker behave exactly as before. The regression test builds a three level grouped header through a recursive component and asserts it produces the same header shape as plain nesting.

One question before merging. I first tried the version without an opt-in, widening the check from `shapeFlag & 2` (functional components only) to `ShapeFlags.COMPONENT`, and it does fix the issue — but it also mounts ordinary cell content into the hidden columns, which breaks the existing `should not rendered other components in hidden-columns` test and throws for any cell component that reads `row`, since that pass renders the slot with `row: {}`. As far as I can tell the two cases are indistinguishable at runtime while the default slot stays dual-purpose, which is presumably why #18144 put the identical `ShapeFlags.COMPONENT` check behind the `cell-slot` prop. That PR is closed and unmerged and `cell-slot` is not on `dev`, so #22230 is still broken today; #22231 was closed on the basis that `cell-slot` had already shipped, which it has not. If you would rather see #18144 relanded than take a marker, say the word and I will close this in its favour.

closes #22230


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom recursive table-column components are now recognized when marked as table-column providers.
  * Added support for deeply nested table headers, including correct row and column spans.

* **Documentation**
  * Added guidance for using recursive custom column components with grouped table headers.

* **Bug Fixes**
  * Improved rendering of nested table-column structures and deepest-level column labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->