### PR TITLE
docs(table-v2): AutoResizer 弹性高度父容器补充 height:0 包裹提示（fix #13163）

### DIFF
--- a/docs/en-US/component/table-v2.md
+++ b/docs/en-US/component/table-v2.md
@@ -40,6 +40,8 @@ Resize your browser to see how it works.
 Make sure the parent node of the `AutoResizer` **HAS A FIXED HEIGHT**, since its default height value is set to 100%.
 Alternatively, you can define it by passing the `style` attribute to `AutoResizer`.
 
+When the parent container can only take a flexible height (e.g. `height: 100%` or `flex: 1`) instead of a fixed one, wrap `el-table-v2` in a `<div style="height: 0">` inside the `AutoResizer` default slot. Otherwise the table keeps growing to fill an ever-increasing height and triggers an infinite render loop.
+
 :::
 
 :::demo


### PR DESCRIPTION
## 关联 Issue
fixes #13163

## 问题
官方文档「Auto resizer」一节要求 `AutoResizer` 的父节点**必须有固定高度**（因其默认高度为 100%）。但实际布局里，父容器常常只能用弹性高度（如 `height: 100%` 或 `flex: 1`），此时 `el-table-v2` 会不断撑高自身高度、陷入无限渲染循环，原文档没有提示这个坑，新手很容易踩。

## 修改
在 AutoResizer 的 `:::tip` 中补充一条：当父容器无法使用固定高度时，可在 `AutoResizer` 默认插槽内用 `<div style="height: 0">` 包裹 `el-table-v2`，避免高度被无限撑开。

仅文档改动，不涉及示例代码逻辑。

## 验证
补充内容基于 issue #13163 中反馈者给出的可运行示例（在 `el-auto-resizer` 内用 `height:0` 的 div 包裹表格即可消除无限撑高）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using `el-table-v2` with flexible-height containers.
  * Documented a wrapper pattern to prevent unbounded growth and infinite render loops when using `AutoResizer`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->