### PR TITLE
fix(components): [tree] when a scroll bar appears in the parent container, the highlighted background will be truncated

### DIFF
--- a/packages/theme-chalk/src/tree.scss
+++ b/packages/theme-chalk/src/tree.scss
@@ -13,6 +13,7 @@
   background: getCssVar('fill-color', 'blank');
   color: getCssVar('tree-text-color');
   font-size: getCssVar('font-size', 'base');
+  width: max-content;
 
   @include e(empty-block) {
     position: relative;

--- a/packages/theme-chalk/src/tree.scss
+++ b/packages/theme-chalk/src/tree.scss
@@ -13,7 +13,7 @@
   background: getCssVar('fill-color', 'blank');
   color: getCssVar('tree-text-color');
   font-size: getCssVar('font-size', 'base');
-  width: max-content;
+  min-width: max-content;
 
   @include e(empty-block) {
     position: relative;


### PR DESCRIPTION
## Bug
When the parent container sets a width and a scrollbar is added, the selected highlight will be clipped. This issue can be resolved by setting `min-width: max-content`.


## Reproduction link
[Link](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZGl2IHN0eWxlPVwiXCIgY2xhc3M9XCJ0cmVlLXdyYXBwZXJcIj5cbiAgICA8ZWwtdHJlZVxuICAgIDpkYXRhPVwiZGF0YVwiXG4gICAgY2xhc3M9XCJteS10cmVlXCJcbiAgICA6cHJvcHM9XCJkZWZhdWx0UHJvcHNcIlxuICAgIEBub2RlLWNsaWNrPVwiaGFuZGxlTm9kZUNsaWNrXCJcbiAgICBoaWdobGlnaHQtY3VycmVudFxuICAvPlxuICA8L2Rpdj5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgbGFuZz1cInRzXCIgc2V0dXA+XG5pbnRlcmZhY2UgVHJlZSB7XG4gIGxhYmVsOiBzdHJpbmdcbiAgY2hpbGRyZW4/OiBUcmVlW11cbn1cblxuY29uc3QgaGFuZGxlTm9kZUNsaWNrID0gKGRhdGE6IFRyZWUpID0+IHtcbiAgY29uc29sZS5sb2coZGF0YSlcbn1cblxuY29uc3QgZGF0YTogVHJlZVtdID0gW1xuICB7XG4gICAgbGFiZWw6ICdMZXZlbCBvbmUgMTIyTGV2ZWwgb25lIDEyMkxldmVsIG9uZSAxMjJMZXZlbCBvbmUgMTIyTGV2ZWwgb25lIDEyMkxldmVsIG9uZSAxMjJMZXZlbCBvbmUgMTIyTGV2ZWwgb25lIDEyMkxldmVsIG9uZSAxMjInLFxuICAgIGNoaWxkcmVuOiBbXG4gICAgICB7XG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDEtMUxldmVsIHR3byAxLTFMZXZlbCB0d28gd28gMS0xTGV2ZWwgdHdvIHdvIDEtMUxldmVsIHR3byB3byAxLTFMZXZlbCB0d28gd28gMS0xTGV2ZWwgdHdvIHdvIDEtMUxldmVsIHR3byB3byAxLTFMZXZlbCB0d28gd28gMS0xTGV2ZWwgdHdvIDEtMUxldmVsIHR3byAxLTFMZXZlbCB0d28gMS0xTGV2ZWwgdHdvIDEtMScsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgbGFiZWw6ICdMZXZlbCB0aHJlZSAxLTEtMScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgXSxcbiAgfSxcbiAge1xuICAgIGxhYmVsOiAnTGV2ZWwgb25lIDIyMjInLFxuICAgIGNoaWxkcmVuOiBbXG4gICAgICB7XG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDItMScsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgbGFiZWw6ICdMZXZlbCB0aHJlZSAyLTEtMScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDItMicsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgbGFiZWw6ICdMZXZlbCB0aHJlZSAyLTItMScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgXSxcbiAgfSxcbiAge1xuICAgIGxhYmVsOiAnTGV2ZWwgb25lIDMnLFxuICAgIGNoaWxkcmVuOiBbXG4gICAgICB7XG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDMtMScsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgbGFiZWw6ICdMZXZlbCB0aHJlZSAzLTEtMScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGxhYmVsOiAnTGV2ZWwgdHdvIDMtMicsXG4gICAgICAgIGNoaWxkcmVuOiBbXG4gICAgICAgICAge1xuICAgICAgICAgICAgbGFiZWw6ICdMZXZlbCB0aHJlZSAzLTItMScsXG4gICAgICAgICAgfSxcbiAgICAgICAgXSxcbiAgICAgIH0sXG4gICAgXSxcbiAgfSxcbl1cblxuY29uc3QgZGVmYXVsdFByb3BzID0ge1xuICBjaGlsZHJlbjogJ2NoaWxkcmVuJyxcbiAgbGFiZWw6ICdsYWJlbCcsXG59XG48L3NjcmlwdD5cblxuPHN0eWxlPlxuLnRyZWUtd3JhcHBlciB7XG4gIHdpZHRoOiA2MDBweDtcbiAgYm9yZGVyOiAxcHggc29saWQgcmVkO1xuICBvdmVyZmxvdzogYXV0bztcbn1cbjwhLS0gLm15LXRyZWUge1xuICBtaW4td2lkdGg6IG1heC1jb250ZW50O1xufSAtLT5cblxuLmVsLXRleHQge1xuICBvdmVyZmxvdzogdmlzaWJsZSAhaW1wb3J0YW50O1xufVxuPC9zdHlsZT5cblxuIiwiZWxlbWVudC1wbHVzLmpzIjoiaW1wb3J0IEVsZW1lbnRQbHVzIGZyb20gJ2VsZW1lbnQtcGx1cydcbmltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcblxubGV0IGluc3RhbGxlZCA9IGZhbHNlXG5hd2FpdCBsb2FkU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gc2V0dXBFbGVtZW50UGx1cygpIHtcbiAgaWYgKGluc3RhbGxlZCkgcmV0dXJuXG4gIGNvbnN0IGluc3RhbmNlID0gZ2V0Q3VycmVudEluc3RhbmNlKClcbiAgaW5zdGFuY2UuYXBwQ29udGV4dC5hcHAudXNlKEVsZW1lbnRQbHVzKVxuICBpbnN0YWxsZWQgPSB0cnVlXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkU3R5bGUoKSB7XG4gIGNvbnN0IHN0eWxlcyA9IFsnaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAMi4xNC41L2Rpc3QvaW5kZXguY3NzJywgJ2h0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQDIuMTQuNS90aGVtZS1jaGFsay9kYXJrL2Nzcy12YXJzLmNzcyddLm1hcCgoc3R5bGUpID0+IHtcbiAgICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKVxuICAgICAgbGluay5yZWwgPSAnc3R5bGVzaGVldCdcbiAgICAgIGxpbmsuaHJlZiA9IHN0eWxlXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2xvYWQnLCByZXNvbHZlKVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdlcnJvcicsIHJlamVjdClcbiAgICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kKGxpbmspXG4gICAgfSlcbiAgfSlcbiAgcmV0dXJuIFByb21pc2UuYWxsU2V0dGxlZChzdHlsZXMpXG59IiwidHNjb25maWcuanNvbiI6IntcbiAgXCJjb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVSZXNvbHV0aW9uXCI6IFwiQnVuZGxlclwiLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdLFxuICAgIFwiYWxsb3dJbXBvcnRpbmdUc0V4dGVuc2lvbnNcIjogdHJ1ZSxcbiAgICBcImFsbG93SnNcIjogdHJ1ZSxcbiAgICBcImNoZWNrSnNcIjogdHJ1ZVxuICB9LFxuICBcInZ1ZUNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogMy4zXG4gIH1cbn1cbiIsIlBsYXlncm91bmRNYWluLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgQXBwIGZyb20gJy4vQXBwLnZ1ZSdcbmltcG9ydCB7IHNldHVwRWxlbWVudFBsdXMgfSBmcm9tICcuL2VsZW1lbnQtcGx1cy5qcydcbnNldHVwRWxlbWVudFBsdXMoKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPEFwcCAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9ydW50aW1lLWRvbUBsYXRlc3QvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAMi4xNC41L2Rpc3QvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAMi4xNC41L1wiLFxuICAgIFwiQGVsZW1lbnQtcGx1cy9pY29ucy12dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsIl9vIjp7ImVwVmVyc2lvbiI6IjIuMTQuNSJ9fQ==)






- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved tree component sizing so it fits its content while remaining flexible in narrower layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->