### PR TITLE
fix(components): [cascader] display label when persistent is false

### DIFF
--- a/packages/components/cascader-panel/index.ts
+++ b/packages/components/cascader-panel/index.ts
@@ -10,3 +10,4 @@ export default ElCascaderPanel
 export * from './src/types'
 export * from './src/config'
 export * from './src/instance'
+export { default as CascaderStore } from './src/store'

--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -142,6 +142,38 @@ describe('Cascader.vue', () => {
     expect(wrapper.find('input').element.value).toBe('Zhejiang / Ningbo')
   })
 
+  test('persistent false should still display label', async () => {
+    const value = ref(['zhejiang', 'hangzhou'])
+    const wrapper = _mount(() => (
+      <Cascader v-model={value.value} options={OPTIONS} persistent={false} />
+    ))
+
+    await nextTick()
+    expect(wrapper.find('input').element.value).toBe('Zhejiang / Hangzhou')
+  })
+
+  test('persistent false should still display tags in multiple mode', async () => {
+    const value = ref([
+      ['zhejiang', 'hangzhou'],
+      ['zhejiang', 'ningbo'],
+    ])
+    const cascaderProps = { multiple: true }
+    const wrapper = _mount(() => (
+      <Cascader
+        v-model={value.value}
+        options={OPTIONS}
+        props={cascaderProps}
+        persistent={false}
+      />
+    ))
+
+    await nextTick()
+    const tags = wrapper.findAll(TAG)
+    expect(tags.length).toBe(2)
+    expect(tags[0].text()).toBe('Zhejiang / Hangzhou')
+    expect(tags[1].text()).toBe('Zhejiang / Ningbo')
+  })
+
   test('options change', async () => {
     const value = ref(['zhejiang', 'hangzhou'])
     const options = ref(OPTIONS)

--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -143,35 +143,118 @@ describe('Cascader.vue', () => {
   })
 
   test('persistent false should still display label', async () => {
-    const value = ref(['zhejiang', 'hangzhou'])
-    const wrapper = _mount(() => (
-      <Cascader v-model={value.value} options={OPTIONS} persistent={false} />
-    ))
+    // Render the tooltip content lazily like in production, so the
+    // fallback path without a mounted panel is actually covered.
+    process.env.RUN_TEST_WITH_PERSISTENT = 'true'
+    try {
+      const value = ref(['zhejiang', 'hangzhou'])
+      const wrapper = _mount(() => (
+        <Cascader v-model={value.value} options={OPTIONS} persistent={false} />
+      ))
 
-    await nextTick()
-    expect(wrapper.find('input').element.value).toBe('Zhejiang / Hangzhou')
+      await nextTick()
+      expect(wrapper.find('input').element.value).toBe('Zhejiang / Hangzhou')
+    } finally {
+      delete process.env.RUN_TEST_WITH_PERSISTENT
+    }
   })
 
   test('persistent false should still display tags in multiple mode', async () => {
-    const value = ref([
-      ['zhejiang', 'hangzhou'],
-      ['zhejiang', 'ningbo'],
-    ])
-    const cascaderProps = { multiple: true }
-    const wrapper = _mount(() => (
-      <Cascader
-        v-model={value.value}
-        options={OPTIONS}
-        props={cascaderProps}
-        persistent={false}
-      />
-    ))
+    process.env.RUN_TEST_WITH_PERSISTENT = 'true'
+    try {
+      const value = ref([
+        ['zhejiang', 'hangzhou'],
+        ['zhejiang', 'ningbo'],
+      ])
+      const cascaderProps = { multiple: true }
+      const wrapper = _mount(() => (
+        <Cascader
+          v-model={value.value}
+          options={OPTIONS}
+          props={cascaderProps}
+          persistent={false}
+        />
+      ))
 
-    await nextTick()
-    const tags = wrapper.findAll(TAG)
-    expect(tags.length).toBe(2)
-    expect(tags[0].text()).toBe('Zhejiang / Hangzhou')
-    expect(tags[1].text()).toBe('Zhejiang / Ningbo')
+      await nextTick()
+      const tags = wrapper.findAll(TAG)
+      expect(tags.length).toBe(2)
+      expect(tags[0].text()).toBe('Zhejiang / Hangzhou')
+      expect(tags[1].text()).toBe('Zhejiang / Ningbo')
+    } finally {
+      delete process.env.RUN_TEST_WITH_PERSISTENT
+    }
+  })
+
+  test('persistent false should collapse fully checked nodes in parent strategy', async () => {
+    process.env.RUN_TEST_WITH_PERSISTENT = 'true'
+    try {
+      const value = ref([
+        ['zhejiang', 'hangzhou'],
+        ['zhejiang', 'ningbo'],
+        ['zhejiang', 'wenzhou'],
+      ])
+      const cascaderProps = { multiple: true }
+      const wrapper = _mount(() => (
+        <Cascader
+          v-model={value.value}
+          options={OPTIONS}
+          props={cascaderProps}
+          persistent={false}
+          showCheckedStrategy="parent"
+        />
+      ))
+
+      await nextTick()
+      // All leaves of "Zhejiang" are selected, collapse to the top node
+      expect(wrapper.findAll(TAG).map((tag) => tag.text())).toEqual([
+        'Zhejiang',
+      ])
+
+      value.value = [
+        ['zhejiang', 'hangzhou'],
+        ['zhejiang', 'ningbo'],
+      ]
+      await nextTick()
+      // Partial selection keeps the leaf tags
+      expect(wrapper.findAll(TAG).map((tag) => tag.text())).toEqual([
+        'Zhejiang / Hangzhou',
+        'Zhejiang / Ningbo',
+      ])
+    } finally {
+      delete process.env.RUN_TEST_WITH_PERSISTENT
+    }
+  })
+
+  test('persistent false should remove collapsed subtree when deleting a parent tag', async () => {
+    process.env.RUN_TEST_WITH_PERSISTENT = 'true'
+    try {
+      const value = ref([
+        ['zhejiang', 'hangzhou'],
+        ['zhejiang', 'ningbo'],
+        ['zhejiang', 'wenzhou'],
+      ])
+      const cascaderProps = { multiple: true }
+      const wrapper = _mount(() => (
+        <Cascader
+          v-model={value.value}
+          options={OPTIONS}
+          props={cascaderProps}
+          persistent={false}
+          showCheckedStrategy="parent"
+        />
+      ))
+
+      await nextTick()
+      const tags = wrapper.findAll(TAG)
+      expect(tags.length).toBe(1)
+
+      await tags[0].find('.el-tag__close').trigger('click')
+      expect(value.value).toEqual([])
+      expect(wrapper.findAll(TAG).length).toBe(0)
+    } finally {
+      delete process.env.RUN_TEST_WITH_PERSISTENT
+    }
   })
 
   test('options change', async () => {

--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -329,6 +329,41 @@ describe('Cascader.vue', () => {
         await nextTick()
       }
       expect(wrapper.find('input').element.value).toBe('Asia / China / Beijing')
+
+      // Any node loaded by the panel can be resolved while closed
+      value.value = ['asia']
+      await nextTick()
+      expect(wrapper.find('input').element.value).toBe('Asia')
+    })
+  })
+
+  test('persistent false should not show a label after options are emptied', async () => {
+    await withRealPersistent(async () => {
+      const value = ref(['zhejiang', 'hangzhou'])
+      const options = ref(OPTIONS)
+      const wrapper = _mount(() => (
+        <Cascader
+          v-model={value.value}
+          options={options.value}
+          persistent={false}
+        />
+      ))
+
+      await nextTick()
+      expect(wrapper.find('input').element.value).toBe('Zhejiang / Hangzhou')
+
+      // Open and close so the panel gets mounted and unmounted once
+      await wrapper.find(TRIGGER).trigger('click')
+      await nextTick()
+      await wrapper.find(TRIGGER).trigger('click')
+      for (let i = 0; i < 5; i++) {
+        await rAF()
+        await nextTick()
+      }
+
+      options.value = []
+      await nextTick()
+      expect(wrapper.find('input').element.value).toBe('')
     })
   })
 

--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -259,6 +259,79 @@ describe('Cascader.vue', () => {
     })
   })
 
