### PR TITLE
fix(components): [table] defer multiple filters until confirm

### DIFF
--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -598,6 +598,63 @@ describe('Table.vue', () => {
       filter.parentNode.removeChild(filter)
     })
 
+    it('applies a single filter from an initially unfiltered column', async () => {
+      wrapper.unmount()
+      wrapper = mount({
+        components: {
+          ElTable,
+          ElTableColumn,
+        },
+        template: `
+          <el-table :data="testData" @filter-change="handleFilterChange">
+            <el-table-column
+              prop="director"
+              column-key="director"
+              :filters="[
+                { text: 'John Lasseter', value: 'John Lasseter' },
+                { text: 'Peter Docter', value: 'Peter Docter' }
+              ]"
+              :filter-method="filterMethod"
+              :filter-multiple="false"
+            />
+          </el-table>
+        `,
+        data() {
+          return {
+            testData: getTestData(),
+            filters: {},
+          }
+        },
+        methods: {
+          filterMethod(value, row) {
+            return value === row.director
+          },
+          handleFilterChange(filters) {
+            this.filters = filters
+          },
+        },
+      })
+      await doubleWait()
+      await wrapper.find('.el-table__column-filter-trigger').trigger('click')
+      await doubleWait()
+
+      const filter = document.body.querySelector('.el-table-filter')
+      const filterItems = filter.querySelectorAll('.el-table-filter__list-item')
+      triggerEvent(filterItems[1], 'click', true, false)
+      await doubleWait()
+
+      expect(
+        (wrapper.vm as ComponentPublicInstance & { filters: any }).filters[
+          'director'
+        ]
+      ).toEqual(['John Lasseter'])
+      expect(wrapper.find('thead .cell.highlight').exists()).toBe(true)
+      expect(wrapper.findAll('.el-table__body-wrapper tbody tr')).toHaveLength(
+        3
+      )
+      filter.parentNode.removeChild(filter)
+    })
+
     it('clear filter', async () => {
       const btn = wrapper.find('.el-table__column-filter-trigger')
 

--- a/packages/components/table/__tests__/table.test.ts
+++ b/packages/components/table/__tests__/table.test.ts
@@ -579,6 +579,25 @@ describe('Table.vue', () => {
       filter.parentNode.removeChild(filter)
     })
 
+    it('does not highlight an unconfirmed multiple filter', async () => {
+      const btn = wrapper.find('.el-table__column-filter-trigger')
+
+      await btn.trigger('click')
+      await doubleWait()
+      const filter = document.body.querySelector('.el-table-filter')
+
+      triggerEvent(filter.querySelector('.el-checkbox'), 'click', true, false)
+      await doubleWait()
+      await btn.trigger('click')
+      await doubleWait()
+
+      expect(wrapper.find('thead .cell.highlight').exists()).toBe(false)
+      expect(wrapper.findAll('.el-table__body-wrapper tbody tr')).toHaveLength(
+        5
+      )
+      filter.parentNode.removeChild(filter)
+    })
+
     it('clear filter', async () => {
       const btn = wrapper.find('.el-table__column-filter-trigger')
 

--- a/packages/components/table/src/filter-panel.vue
+++ b/packages/components/table/src/filter-panel.vue
@@ -214,7 +214,7 @@ export default defineComponent({
       filterValue.value = _filterValue!
       checkedIndex.value = index
       if (!isPropAbsent(_filterValue)) {
-        confirmFilter(filteredValue.value)
+        confirmFilter([_filterValue])
       } else {
         confirmFilter([])
       }

--- a/packages/components/table/src/filter-panel.vue
+++ b/packages/components/table/src/filter-panel.vue
@@ -120,7 +120,7 @@ import { getEventCode, isPropAbsent } from '@element-plus/utils'
 import type { DefaultRow } from './table/defaults'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
 import type { Placement } from '@element-plus/components/popper'
-import type { PropType, WritableComputedRef } from 'vue'
+import type { PropType } from 'vue'
 import type { TableColumnCtx } from './table-column/defaults'
 import type { TableHeader } from './table-header'
 import type { Store } from './store'
@@ -188,19 +188,7 @@ export default defineComponent({
         }
       },
     })
-    const filteredValue: WritableComputedRef<string[]> = computed({
-      get() {
-        if (props.column) {
-          return props.column.filteredValue || []
-        }
-        return []
-      },
-      set(value: string[]) {
-        if (props.column) {
-          props.upDataColumn?.('filteredValue', value)
-        }
-      },
-    })
+    const filteredValue = ref<string[]>([])
     const multiple = computed(() => {
       if (props.column) {
         return props.column.filterMultiple
@@ -233,6 +221,7 @@ export default defineComponent({
       hidden()
     }
     const confirmFilter = (filteredValue: unknown[]) => {
+      props.upDataColumn?.('filteredValue', filteredValue)
       props.store?.commit('filterChange', {
         column: props.column,
         values: filteredValue,
@@ -240,6 +229,7 @@ export default defineComponent({
       props.store?.updateAllSelected()
     }
     const handleShowTooltip = () => {
+      filteredValue.value = [...(props.column?.filteredValue || [])]
       rootRef.value?.focus()
       !multiple.value && initCheckedIndex()
       if (props.column) {

--- a/packages/components/table/src/filter-panel.vue
+++ b/packages/components/table/src/filter-panel.vue
@@ -13,6 +13,7 @@
     :popper-class="filterClassName"
     persistent
     :append-to="appendTo"
+    @before-show="handleBeforeShowTooltip"
     @show="handleShowTooltip"
     @hide="handleHideTooltip"
   >
@@ -228,6 +229,9 @@ export default defineComponent({
       })
       props.store?.updateAllSelected()
     }
+    const handleBeforeShowTooltip = () => {
+      filteredValue.value = [...(props.column?.filteredValue || [])]
+    }
     const handleShowTooltip = () => {
       rootRef.value?.focus()
       !multiple.value && initCheckedIndex()
@@ -239,7 +243,6 @@ export default defineComponent({
       if (props.column) {
         props.upDataColumn?.('filterOpened', false)
       }
-      filteredValue.value = [...(props.column?.filteredValue || [])]
     }
 
     const initCheckedIndex = () => {
@@ -311,6 +314,7 @@ export default defineComponent({
       tooltipRef,
       rootRef,
       checkedIndex,
+      handleBeforeShowTooltip,
       handleShowTooltip,
       handleHideTooltip,
       handleKeydown,

--- a/packages/components/table/src/filter-panel.vue
+++ b/packages/components/table/src/filter-panel.vue
@@ -229,7 +229,6 @@ export default defineComponent({
       props.store?.updateAllSelected()
     }
     const handleShowTooltip = () => {
-      filteredValue.value = [...(props.column?.filteredValue || [])]
       rootRef.value?.focus()
       !multiple.value && initCheckedIndex()
       if (props.column) {
@@ -240,6 +239,7 @@ export default defineComponent({
       if (props.column) {
         props.upDataColumn?.('filterOpened', false)
       }
+      filteredValue.value = [...(props.column?.filteredValue || [])]
     }
 
     const initCheckedIndex = () => {

--- a/packages/components/table/src/filter-panel.vue
+++ b/packages/components/table/src/filter-panel.vue
@@ -164,6 +164,7 @@ export default defineComponent({
     const tooltipRef = ref<TooltipInstance | null>(null)
     const rootRef = ref<HTMLElement | null>(null)
     const checkedIndex = ref(0)
+    const filteredValue = ref<string[]>([])
 
     const filters = computed(() => {
       return props.column && props.column.filters
@@ -188,7 +189,6 @@ export default defineComponent({
         }
       },
     })
-    const filteredValue = ref<string[]>([])
     const multiple = computed(() => {
       if (props.column) {
         return props.column.filterMultiple


### PR DESCRIPTION
## What

Keep multiple-filter checkbox edits in a panel-local draft and write them to the column only when Confirm or Reset is used. Closing the panel now discards an unconfirmed selection, so the header highlight and filtered rows continue to represent the last committed filter.

## Why

The checkbox group currently writes directly to `column.filteredValue`. The table header uses that value for its highlight state even though `filterChange` has not run, causing the displayed filter state to diverge from the actual rows when the panel is dismissed.

Closes #24746.

## Tests

- `pnpm test packages/components/table/__tests__/table.test.ts --run` (86 passed)
- `pnpm exec eslint packages/components/table/src/filter-panel.vue packages/components/table/__tests__/table.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table filters so unconfirmed checkbox selections are not applied when the filter panel is reopened.
  * Filtered rows and column highlighting now update only after confirming the filter selection.
  * Fixed single-select filters so choosing an option from an unfiltered column immediately applies the filter and displays the matching rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->