### PR TITLE
Revert "fix(components): [select/v2] hide empty input-wrapper only when multiple (#23394, #24177)"

### DIFF
--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -3040,29 +3040,6 @@ describe('Select', () => {
       // When empty again, should be hidden
       expect(inputWrapper.classes()).toContain('is-hidden')
     })
-
-    // #24167: in single mode the empty/blur condition must NOT hide the
-    // input-wrapper, otherwise it falls out of flow and the selection
-    // collapses to zero width inside auto-sized form layouts.
-    it('should not hide input-wrapper in single mode when empty and not focused', async () => {
-      const wrapper = createSelect({
-        data: () => ({
-          filterable: true,
-        }),
-      })
-      await nextTick()
-      const select = wrapper.findComponent(Select)
-      const inputWrapper = select.find('.el-select__input-wrapper')
-      const input = select.find('input')
-
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      await input.trigger('focus')
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      await input.trigger('blur')
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-    })
   })
 
   it('should not bubble native change event from filter input', async () => {

--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -2984,64 +2984,6 @@ describe('Select', () => {
     expect((select.vm as any).expanded).toBe(true)
   })
 
-  describe('input-wrapper in multiple mode', () => {
-    it('should hide input-wrapper when empty and not focused', async () => {
-      const wrapper = createSelect({
-        data: () => ({
-          multiple: true,
-          filterable: true,
-        }),
-      })
-      await nextTick()
-      const select = wrapper.findComponent(Select)
-      const inputWrapper = select.find('.el-select__input-wrapper')
-      const input = select.find('input')
-
-      // When input is empty and not focused, input-wrapper should have hidden class
-      expect(inputWrapper.classes()).toContain('is-hidden')
-
-      // Focus the input
-      await input.trigger('focus')
-
-      // When focused, input-wrapper should not have hidden class
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      // Blur the input
-      await input.trigger('blur')
-
-      // When blurred and empty, input-wrapper should have hidden class again
-      expect(inputWrapper.classes()).toContain('is-hidden')
-    })
-
-    it('should show input-wrapper when input has value', async () => {
-      const wrapper = createSelect({
-        data: () => ({
-          multiple: true,
-          filterable: true,
-        }),
-      })
-      await nextTick()
-      const select = wrapper.findComponent(Select)
-      const inputWrapper = select.find('.el-select__input-wrapper')
-      const input = select.find('input')
-
-      // Initially empty, should be hidden
-      expect(inputWrapper.classes()).toContain('is-hidden')
-
-      // Set input value
-      await input.setValue('test')
-
-      // When input has value, input-wrapper should not have hidden class
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      // Clear input
-      await input.setValue('')
-
-      // When empty again, should be hidden
-      expect(inputWrapper.classes()).toContain('is-hidden')
-    })
-  })
-
   it('should not bubble native change event from filter input', async () => {
     const wrapper = createSelect({
       data: () => ({ filterable: true }),

--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -173,12 +173,7 @@
               :class="[
                 nsSelect.e('selected-item'),
                 nsSelect.e('input-wrapper'),
-                nsSelect.is(
-                  'hidden',
-                  !filterable ||
-                    selectDisabled ||
-                    (!states.inputValue && !isFocused)
-                ),
+                nsSelect.is('hidden', !filterable || selectDisabled),
               ]"
             >
               <input

--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -177,7 +177,7 @@
                   'hidden',
                   !filterable ||
                     selectDisabled ||
-                    (multiple && !states.inputValue && !isFocused)
+                    (!states.inputValue && !isFocused)
                 ),
               ]"
             >

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4450,25 +4450,6 @@ describe('Select', () => {
       // When empty again, should be hidden
       expect(inputWrapper.classes()).toContain('is-hidden')
     })
-
-    // #24167: in single mode the empty/blur condition must NOT hide the
-    // input-wrapper, otherwise it falls out of flow and the selection
-    // collapses to zero width inside auto-sized form layouts.
-    test('should not hide input-wrapper in single mode when empty and not focused', async () => {
-      wrapper = getSelectVm({
-        filterable: true,
-      })
-      const inputWrapper = wrapper.find('.el-select__input-wrapper')
-      const input = wrapper.find('input')
-
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      await input.trigger('focus')
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      await input.trigger('blur')
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-    })
   })
 
   it('should not bubble native change event from filter input', async () => {

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4402,56 +4402,6 @@ describe('Select', () => {
     vi.useRealTimers()
   })
 
-  describe('input-wrapper in multiple mode', () => {
-    test('should hide input-wrapper when empty and not focused', async () => {
-      wrapper = getSelectVm({
-        multiple: true,
-        filterable: true,
-      })
-      const inputWrapper = wrapper.find('.el-select__input-wrapper')
-      const input = wrapper.find('input')
-
-      // When input is empty and not focused, input-wrapper should have hidden class
-      expect(inputWrapper.classes()).toContain('is-hidden')
-
-      // Focus the input
-      await input.trigger('focus')
-
-      // When focused, input-wrapper should not have hidden class
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      // Blur the input
-      await input.trigger('blur')
-
-      // When blurred and empty, input-wrapper should have hidden class again
-      expect(inputWrapper.classes()).toContain('is-hidden')
-    })
-
-    test('should show input-wrapper when input has value', async () => {
-      wrapper = getSelectVm({
-        multiple: true,
-        filterable: true,
-      })
-      const inputWrapper = wrapper.find('.el-select__input-wrapper')
-      const input = wrapper.find('input')
-
-      // Initially empty, should be hidden
-      expect(inputWrapper.classes()).toContain('is-hidden')
-
-      // Set input value
-      await input.setValue('test')
-
-      // When input has value, input-wrapper should not have hidden class
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      // Clear input
-      await input.setValue('')
-
-      // When empty again, should be hidden
-      expect(inputWrapper.classes()).toContain('is-hidden')
-    })
-  })
-
   it('should not bubble native change event from filter input', async () => {
     const wrapper = mount({
       template: `

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -175,7 +175,7 @@
                   'hidden',
                   !filterable ||
                     selectDisabled ||
-                    (multiple && !states.inputValue && !isFocused)
+                    (!states.inputValue && !isFocused)
                 ),
               ]"
             >

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -171,12 +171,7 @@
               :class="[
                 nsSelect.e('selected-item'),
                 nsSelect.e('input-wrapper'),
-                nsSelect.is(
-                  'hidden',
-                  !filterable ||
-                    selectDisabled ||
-                    (!states.inputValue && !isFocused)
-                ),
+                nsSelect.is('hidden', !filterable || selectDisabled),
               ]"
             >
               <input


### PR DESCRIPTION
This reverts commit https://github.com/element-plus/element-plus/pull/23394, https://github.com/element-plus/element-plus/pull/24177

Removing the `input-wrapper` from the flex flow creates a circular dependency between the `selectionWidth` and tag `maxWidth`, causing incorrect tag sizing and ResizeObserver loops.

Although the original extra-row issue may return, restoring stable tag sizing provides significantly more benefit than the localized issue being reintroduced.

close #24457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Select input wrappers now remain visible for multiple selections when filtering is enabled, even when the field is unfocused or empty.
  * Input wrappers continue to be hidden when filtering or the select control is disabled.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->