### PR TITLE
feat(theme-chalk): expose form item margin bottom variable

### DIFF
--- a/packages/theme-chalk/src/form-item.scss
+++ b/packages/theme-chalk/src/form-item.scss
@@ -55,9 +55,14 @@ $form-item-label-top-margin-bottom: map.merge(
 );
 
 @include b(form-item) {
+  @include set-css-var-value(
+    ('form-item', 'margin-bottom'),
+    map.get($form-item-margin-bottom, 'default')
+  );
+
   display: flex;
   --font-size: #{map.get($input-font-size, 'default')};
-  margin-bottom: #{map.get($form-item-margin-bottom, 'default')};
+  margin-bottom: getCssVar('form-item', 'margin-bottom');
 
   .#{$namespace}-form-item {
     margin-bottom: 0;
@@ -71,8 +76,10 @@ $form-item-label-top-margin-bottom: map.merge(
     @include m($size) {
       --font-size: #{map.get($input-font-size, $size)};
       @include set-css-var-value(('form', 'label-font-size'), var(--font-size));
-
-      margin-bottom: #{map.get($form-item-margin-bottom, $size)};
+      @include set-css-var-value(
+        ('form-item', 'margin-bottom'),
+        map.get($form-item-margin-bottom, $size)
+      );
 
       @include e(label) {
         height: #{map.get($form-item-line-height, $size)};

--- a/packages/theme-chalk/src/form-item.scss
+++ b/packages/theme-chalk/src/form-item.scss
@@ -59,9 +59,9 @@ $form-item-label-top-margin-bottom: map.merge(
     ('form-item', 'margin-bottom'),
     map.get($form-item-margin-bottom, 'default')
   );
+  --font-size: #{map.get($input-font-size, 'default')};
 
   display: flex;
-  --font-size: #{map.get($input-font-size, 'default')};
   margin-bottom: getCssVar('form-item', 'margin-bottom');
 
   .#{$namespace}-form-item {


### PR DESCRIPTION
## Description

This PR exposes the existing `$form-item-margin-bottom` Sass value as the `--el-form-item-margin-bottom` CSS variable through `set-css-var-value`.

The existing margin values for `large`, `default`, and `small` sizes remain unchanged. Users can now customize the FormItem bottom margin through CSS without recompiling the theme styles.

Related discussion: https://github.com/element-plus/element-plus/discussions/24751

## Validation

- [x] Compiled `form-item.scss` with Sass
- [x] Verified the generated CSS variable and size-specific values

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form item spacing consistency across different component sizes.
  * Centralized spacing behavior through a shared styling variable for more predictable layout results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->