### PR TITLE
fix(components): [input-number] Fix border overlap on high-DPI displays

### DIFF
--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -332,6 +332,27 @@ describe('InputNumber.vue', () => {
     expect(inputNumber.classes()).not.toContain('is-controls-hover')
   })
 
+  test.each(['increase', 'decrease'] as const)(
+    'resets controls hover state when controls are disabled after %s is hovered',
+    async (control) => {
+      const controls = ref(true)
+      const wrapper = mount(() => <InputNumber controls={controls.value} />)
+      const inputNumber = wrapper.find('.el-input-number')
+      const button = wrapper.find(`.el-input-number__${control}`)
+
+      await button.trigger('mouseenter')
+      expect(inputNumber.classes()).toContain('is-controls-hover')
+
+      controls.value = false
+      await nextTick()
+      expect(inputNumber.classes()).not.toContain('is-controls-hover')
+
+      controls.value = true
+      await nextTick()
+      expect(inputNumber.classes()).not.toContain('is-controls-hover')
+    }
+  )
+
   test.each(['', 'large', 'small'] as const)(
     'controls-right renders controls for %s size',
     (size) => {

--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -314,6 +314,39 @@ describe('InputNumber.vue', () => {
     expect(wrapper.findComponent(ArrowUp).exists()).toBe(true)
   })
 
+  test('controls hover state', async () => {
+    const wrapper = mount(() => <InputNumber />)
+    const inputNumber = wrapper.find('.el-input-number')
+    const decrease = wrapper.find('.el-input-number__decrease')
+    const increase = wrapper.find('.el-input-number__increase')
+
+    expect(inputNumber.classes()).not.toContain('is-controls-hover')
+    await decrease.trigger('mouseenter')
+    expect(inputNumber.classes()).toContain('is-controls-hover')
+    await decrease.trigger('mouseleave')
+    expect(inputNumber.classes()).not.toContain('is-controls-hover')
+
+    await increase.trigger('mouseenter')
+    expect(inputNumber.classes()).toContain('is-controls-hover')
+    await increase.trigger('mouseleave')
+    expect(inputNumber.classes()).not.toContain('is-controls-hover')
+  })
+
+  test.each(['', 'large', 'small'] as const)(
+    'controls-right renders controls for %s size',
+    (size) => {
+      const wrapper = mount(() => (
+        <InputNumber controls-position="right" size={size || undefined} />
+      ))
+
+      expect(wrapper.find('.el-input-number').classes()).toContain(
+        'is-controls-right'
+      )
+      expect(wrapper.find('.el-input-number__increase').exists()).toBe(true)
+      expect(wrapper.find('.el-input-number__decrease').exists()).toBe(true)
+    }
+  )
+
   test('input-event', async () => {
     const handleInput = vi.fn()
     const num = ref(0)

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -180,6 +180,13 @@ const inputNumberSize = useFormSize()
 const inputNumberDisabled = useFormDisabled()
 const controlsHovering = ref(false)
 
+watch(
+  () => props.controls,
+  () => {
+    controlsHovering.value = false
+  }
+)
+
 const onControlsMouseEnter = () => {
   controlsHovering.value = true
 }

--- a/packages/components/input-number/src/input-number.vue
+++ b/packages/components/input-number/src/input-number.vue
@@ -6,6 +6,7 @@
       ns.is('disabled', inputNumberDisabled),
       ns.is('without-controls', !controls),
       ns.is('controls-right', controlsAtRight),
+      ns.is('controls-hover', controlsHovering),
       ns.is(align, !!align),
     ]"
     @dragstart.prevent
@@ -16,6 +17,8 @@
       role="button"
       :aria-label="t('el.inputNumber.decrease')"
       :class="[ns.e('decrease'), ns.is('disabled', minDisabled)]"
+      @mouseenter="onControlsMouseEnter"
+      @mouseleave="onControlsMouseLeave"
       @keydown.enter="decrease"
     >
       <slot name="decrease-icon">
@@ -31,6 +34,8 @@
       role="button"
       :aria-label="t('el.inputNumber.increase')"
       :class="[ns.e('increase'), ns.is('disabled', maxDisabled)]"
+      @mouseenter="onControlsMouseEnter"
+      @mouseleave="onControlsMouseLeave"
       @keydown.enter="increase"
     >
       <slot name="increase-icon">
@@ -173,6 +178,15 @@ const controlsAtRight = computed(() => {
 
 const inputNumberSize = useFormSize()
 const inputNumberDisabled = useFormDisabled()
+const controlsHovering = ref(false)
+
+const onControlsMouseEnter = () => {
+  controlsHovering.value = true
+}
+
+const onControlsMouseLeave = () => {
+  controlsHovering.value = false
+}
 
 const displayValue = computed(() => {
   if (data.userInput !== null) {

--- a/packages/theme-chalk/src/form-item.scss
+++ b/packages/theme-chalk/src/form-item.scss
@@ -229,7 +229,7 @@ $form-item-label-top-margin-bottom: map.merge(
       }
 
       .#{$namespace}-input-number::after {
-        box-shadow: 0 0 0 1px getCssVar('color-danger');
+        box-shadow: 0 0 0 1px getCssVar('color-danger') inset;
       }
 
       .#{$namespace}-input-group__append,

--- a/packages/theme-chalk/src/form-item.scss
+++ b/packages/theme-chalk/src/form-item.scss
@@ -228,6 +228,10 @@ $form-item-label-top-margin-bottom: map.merge(
         }
       }
 
+      .#{$namespace}-input-number::after {
+        box-shadow: 0 0 0 1px getCssVar('color-danger');
+      }
+
       .#{$namespace}-input-group__append,
       .#{$namespace}-input-group__prepend {
         .#{$namespace}-input__wrapper {

--- a/packages/theme-chalk/src/input-number.scss
+++ b/packages/theme-chalk/src/input-number.scss
@@ -11,6 +11,47 @@
   line-height: #{map.get($input-height, 'default') - 2};
   vertical-align: middle;
 
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    pointer-events: none;
+    border-radius: getCssVar('border-radius', 'base');
+    box-sizing: border-box;
+    box-shadow: 0 0 0 1px getCssVar('border-color');
+    transition: getCssVar('transition-box-shadow');
+  }
+
+  &:hover::after {
+    box-shadow: 0 0 0 1px getCssVar('border-color-hover');
+  }
+
+  &:focus-within::after {
+    box-shadow: 0 0 0 1px getCssVar('color-primary');
+  }
+
+  @include when(controls-hover) {
+    &::after {
+      box-shadow: 0 0 0 1px getCssVar('color-primary');
+    }
+  }
+
+  @include when(disabled) {
+    &::after,
+    &:hover::after,
+    &:focus-within::after,
+    &.is-controls-hover::after {
+      box-shadow: 0 0 0 1px getCssVar('disabled-border-color');
+    }
+  }
+
+  .#{$namespace}-input__wrapper,
+  .#{$namespace}-input:hover .#{$namespace}-input__wrapper,
+  .#{$namespace}-input.is-focus .#{$namespace}-input__wrapper {
+    box-shadow: none !important;
+  }
+
   .#{$namespace}-input {
     &__wrapper {
       padding-left: #{map.get($input-height, 'default') + 10};
@@ -44,8 +85,8 @@
 
     position: absolute;
     z-index: 1;
-    top: 1px;
-    bottom: 1px;
+    top: 0;
+    bottom: 0;
 
     width: map.get($input-height, 'default');
     background: getCssVar('fill-color', 'light');
@@ -74,14 +115,14 @@
   }
 
   @include e(increase) {
-    right: 1px;
+    right: 0;
     border-radius: 0 getCssVar('border-radius-base')
       getCssVar('border-radius-base') 0;
     border-left: getCssVar('border');
   }
 
   @include e(decrease) {
-    left: 1px;
+    left: 0;
     border-radius: getCssVar('border-radius-base') 0 0
       getCssVar('border-radius-base');
     border-right: getCssVar('border');
@@ -148,13 +189,9 @@
     }
 
     @include e((increase, decrease)) {
-      @include set-css-var-value(
-        ('input', 'number-controls-height'),
-        math.div(map.get($input-height, 'default') - 2, 2)
-      );
+      @include set-css-var-value(('input', 'number-controls-height'), 50%);
 
       height: getCssVar('input-number-controls-height');
-      line-height: getCssVar('input-number-controls-height');
 
       [class*='#{$namespace}-icon'] {
         transform: scale(0.8);
@@ -169,7 +206,7 @@
     }
 
     @include e(decrease) {
-      right: 1px;
+      right: 0;
       top: auto;
       left: auto;
       border-right: none;
@@ -183,7 +220,7 @@
         [class*='decrease'] {
           @include set-css-var-value(
             ('input', 'number-controls-height'),
-            math.div(map.get($input-height, $size) - 2, 2)
+            math.div(map.get($input-height, $size), 2)
           );
         }
       }

--- a/packages/theme-chalk/src/input-number.scss
+++ b/packages/theme-chalk/src/input-number.scss
@@ -17,7 +17,10 @@
     inset: 0;
     z-index: 2;
     pointer-events: none;
-    border-radius: getCssVar('border-radius', 'base');
+    border-radius: getCssVarWithDefault(
+      'input-border-radius',
+      map.get($input, 'border-radius')
+    );
     box-sizing: border-box;
     box-shadow: 0 0 0 1px getCssVar('border-color') inset;
     transition: getCssVar('transition-box-shadow');

--- a/packages/theme-chalk/src/input-number.scss
+++ b/packages/theme-chalk/src/input-number.scss
@@ -19,21 +19,21 @@
     pointer-events: none;
     border-radius: getCssVar('border-radius', 'base');
     box-sizing: border-box;
-    box-shadow: 0 0 0 1px getCssVar('border-color');
+    box-shadow: 0 0 0 1px getCssVar('border-color') inset;
     transition: getCssVar('transition-box-shadow');
   }
 
   &:hover::after {
-    box-shadow: 0 0 0 1px getCssVar('border-color-hover');
+    box-shadow: 0 0 0 1px getCssVar('border-color-hover') inset;
   }
 
   &:focus-within::after {
-    box-shadow: 0 0 0 1px getCssVar('color-primary');
+    box-shadow: 0 0 0 1px getCssVar('color-primary') inset;
   }
 
   @include when(controls-hover) {
     &::after {
-      box-shadow: 0 0 0 1px getCssVar('color-primary');
+      box-shadow: 0 0 0 1px getCssVar('color-primary') inset;
     }
   }
 
@@ -42,7 +42,7 @@
     &:hover::after,
     &:focus-within::after,
     &.is-controls-hover::after {
-      box-shadow: 0 0 0 1px getCssVar('disabled-border-color');
+      box-shadow: 0 0 0 1px getCssVar('disabled-border-color') inset;
     }
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

Closes #24796
close #20369
close #20979
close #20980

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

### Bug Fixes
Fix the `el-input-number` border being partially covered by the `increase` / `decrease` controls on high-DPI displays.
- Render the outer border with a root-level `box-shadow`
- Remove the unnecessary 1px gaps around the controls
- Fix control heights in `controls-position="right"` mode

### Visual Comparison
Before: 
<img width="298" height="99" alt="image" src="https://github.com/user-attachments/assets/4fff3b1b-70dc-4a58-af44-7f2705c2af14" />

After: 
<img width="322" height="105" alt="image" src="https://github.com/user-attachments/assets/32953f0d-e0d7-40b3-bc13-a81adab16bb9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved InputNumber styling across hover, focus, disabled, and control-hover states.
  * Added clearer visual feedback when hovering over increase and decrease controls.
  * Refined right-aligned controls across default, large, and small sizes.
  * Improved control button alignment and sizing for a more consistent appearance.
* **Bug Fixes**
  * Improved error-state styling for InputNumber fields within forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->