### PR TITLE
fix(components): [tree-v2] sync checked state after clearing keys

### DIFF
--- a/packages/components/tree-v2/__tests__/tree.test.ts
+++ b/packages/components/tree-v2/__tests__/tree.test.ts
@@ -1536,7 +1536,7 @@ describe('Virtual Tree', () => {
     })
 
     test('setCheckedKeys', async () => {
-      const { treeRef } = createTree({
+      const { treeRef, wrapper } = createTree({
         data() {
           return {
             showCheckbox: true,
@@ -1590,6 +1590,26 @@ describe('Virtual Tree', () => {
       const halfCheckedKeys = treeRef.getHalfCheckedKeys()
       expect(checkedKeys.toString()).toBe(['1-1', '1-1-1', '1-1-2'].toString())
       expect(halfCheckedKeys.toString()).toBe(['1'].toString())
+
+      const allCheckedKeys = [
+        '1',
+        '1-1',
+        '1-1-1',
+        '1-1-2',
+        '1-2',
+        '1-2-1',
+        '1-3',
+      ]
+      treeRef.setCheckedKeys(['1'])
+      await nextTick()
+      expect(treeRef.getCheckedKeys()).toEqual(allCheckedKeys)
+
+      treeRef.setCheckedKeys([])
+      await nextTick()
+      expect(treeRef.getCheckedKeys()).toHaveLength(0)
+
+      await wrapper.find(TREE_NODE_CHECKBOX_CLASS_NAME).trigger('click')
+      expect(treeRef.getCheckedKeys()).toEqual(allCheckedKeys)
     })
 
     test('setChecked', async () => {

--- a/packages/components/tree-v2/src/composables/useCheck.ts
+++ b/packages/components/tree-v2/src/composables/useCheck.ts
@@ -212,7 +212,7 @@ export function useCheck(props: TreeProps, tree: Ref<Tree | undefined>) {
   function _setCheckedKeys(keys: TreeKey[]) {
     if (tree?.value) {
       const { treeNodeMap } = tree.value
-      if (props.showCheckbox && treeNodeMap && keys?.length > 0) {
+      if (props.showCheckbox && treeNodeMap) {
         for (const key of keys) {
           const node = treeNodeMap.get(key)
           if (node && !isChecked(node)) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

close #24755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing all selected tree items now correctly removes every checked checkbox.
  * Setting an empty or missing selection list now reliably resets checkbox states.
  * Selecting the root checkbox correctly checks the root and all descendant items.
  * Checkbox states now remain consistent when selections are cleared and restored.

* **Tests**
  * Expanded coverage for selecting, clearing, and restoring checkbox states in tree components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->