### PR TITLE
fix(components): [message, notification] call nextZIndex eagerly to prevent z-index conflicts with overlays

### DIFF
--- a/packages/components/message/src/message.vue
+++ b/packages/components/message/src/message.vue
@@ -90,6 +90,11 @@ const isStartTransition = ref(false)
 const { ns, zIndex } = useGlobalComponentSettings('message')
 const { currentZIndex, nextZIndex } = zIndex
 
+// Call nextZIndex eagerly so the first render gets the correct z-index,
+// avoiding the message being covered by overlay elements (e.g. el-drawer
+// with appendToBody) on the first call.
+nextZIndex()
+
 const messageRef = ref<HTMLDivElement>()
 const visible = ref(false)
 const height = ref(0)
@@ -166,7 +171,6 @@ function keydown(event: KeyboardEvent) {
 
 onMounted(() => {
   startTimer()
-  nextZIndex()
   visible.value = true
 })
 

--- a/packages/components/notification/src/notification.vue
+++ b/packages/components/notification/src/notification.vue
@@ -79,6 +79,10 @@ defineEmits(notificationEmits)
 const { ns, zIndex } = useGlobalComponentSettings('notification')
 const { nextZIndex, currentZIndex } = zIndex
 
+// Call nextZIndex eagerly so the first render gets the correct z-index,
+// avoiding the notification being covered by overlay elements on the first call.
+nextZIndex()
+
 const visible = ref(false)
 let timer: (() => void) | undefined = undefined
 const percentage = ref(100)
@@ -219,7 +223,6 @@ function onKeydown(event: KeyboardEvent) {
 // lifecycle
 onMounted(() => {
   startTimer()
-  nextZIndex()
   visible.value = true
 })
 


### PR DESCRIPTION
## Summary

Fixes #24738 — `ElMessage` (and `ElNotification`) are covered by the `el-drawer` overlay mask on their **first** call.

## Root cause

In `message.vue` / `notification.vue`, `nextZIndex()` is called inside `onMounted`, but the rendered style (`zIndex`) is computed **before** that:

```ts
const customStyle = computed(() => ({
  zIndex: currentZIndex.value,  // evaluated at first render
}))

onMounted(() => {
  startTimer()
  nextZIndex()  // too late — first paint already happened
  visible.value = true
})
```

On the first call, `currentZIndex` is still the initial value (`2000`), which is **lower** than the z-index already claimed by the `el-drawer` overlay (drawer claims its z-index via `useDialog` → `nextZIndex()` **eagerly** when it opens). As a result the first message is painted underneath the overlay. The second call works because `zIndex` was already incremented by the first `onMounted`.

## Fix

Move `nextZIndex()` to the setup body (before any computed is evaluated), and remove it from `onMounted`. This guarantees the very first render carries the correct, already-incremented z-index.

## Changes

- `packages/components/message/src/message.vue` — call `nextZIndex()` eagerly in setup; remove from `onMounted`
- `packages/components/notification/src/notification.vue` — same fix (identical pattern, same bug)

## Test plan

1. In a Nuxt (or plain Vue) app, open an `el-drawer` with `append-to-body`
2. Click a button inside that calls `ElMessage.success()` — the message must appear **above** the drawer overlay on the first call
3. Repeat — still correct
4. Same for `ElNotification`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message and notification layering during initial display.
  * Prevented visual stacking issues by assigning the correct z-index before components become visible.
  * Preserved notification timing and visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->