### PR TITLE
fix(components): [table] support SSR rendering

### DIFF
--- a/packages/components/table/__tests__/table-column.test.ts
+++ b/packages/components/table/__tests__/table-column.test.ts
@@ -1033,6 +1033,33 @@ describe('table column', () => {
   })
 
   describe('multi level column', () => {
+    it('should ignore removing an absent subcolumn', async () => {
+      const wrapper = mount({
+        components: {
+          ElTable,
+          ElTableColumn,
+        },
+        template: `
+          <el-table ref="table">
+            <el-table-column label="group">
+              <el-table-column prop="release" />
+              <el-table-column prop="director" />
+            </el-table-column>
+          </el-table>
+        `,
+      })
+
+      await doubleWait()
+      const store = wrapper.vm.$refs.table.store
+      const parent = store.states._columns.value[0]
+      const children = [...parent.children]
+
+      store.commit('removeColumn', { id: 'absent-column' }, parent, vi.fn())
+
+      expect(parent.children).toEqual(children)
+      wrapper.unmount()
+    })
+
     it('should works', async () => {
       const wrapper = mount({
         components: {

--- a/packages/components/table/__tests__/table.hydration.test.tsx
+++ b/packages/components/table/__tests__/table.hydration.test.tsx
@@ -1,9 +1,10 @@
-import { createSSRApp, defineComponent, h } from 'vue'
+import { createSSRApp, defineComponent, h, nextTick } from 'vue'
 import { renderToString } from '@vue/server-renderer'
 import { describe, expect, it } from 'vitest'
 import { ID_INJECTION_KEY } from '@element-plus/hooks'
 import ElTable from '../src/table.vue'
 import ElTableColumn from '../src/table-column'
+import { rAF } from '@element-plus/test-utils/tick.js'
 
 const TableApp = defineComponent({
   setup() {
@@ -11,19 +12,21 @@ const TableApp = defineComponent({
       {
         date: '2016-05-03',
         name: 'Tom',
+        address: 'No. 189, Grove St, Los Angeles',
       },
     ]
 
     return () =>
       h(ElTable, { data }, () => [
-        h(ElTableColumn, { prop: 'date', label: 'Date' }),
-        h(ElTableColumn, { prop: 'name', label: 'Name' }),
+        h(ElTableColumn, { prop: 'date', label: 'Date', width: 180 }),
+        h(ElTableColumn, { prop: 'name', label: 'Name', width: 180 }),
+        h(ElTableColumn, { prop: 'address', label: 'Address' }),
       ])
   },
 })
 
-const createTableApp = () => {
-  const app = createSSRApp(TableApp)
+const createTableApp = (rootComponent = TableApp) => {
+  const app = createSSRApp(rootComponent)
   app.provide(ID_INJECTION_KEY, { prefix: 1024, current: 0 })
   return app
 }
@@ -35,25 +38,27 @@ describe('table hydration', () => {
 
     expect(
       container.querySelectorAll('.el-table__header colgroup col')
-    ).toHaveLength(2)
+    ).toHaveLength(3)
     expect(
       container.querySelectorAll('.el-table__body colgroup col')
-    ).toHaveLength(2)
-
+    ).toHaveLength(3)
     const app = createTableApp()
 
     app.mount(container)
+    await nextTick()
+    await rAF()
+    await rAF()
 
     expect(
       container.querySelectorAll('.el-table__header colgroup col')
-    ).toHaveLength(2)
+    ).toHaveLength(3)
     expect(
       container.querySelectorAll('.el-table__body colgroup col')
-    ).toHaveLength(2)
+    ).toHaveLength(3)
     expect(container.querySelectorAll('.el-table__header .cell')).toHaveLength(
-      2
+      3
     )
-    expect(container.querySelectorAll('.el-table__body td')).toHaveLength(2)
+    expect(container.querySelectorAll('.el-table__body td')).toHaveLength(3)
 
     app.unmount()
   })

--- a/packages/components/table/__tests__/table.hydration.test.tsx
+++ b/packages/components/table/__tests__/table.hydration.test.tsx
@@ -1,0 +1,60 @@
+import { createSSRApp, defineComponent, h } from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import { describe, expect, it } from 'vitest'
+import { ID_INJECTION_KEY } from '@element-plus/hooks'
+import ElTable from '../src/table.vue'
+import ElTableColumn from '../src/table-column'
+
+const TableApp = defineComponent({
+  setup() {
+    const data = [
+      {
+        date: '2016-05-03',
+        name: 'Tom',
+      },
+    ]
+
+    return () =>
+      h(ElTable, { data }, () => [
+        h(ElTableColumn, { prop: 'date', label: 'Date' }),
+        h(ElTableColumn, { prop: 'name', label: 'Name' }),
+      ])
+  },
+})
+
+const createTableApp = () => {
+  const app = createSSRApp(TableApp)
+  app.provide(ID_INJECTION_KEY, { prefix: 1024, current: 0 })
+  return app
+}
+
+describe('table hydration', () => {
+  it('keeps server-rendered cells during hydration', async () => {
+    const container = document.createElement('div')
+    container.innerHTML = await renderToString(createTableApp())
+
+    expect(
+      container.querySelectorAll('.el-table__header colgroup col')
+    ).toHaveLength(2)
+    expect(
+      container.querySelectorAll('.el-table__body colgroup col')
+    ).toHaveLength(2)
+
+    const app = createTableApp()
+
+    app.mount(container)
+
+    expect(
+      container.querySelectorAll('.el-table__header colgroup col')
+    ).toHaveLength(2)
+    expect(
+      container.querySelectorAll('.el-table__body colgroup col')
+    ).toHaveLength(2)
+    expect(container.querySelectorAll('.el-table__header .cell')).toHaveLength(
+      2
+    )
+    expect(container.querySelectorAll('.el-table__body td')).toHaveLength(2)
+
+    app.unmount()
+  })
+})

--- a/packages/components/table/__tests__/table.hydration.test.tsx
+++ b/packages/components/table/__tests__/table.hydration.test.tsx
@@ -35,6 +35,22 @@ describe('table hydration', () => {
   it('keeps server-rendered cells during hydration', async () => {
     const container = document.createElement('div')
     container.innerHTML = await renderToString(createTableApp())
+    const getCellText = (selector: string) =>
+      [...container.querySelectorAll(selector)].map((cell) =>
+        cell.textContent?.trim()
+      )
+    const expectRenderedCellContent = () => {
+      expect(getCellText('.el-table__header .cell')).toEqual([
+        'Date',
+        'Name',
+        'Address',
+      ])
+      expect(getCellText('.el-table__body td .cell')).toEqual([
+        '2016-05-03',
+        'Tom',
+        'No. 189, Grove St, Los Angeles',
+      ])
+    }
 
     expect(
       container.querySelectorAll('.el-table__header colgroup col')
@@ -42,6 +58,7 @@ describe('table hydration', () => {
     expect(
       container.querySelectorAll('.el-table__body colgroup col')
     ).toHaveLength(3)
+    expectRenderedCellContent()
     const app = createTableApp()
 
     app.mount(container)
@@ -59,6 +76,7 @@ describe('table hydration', () => {
       3
     )
     expect(container.querySelectorAll('.el-table__body td')).toHaveLength(3)
+    expectRenderedCellContent()
 
     app.unmount()
   })

--- a/packages/components/table/__tests__/table.ssr.test.tsx
+++ b/packages/components/table/__tests__/table.ssr.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment node
+ */
+
+import { createSSRApp, h } from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import { describe, expect, it } from 'vitest'
+import { ID_INJECTION_KEY } from '@element-plus/hooks'
+import ElTable from '../src/table.vue'
+import ElTableColumn from '../src/table-column'
+
+describe('table SSR', () => {
+  it('renders columns and data on the server', async () => {
+    const data = [
+      {
+        date: '2016-05-03',
+        name: 'Tom',
+      },
+    ]
+    const app = createSSRApp({
+      render: () =>
+        h(ElTable, { data }, () => [
+          h(ElTableColumn, { prop: 'date', label: 'Date' }),
+          h(ElTableColumn, { prop: 'name', label: 'Name' }),
+        ]),
+    })
+    app.provide(ID_INJECTION_KEY, { prefix: 1024, current: 0 })
+
+    const html = await renderToString(app)
+
+    expect(html).toContain('Date')
+    expect(html).toContain('Name')
+    expect(html).toContain('2016-05-03')
+    expect(html).toContain('Tom')
+  })
+
+  it('renders grouped columns on the server', async () => {
+    const app = createSSRApp({
+      render: () =>
+        h(ElTable, { data: [{ name: 'Tom', release: '2026-08-15' }] }, () => [
+          h(ElTableColumn, { prop: 'name', label: 'Name' }),
+          h(ElTableColumn, { label: 'Group' }, () => [
+            h(ElTableColumn, { prop: 'release', label: 'Release' }),
+          ]),
+        ]),
+    })
+    app.provide(ID_INJECTION_KEY, { prefix: 1024, current: 0 })
+
+    const html = await renderToString(app)
+
+    expect(html).toContain('Group')
+    expect(html).toContain('Release')
+    expect(html).toContain('2026-08-15')
+  })
+})

--- a/packages/components/table/src/h-helper.ts
+++ b/packages/components/table/src/h-helper.ts
@@ -1,17 +1,18 @@
-import { h } from 'vue'
+import { h, unref } from 'vue'
 import { isUndefined } from '@element-plus/utils'
 
+import type { MaybeRef } from 'vue'
 import type { TableColumnCtx } from './table-column/defaults'
 import type { DefaultRow } from './table/defaults'
 
 type Props = {
   tableLayout: 'fixed' | 'auto'
-  columns?: TableColumnCtx<DefaultRow>[]
+  columns?: MaybeRef<TableColumnCtx<DefaultRow>[]>
 }
 
 export function hColgroup(props: Props) {
   const isAuto = props.tableLayout === 'auto'
-  let columns = props.columns || []
+  let columns = unref(props.columns) || []
   if (isAuto) {
     if (columns.every(({ width }) => isUndefined(width))) {
       columns = []

--- a/packages/components/table/src/layout-observer.ts
+++ b/packages/components/table/src/layout-observer.ts
@@ -35,7 +35,8 @@ function useLayoutObserver<T extends DefaultRow>(root: Table<T>) {
     return layout
   })
   const onColumnsChange = (layout: TableLayout<T>) => {
-    const cols = root.vnode.el?.querySelectorAll('colgroup > col') || []
+    const cols =
+      root.refs.tableWrapper?.querySelectorAll('colgroup > col') || []
     if (!cols.length) return
     const flattenColumns = layout.getFlattenColumns()
     const columnsMap: Record<string, TableColumnCtx<T>> = {}
@@ -45,21 +46,28 @@ function useLayoutObserver<T extends DefaultRow>(root: Table<T>) {
     for (let i = 0, j = cols.length; i < j; i++) {
       const col = cols[i]
       const name = col.getAttribute('name')
-      const column = columnsMap[name]
+      const column = name && columnsMap[name]
       if (column) {
-        col.setAttribute('width', column.realWidth || column.width)
+        col.setAttribute('width', (column.realWidth || column.width) as string)
       }
     }
   }
 
   const onScrollableChange = (layout: TableLayout<T>) => {
     const cols =
-      root.vnode.el?.querySelectorAll('colgroup > col[name=gutter]') || []
+      root.refs.tableWrapper?.querySelectorAll('colgroup > col[name=gutter]') ||
+      []
     for (let i = 0, j = cols.length; i < j; i++) {
       const col = cols[i]
-      col.setAttribute('width', layout.scrollY.value ? layout.gutterWidth : '0')
+      col.setAttribute(
+        'width',
+        String(layout.scrollY.value ? layout.gutterWidth : '0')
+      )
     }
-    const ths = root.vnode.el?.querySelectorAll('th.gutter') || []
+    const ths =
+      root.refs.tableWrapper?.querySelectorAll<HTMLTableCellElement>(
+        'th.gutter'
+      ) || []
     for (let i = 0, j = ths.length; i < j; i++) {
       const th = ths[i]
       th.style.width = layout.scrollY.value ? `${layout.gutterWidth}px` : '0'

--- a/packages/components/table/src/store/index.ts
+++ b/packages/components/table/src/store/index.ts
@@ -1,5 +1,6 @@
 import { getCurrentInstance, nextTick, unref } from 'vue'
 import { isNull } from 'lodash-unified'
+import { isUndefined } from '@element-plus/utils'
 import { useLocale, useNamespace } from '@element-plus/hooks'
 import useWatcher from './watcher'
 
@@ -97,8 +98,8 @@ function useStore<T extends DefaultRow>() {
         states.selectable.value = column.selectable
         states.reserveSelection.value = column.reserveSelection
       }
+      instance.store.updateColumns()
       if (instance.$ready) {
-        instance.store.updateColumns() // hack for dynamics insert column
         instance.store.scheduleLayout()
       }
     },
@@ -122,10 +123,12 @@ function useStore<T extends DefaultRow>() {
     ) {
       const array = unref(states._columns) || []
       if (parent) {
-        parent.children?.splice(
-          parent.children.findIndex((item) => item.id === column.id),
-          1
+        const index = parent.children?.findIndex(
+          (item) => item.id === column.id
         )
+        if (!isUndefined(index) && index >= 0) {
+          parent.children?.splice(index, 1)
+        }
         // fix #10699, delete parent.children immediately will trigger again
         nextTick(() => {
           if (parent.children?.length === 0) {
@@ -144,8 +147,8 @@ function useStore<T extends DefaultRow>() {
       const updateFnIndex = states.updateOrderFns.indexOf(updateColumnOrder)
       updateFnIndex > -1 && states.updateOrderFns.splice(updateFnIndex, 1)
 
+      instance.store.updateColumns()
       if (instance.$ready) {
-        instance.store.updateColumns() // hack for dynamics remove column
         instance.store.scheduleLayout()
       }
     },

--- a/packages/components/table/src/table-column/index.vue
+++ b/packages/components/table/src/table-column/index.vue
@@ -8,11 +8,11 @@ import {
   computed,
   getCurrentInstance,
   h,
-  onBeforeMount,
   onBeforeUnmount,
   onMounted,
   ref,
 } from 'vue'
+import { useId } from '@element-plus/hooks'
 import { useGlobalConfig } from '@element-plus/components/config-provider'
 import { isArray, isString, isUndefined } from '@element-plus/utils'
 import { cellStarts } from '../config'
@@ -80,117 +80,112 @@ const {
 
 const parent = columnOrTableParent.value
 const parentId = 'tableId' in parent ? parent.tableId : parent.columnId
-columnId.value = createTableColumnId(parentId)
+columnId.value = createTableColumnId(parentId, useId().value)
 
-onBeforeMount(() => {
-  isSubColumn.value = owner.value !== parent
+isSubColumn.value = owner.value !== parent
 
-  const type = (props.type as keyof typeof cellStarts) || 'default'
-  const sortable = props.sortable === '' ? true : props.sortable
-  //The selection column should not be affected by `showOverflowTooltip`.
-  const showOverflowTooltip =
-    type === 'selection'
-      ? false
-      : isUndefined(props.showOverflowTooltip)
-        ? (parent.props.showOverflowTooltip ??
-          globalConfig.value?.showOverflowTooltip)
-        : props.showOverflowTooltip
-  const tooltipFormatter = isUndefined(props.tooltipFormatter)
-    ? (parent.props.tooltipFormatter ?? globalConfig.value?.tooltipFormatter)
-    : props.tooltipFormatter
-  const defaults = {
-    ...cellStarts[type],
-    id: columnId.value,
-    type,
-    property: props.prop || props.property,
-    align: realAlign,
-    headerAlign: realHeaderAlign,
-    showOverflowTooltip,
-    tooltipFormatter,
-    // filter 相关属性
-    filterable: props.filters || props.filterMethod,
-    filteredValue: [],
-    filterPlacement: '',
-    filterClassName: '',
-    isColumnGroup: false,
-    isSubColumn: false,
-    filterOpened: false,
-    // sort 相关属性
-    sortable,
-    // index 列
-    index: props.index,
-    // <el-table-column key="xxx" />
-    rawColumnKey: instance.vnode.key,
-  }
+const type = (props.type as keyof typeof cellStarts) || 'default'
+const sortable = props.sortable === '' ? true : props.sortable
+//The selection column should not be affected by `showOverflowTooltip`.
+const showOverflowTooltip =
+  type === 'selection'
+    ? false
+    : isUndefined(props.showOverflowTooltip)
+      ? (parent.props.showOverflowTooltip ??
+        globalConfig.value?.showOverflowTooltip)
+      : props.showOverflowTooltip
+const tooltipFormatter = isUndefined(props.tooltipFormatter)
+  ? (parent.props.tooltipFormatter ?? globalConfig.value?.tooltipFormatter)
+  : props.tooltipFormatter
+const defaults = {
+  ...cellStarts[type],
+  id: columnId.value,
+  type,
+  property: props.prop || props.property,
+  align: realAlign,
+  headerAlign: realHeaderAlign,
+  showOverflowTooltip,
+  tooltipFormatter,
+  // filter 相关属性
+  filterable: props.filters || props.filterMethod,
+  filteredValue: [],
+  filterPlacement: '',
+  filterClassName: '',
+  isColumnGroup: false,
+  isSubColumn: false,
+  filterOpened: false,
+  // sort 相关属性
+  sortable,
+  // index 列
+  index: props.index,
+  // <el-table-column key="xxx" />
+  rawColumnKey: instance.vnode.key,
+}
 
-  const basicProps = [
-    'columnKey',
-    'label',
-    'className',
-    'labelClassName',
-    'type',
-    'renderHeader',
-    'formatter',
-    'fixed',
-    'resizable',
-  ]
-  const sortProps = ['sortMethod', 'sortBy', 'sortOrders']
-  const selectProps = ['selectable', 'reserveSelection']
-  const filterProps = [
-    'filterMethod',
-    'filters',
-    'filterMultiple',
-    'filterOpened',
-    'filteredValue',
-    'filterPlacement',
-    'filterClassName',
-  ]
+const basicProps = [
+  'columnKey',
+  'label',
+  'className',
+  'labelClassName',
+  'type',
+  'renderHeader',
+  'formatter',
+  'fixed',
+  'resizable',
+]
+const sortProps = ['sortMethod', 'sortBy', 'sortOrders']
+const selectProps = ['selectable', 'reserveSelection']
+const filterProps = [
+  'filterMethod',
+  'filters',
+  'filterMultiple',
+  'filterOpened',
+  'filteredValue',
+  'filterPlacement',
+  'filterClassName',
+]
 
-  let column = getPropsData(basicProps, sortProps, selectProps, filterProps)
+let column = getPropsData(basicProps, sortProps, selectProps, filterProps)
 
-  column = mergeOptions(defaults, column)
-  // 注意 compose 中函数执行的顺序是从右到左
-  const chains = compose(setColumnRenders, setColumnWidth, setColumnForcedProps)
-  column = chains(column) as unknown as TableColumnCtx<T>
-  columnConfig.value = column
+column = mergeOptions(defaults, column)
+// 注意 compose 中函数执行的顺序是从右到左
+const chains = compose(setColumnRenders, setColumnWidth, setColumnForcedProps)
+column = chains(column) as unknown as TableColumnCtx<T>
+columnConfig.value = column
 
-  // 注册 watcher
-  registerNormalWatchers()
-  registerComplexWatchers()
-})
+// 注册 watcher
+registerNormalWatchers()
+registerComplexWatchers()
 
-onMounted(() => {
-  const parent = columnOrTableParent.value
+const getColumnIndex = () => {
   const children = isSubColumn.value
     ? parent.vnode.el?.children
     : parent.refs.hiddenColumns?.children
-  const getColumnIndex = () =>
-    getColumnElIndex(children || [], instance.vnode.el)
-  columnConfig.value.getColumnIndex = getColumnIndex
-  const columnIndex = getColumnIndex()
-  columnIndex > -1 &&
-    owner.value.store.commit(
-      'insertColumn',
-      columnConfig.value,
-      isSubColumn.value
-        ? 'columnConfig' in parent && parent.columnConfig.value
-        : null,
-      updateColumnOrder
-    )
+  return getColumnElIndex(children || [], instance.vnode.el)
+}
+columnConfig.value.getColumnIndex = getColumnIndex
+owner.value.store.commit(
+  'insertColumn',
+  columnConfig.value,
+  isSubColumn.value
+    ? 'columnConfig' in parent && parent.columnConfig.value
+    : null,
+  updateColumnOrder
+)
+
+onMounted(() => {
+  updateColumnOrder()
 })
 
 onBeforeUnmount(() => {
-  const getColumnIndex = columnConfig.value.getColumnIndex
-  const columnIndex = getColumnIndex ? getColumnIndex() : -1
-  columnIndex > -1 &&
-    owner.value.store.commit(
-      'removeColumn',
-      columnConfig.value,
-      isSubColumn.value
-        ? 'columnConfig' in parent && parent.columnConfig.value
-        : null,
-      updateColumnOrder
-    )
+  owner.value.store.commit(
+    'removeColumn',
+    columnConfig.value,
+    isSubColumn.value
+      ? 'columnConfig' in parent && parent.columnConfig.value
+      : null,
+    updateColumnOrder
+  )
 })
 
 instance.columnId = columnId.value

--- a/packages/components/table/src/table.vue
+++ b/packages/components/table/src/table.vue
@@ -45,7 +45,7 @@
           cellspacing="0"
         >
           <hColgroup
-            :columns="store.states.columns.value"
+            :columns="store.states.columns"
             :table-layout="tableLayout"
           />
           <table-header
@@ -81,7 +81,7 @@
             }"
           >
             <hColgroup
-              :columns="store.states.columns.value"
+              :columns="store.states.columns"
               :table-layout="tableLayout"
             />
             <table-header
@@ -148,7 +148,7 @@
           :style="tableBodyStyles"
         >
           <hColgroup
-            :columns="store.states.columns.value"
+            :columns="store.states.columns"
             :table-layout="tableLayout"
           />
           <table-footer
@@ -174,7 +174,7 @@
 import { computed, getCurrentInstance, onBeforeUnmount, provide } from 'vue'
 import { debounce } from 'lodash-unified'
 import { Mousewheel as vMousewheel } from '@element-plus/directives'
-import { useLocale, useNamespace } from '@element-plus/hooks'
+import { useId, useLocale, useNamespace } from '@element-plus/hooks'
 import { useGlobalConfig } from '@element-plus/components/config-provider'
 import ElScrollbar from '@element-plus/components/scrollbar'
 import { createStore } from './store/helper'
@@ -279,7 +279,7 @@ const { scrollBarRef, scrollTo, setScrollLeft, setScrollTop } = useScrollbar()
 
 const debouncedUpdateLayout = debounce(doLayout, 50)
 
-const tableId = createTableId(ns.namespace.value)
+const tableId = createTableId(ns.namespace.value, useId().value)
 const context = table
 table.tableId = tableId
 table.state = {

--- a/packages/components/table/src/table/key-render-helper.ts
+++ b/packages/components/table/src/table/key-render-helper.ts
@@ -6,15 +6,15 @@ export default function useKeyRender<T extends DefaultRow>(table: Table<T>) {
   let observer: MutationObserver | undefined
 
   const initWatchDom = () => {
-    const el = table.vnode.el
-    const columnsWrapper = (el as HTMLElement).querySelector('.hidden-columns')
+    const columnsWrapper = table.refs.hiddenColumns
+    if (!columnsWrapper) return
     const config = { childList: true, subtree: true }
     const updateOrderFns = table.store.states.updateOrderFns
     observer = new MutationObserver(() => {
       updateOrderFns.forEach((fn: () => void) => fn())
     })
 
-    observer.observe(columnsWrapper!, config)
+    observer.observe(columnsWrapper, config)
   }
 
   onMounted(() => {

--- a/packages/components/table/src/util.ts
+++ b/packages/components/table/src/util.ts
@@ -20,14 +20,11 @@ import type { DefaultRow, Table, TreeProps } from './table/defaults'
 import type { TableColumnCtx } from './table-column/defaults'
 import type { CSSProperties, VNode, VNodeArrayChildren } from 'vue'
 
-let tableIdSeed = 1
-let columnIdSeed = 1
+export const createTableId = (namespace: string, id: string) =>
+  `${namespace}-table_${id}`
 
-export const createTableId = (namespace: string) =>
-  `${namespace}-table_${tableIdSeed++}`
-
-export const createTableColumnId = (parentId: string) =>
-  `${parentId}_column_${columnIdSeed++}`
+export const createTableColumnId = (parentId: string, id: string) =>
+  `${parentId}_column_${id}`
 
 export type TableOverflowTooltipOptions = Partial<
   Omit<


### PR DESCRIPTION
close #24712 
close #24713


`ElTableColumn` previously initialized and registered columns in `onBeforeMount`. Since mount lifecycle hooks are not invoked during SSR, the table store had no columns while rendering on the server. As a result, the table content appeared only after client-side hydration, causing a visible flash.

This PR:

- initializes and registers columns during `setup()`, making them available during SSR

- uses `useId()` to generate stable table and column IDs across SSR and hydration

- updates normalized columns immediately when columns are inserted or removed

- keeps DOM-order synchronization in `onMounted`

- makes `removeColumn` a no-op when the target column is absent

- passes the columns ref to `hColgroup` and resolves it during its render, ensuring header and body colgroups contain all columns in the initial SSR output

## Tests

Added regression coverage for:

- rendering regular table columns and data during SSR

- rendering grouped columns during SSR

- preserving header cells, body cells, and colgroups during hydration

- removing an absent nested column without deleting the last sibling

_This PR was generated with OpenAI Codex and reviewed by the author._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved reliability when adding or removing nested table columns, including safely handling nonexistent columns.
* Preserved table structure and data during server-side rendering and client hydration.
* Improved table layout measurements and column sizing across rendering scenarios.
* Improved consistency of table and column identification.

## Tests

* Added coverage for grouped columns, server-side rendering, hydration, and nested-column updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->