### PR TITLE
fix(hooks): [use-z-index] align the counter without an app context

### DIFF
--- a/packages/hooks/__tests__/use-z-index.test.tsx
+++ b/packages/hooks/__tests__/use-z-index.test.tsx
@@ -1,3 +1,4 @@
+import { h, render } from 'vue'
 import { config, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ZINDEX_INJECTION_KEY, useZIndex } from '../use-z-index'
@@ -61,7 +62,7 @@ describe('with and without injection value', () => {
   beforeEach(() => {
     config.global.provide = {
       [ZINDEX_INJECTION_KEY as symbol]: {
-        current: 0,
+        current: 100,
       },
     }
   })
@@ -75,16 +76,25 @@ describe('with and without injection value', () => {
     const wrapper = mount({
       setup() {
         const { nextZIndex } = useZIndex()
-
-        nextZIndex()
-        return { zIndexWithInjection: nextZIndex() }
+        return { zIndex: nextZIndex() }
       },
       render: () => undefined,
     })
-    const zIndexWithoutInjection = useZIndex().nextZIndex()
 
-    expect(zIndexWithoutInjection).toBeGreaterThan(
-      wrapper.vm.zIndexWithInjection
+    // rendered without an app context, the way `ElMessage` is
+    let zIndexWithoutInjection = 0
+    render(
+      h({
+        setup() {
+          const { nextZIndex } = useZIndex()
+          zIndexWithoutInjection = nextZIndex()
+          return () => undefined
+        },
+      }),
+      document.createElement('div')
     )
+
+    expect(wrapper.vm.zIndex).toBe(2101)
+    expect(zIndexWithoutInjection).toBe(2102)
   })
 })

--- a/packages/hooks/__tests__/use-z-index.test.tsx
+++ b/packages/hooks/__tests__/use-z-index.test.tsx
@@ -94,7 +94,7 @@ describe('with and without injection value', () => {
       document.createElement('div')
     )
 
-    expect(wrapper.vm.zIndex).toBe(2101)
-    expect(zIndexWithoutInjection).toBe(2102)
+    expect(wrapper.vm.zIndex).toBeGreaterThanOrEqual(2101)
+    expect(zIndexWithoutInjection).toBe(wrapper.vm.zIndex + 1)
   })
 })

--- a/packages/hooks/__tests__/use-z-index.test.tsx
+++ b/packages/hooks/__tests__/use-z-index.test.tsx
@@ -56,3 +56,35 @@ describe('with injection value', () => {
     expect(wrapper.vm.nextZIndex).toBe(2012)
   })
 })
+
+describe('with and without injection value', () => {
+  beforeEach(() => {
+    config.global.provide = {
+      [ZINDEX_INJECTION_KEY as symbol]: {
+        current: 0,
+      },
+    }
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    config.global.provide = {}
+  })
+
+  it('useZIndex', () => {
+    const wrapper = mount({
+      setup() {
+        const { nextZIndex } = useZIndex()
+
+        nextZIndex()
+        return { zIndexWithInjection: nextZIndex() }
+      },
+      render: () => undefined,
+    })
+    const zIndexWithoutInjection = useZIndex().nextZIndex()
+
+    expect(zIndexWithoutInjection).toBeGreaterThan(
+      wrapper.vm.zIndexWithInjection
+    )
+  })
+})

--- a/packages/hooks/use-z-index/index.ts
+++ b/packages/hooks/use-z-index/index.ts
@@ -41,6 +41,14 @@ export const useZIndex = (zIndexOverrides?: Ref<number>) => {
   const currentZIndex = computed(() => initialZIndex.value + zIndex.value)
 
   const nextZIndex = () => {
+    // components created outside of the app, like `ElMessage`, fall back to the
+    // module scoped counter, so realign it to avoid handing out a used z-index
+    if (isClient) {
+      increasingInjection.current = Math.max(
+        increasingInjection.current,
+        zIndex.value
+      )
+    }
     increasingInjection.current++
     zIndex.value = increasingInjection.current
     return currentZIndex.value

--- a/packages/hooks/use-z-index/index.ts
+++ b/packages/hooks/use-z-index/index.ts
@@ -41,8 +41,8 @@ export const useZIndex = (zIndexOverrides?: Ref<number>) => {
   const currentZIndex = computed(() => initialZIndex.value + zIndex.value)
 
   const nextZIndex = () => {
-    // components created outside of the app, like `ElMessage`, fall back to the
-    // module scoped counter, so realign it to avoid handing out a used z-index
+    // a component created outside of the app, like `ElMessage`, falls back to
+    // the module scoped counter, so lift it to the last handed out value first
     if (isClient) {
       increasingInjection.current = Math.max(
         increasingInjection.current,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #24738

`useZIndex` counts through two objects: the one provided under `ZINDEX_INJECTION_KEY` and a module scoped fallback used when nothing is injected. In Nuxt the drawer counts on the provided object, while `ElMessage` renders its own vnode with no app context and counts on the fallback. Both write the same shared `zIndex` ref, so the first message inside an open drawer takes a z-index the mask already used and sits behind it. The second call is the one that finally goes above.

`nextZIndex` now lifts the counter to the last handed out value before increasing it, so a returned z-index is always higher than the previous one, whichever counter the caller ended up with. Server rendering keeps the old behavior so the per request counter stays deterministic during hydration.

Checked with the Nuxt 4 project from the issue: the first message renders at `z-index: 2001` under a `2002` mask before the change, and at `2003` after it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved z-index management to prevent duplicate layering values across application components.
  * Ensured components created outside the main application receive correctly ordered z-index values.
  * Improved the consistency of overlapping dialogs, menus, and other layered interface elements.

* **Tests**
  * Added coverage verifying that z-index values remain correctly ordered across different component contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->