### PR TITLE
fix(components): prevent side effect in computed getter (#24789)

### DIFF
--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -1299,6 +1299,86 @@ describe('Cascader.vue', () => {
       )
     })
   })
+  describe('Cascader - persistent=false keeps selected values visible', () => {
+    const runWithPersistent = (fn: () => Promise<void>) =>
+      (async () => {
+        const prev = process.env.RUN_TEST_WITH_PERSISTENT
+        process.env.RUN_TEST_WITH_PERSISTENT = 'true'
+        try {
+          await fn()
+        } finally {
+          if (prev === undefined) delete process.env.RUN_TEST_WITH_PERSISTENT
+          else process.env.RUN_TEST_WITH_PERSISTENT = prev
+        }
+      })()
+
+    it('should keep selected tags after the dropdown is destroyed (multiple)', async () => {
+      await runWithPersistent(async () => {
+        const value = ref<string[][]>([])
+        const wrapper = _mount(() => (
+          <Cascader
+            v-model={value.value}
+            options={OPTIONS}
+            props={{ multiple: true, checkOnClickNode: true }}
+            persistent={false}
+          />
+        ))
+        const trigger = wrapper.find(TRIGGER)
+        await trigger.trigger('click')
+        await nextTick()
+        const firstNode = document.querySelector(NODE) as HTMLElement
+        firstNode.click()
+        await nextTick()
+        expect(wrapper.findAll(TAG).length).toBeGreaterThan(0)
+
+        // close the dropdown, which destroys the panel
+        await trigger.trigger('keydown', {
+          key: EVENT_CODE.esc,
+          code: EVENT_CODE.esc,
+        })
+        await nextTick()
+        await nextTick()
+
+        expect(value.value.length).toBe(1)
+        // tags must remain visible even though the panel was destroyed
+        expect(wrapper.findAll(TAG).length).toBe(1)
+      })
+    })
+
+    it('should keep the selected label after the dropdown is destroyed (single)', async () => {
+      await runWithPersistent(async () => {
+        const value = ref<string[]>([])
+        const wrapper = _mount(() => (
+          <Cascader
+            v-model={value.value}
+            options={OPTIONS}
+            persistent={false}
+          />
+        ))
+        const trigger = wrapper.find(TRIGGER)
+        await trigger.trigger('click')
+        await nextTick()
+        const firstNode = document.querySelector(NODE) as HTMLElement
+        // expand the first (parent) node
+        firstNode.click()
+        await nextTick()
+        // click a leaf node to select it
+        const leafNode = Array.from(document.querySelectorAll(NODE_LABEL)).find(
+          (el) => el.textContent?.includes('Hangzhou')
+        ) as HTMLElement
+        leafNode.click()
+        await nextTick()
+        await nextTick()
+
+        expect(value.value).toEqual(['zhejiang', 'hangzhou'])
+        const input = wrapper.find('input')
+        expect((input.element as HTMLInputElement).value).toBe(
+          'Zhejiang / Hangzhou'
+        )
+      })
+    })
+  })
+
   it('should select leaf node when checkOnClickLeaf is enabled', async () => {
     const value = ref([])
     const checkOnClickLeaf = ref(true)

--- a/packages/components/cascader/src/cascader.vue
+++ b/packages/components/cascader/src/cascader.vue
@@ -323,7 +323,7 @@ import { ArrowDown, Check, CircleClose } from '@element-plus/icons-vue'
 import { cascaderEmits } from './cascader'
 
 import type { Options } from '@element-plus/components/popper'
-import type { ComputedRef, StyleValue } from 'vue'
+import type { StyleValue } from 'vue'
 import type { TooltipInstance } from '@element-plus/components/tooltip'
 import type { InputInstance } from '@element-plus/components/input'
 import type { ScrollbarInstance } from '@element-plus/components/scrollbar'
@@ -477,8 +477,18 @@ const readonly = computed(() => !props.filterable || multiple.value)
 const searchKeyword = computed(() =>
   multiple.value ? searchInputValue.value : inputValue.value
 )
-const checkedNodes: ComputedRef<CascaderNode[]> = computed(
-  () => cascaderPanelRef.value?.checkedNodes || []
+const lastCheckedNodes = ref<CascaderNode[]>([])
+const checkedNodes = computed(() => {
+  const nodes = cascaderPanelRef.value?.checkedNodes
+  return nodes ?? lastCheckedNodes.value
+})
+watch(
+  () => cascaderPanelRef.value?.checkedNodes,
+  (nodes) => {
+    if (nodes) {
+      lastCheckedNodes.value = nodes
+    }
+  }
 )
 
 const { wrapperRef, isFocused, handleBlur } = useFocusController(inputRef, {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

#24789 

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Selected Cascader values now remain visible after the dropdown panel is closed or destroyed when persistence is disabled.
  * Improved value display for both single-selection and multiple-selection modes.

* **Tests**
  * Added regression coverage for Cascader value visibility across supported selection modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->