### PR TITLE
fix(components): [tabs] fix editable overflow spacing

### DIFF
--- a/packages/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/components/tabs/__tests__/tabs.test.tsx
@@ -24,6 +24,34 @@ const Comp = defineComponent({
   },
 })
 
+const transitionEnd = (propertyName: string) => {
+  const event = new Event('transitionend')
+  Object.defineProperty(event, 'propertyName', { value: propertyName })
+  return event
+}
+
+const mountEditableTabs = async () => {
+  const activeName = ref('first')
+  const wrapper = mount(() => (
+    <Tabs v-model={activeName.value} editable>
+      <TabPane name="first" label="First" />
+      <TabPane name="second" label="Second" />
+      <TabPane name="third" label="Third" />
+    </Tabs>
+  ))
+  await nextTick()
+
+  const closeIcon = (name: string) => {
+    const icon = wrapper.find(`#tab-${name} .is-icon-close`).element
+    vi.spyOn(icon, 'getBoundingClientRect').mockReturnValue({
+      width: 14,
+    } as DOMRect)
+    return icon
+  }
+
+  return { activeName, closeIcon, wrapper }
+}
+
 describe('Tabs.vue', () => {
   test('create', async () => {
     const wrapper = mount(() => (
@@ -741,6 +769,90 @@ describe('Tabs.vue', () => {
     mockOffsetLeft.mockRestore()
     mockComputedStyle.mockRestore()
     wrapper.unmount()
+  })
+
+  test('recalculates nav after the previous close icon width transition', async () => {
+    const { activeName, closeIcon, wrapper } = await mountEditableTabs()
+    const firstCloseIcon = closeIcon('first')
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockReturnValue(1)
+
+    activeName.value = 'second'
+    await nextTick()
+    requestAnimationFrame.mockClear()
+
+    firstCloseIcon.dispatchEvent(transitionEnd('width'))
+
+    expect(requestAnimationFrame).toHaveBeenCalledOnce()
+
+    requestAnimationFrame.mockRestore()
+    wrapper.unmount()
+  })
+
+  test('ignores non-width transitions on the previous close icon', async () => {
+    const { activeName, closeIcon, wrapper } = await mountEditableTabs()
+    const firstCloseIcon = closeIcon('first')
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockReturnValue(1)
+
+    activeName.value = 'second'
+    await nextTick()
+    requestAnimationFrame.mockClear()
+
+    firstCloseIcon.dispatchEvent(transitionEnd('opacity'))
+
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+
+    firstCloseIcon.dispatchEvent(transitionEnd('width'))
+    expect(requestAnimationFrame).toHaveBeenCalledOnce()
+
+    requestAnimationFrame.mockRestore()
+    wrapper.unmount()
+  })
+
+  test('cleans up a stale close icon listener after rapid tab changes', async () => {
+    const { activeName, closeIcon, wrapper } = await mountEditableTabs()
+    const firstCloseIcon = closeIcon('first')
+    const secondCloseIcon = closeIcon('second')
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockReturnValue(1)
+
+    activeName.value = 'second'
+    await nextTick()
+    activeName.value = 'third'
+    await nextTick()
+    requestAnimationFrame.mockClear()
+
+    firstCloseIcon.dispatchEvent(transitionEnd('width'))
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+
+    secondCloseIcon.dispatchEvent(transitionEnd('width'))
+    expect(requestAnimationFrame).toHaveBeenCalledOnce()
+
+    requestAnimationFrame.mockRestore()
+    wrapper.unmount()
+  })
+
+  test('cleans up the close icon listener when tabs unmount', async () => {
+    const { activeName, closeIcon, wrapper } = await mountEditableTabs()
+    const firstCloseIcon = closeIcon('first')
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockReturnValue(1)
+
+    activeName.value = 'second'
+    await nextTick()
+    requestAnimationFrame.mockClear()
+    wrapper.unmount()
+
+    firstCloseIcon.dispatchEvent(transitionEnd('width'))
+
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+
+    requestAnimationFrame.mockRestore()
   })
 
   test('value type', async () => {

--- a/packages/components/tabs/src/tab-nav.tsx
+++ b/packages/components/tabs/src/tab-nav.tsx
@@ -356,6 +356,28 @@ const TabNav = defineComponent({
       rAF(update)
     })
 
+    watch(
+      () => props.currentName,
+      (_, oldName, onCleanup) => {
+        const previousTab = tabRefsMap.value[oldName]
+        const closeIcon =
+          previousTab?.querySelector<HTMLElement>('.is-icon-close')
+        if (!closeIcon || closeIcon.getBoundingClientRect().width === 0) return
+
+        const handleTransitionEnd = (event: TransitionEvent) => {
+          if (event.propertyName !== 'width') return
+
+          closeIcon.removeEventListener('transitionend', handleTransitionEnd)
+          rAF(update)
+        }
+
+        closeIcon.addEventListener('transitionend', handleTransitionEnd)
+        onCleanup(() =>
+          closeIcon.removeEventListener('transitionend', handleTransitionEnd)
+        )
+      }
+    )
+
     onMounted(() => setTimeout(() => scrollToActiveTab(), 0))
     onUpdated(() => update())
 


### PR DESCRIPTION
## Summary

- wait for the previous active tab close icon width transition before recalculating the nav overflow state
- ignore unrelated transition properties and schedule the existing update through requestAnimationFrame
- clean up stale transition listeners after rapid tab changes and component unmount

## Tests

- pnpm test packages/components/tabs/__tests__/tabs.test.tsx (34 tests)
- pnpm test --run (162 files, 2618 tests)
- pnpm lint
- pnpm typecheck

Closes #23794

- [x] Make sure you follow the contributing guide.
- [x] Make sure you are merging your commits to the dev branch.
- [x] Add some descriptions and refer to relative issues for your PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab layout recalculation after a previous tab’s close icon finishes resizing.
  * Prevented outdated transition events from affecting the tab navigation.
  * Ensured event listeners are properly cleaned up during rapid tab changes and component removal.

* **Tests**
  * Added coverage for transition handling, unrelated events, rapid tab changes, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->