### PR TITLE
fix(components): [textarea] prevent autosize scroll reset in Firefox

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -54,6 +54,8 @@
     position: relative;
     display: block;
     resize: vertical;
+    // #24721 Keep Firefox's caret in view after autosize temporarily hides overflow.
+    overflow-y: auto;
     padding: 5px map.get($input-padding-horizontal, 'default')-$border-width;
     line-height: 1.5;
     box-sizing: border-box;

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -54,6 +54,7 @@
     position: relative;
     display: block;
     resize: vertical;
+
     // #24721 Keep Firefox's caret in view after autosize temporarily hides overflow.
     overflow-y: auto;
     padding: 5px map.get($input-padding-horizontal, 'default')-$border-width;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fix #24721

When an autosized textarea reaches `maxRows`, `resizeTextarea()` temporarily sets `overflow-y: hidden` while measuring its height. In Firefox, removing that inline style afterward can reset the textarea's internal scroll position, leaving the caret outside the visible area.

This PR adds `overflow-y: auto` to `.el-textarea__inner`, providing a stable overflow state after autosize measurement finishes.

The existing `overflow-y: hidden` measurement workaround for #8825 is preserved:

1. The inline `overflow-y: hidden` still takes precedence during measurement.
2. After the inline style is removed, the textarea returns to `overflow-y: auto`.
3. This keeps the caret visible in Firefox without reintroducing the scrollbar-sizing issue from #8825.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved textarea behavior in Firefox by keeping the text caret visible while fields resize automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->