### PR TITLE
fix(components): [date-picker] remove keyboard navigation for `quarters`

### DIFF
--- a/packages/components/date-picker-panel/src/date-picker-com/panel-date-pick.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/panel-date-pick.vue
@@ -789,9 +789,7 @@ const getDefaultValue = () => {
 
 const handleFocusPicker = () => {
   if (
-    ['week', 'month', 'year', 'date', 'quarter', 'quarters'].includes(
-      selectionMode.value
-    )
+    ['week', 'month', 'year', 'date', 'quarter'].includes(selectionMode.value)
   ) {
     currentViewRef.value?.focus()
   }
@@ -899,9 +897,7 @@ const handleKeyControl = (code: string) => {
 
   const newDate = innerDate.value.toDate()
   while (Math.abs(innerDate.value.diff(newDate, 'year', true)) < 1) {
-    const mode =
-      keyboardMode.value === 'quarters' ? 'quarter' : keyboardMode.value
-    const map = mapping[mode]
+    const map = mapping[keyboardMode.value]
     if (!map) return
     map.offset(
       newDate,
@@ -911,7 +907,7 @@ const handleKeyControl = (code: string) => {
     )
 
     let result: Dayjs
-    if (mode === 'quarter') {
+    if (keyboardMode.value === 'quarter') {
       const candidate = dayjs(newDate).locale(lang.value)
       if (isQuarterFullyDisabled(candidate, lang.value, disabledDate.value)) {
         break

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -3901,31 +3901,6 @@ describe('Quarters', () => {
       vi.useRealTimers()
     }
   })
-
-  it('should focus quarter table on ArrowDown from input', async () => {
-    vi.useFakeTimers()
-    try {
-      vi.setSystemTime(new Date('2026-03-15'))
-      _mount(
-        `<el-date-picker
-          type="quarters"
-          v-model="value"
-        />`,
-        () => ({ value: [] as Date[] })
-      )
-      await nextTick()
-      const input = document.querySelector<HTMLInputElement>('input')!
-      input.blur()
-      await nextTick()
-      input.focus()
-      await nextTick()
-      triggerEvent(input, 'keydown', EVENT_CODE.down)
-      await nextTick()
-      expect(document.activeElement?.closest('.el-quarter-table')).toBeTruthy()
-    } finally {
-      vi.useRealTimers()
-    }
-  })
 })
 
 describe('QuarterRange', () => {

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -3926,47 +3926,6 @@ describe('Quarters', () => {
       vi.useRealTimers()
     }
   })
-
-  it('should navigate quarters with arrow keys without changing value', async () => {
-    vi.useFakeTimers()
-    try {
-      vi.setSystemTime(new Date('2026-03-15'))
-      const wrapper = _mount(
-        `<el-date-picker
-          type="quarters"
-          v-model="value"
-        />`,
-        () => ({ value: [] as Date[] })
-      )
-      await nextTick()
-      const input = document.querySelector<HTMLInputElement>('input')!
-      input.focus()
-      await nextTick()
-      triggerEvent(input, 'keydown', EVENT_CODE.down)
-      await nextTick()
-
-      expect(
-        document
-          .querySelector('.el-quarter-table td[tabindex="0"]')
-          ?.getAttribute('aria-label')
-      ).toBe('Q1')
-
-      const panelContent = document.querySelector(
-        '.el-picker-panel__content'
-      ) as HTMLElement
-      triggerEvent(panelContent, 'keydown', EVENT_CODE.right)
-      await nextTick()
-
-      expect(
-        document
-          .querySelector('.el-quarter-table td[tabindex="0"]')
-          ?.getAttribute('aria-label')
-      ).toBe('Q2')
-      expect((wrapper.vm as any).value).toEqual([])
-    } finally {
-      vi.useRealTimers()
-    }
-  })
 })
 
 describe('QuarterRange', () => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

rel #24490

~~1. Press `Enter` to accept the currently selected suggestion and close the popover.
https://www.w3.org/WAI/ARIA/apg/patterns/combobox/#:~:text=to%20focus%20movements.-,Enter,%3A%20Accepts%20the%20currently%20selected%20suggested%20value%20by%20closing%20the%20popup,-%2C%20placing%20the%20selected~~

2. The grid system only allows one suggestion to be selected at a time in the combobox.
https://www.w3.org/WAI/ARIA/apg/patterns/combobox/#:~:text=The%20grid%20allows%20only%20one%20suggested%20value%20to%20be%20selected%20at%20a%20time%20for%20the%20combobox%20value

Based on the above ~~two points~~ point, `quarters` may not be suitable for keyboard navigation. Other multi-select pickers also do not support keyboard navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus and navigation in the date picker’s quarter selection mode.
  * Quarter-specific keyboard controls now provide more consistent navigation between quarters.
  * Updated quarter selection behavior to avoid unexpected focus changes during keyboard interaction.

* **Tests**
  * Refined date-picker coverage to align with the updated quarter navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->