+  test('persistent false should drop invalid values when deleting a tag', async () => {
+    await withRealPersistent(async () => {
+      const value = ref([['zhejiang', 'hangzhou'], ['not-exist']])
+      const cascaderProps = { multiple: true }
+      const wrapper = _mount(() => (
+        <Cascader
+          v-model={value.value}
+          options={OPTIONS}
+          props={cascaderProps}
+          persistent={false}
+        />
+      ))
+
+      await nextTick()
+      // Only the value matching an option gets a tag
+      expect(wrapper.findAll(TAG).map((tag) => tag.text())).toEqual([
+        'Zhejiang / Hangzhou',
+      ])
+
+      const tags = wrapper.findAll(TAG)
+      await tags[0].find('.el-tag__close').trigger('click')
+      // The leftover value without a matching option is dropped as well
+      expect(value.value).toEqual([])
+      expect(wrapper.findAll(TAG).length).toBe(0)
+    })
+  })
+
+  test('persistent false should keep the label after the lazy panel closes', async () => {
+    await withRealPersistent(async () => {
+      const value = ref(['asia', 'china', 'beijing'])
+      const lazyData: Record<string, any> = {
+        root: [{ value: 'asia', label: 'Asia' }],
+        asia: [{ value: 'china', label: 'China' }],
+        china: [{ value: 'beijing', label: 'Beijing' }],
+      }
+      const cascaderProps = {
+        lazy: true,
+        lazyLoad: (node: any, resolve: (data: any[]) => void) => {
+          setTimeout(() => resolve(lazyData[node?.value ?? 'root'] ?? []), 0)
+        },
+      }
+      const wrapper = _mount(() => (
+        <Cascader
+          v-model={value.value}
+          props={cascaderProps}
+          persistent={false}
+        />
+      ))
+
+      await nextTick()
+      expect(wrapper.find('input').element.value).toBe('')
+
+      // Open the dropdown so the panel mounts and lazy loads the value path
+      await wrapper.find(TRIGGER).trigger('click')
+      for (let i = 0; i < 10; i++) {
+        await nextTick()
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      for (let i = 0; i < 10; i++) {
+        await nextTick()
+      }
+      expect(wrapper.find('input').element.value).toBe('Asia / China / Beijing')
+
+      // Close the dropdown, the panel unmounts but the label stays
+      await wrapper.find(TRIGGER).trigger('click')
+      for (let i = 0; i < 5; i++) {
+        await rAF()
+        await nextTick()
+      }
+      expect(wrapper.find('input').element.value).toBe('Asia / China / Beijing')
+    })
+  })
+
   test('options change', async () => {
     const value = ref(['zhejiang', 'hangzhou'])
     const options = ref(OPTIONS)

--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -73,6 +73,22 @@ const _mount = (render: () => VNode) =>
     attachTo: document.body,
   })
 
+// Renders the tooltip content lazily like in production, so tests with
+// persistent={false} cover the fallback path without a mounted panel.
+const withRealPersistent = async (run: () => Promise<void>) => {
+  const previousValue = process.env.RUN_TEST_WITH_PERSISTENT
+  process.env.RUN_TEST_WITH_PERSISTENT = 'true'
+  try {
+    await run()
+  } finally {
+    if (previousValue === undefined) {
+      delete process.env.RUN_TEST_WITH_PERSISTENT
+    } else {
+      process.env.RUN_TEST_WITH_PERSISTENT = previousValue
+    }
+  }
+}
+
 afterEach(() => {
   document.body.innerHTML = ''
 })
@@ -143,10 +159,7 @@ describe('Cascader.vue', () => {
   })
 
   test('persistent false should still display label', async () => {
-    // Render the tooltip content lazily like in production, so the
-    // fallback path without a mounted panel is actually covered.
-    process.env.RUN_TEST_WITH_PERSISTENT = 'true'
-    try {
+    await withRealPersistent(async () => {
       const value = ref(['zhejiang', 'hangzhou'])
       const wrapper = _mount(() => (
         <Cascader v-model={value.value} options={OPTIONS} persistent={false} />
@@ -154,14 +167,11 @@ describe('Cascader.vue', () => {
 
       await nextTick()
       expect(wrapper.find('input').element.value).toBe('Zhejiang / Hangzhou')
-    } finally {
-      delete process.env.RUN_TEST_WITH_PERSISTENT
-    }
+    })
   })
 
   test('persistent false should still display tags in multiple mode', async () => {
-    process.env.RUN_TEST_WITH_PERSISTENT = 'true'
-    try {
+    await withRealPersistent(async () => {
       const value = ref([
         ['zhejiang', 'hangzhou'],
         ['zhejiang', 'ningbo'],
@@ -181,14 +191,11 @@ describe('Cascader.vue', () => {
       expect(tags.length).toBe(2)
       expect(tags[0].text()).toBe('Zhejiang / Hangzhou')
       expect(tags[1].text()).toBe('Zhejiang / Ningbo')
-    } finally {
-      delete process.env.RUN_TEST_WITH_PERSISTENT
-    }
+    })
   })
 
   test('persistent false should collapse fully checked nodes in parent strategy', async () => {
-    process.env.RUN_TEST_WITH_PERSISTENT = 'true'
-    try {
+    await withRealPersistent(async () => {
       const value = ref([
         ['zhejiang', 'hangzhou'],
         ['zhejiang', 'ningbo'],
@@ -221,14 +228,11 @@ describe('Cascader.vue', () => {
         'Zhejiang / Hangzhou',
         'Zhejiang / Ningbo',
       ])
-    } finally {
-      delete process.env.RUN_TEST_WITH_PERSISTENT
-    }
+    })
   })
 
   test('persistent false should remove collapsed subtree when deleting a parent tag', async () => {
-    process.env.RUN_TEST_WITH_PERSISTENT = 'true'
-    try {
+    await withRealPersistent(async () => {
       const value = ref([
         ['zhejiang', 'hangzhou'],
         ['zhejiang', 'ningbo'],
@@ -252,9 +256,7 @@ describe('Cascader.vue', () => {
       await tags[0].find('.el-tag__close').trigger('click')
       expect(value.value).toEqual([])
       expect(wrapper.findAll(TAG).length).toBe(0)
-    } finally {
-      delete process.env.RUN_TEST_WITH_PERSISTENT
-    }
+    })
   })
 
   test('options change', async () => {

--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -292,7 +292,10 @@ describe('Cascader.vue', () => {
       const lazyData: Record<string, any> = {
         root: [{ value: 'asia', label: 'Asia' }],
         asia: [{ value: 'china', label: 'China' }],
-        china: [{ value: 'beijing', label: 'Beijing' }],
+        china: [
+          { value: 'beijing', label: 'Beijing' },
+          { value: 'shenzhen', label: 'Shenzhen' },
+        ],
       }
       const cascaderProps = {
         lazy: true,
@@ -330,11 +333,85 @@ describe('Cascader.vue', () => {
       }
       expect(wrapper.find('input').element.value).toBe('Asia / China / Beijing')
 
-      // Any node loaded by the panel can be resolved while closed
+      // Any loaded leaf value can be resolved while closed, while
+      // non-leaf values are dropped like the mounted panel does
       value.value = ['asia']
       await nextTick()
-      expect(wrapper.find('input').element.value).toBe('Asia')
+      expect(wrapper.find('input').element.value).toBe('')
+
+      value.value = ['asia', 'china', 'shenzhen']
+      await nextTick()
+      expect(wrapper.find('input').element.value).toBe(
+        'Asia / China / Shenzhen'
+      )
+
+      // Reopen with updated lazy data, the newest loaded node wins
+      lazyData.china = [{ value: 'beijing', label: 'Beijing II' }]
+      value.value = ['asia', 'china', 'beijing']
+      await nextTick()
+      expect(wrapper.find('input').element.value).toBe('Asia / China / Beijing')
+
+      await wrapper.find(TRIGGER).trigger('click')
+      for (let i = 0; i < 10; i++) {
+        await nextTick()
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      for (let i = 0; i < 10; i++) {
+        await nextTick()
+      }
+      expect(wrapper.find('input').element.value).toBe(
+        'Asia / China / Beijing II'
+      )
+
+      await wrapper.find(TRIGGER).trigger('click')
+      for (let i = 0; i < 5; i++) {
+        await rAF()
+        await nextTick()
+      }
+      expect(wrapper.find('input').element.value).toBe(
+        'Asia / China / Beijing II'
+      )
     })
+  })
+
+  test('lazy cascader should not duplicate lazy load requests when opening', async () => {
+    const value = ref(['asia', 'china', 'beijing'])
+    const lazyData: Record<string, any> = {
+      asia: [{ value: 'china', label: 'China' }],
+      china: [{ value: 'beijing', label: 'Beijing' }],
+    }
+    const lazyLoadSpy = vi.fn((node: any, resolve: (data: any[]) => void) => {
+      setTimeout(() => resolve(lazyData[node?.value] ?? []), 0)
+    })
+    const cascaderProps = { lazy: true, lazyLoad: lazyLoadSpy }
+    const options = [{ value: 'asia', label: 'Asia' }]
+    const wrapper = _mount(() => (
+      <Cascader v-model={value.value} options={options} props={cascaderProps} />
+    ))
+
+    for (let i = 0; i < 10; i++) {
+      await nextTick()
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    for (let i = 0; i < 10; i++) {
+      await nextTick()
+    }
+    expect(wrapper.find('input').element.value).toBe('Asia / China / Beijing')
+
+    const callsBeforeOpen = lazyLoadSpy.mock.calls.length
+    await wrapper.find(TRIGGER).trigger('click')
+    for (let i = 0; i < 10; i++) {
+      await nextTick()
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    for (let i = 0; i < 10; i++) {
+      await nextTick()
+    }
+    // Only the pending ancestors are requested once more
+    const requestedValues = lazyLoadSpy.mock.calls
+      .slice(callsBeforeOpen)
+      .map((call) => call[0]?.value)
+    expect(requestedValues).toEqual(['asia', 'china', 'beijing'])
   })
 
   test('persistent false should not show a label after options are emptied', async () => {

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -644,10 +644,9 @@ const deleteTag = (tag: Tag) => {
     const values = castArray(props.modelValue as CascaderNodeValue[]).filter(
       (val) => !isEqual(val, node.valueByOption)
     )
-    emit(
-      UPDATE_MODEL_EVENT,
+    checkedValue.value = (
       cfg.multiple ? values : (values[0] ?? valueOnClear.value)
-    )
+    ) as CascaderValue
   }
   emit('removeTag', node.valueByOption)
 }
@@ -657,12 +656,18 @@ const getStrategyCheckedNodes = (): CascaderNode[] => {
     case 'child':
       return checkedNodes.value
     case 'parent': {
-      const clickedNodes = getCheckedNodes(false) ?? []
-      const clickedNodesValue = clickedNodes.map((o) => o.value)
-      const parentNodes = clickedNodes.filter(
-        (o) => !o.parent || !clickedNodesValue.includes(o.parent.value)
+      const clickedNodes = getCheckedNodes(false)
+      if (clickedNodes.length) {
+        const clickedNodesValue = clickedNodes.map((o) => o.value)
+        return clickedNodes.filter(
+          (o) => !o.parent || !clickedNodesValue.includes(o.parent.value)
+        )
+      }
+      // When the panel is not mounted, derive parent nodes from the
+      // fallback checkedNodes (leaf-only) by walking up the parent chain.
+      return checkedNodes.value.filter(
+        (node) => !node.parent || !checkedNodes.value.includes(node.parent)
       )
-      return parentNodes
     }
     default:
       return []
@@ -877,8 +882,9 @@ const handleClear = () => {
   if (cascaderPanelRef.value) {
     cascaderPanelRef.value.clearCheckedNodes()
   } else {
-    emit(UPDATE_MODEL_EVENT, valueOnClear.value)
-    emit(CHANGE_EVENT, valueOnClear.value)
+    checkedValue.value = (
+      multiple.value ? [] : valueOnClear.value
+    ) as CascaderValue
   }
   if (!popperVisible.value && props.filterable) {
     syncPresentTextValue()

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -284,16 +284,21 @@ import { clamp, cloneDeep } from 'lodash-unified'
 import { useCssVar, useDebounceFn, useResizeObserver } from '@vueuse/core'
 import {
   NOOP,
+  castArray,
   focusNode,
   getEventCode,
   getSibling,
   isClient,
+  isEmpty,
   isNumber,
   isPromise,
+  unique,
 } from '@element-plus/utils'
 import ElCascaderPanel, {
   CASCADER_PANEL_HEIGHT,
   CASCADER_PANEL_ITEM_SIZE,
+  CascaderStore,
+  useCascaderConfig,
 } from '@element-plus/components/cascader-panel'
 import ElInput from '@element-plus/components/input'
 import ElTooltip from '@element-plus/components/tooltip'
@@ -473,13 +478,35 @@ const tagSize = computed(() =>
   realSize.value === 'small' ? 'small' : 'default'
 )
 const multiple = computed(() => !!props.props.multiple)
+const config = useCascaderConfig(props)
 const readonly = computed(() => !props.filterable || multiple.value)
 const searchKeyword = computed(() =>
   multiple.value ? searchInputValue.value : inputValue.value
 )
-const checkedNodes: ComputedRef<CascaderNode[]> = computed(
-  () => cascaderPanelRef.value?.checkedNodes || []
-)
+const checkedNodes: ComputedRef<CascaderNode[]> = computed(() => {
+  const panelNodes = cascaderPanelRef.value?.checkedNodes
+  if (panelNodes) return panelNodes
+
+  // When persistent=false and the panel is not yet mounted, resolve
+  // checked nodes directly from modelValue + options so the cascader
+  // can display labels / tags without the panel being rendered.
+  if (!isEmpty(props.modelValue)) {
+    const cfg = config.value
+    if (!cfg.lazy && props.options?.length) {
+      const store = new CascaderStore(props.options, cfg)
+      const leafOnly = !cfg.checkStrictly
+      const values = cfg.multiple
+        ? castArray(props.modelValue)
+        : [props.modelValue]
+      return unique(
+        values
+          .map((val) => store.getNodeByValue(val as CascaderValue, leafOnly))
+          .filter((node) => !!node && (cfg.checkStrictly || node.isLeaf))
+      ) as CascaderNode[]
+    }
+  }
+  return []
+})
 
 const { wrapperRef, isFocused, handleBlur } = useFocusController(inputRef, {
   disabled: isDisabled,
@@ -996,7 +1023,8 @@ watch(
     () => props.collapseTags,
     () => props.maxCollapseTags,
   ],
-  calculatePresentTags
+  calculatePresentTags,
+  { immediate: true }
 )
 
 watch(tags, () => {

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -838,7 +838,7 @@ const calculateSuggestionMaxWidth = () => {
 }
 
 const getCheckedNodes = (leafOnly: boolean) => {
-  return cascaderPanelRef.value?.getCheckedNodes(leafOnly)
+  return cascaderPanelRef.value?.getCheckedNodes(leafOnly) ?? []
 }
 
 const handleExpandChange = (value: CascaderValue) => {

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -280,7 +280,7 @@ import {
   useSlots,
   watch,
 } from 'vue'
-import { clamp, cloneDeep } from 'lodash-unified'
+import { clamp, cloneDeep, isEqual } from 'lodash-unified'
 import { useCssVar, useDebounceFn, useResizeObserver } from '@vueuse/core'
 import {
   NOOP,
@@ -289,9 +289,9 @@ import {
   getEventCode,
   getSibling,
   isClient,
-  isEmpty,
   isNumber,
   isPromise,
+  isPropAbsent,
   unique,
 } from '@element-plus/utils'
 import ElCascaderPanel, {
@@ -335,6 +335,7 @@ import type { ScrollbarInstance } from '@element-plus/components/scrollbar'
 import type { FixedSizeListInstance } from '@element-plus/components/virtual-list'
 import type {
   CascaderNode,
+  CascaderNodeValue,
   CascaderPanelInstance,
   CascaderValue,
   Tag,
@@ -490,7 +491,7 @@ const checkedNodes: ComputedRef<CascaderNode[]> = computed(() => {
   // When persistent=false and the panel is not yet mounted, resolve
   // checked nodes directly from modelValue + options so the cascader
   // can display labels / tags without the panel being rendered.
-  if (!isEmpty(props.modelValue)) {
+  if (!isPropAbsent(props.modelValue)) {
     const cfg = config.value
     if (!cfg.lazy && props.options?.length) {
       const store = new CascaderStore(props.options, cfg)
@@ -635,8 +636,19 @@ const genTag = (node: CascaderNode): Tag => {
 
 const deleteTag = (tag: Tag) => {
   const node = tag.node as CascaderNode
-  node.doCheck(false)
-  cascaderPanelRef.value?.calculateCheckedValue()
+  if (cascaderPanelRef.value) {
+    node.doCheck(false)
+    cascaderPanelRef.value.calculateCheckedValue()
+  } else {
+    const cfg = config.value
+    const values = castArray(props.modelValue as CascaderNodeValue[]).filter(
+      (val) => !isEqual(val, node.valueByOption)
+    )
+    emit(
+      UPDATE_MODEL_EVENT,
+      cfg.multiple ? values : (values[0] ?? valueOnClear.value)
+    )
+  }
   emit('removeTag', node.valueByOption)
 }
 
@@ -645,9 +657,9 @@ const getStrategyCheckedNodes = (): CascaderNode[] => {
     case 'child':
       return checkedNodes.value
     case 'parent': {
-      const clickedNodes = getCheckedNodes(false)
-      const clickedNodesValue = clickedNodes!.map((o) => o.value)
-      const parentNodes = clickedNodes!.filter(
+      const clickedNodes = getCheckedNodes(false) ?? []
+      const clickedNodesValue = clickedNodes.map((o) => o.value)
+      const parentNodes = clickedNodes.filter(
         (o) => !o.parent || !clickedNodesValue.includes(o.parent.value)
       )
       return parentNodes
@@ -862,7 +874,12 @@ const handleKeyDown = (e: KeyboardEvent) => {
 }
 
 const handleClear = () => {
-  cascaderPanelRef.value?.clearCheckedNodes()
+  if (cascaderPanelRef.value) {
+    cascaderPanelRef.value.clearCheckedNodes()
+  } else {
+    emit(UPDATE_MODEL_EVENT, valueOnClear.value)
+    emit(CHANGE_EVENT, valueOnClear.value)
+  }
   if (!popperVisible.value && props.filterable) {
     syncPresentTextValue()
   }

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -689,15 +689,23 @@ const getStrategyCheckedNodes = (): CascaderNode[] => {
         )
       }
       const selectedNodes = new Set(nodes)
+      // Memoize the result per run so shared ancestors are only
+      // traversed once instead of once per selected leaf.
+      const fullySelectedCache = new Map<CascaderNode, boolean>()
       const isFullySelected = (node: CascaderNode): boolean => {
-        if (selectedNodes.has(node)) return true
-        const validChildren = (node.children ?? []).filter(
-          (child) => !child.isDisabled
-        )
-        return (
-          validChildren.length > 0 &&
-          validChildren.every((child) => isFullySelected(child))
-        )
+        const cached = fullySelectedCache.get(node)
+        if (cached !== undefined) return cached
+        let result = selectedNodes.has(node)
+        if (!result) {
+          const validChildren = (node.children ?? []).filter(
+            (child) => !child.isDisabled
+          )
+          result =
+            validChildren.length > 0 &&
+            validChildren.every((child) => isFullySelected(child))
+        }
+        fullySelectedCache.set(node, result)
+        return result
       }
       // Sort by uid to keep the same order as the mounted panel, whose
       // nodes come from the store in depth-first order.

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -641,14 +641,29 @@ const deleteTag = (tag: Tag) => {
     cascaderPanelRef.value.calculateCheckedValue()
   } else {
     const cfg = config.value
+    // Deleting a fully selected subtree node unchecks every enabled
+    // leaf under it, mirroring the mounted panel's doCheck(false).
+    const removedValues =
+      cfg.multiple && !cfg.checkStrictly
+        ? getSubtreeLeafValues(node)
+        : [node.valueByOption]
     const values = castArray(props.modelValue as CascaderNodeValue[]).filter(
-      (val) => !isEqual(val, node.valueByOption)
+      (val) => !removedValues.some((removed) => isEqual(val, removed))
     )
     checkedValue.value = (
       cfg.multiple ? values : (values[0] ?? valueOnClear.value)
     ) as CascaderValue
   }
   emit('removeTag', node.valueByOption)
+}
+
+const getSubtreeLeafValues = (node: CascaderNode): CascaderNodeValue[] => {
+  if (node.isLeaf) return node.isDisabled ? [] : [node.valueByOption]
+  return (node.children ?? []).reduce(
+    (values: CascaderNodeValue[], child) =>
+      values.concat(getSubtreeLeafValues(child)),
+    []
+  )
 }
 
 const getStrategyCheckedNodes = (): CascaderNode[] => {
@@ -663,11 +678,40 @@ const getStrategyCheckedNodes = (): CascaderNode[] => {
           (o) => !o.parent || !clickedNodesValue.includes(o.parent.value)
         )
       }
-      // When the panel is not mounted, derive parent nodes from the
-      // fallback checkedNodes (leaf-only) by walking up the parent chain.
-      return checkedNodes.value.filter(
-        (node) => !node.parent || !checkedNodes.value.includes(node.parent)
-      )
+      // When the panel is not mounted, checkedNodes only contains the
+      // nodes resolved from modelValue (leaf nodes in non-strict mode),
+      // so collapse fully selected subtrees to their topmost node to
+      // match the behavior of the mounted panel.
+      const nodes = checkedNodes.value
+      if (config.value.checkStrictly) {
+        return nodes.filter(
+          (node) => !node.parent || !nodes.includes(node.parent)
+        )
+      }
+      const selectedNodes = new Set(nodes)
+      const isFullySelected = (node: CascaderNode): boolean => {
+        if (selectedNodes.has(node)) return true
+        const validChildren = (node.children ?? []).filter(
+          (child) => !child.isDisabled
+        )
+        return (
+          validChildren.length > 0 &&
+          validChildren.every((child) => isFullySelected(child))
+        )
+      }
+      // Sort by uid to keep the same order as the mounted panel, whose
+      // nodes come from the store in depth-first order.
+      return unique(
+        nodes.map((node) => {
+          let topNode = node
+          let parent = node.parent
+          while (parent && isFullySelected(parent)) {
+            topNode = parent
+            parent = parent.parent
+          }
+          return topNode
+        })
+      ).sort((a, b) => a.uid - b.uid)
     }
     default:
       return []

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -512,7 +512,10 @@ const checkedNodes: ComputedRef<CascaderNode[]> = computed(() => {
     if (cfg.lazy) {
       // Lazy options cannot be resolved without the panel's loaded
       // data, so match the values against the nodes loaded by the
-      // panel most recently.
+      // panel most recently. Nodes the panel never resolved keep an
+      // unknown leaf state and are kept as valid selections.
+      const isSelectableNode = (node: CascaderNode): boolean =>
+        cfg.checkStrictly || node.loaded ? node.isLeaf : true
       const values = cfg.multiple
         ? castArray(props.modelValue)
         : [props.modelValue]
@@ -523,7 +526,9 @@ const checkedNodes: ComputedRef<CascaderNode[]> = computed(() => {
               isEqual(node.valueByOption, val)
             )
           )
-          .filter((node) => !!node)
+          .filter(
+            (node): node is CascaderNode => !!node && isSelectableNode(node)
+          )
       )
     }
     return []
@@ -713,8 +718,9 @@ const getStrategyCheckedNodes = (): CascaderNode[] => {
       // match the behavior of the mounted panel.
       const nodes = checkedNodes.value
       if (config.value.checkStrictly) {
+        const nodeValues = nodes.map((node) => node.value)
         return nodes.filter(
-          (node) => !node.parent || !nodes.includes(node.parent)
+          (node) => !node.parent || !nodeValues.includes(node.parent.value)
         )
       }
       const selectedNodes = new Set(nodes)
@@ -1153,22 +1159,17 @@ watch(
     }
     if (!val && props.props.lazy) {
       // Keep all nodes the panel loaded before it unmounts, so lazy
-      // cascaders can resolve any loaded value while closed.
+      // cascaders can resolve any loaded value while closed. Merge by
+      // value so each value resolves to its newest loaded node.
       const loadedNodes = cascaderPanelRef.value?.getFlattedNodes(false)
       if (loadedNodes?.length) {
-        resolvedPanelNodes.value = unique(
-          resolvedPanelNodes.value.concat(loadedNodes)
+        const mergedNodes = new Map(
+          resolvedPanelNodes.value
+            .concat(loadedNodes)
+            .map((node) => [JSON.stringify(node.valueByOption), node])
         )
+        resolvedPanelNodes.value = [...mergedNodes.values()]
       }
-    }
-  }
-)
-
-watch(
-  () => popperVisible.value,
-  (val) => {
-    if (val && props.props.lazy && props.props.lazyLoad) {
-      cascaderPanelRef.value?.loadLazyRootNodes()
     }
   }
 )

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -480,6 +480,10 @@ const tagSize = computed(() =>
 )
 const multiple = computed(() => !!props.props.multiple)
 const config = useCascaderConfig(props)
+// Last non-empty checked nodes resolved by the mounted panel, used as
+// a fallback for lazy mode where the unmounted cascader cannot resolve
+// model values into labels on its own.
+const resolvedPanelNodes = ref<CascaderNode[]>([])
 const readonly = computed(() => !props.filterable || multiple.value)
 const searchKeyword = computed(() =>
   multiple.value ? searchInputValue.value : inputValue.value
@@ -505,6 +509,20 @@ const checkedNodes: ComputedRef<CascaderNode[]> = computed(() => {
           .filter((node) => !!node && (cfg.checkStrictly || node.isLeaf))
       ) as CascaderNode[]
     }
+    // Lazy options cannot be resolved without the panel's loaded data,
+    // so match the values against the nodes the panel resolved last.
+    const values = cfg.multiple
+      ? castArray(props.modelValue)
+      : [props.modelValue]
+    return unique(
+      values
+        .map((val) =>
+          resolvedPanelNodes.value.find((node) =>
+            isEqual(node.valueByOption, val)
+          )
+        )
+        .filter((node) => !!node)
+    )
   }
   return []
 })
@@ -647,9 +665,16 @@ const deleteTag = (tag: Tag) => {
       cfg.multiple && !cfg.checkStrictly
         ? getSubtreeLeafValues(node)
         : [node.valueByOption]
-    const values = castArray(props.modelValue as CascaderNodeValue[]).filter(
-      (val) => !removedValues.some((removed) => isEqual(val, removed))
-    )
+    // Recalculate from the resolved nodes so values that no longer
+    // match any option are dropped, like the mounted panel does.
+    const values = checkedNodes.value
+      .filter(
+        (checkedNode) =>
+          !removedValues.some((removed) =>
+            isEqual(checkedNode.valueByOption, removed)
+          )
+      )
+      .map((checkedNode) => checkedNode.valueByOption)
     checkedValue.value = (
       cfg.multiple ? values : (values[0] ?? valueOnClear.value)
     ) as CascaderValue
@@ -1114,6 +1139,15 @@ watch(realSize, async () => {
 })
 
 watch(presentText, syncPresentTextValue, { immediate: true })
+
+watch(
+  () => cascaderPanelRef.value?.checkedNodes,
+  (nodes) => {
+    if (nodes?.length) {
+      resolvedPanelNodes.value = nodes
+    }
+  }
+)
 
 watch(
   () => popperVisible.value,

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -480,9 +480,9 @@ const tagSize = computed(() =>
 )
 const multiple = computed(() => !!props.props.multiple)
 const config = useCascaderConfig(props)
-// Last non-empty checked nodes resolved by the mounted panel, used as
-// a fallback for lazy mode where the unmounted cascader cannot resolve
-// model values into labels on its own.
+// Nodes loaded by the panel while it was mounted, used as a fallback
+// for lazy mode where the unmounted cascader cannot resolve model
+// values into labels on its own.
 const resolvedPanelNodes = ref<CascaderNode[]>([])
 const readonly = computed(() => !props.filterable || multiple.value)
 const searchKeyword = computed(() =>
@@ -509,20 +509,24 @@ const checkedNodes: ComputedRef<CascaderNode[]> = computed(() => {
           .filter((node) => !!node && (cfg.checkStrictly || node.isLeaf))
       ) as CascaderNode[]
     }
-    // Lazy options cannot be resolved without the panel's loaded data,
-    // so match the values against the nodes the panel resolved last.
-    const values = cfg.multiple
-      ? castArray(props.modelValue)
-      : [props.modelValue]
-    return unique(
-      values
-        .map((val) =>
-          resolvedPanelNodes.value.find((node) =>
-            isEqual(node.valueByOption, val)
+    if (cfg.lazy) {
+      // Lazy options cannot be resolved without the panel's loaded
+      // data, so match the values against the nodes loaded by the
+      // panel most recently.
+      const values = cfg.multiple
+        ? castArray(props.modelValue)
+        : [props.modelValue]
+      return unique(
+        values
+          .map((val) =>
+            resolvedPanelNodes.value.find((node) =>
+              isEqual(node.valueByOption, val)
+            )
           )
-        )
-        .filter((node) => !!node)
-    )
+          .filter((node) => !!node)
+      )
+    }
+    return []
   }
   return []
 })
@@ -1141,10 +1145,21 @@ watch(realSize, async () => {
 watch(presentText, syncPresentTextValue, { immediate: true })
 
 watch(
-  () => cascaderPanelRef.value?.checkedNodes,
-  (nodes) => {
-    if (nodes?.length) {
-      resolvedPanelNodes.value = nodes
+  () => popperVisible.value,
+  (val) => {
+    if (val && props.props.lazy && props.props.lazyLoad) {
+      cascaderPanelRef.value?.loadLazyRootNodes()
+      return
+    }
+    if (!val && props.props.lazy) {
+      // Keep all nodes the panel loaded before it unmounts, so lazy
+      // cascaders can resolve any loaded value while closed.
+      const loadedNodes = cascaderPanelRef.value?.getFlattedNodes(false)
+      if (loadedNodes?.length) {
+        resolvedPanelNodes.value = unique(
+          resolvedPanelNodes.value.concat(loadedNodes)
+        )
+      }
     }
   }
 )


### PR DESCRIPTION
When persistent=false, el-tooltip does not render its content slot until first show, so el-cascader-panel is not mounted initially. This caused the cascader input to show empty text because presentText/tags depend on checkedNodes from the panel instance ref.

Fix by making checkedNodes resolve nodes directly from modelValue + options via a temporary Store when the panel is not yet mounted. Also add { immediate: true } to the calculatePresentTags watcher so tags are computed on initial render instead of waiting for checkedNodes to change.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Cascader selection handling when persistent selection is disabled, including multiple selections and label display.
  * Cascader selections remain available and display correctly even when the selection panel is not open.
  * Parent selection strategy now collapses fully selected subtrees into a single tag while preserving leaf tags for partial selections.

* **Bug Fixes**
  * Duplicate selections are removed, and results are limited to valid leaf options.
  * Removing tags and clearing selections now work correctly without an open selection panel.
  * Removing a collapsed parent tag now clears all selections within that subtree.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->