### PR TITLE
fix(tabs): prevent SSR flash by pre-rendering active bar during server render

### DIFF
--- a/packages/components/tabs/src/tab-bar.vue
+++ b/packages/components/tabs/src/tab-bar.vue
@@ -32,18 +32,21 @@ if (!rootTabs) throwError(COMPONENT_NAME, '<el-tabs><el-tab-bar /></el-tabs>')
 const ns = useNamespace('tabs')
 
 const barRef = ref<HTMLDivElement>()
-const barStyle = ref<CSSProperties>()
+const barStyle = ref<CSSProperties>({ opacity: 0 })
 /**
  * when defaultValue is not set, the bar is always shown.
  *
  * when defaultValue is set, the bar will be hidden until style is calculated
  * to avoid the bar showing in the wrong position on initial render.
  */
-const renderActiveBar = computed(
-  () =>
+const renderActiveBar = computed(() => {
+  // Always render the active bar during SSR to prevent flash on hydration
+  if (typeof window === 'undefined') return true
+  return (
     isUndefined(rootTabs.props.defaultValue) ||
     Boolean(barStyle.value?.transform)
-)
+  )
+})
 
 const getBarStyle = (): CSSProperties => {
   let offset = 0


### PR DESCRIPTION
## What

Fixes the SSR flash on `el-tabs` in Nuxt 4 SSR apps (#24733). When `default-value`/`model-value` was set, the active-bar (`tab-bar.vue`) was **hidden during server render** because `renderActiveBar` computed depended on DOM measurements (`barStyle.transform`) that don't exist on the server.

During hydration the bar suddenly appeared, causing the visible flicker.

## Why

Element Plus is SSR-compatible (Nuxt module, SSR mode). Components must render stable HTML on the server so hydration doesn't cause visual jumps.

## How

- `barStyle` initialised to `{ opacity: 0 }` — the bar is in the DOM during SSR but invisible
- `renderActiveBar` now returns `true` during SSR (`typeof window === 'undefined'`)
- After hydration, the client computes the real position and `barStyle` is replaced with the measured transform (which has no `opacity`, so it becomes visible)

## Verification

- [ ] SSR render contains the `el-tabs__active-bar` element
- [ ] No flash of missing active bar on hydration in Nuxt SSR
- [ ] Existing behavior preserved: when `defaultValue` is set, bar still waits for correct position before showing (opacity 0 until measured)

Closes #24733


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab bar loading behavior to prevent visual flashes during server-side rendering.
  * Ensured the active tab indicator appears consistently when a default tab is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->