### PR TITLE
fix(theme-chalk): [popconfirm] align icon to first text line

### DIFF
--- a/packages/theme-chalk/src/popconfirm.scss
+++ b/packages/theme-chalk/src/popconfirm.scss
@@ -5,10 +5,13 @@
   outline: none;
   @include e(main) {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
   }
   @include e(icon) {
     margin-right: 5px;
+    flex-shrink: 0;
+    // Keep the icon optically aligned with the first line of text
+    margin-top: 0.2em;
   }
   @include e(action) {
     text-align: right;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

Fix Popconfirm icon alignment when the title wraps to multiple lines.

The title and icon sit in a flex row. `align-items: center` vertically centered the icon against the whole text block, so a long title made the icon look stranded in the middle. This change:

- aligns the icon to the first line with `align-items: flex-start`
- keeps the icon from shrinking when the title is long
- adds a small `0.2em` top offset so the icon stays optically aligned with the first line (`line-height: 1.4`)

No public API change.

## Related issue

Closes #23651


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved pop-up confirmation layout alignment.
  * Preserved icon sizing and adjusted its vertical positioning for better visual alignment with the accompanying text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->