### PR TITLE
fix(components): [select/v2] avoid circular tag width calculation

### DIFF
--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -3055,7 +3055,7 @@ describe('Select', () => {
 
       await input.trigger('blur')
       expect(inputWrapper.classes()).toContain('is-hidden')
-      expect(tagItem.style.maxWidth).toBe('calc(100% - 44px)')
+      expect(tagItem.style.maxWidth).toBe('calc(100% - 61px)')
 
       await input.trigger('focus')
       expect(inputWrapper.classes()).not.toContain('is-hidden')

--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -2304,14 +2304,47 @@ describe('Select', () => {
     await nextTick()
     options[2].click()
     await nextTick()
-    const tagWrappers = wrapper.findAll('.el-select__tags-text')
+    const tagWrappers = wrapper.findAll('.el-tag')
     for (const tagWrapper of tagWrappers) {
       const tagWrapperDom = tagWrapper.element
-      expect(
-        Number.parseInt(tagWrapperDom.style.maxWidth) === selectRect.width - 42
-      ).toBe(true)
+      expect(tagWrapperDom.style.maxWidth).toBe('')
+      expect(tagWrapperDom.parentElement!.style.maxWidth).toBe(
+        'calc(100% - 0px)'
+      )
     }
     mockSelectWidth.mockRestore()
+  })
+
+  it('multiple select with collapseTags when content overflow', async () => {
+    const wrapper = createSelect({
+      data: () => ({
+        multiple: true,
+        collapseTags: true,
+        value: [],
+      }),
+    })
+    await nextTick()
+    const select = wrapper.findComponent(Select)
+    const options = getOptions()
+    options[0].click()
+    await nextTick()
+
+    const tag = select.find('.el-tag')
+    const tagItem = tag.element.parentElement!
+    expect(tag.element.style.maxWidth).toBe('')
+    expect(tagItem.style.maxWidth).toBe('calc(100% - 0px)')
+
+    options[1].click()
+    await nextTick()
+    options[2].click()
+    const selectVm = select.vm as any
+    selectVm.states.collapseItemWidth = 38
+    await nextTick()
+
+    expect(tagItem.style.maxWidth).toBe('calc(100% - 44px)')
+    const collapseItem = select.find('.el-select__collapse-item')
+    expect(collapseItem.exists()).toBe(true)
+    expect(collapseItem.find('.el-tag').element.style.maxWidth).toBe('')
   })
 
   describe('scrollbarAlwaysOn flag control the scrollbar whether always displayed', () => {
@@ -2985,6 +3018,50 @@ describe('Select', () => {
   })
 
   describe('input-wrapper in multiple mode', () => {
+    it('should reserve input width only when input-wrapper is visible', async () => {
+      const wrapper = createSelect({
+        data: () => ({
+          multiple: true,
+          filterable: true,
+          collapseTags: true,
+          value: [],
+        }),
+      })
+      await nextTick()
+      const select = wrapper.findComponent(Select)
+      const inputWrapper = select.find('.el-select__input-wrapper')
+      const input = select.find('input')
+      await input.trigger('focus')
+
+      const options = getOptions()
+      options[0].click()
+      await nextTick()
+      options[1].click()
+      await nextTick()
+      options[2].click()
+
+      const selectVm = select.vm as any
+      selectVm.states.collapseItemWidth = 38
+      await nextTick()
+
+      const tag = select.find('.el-tag')
+      const tagItem = tag.element.parentElement!
+      expect(inputWrapper.classes()).not.toContain('is-hidden')
+      expect(tag.element.style.maxWidth).toBe('')
+      expect(tagItem.style.maxWidth).toBe('calc(100% - 61px)')
+      const collapseItem = select.find('.el-select__collapse-item')
+      expect(collapseItem.exists()).toBe(true)
+      expect(collapseItem.find('.el-tag').element.style.maxWidth).toBe('')
+
+      await input.trigger('blur')
+      expect(inputWrapper.classes()).toContain('is-hidden')
+      expect(tagItem.style.maxWidth).toBe('calc(100% - 44px)')
+
+      await input.trigger('focus')
+      expect(inputWrapper.classes()).not.toContain('is-hidden')
+      expect(tagItem.style.maxWidth).toBe('calc(100% - 61px)')
+    })
+
     it('should hide input-wrapper when empty and not focused', async () => {
       const wrapper = createSelect({
         data: () => ({

--- a/packages/components/select-v2/src/select.types.ts
+++ b/packages/components/select-v2/src/select.types.ts
@@ -19,7 +19,6 @@ export type SelectStates = {
   createdOptions: Option[]
   hoveringIndex: number
   inputHovering: boolean
-  selectionWidth: number
   collapseItemWidth: number
   previousQuery: string | null
   previousValue: unknown

--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -68,6 +68,7 @@
                 v-for="item in showTagList"
                 :key="getValueKey(getValue(item))"
                 :class="nsSelect.e('selected-item')"
+                :style="tagStyle"
               >
                 <el-tag
                   :closable="!selectDisabled && !getDisabled(item)"
@@ -75,7 +76,6 @@
                   :type="tagType"
                   :effect="tagEffect"
                   disable-transitions
-                  :style="tagStyle"
                   @close="deleteTag($event, item)"
                 >
                   <span :class="nsSelect.e('tags-text')">
@@ -121,14 +121,16 @@
                 <template #default>
                   <div
                     ref="collapseItemRef"
-                    :class="nsSelect.e('selected-item')"
+                    :class="[
+                      nsSelect.e('selected-item'),
+                      nsSelect.e('collapse-item'),
+                    ]"
                   >
                     <el-tag
                       :closable="false"
                       :size="collapseTagSize"
                       :type="tagType"
                       :effect="tagEffect"
-                      :style="collapseTagStyle"
                       disable-transitions
                     >
                       <span :class="nsSelect.e('tags-text')">
@@ -173,12 +175,7 @@
               :class="[
                 nsSelect.e('selected-item'),
                 nsSelect.e('input-wrapper'),
-                nsSelect.is(
-                  'hidden',
-                  !filterable ||
-                    selectDisabled ||
-                    (multiple && !states.inputValue && !isFocused)
-                ),
+                nsSelect.is('hidden', !inputWrapperVisible),
               ]"
             >
               <input

--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -175,7 +175,12 @@
               :class="[
                 nsSelect.e('selected-item'),
                 nsSelect.e('input-wrapper'),
-                nsSelect.is('hidden', !inputWrapperVisible),
+                nsSelect.is(
+                  'hidden',
+                  !filterable ||
+                    selectDisabled ||
+                    (multiple && !states.inputValue && !isFocused)
+                ),
               ]"
             >
               <input

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -22,6 +22,7 @@ import {
   isNumber,
   isObject,
   isUndefined,
+  rAF,
 } from '@element-plus/utils'
 import {
   useComposition,
@@ -72,7 +73,6 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     createdOptions: [],
     hoveringIndex: -1,
     inputHovering: false,
-    selectionWidth: 0,
     collapseItemWidth: 0,
     previousQuery: null,
     previousValue: undefined,
@@ -130,6 +130,13 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
       }
     },
   })
+
+  const inputWrapperVisible = computed(
+    () =>
+      props.filterable &&
+      !selectDisabled.value &&
+      (!props.multiple || !!states.inputValue || isFocused.value)
+  )
 
   const allOptions = computed(() => filterOptions(''))
 
@@ -332,19 +339,15 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
   // computed style
   const tagStyle = computed(() => {
     const gapWidth = getGapWidth()
-    const inputSlotWidth = props.filterable ? gapWidth + MINIMUM_INPUT_WIDTH : 0
-    const maxWidth =
+    const inputSlotWidth = inputWrapperVisible.value
+      ? gapWidth + MINIMUM_INPUT_WIDTH
+      : 0
+    const collapseSlotWidth =
       collapseItemRef.value && props.maxCollapseTags === 1
-        ? states.selectionWidth -
-          states.collapseItemWidth -
-          gapWidth -
-          inputSlotWidth
-        : states.selectionWidth - inputSlotWidth
-    return { maxWidth: `${maxWidth}px` }
-  })
-
-  const collapseTagStyle = computed(() => {
-    return { maxWidth: `${states.selectionWidth}px` }
+        ? states.collapseItemWidth + gapWidth
+        : 0
+    const reservedWidth = inputSlotWidth + collapseSlotWidth
+    return { maxWidth: `calc(100% - ${reservedWidth}px)` }
   })
 
   const shouldShowPlaceholder = computed(() => {
@@ -569,12 +572,6 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
 
   const onEndReached = (direction: ScrollbarDirection) => {
     emit('end-reached', direction)
-  }
-
-  const resetSelectionWidth = () => {
-    states.selectionWidth = Number.parseFloat(
-      window.getComputedStyle(selectionRef.value!).width
-    )
   }
 
   const resetCollapseItemWidth = () => {
@@ -995,8 +992,7 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
   onMounted(() => {
     initStates()
   })
-  useResizeObserver(selectRef, handleResize)
-  useResizeObserver(selectionRef, resetSelectionWidth)
+  useResizeObserver(selectRef, () => rAF(handleResize))
   useResizeObserver(wrapperRef, updateTooltip)
   useResizeObserver(tagMenuRef, updateTagTooltip)
   useResizeObserver(collapseItemRef, resetCollapseItemWidth)
@@ -1031,7 +1027,6 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     iconComponent,
     iconReverse,
     tagStyle,
-    collapseTagStyle,
     popperSize,
     dropdownMenuVisible,
     hasModelValue,
@@ -1042,6 +1037,7 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     showClearBtn,
     states,
     isFocused,
+    inputWrapperVisible,
     nsSelect,
     nsInput,
 
@@ -1081,7 +1077,6 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     blur,
     handleMenuEnter,
     handleResize,
-    resetSelectionWidth,
     updateTooltip,
     updateTagTooltip,
     updateOptions,

--- a/packages/components/select-v2/src/useSelect.ts
+++ b/packages/components/select-v2/src/useSelect.ts
@@ -131,13 +131,6 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     },
   })
 
-  const inputWrapperVisible = computed(
-    () =>
-      props.filterable &&
-      !selectDisabled.value &&
-      (!props.multiple || !!states.inputValue || isFocused.value)
-  )
-
   const allOptions = computed(() => filterOptions(''))
 
   const hasOptions = computed(() => {
@@ -339,9 +332,10 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
   // computed style
   const tagStyle = computed(() => {
     const gapWidth = getGapWidth()
-    const inputSlotWidth = inputWrapperVisible.value
-      ? gapWidth + MINIMUM_INPUT_WIDTH
-      : 0
+    const inputSlotWidth =
+      props.filterable && !selectDisabled.value
+        ? gapWidth + MINIMUM_INPUT_WIDTH
+        : 0
     const collapseSlotWidth =
       collapseItemRef.value && props.maxCollapseTags === 1
         ? states.collapseItemWidth + gapWidth
@@ -1037,7 +1031,6 @@ const useSelect = (props: SelectV2Props, emit: SelectV2EmitFn) => {
     showClearBtn,
     states,
     isFocused,
-    inputWrapperVisible,
     nsSelect,
     nsInput,
 

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4435,7 +4435,7 @@ describe('Select', () => {
 
       await input.trigger('blur')
       expect(inputWrapper.classes()).toContain('is-hidden')
-      expect(tagItem.style.maxWidth).toBe('calc(100% - 44px)')
+      expect(tagItem.style.maxWidth).toBe('calc(100% - 61px)')
 
       await input.trigger('focus')
       expect(inputWrapper.classes()).not.toContain('is-hidden')

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -1500,8 +1500,6 @@ describe('Select', () => {
     )
     await wrapper.find(`.${WRAPPER_CLASS_NAME}`).trigger('click')
     const options = getOptions()
-    const selectRef = wrapper.findComponent(Select)
-    selectRef.vm.states.selectionWidth = 200
     options[0].click()
     await nextTick()
     options[1].click()
@@ -1511,7 +1509,10 @@ describe('Select', () => {
     const tagWrappers = wrapper.findAll('.el-tag')
     for (const tagWrapper of tagWrappers) {
       const tagWrapperDom = tagWrapper.element
-      expect(tagWrapperDom.style.maxWidth).toBe('200px')
+      expect(tagWrapperDom.style.maxWidth).toBe('')
+      expect(tagWrapperDom.parentElement!.style.maxWidth).toBe(
+        'calc(100% - 0px)'
+      )
     }
   })
 
@@ -1554,18 +1555,22 @@ describe('Select', () => {
     await wrapper.find(`.${WRAPPER_CLASS_NAME}`).trigger('click')
     const options = getOptions()
     const selectRef = wrapper.findComponent(Select)
-    selectRef.vm.states.selectionWidth = 200
     options[0].click()
     await nextTick()
     const tagWrappers = wrapper.findAll('.el-tag')
     const tagWrapperDom = tagWrappers[0].element
-    expect(tagWrapperDom.style.maxWidth).toBe('200px')
+    const tagItemDom = tagWrapperDom.parentElement!
+    expect(tagWrapperDom.style.maxWidth).toBe('')
+    expect(tagItemDom.style.maxWidth).toBe('calc(100% - 0px)')
     options[1].click()
     await nextTick()
     options[2].click()
     selectRef.vm.states.collapseItemWidth = 38
     await nextTick()
-    expect(tagWrapperDom.style.maxWidth).toBe('156px')
+    expect(tagItemDom.style.maxWidth).toBe('calc(100% - 44px)')
+    const collapseItem = wrapper.find('.el-select__collapse-item')
+    expect(collapseItem.exists()).toBe(true)
+    expect(collapseItem.find('.el-tag').element.style.maxWidth).toBe('')
   })
 
   test('multiple select with collapseTagsTooltip', async () => {
@@ -4403,6 +4408,39 @@ describe('Select', () => {
   })
 
   describe('input-wrapper in multiple mode', () => {
+    test('should reserve input width only when input-wrapper is visible', async () => {
+      wrapper = getSelectVm({
+        multiple: true,
+        filterable: true,
+        collapseTags: true,
+      })
+      await wrapper.find(`.${WRAPPER_CLASS_NAME}`).trigger('click')
+      const options = getOptions()
+      options[0].click()
+      await nextTick()
+      options[1].click()
+      await nextTick()
+      options[2].click()
+
+      const selectRef = wrapper.findComponent(Select)
+      selectRef.vm.states.collapseItemWidth = 38
+      await nextTick()
+
+      const inputWrapper = wrapper.find('.el-select__input-wrapper')
+      const input = wrapper.find('input')
+      const tagItem = wrapper.find('.el-tag').element.parentElement!
+      expect(inputWrapper.classes()).not.toContain('is-hidden')
+      expect(tagItem.style.maxWidth).toBe('calc(100% - 61px)')
+
+      await input.trigger('blur')
+      expect(inputWrapper.classes()).toContain('is-hidden')
+      expect(tagItem.style.maxWidth).toBe('calc(100% - 44px)')
+
+      await input.trigger('focus')
+      expect(inputWrapper.classes()).not.toContain('is-hidden')
+      expect(tagItem.style.maxWidth).toBe('calc(100% - 61px)')
+    })
+
     test('should hide input-wrapper when empty and not focused', async () => {
       wrapper = getSelectVm({
         multiple: true,

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4415,6 +4415,8 @@ describe('Select', () => {
         collapseTags: true,
       })
       await wrapper.find(`.${WRAPPER_CLASS_NAME}`).trigger('click')
+      const input = wrapper.find('input')
+      await input.trigger('focus')
       const options = getOptions()
       options[0].click()
       await nextTick()
@@ -4427,7 +4429,6 @@ describe('Select', () => {
       await nextTick()
 
       const inputWrapper = wrapper.find('.el-select__input-wrapper')
-      const input = wrapper.find('input')
       const tagItem = wrapper.find('.el-tag').element.parentElement!
       expect(inputWrapper.classes()).not.toContain('is-hidden')
       expect(tagItem.style.maxWidth).toBe('calc(100% - 61px)')

--- a/packages/components/select/src/select-dropdown.vue
+++ b/packages/components/select/src/select-dropdown.vue
@@ -19,6 +19,7 @@ import { useResizeObserver } from '@vueuse/core'
 import { useNamespace } from '@element-plus/hooks'
 import { selectKey } from './token'
 import { BORDER_HORIZONTAL_WIDTH } from '@element-plus/constants'
+import { rAF } from '@element-plus/utils'
 
 export default defineComponent({
   name: 'ElSelectDropdown',
@@ -48,7 +49,9 @@ export default defineComponent({
       // TODO: updatePopper
       // popper.value.update()
       updateMinWidth()
-      useResizeObserver(select.selectRef, updateMinWidth)
+      useResizeObserver(select.selectRef, () => {
+        rAF(updateMinWidth)
+      })
     })
 
     return {

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -68,6 +68,7 @@
                 v-for="item in showTagList"
                 :key="getValueKey(item)"
                 :class="nsSelect.e('selected-item')"
+                :style="tagStyle"
               >
                 <el-tag
                   :closable="!selectDisabled && !item.isDisabled"
@@ -75,7 +76,6 @@
                   :type="tagType"
                   :effect="tagEffect"
                   disable-transitions
-                  :style="tagStyle"
                   @close="deleteTag($event, item)"
                 >
                   <span :class="nsSelect.e('tags-text')">
@@ -119,7 +119,10 @@
                 <template #default>
                   <div
                     ref="collapseItemRef"
-                    :class="nsSelect.e('selected-item')"
+                    :class="[
+                      nsSelect.e('selected-item'),
+                      nsSelect.e('collapse-item'),
+                    ]"
                   >
                     <el-tag
                       :closable="false"
@@ -127,7 +130,6 @@
                       :type="tagType"
                       :effect="tagEffect"
                       disable-transitions
-                      :style="collapseTagStyle"
                     >
                       <span :class="nsSelect.e('tags-text')">
                         + {{ states.selected.length - maxCollapseTags }}
@@ -171,12 +173,7 @@
               :class="[
                 nsSelect.e('selected-item'),
                 nsSelect.e('input-wrapper'),
-                nsSelect.is(
-                  'hidden',
-                  !filterable ||
-                    selectDisabled ||
-                    (multiple && !states.inputValue && !isFocused)
-                ),
+                nsSelect.is('hidden', !inputWrapperVisible),
               ]"
             >
               <input

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -173,7 +173,12 @@
               :class="[
                 nsSelect.e('selected-item'),
                 nsSelect.e('input-wrapper'),
-                nsSelect.is('hidden', !inputWrapperVisible),
+                nsSelect.is(
+                  'hidden',
+                  !filterable ||
+                    selectDisabled ||
+                    (multiple && !states.inputValue && !isFocused)
+                ),
               ]"
             >
               <input

--- a/packages/components/select/src/type.ts
+++ b/packages/components/select/src/type.ts
@@ -30,7 +30,6 @@ export type SelectStates = {
   selected: OptionBasic[]
   hoveringIndex: number
   inputHovering: boolean
-  selectionWidth: number
   collapseItemWidth: number
   previousQuery: string | null
   selectedLabel: string

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -74,7 +74,6 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
     cachedOptions: new Map(),
     optionValues: [], // sorted value of options
     selected: [],
-    selectionWidth: 0,
     collapseItemWidth: 0,
     selectedLabel: '',
     hoveringIndex: -1,
@@ -140,6 +139,13 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
       }
     },
   })
+
+  const inputWrapperVisible = computed(
+    () =>
+      props.filterable &&
+      !selectDisabled.value &&
+      (!props.multiple || !!states.inputValue || isFocused.value)
+  )
 
   const hasModelValue = computed(() => {
     return isArray(props.modelValue)
@@ -484,12 +490,6 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
     } else {
       states.hoveringIndex = -1
     }
-  }
-
-  const resetSelectionWidth = () => {
-    states.selectionWidth = Number.parseFloat(
-      window.getComputedStyle(selectionRef.value!).width
-    )
   }
 
   const resetCollapseItemWidth = () => {
@@ -894,19 +894,15 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
   // computed style
   const tagStyle = computed(() => {
     const gapWidth = getGapWidth()
-    const inputSlotWidth = props.filterable ? gapWidth + MINIMUM_INPUT_WIDTH : 0
-    const maxWidth =
+    const inputSlotWidth = inputWrapperVisible.value
+      ? gapWidth + MINIMUM_INPUT_WIDTH
+      : 0
+    const collapseSlotWidth =
       collapseItemRef.value && props.maxCollapseTags === 1
-        ? states.selectionWidth -
-          states.collapseItemWidth -
-          gapWidth -
-          inputSlotWidth
-        : states.selectionWidth - inputSlotWidth
-    return { maxWidth: `${maxWidth}px` }
-  })
-
-  const collapseTagStyle = computed(() => {
-    return { maxWidth: `${states.selectionWidth}px` }
+        ? states.collapseItemWidth + gapWidth
+        : 0
+    const reservedWidth = inputSlotWidth + collapseSlotWidth
+    return { maxWidth: `calc(100% - ${reservedWidth}px)` }
   })
 
   const popupScroll = (data: { scrollTop: number; scrollLeft: number }) => {
@@ -917,7 +913,6 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
     emit('end-reached', direction)
   }
 
-  useResizeObserver(selectionRef, resetSelectionWidth)
   useResizeObserver(wrapperRef, updateTooltip)
   useResizeObserver(tagMenuRef, updateTagTooltip)
   useResizeObserver(collapseItemRef, resetCollapseItemWidth)
@@ -948,6 +943,7 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
     nsInput,
     states,
     isFocused,
+    inputWrapperVisible,
     expanded,
     optionsArray,
     hoverOption,
@@ -1003,7 +999,6 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
 
     // computed style
     tagStyle,
-    collapseTagStyle,
 
     // DOM ref
     popperRef,

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -140,13 +140,6 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
     },
   })
 
-  const inputWrapperVisible = computed(
-    () =>
-      props.filterable &&
-      !selectDisabled.value &&
-      (!props.multiple || !!states.inputValue || isFocused.value)
-  )
-
   const hasModelValue = computed(() => {
     return isArray(props.modelValue)
       ? props.modelValue.length > 0
@@ -894,9 +887,10 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
   // computed style
   const tagStyle = computed(() => {
     const gapWidth = getGapWidth()
-    const inputSlotWidth = inputWrapperVisible.value
-      ? gapWidth + MINIMUM_INPUT_WIDTH
-      : 0
+    const inputSlotWidth =
+      props.filterable && !selectDisabled.value
+        ? gapWidth + MINIMUM_INPUT_WIDTH
+        : 0
     const collapseSlotWidth =
       collapseItemRef.value && props.maxCollapseTags === 1
         ? states.collapseItemWidth + gapWidth
@@ -943,7 +937,6 @@ export const useSelect = (props: SelectProps, emit: SelectEmits) => {
     nsInput,
     states,
     isFocused,
-    inputWrapperVisible,
     expanded,
     optionsArray,
     hoverOption,

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -176,10 +176,7 @@
 
   @include e(collapse-item) {
     flex-shrink: 0;
-
-    > .#{$namespace}-tag {
-      max-width: none;
-    }
+    max-width: 100%;
   }
 
   @include e(tags-text) {

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -168,6 +168,18 @@
     display: flex;
     flex-wrap: wrap;
     user-select: none;
+
+    > .#{$namespace}-tag {
+      max-width: 100%;
+    }
+  }
+
+  @include e(collapse-item) {
+    flex-shrink: 0;
+
+    > .#{$namespace}-tag {
+      max-width: none;
+    }
   }
 
   @include e(tags-text) {


### PR DESCRIPTION
When the `input-wrapper` is removed from the flex flow, the `selectionWidth` depends on the tag width while the first tag’s `max-width` is calculated from the `selectionWidth`, causing it to be incorrectly truncated.

close #24457

[demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB7IEVsZW1lbnRQbHVzIH0gZnJvbSAnQGVsZW1lbnQtcGx1cy9pY29ucy12dWUnXG5pbXBvcnQgeyB2ZXJzaW9uIGFzIGVwVmVyc2lvbiB9IGZyb20gJ2VsZW1lbnQtcGx1cydcbmltcG9ydCB7IHJlZiwgdmVyc2lvbiBhcyB2dWVWZXJzaW9uIH0gZnJvbSAndnVlJ1xuXG5jb25zdCBtc2cgPSByZWYoJ2lubGluZeWkmumAieWwkeS6jjLkuKrml7blrr3luqblvILluLjvvJsgbWF4LWNvbGxhcHNlLXRhZ3M9MeaXtiznrKzkuIDkuKrpgInkuK3nmoTmmL7npLrkuI3lhagnKVxuY29uc3QgdHlwZSA9IHJlZigpXG5jb25zdCBvcHRpb25zID0gW1xuICB7XG4gICAgdmFsdWU6ICdPcHRpb24xJyxcbiAgICBsYWJlbDogJ09wdGlvbjEnLFxuICB9LFxuICB7XG4gICAgdmFsdWU6ICdPcHRpb24yJyxcbiAgICBsYWJlbDogJ09wdGlvbjInLFxuICB9LFxuICB7XG4gICAgdmFsdWU6ICdPcHRpb24zJyxcbiAgICBsYWJlbDogJ09wdGlvbjMnLFxuICB9XG5dXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8aDE+e3sgbXNnIH19PC9oMT5cbiAgPGVsLWZvcm0gaW5saW5lPlxuICAgIDxlbC1mb3JtLWl0ZW0gbGFiZWw9XCJzZWxlY3Tpu5jorqRcIj5cbiAgICAgIDxlbC1zZWxlY3Qgdi1tb2RlbD1cInR5cGVcIiBtdWx0aXBsZSBmaWx0ZXJhYmxlPlxuICAgICAgICA8ZWwtb3B0aW9uXG4gICAgICAgICAgdi1mb3I9XCJpdGVtIGluIG9wdGlvbnNcIlxuICAgICAgICAgIDprZXk9XCJpdGVtLnZhbHVlXCJcbiAgICAgICAgICA6bGFiZWw9XCJpdGVtLmxhYmVsXCJcbiAgICAgICAgICA6dmFsdWU9XCJpdGVtLnZhbHVlXCJcbiAgICAgICAgLz5cbiAgICAgIDwvZWwtc2VsZWN0PlxuICAgIDwvZWwtZm9ybS1pdGVtPlxuICAgIDxlbC1mb3JtLWl0ZW0gbGFiZWw9XCJzZWxlY3QgbWF4LWNvbGxhcHNlLXRhZ3M9MVwiPlxuICAgICAgPGVsLXNlbGVjdCB2LW1vZGVsPVwidHlwZVwiIG11bHRpcGxlIGZpbHRlcmFibGUgY29sbGFwc2UtdGFncyBjb2xsYXBzZS10YWdzLXRvb2x0aXA+XG4gICAgICAgIDxlbC1vcHRpb25cbiAgICAgICAgICB2LWZvcj1cIml0ZW0gaW4gb3B0aW9uc1wiXG4gICAgICAgICAgOmtleT1cIml0ZW0udmFsdWVcIlxuICAgICAgICAgIDpsYWJlbD1cIml0ZW0ubGFiZWxcIlxuICAgICAgICAgIDp2YWx1ZT1cIml0ZW0udmFsdWVcIlxuICAgICAgICAvPlxuICAgICAgPC9lbC1zZWxlY3Q+XG4gICAgPC9lbC1mb3JtLWl0ZW0+XG4gICAgPGVsLWZvcm0taXRlbSBsYWJlbD1cInRyZWVzZWxlY3Tpu5jorqRcIj5cbiAgICAgIDxlbC10cmVlLXNlbGVjdFxuICAgICAgICB2LW1vZGVsPVwidHlwZVwiXG4gICAgICAgIDpkYXRhPVwib3B0aW9uc1wiXG4gICAgICAgIG11bHRpcGxlXG4gICAgICAgIDpyZW5kZXItYWZ0ZXItZXhwYW5kPVwiZmFsc2VcIlxuICAgICAgICBzaG93LWNoZWNrYm94XG4gICAgICAgIGNoZWNrLXN0cmljdGx5XG4gICAgICAgIGNoZWNrLW9uLWNsaWNrLW5vZGVcbiAgICAgIC8+XG4gICAgPC9lbC1mb3JtLWl0ZW0+XG4gICAgPGVsLWZvcm0taXRlbSBsYWJlbD1cInRyZWVzZWxlY3QgbWF4LWNvbGxhcHNlLXRhZ3M9MVwiPlxuICAgICAgPGVsLXRyZWUtc2VsZWN0XG4gICAgICAgIHYtbW9kZWw9XCJ0eXBlXCJcbiAgICAgICAgOmRhdGE9XCJvcHRpb25zXCJcbiAgICAgICAgbXVsdGlwbGVcbiAgICAgICAgOnJlbmRlci1hZnRlci1leHBhbmQ9XCJmYWxzZVwiXG4gICAgICAgIHNob3ctY2hlY2tib3hcbiAgICAgICAgY2hlY2stc3RyaWN0bHlcbiAgICAgICAgY2hlY2stb24tY2xpY2stbm9kZVxuICAgICAgICBjb2xsYXBzZS10YWdzXG4gICAgICAgIGNvbGxhcHNlLXRhZ3MtdG9vbHRpcFxuICAgICAgLz5cbiAgICA8L2VsLWZvcm0taXRlbT5cbiAgPC9lbC1mb3JtPlxuXG4gIDxwPlxuICAgIDxlbC1pY29uIGNvbG9yPVwidmFyKC0tZWwtY29sb3ItcHJpbWFyeSlcIj48RWxlbWVudFBsdXMgLz48L2VsLWljb24+XG4gICAgRWxlbWVudCBQbHVzIHt7IGVwVmVyc2lvbiB9fSArIFZ1ZSB7eyB2dWVWZXJzaW9uIH19XG4gIDwvcD5cbjwvdGVtcGxhdGU+IiwiZWxlbWVudC1wbHVzLmpzIjoiaW1wb3J0IEVsZW1lbnRQbHVzIGZyb20gJ2VsZW1lbnQtcGx1cydcbmltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcblxubGV0IGluc3RhbGxlZCA9IGZhbHNlXG5hd2FpdCBsb2FkU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gc2V0dXBFbGVtZW50UGx1cygpIHtcbiAgaWYgKGluc3RhbGxlZCkgcmV0dXJuXG4gIGNvbnN0IGluc3RhbmNlID0gZ2V0Q3VycmVudEluc3RhbmNlKClcbiAgaW5zdGFuY2UuYXBwQ29udGV4dC5hcHAudXNlKEVsZW1lbnRQbHVzKVxuICBpbnN0YWxsZWQgPSB0cnVlXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkU3R5bGUoKSB7XG4gIGNvbnN0IHN0eWxlcyA9IFsnaHR0cHM6Ly9yYXcuZXNtLnNoL3ByL2VsZW1lbnQtcGx1c0AyNDc0My9kaXN0L2luZGV4LmNzcycsICdodHRwczovL3Jhdy5lc20uc2gvcHIvZWxlbWVudC1wbHVzQDI0NzQzL3RoZW1lLWNoYWxrL2RhcmsvY3NzLXZhcnMuY3NzJ10ubWFwKChzdHlsZSkgPT4ge1xuICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgICAgbGluay5ocmVmID0gc3R5bGVcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgICB9KVxuICB9KVxuICByZXR1cm4gUHJvbWlzZS5hbGxTZXR0bGVkKHN0eWxlcylcbn1cbiIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AbGF0ZXN0L2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvc2hhcmVkXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vcmF3LmVzbS5zaC9wci9lbGVtZW50LXBsdXNAMjQ3NDMvZGlzdC9pbmRleC5mdWxsLm1pbi5tanNcIixcbiAgICBcImVsZW1lbnQtcGx1cy9cIjogXCJodHRwczovL3Jhdy5lc20uc2gvcHIvZWxlbWVudC1wbHVzQDI0NzQzL1wiLFxuICAgIFwiQGVsZW1lbnQtcGx1cy9pY29ucy12dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsIl9vIjp7InNob3dIaWRkZW4iOnRydWUsInN0eWxlU291cmNlIjoiaHR0cHM6Ly9yYXcuZXNtLnNoL3ByL2VsZW1lbnQtcGx1c0AyNDc0My9kaXN0L2luZGV4LmNzcyJ9fQ==)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multi-select tag sizing when selections overflow available space.
  - Collapsed selection tags now fit more consistently within the control.
  - Filter inputs remain visible while focused and hide appropriately when blurred, while preserving correct tag spacing.
  - Improved select and dropdown resizing for smoother layout updates.
- **Tests**
  - Added coverage for overflowing selections, collapsed tags, and input-wrapper visibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->