### PR TITLE
fix(components): [select/select-v2] keep input-wrapper in flow so auto-sized layouts keep their width

### DIFF
--- a/packages/components/select-v2/__tests__/select.test.ts
+++ b/packages/components/select-v2/__tests__/select.test.ts
@@ -2984,84 +2984,61 @@ describe('Select', () => {
     expect((select.vm as any).expanded).toBe(true)
   })
 
-  describe('input-wrapper in multiple mode', () => {
-    it('should hide input-wrapper when empty and not focused', async () => {
+  describe('input-wrapper visibility', () => {
+    // #24457 / #24167: hiding the input-wrapper on "empty and not focused"
+    // took it out of the document flow (position: absolute), which collapsed
+    // the select to the width of its tags inside auto-sized layouts such as
+    // inline forms. The wrapper must stay in flow and only be hidden when it
+    // carries no input at all.
+    it.each([
+      ['multiple', { multiple: true, filterable: true }],
+      ['single', { filterable: true }],
+    ])(
+      'should keep input-wrapper in flow in %s mode when empty and not focused',
+      async (_mode, data) => {
+        const wrapper = createSelect({ data: () => data })
+        await nextTick()
+        const select = wrapper.findComponent(Select)
+        const inputWrapper = select.find('.el-select__input-wrapper')
+        const input = select.find('input')
+
+        expect(inputWrapper.classes()).not.toContain('is-hidden')
+
+        await input.trigger('focus')
+        expect(inputWrapper.classes()).not.toContain('is-hidden')
+
+        await input.trigger('blur')
+        expect(inputWrapper.classes()).not.toContain('is-hidden')
+      }
+    )
+
+    it('should hide input-wrapper when not filterable', async () => {
+      const wrapper = createSelect({
+        data: () => ({
+          multiple: true,
+          filterable: false,
+        }),
+      })
+      await nextTick()
+      const select = wrapper.findComponent(Select)
+      const inputWrapper = select.find('.el-select__input-wrapper')
+
+      expect(inputWrapper.classes()).toContain('is-hidden')
+    })
+
+    it('should hide input-wrapper when disabled', async () => {
       const wrapper = createSelect({
         data: () => ({
           multiple: true,
           filterable: true,
+          disabled: true,
         }),
       })
       await nextTick()
       const select = wrapper.findComponent(Select)
       const inputWrapper = select.find('.el-select__input-wrapper')
-      const input = select.find('input')
 
-      // When input is empty and not focused, input-wrapper should have hidden class
       expect(inputWrapper.classes()).toContain('is-hidden')
-
-      // Focus the input
-      await input.trigger('focus')
-
-      // When focused, input-wrapper should not have hidden class
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      // Blur the input
-      await input.trigger('blur')
-
-      // When blurred and empty, input-wrapper should have hidden class again
-      expect(inputWrapper.classes()).toContain('is-hidden')
-    })
-
-    it('should show input-wrapper when input has value', async () => {
-      const wrapper = createSelect({
-        data: () => ({
-          multiple: true,
-          filterable: true,
-        }),
-      })
-      await nextTick()
-      const select = wrapper.findComponent(Select)
-      const inputWrapper = select.find('.el-select__input-wrapper')
-      const input = select.find('input')
-
-      // Initially empty, should be hidden
-      expect(inputWrapper.classes()).toContain('is-hidden')
-
-      // Set input value
-      await input.setValue('test')
-
-      // When input has value, input-wrapper should not have hidden class
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      // Clear input
-      await input.setValue('')
-
-      // When empty again, should be hidden
-      expect(inputWrapper.classes()).toContain('is-hidden')
-    })
-
-    // #24167: in single mode the empty/blur condition must NOT hide the
-    // input-wrapper, otherwise it falls out of flow and the selection
-    // collapses to zero width inside auto-sized form layouts.
-    it('should not hide input-wrapper in single mode when empty and not focused', async () => {
-      const wrapper = createSelect({
-        data: () => ({
-          filterable: true,
-        }),
-      })
-      await nextTick()
-      const select = wrapper.findComponent(Select)
-      const inputWrapper = select.find('.el-select__input-wrapper')
-      const input = select.find('input')
-
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      await input.trigger('focus')
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      await input.trigger('blur')
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
     })
   })
 

--- a/packages/components/select-v2/src/select.vue
+++ b/packages/components/select-v2/src/select.vue
@@ -173,12 +173,7 @@
               :class="[
                 nsSelect.e('selected-item'),
                 nsSelect.e('input-wrapper'),
-                nsSelect.is(
-                  'hidden',
-                  !filterable ||
-                    selectDisabled ||
-                    (multiple && !states.inputValue && !isFocused)
-                ),
+                nsSelect.is('hidden', !filterable || selectDisabled),
               ]"
             >
               <input

--- a/packages/components/select/__tests__/select.test.ts
+++ b/packages/components/select/__tests__/select.test.ts
@@ -4402,72 +4402,46 @@ describe('Select', () => {
     vi.useRealTimers()
   })
 
-  describe('input-wrapper in multiple mode', () => {
-    test('should hide input-wrapper when empty and not focused', async () => {
-      wrapper = getSelectVm({
-        multiple: true,
-        filterable: true,
-      })
+  describe('input-wrapper visibility', () => {
+    // #24457 / #24167: hiding the input-wrapper on "empty and not focused"
+    // took it out of the document flow (position: absolute), which collapsed
+    // the select to the width of its tags inside auto-sized layouts such as
+    // inline forms. The wrapper must stay in flow and only be hidden when it
+    // carries no input at all.
+    test.each([
+      ['multiple', { multiple: true, filterable: true }],
+      ['single', { filterable: true }],
+    ])(
+      'should keep input-wrapper in flow in %s mode when empty and not focused',
+      async (_mode, props) => {
+        wrapper = getSelectVm(props)
+        const inputWrapper = wrapper.find('.el-select__input-wrapper')
+        const input = wrapper.find('input')
+
+        expect(inputWrapper.classes()).not.toContain('is-hidden')
+
+        await input.trigger('focus')
+        expect(inputWrapper.classes()).not.toContain('is-hidden')
+
+        await input.trigger('blur')
+        expect(inputWrapper.classes()).not.toContain('is-hidden')
+      }
+    )
+
+    test('should hide input-wrapper when not filterable', async () => {
+      wrapper = getSelectVm({ multiple: true, filterable: false })
       const inputWrapper = wrapper.find('.el-select__input-wrapper')
-      const input = wrapper.find('input')
 
-      // When input is empty and not focused, input-wrapper should have hidden class
-      expect(inputWrapper.classes()).toContain('is-hidden')
-
-      // Focus the input
-      await input.trigger('focus')
-
-      // When focused, input-wrapper should not have hidden class
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      // Blur the input
-      await input.trigger('blur')
-
-      // When blurred and empty, input-wrapper should have hidden class again
       expect(inputWrapper.classes()).toContain('is-hidden')
     })
 
-    test('should show input-wrapper when input has value', async () => {
-      wrapper = getSelectVm({
-        multiple: true,
-        filterable: true,
-      })
+    test('should hide input-wrapper when disabled', async () => {
+      wrapper = _mount(
+        `<el-select disabled filterable multiple><el-option label="a" value="a" /></el-select>`
+      )
       const inputWrapper = wrapper.find('.el-select__input-wrapper')
-      const input = wrapper.find('input')
 
-      // Initially empty, should be hidden
       expect(inputWrapper.classes()).toContain('is-hidden')
-
-      // Set input value
-      await input.setValue('test')
-
-      // When input has value, input-wrapper should not have hidden class
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      // Clear input
-      await input.setValue('')
-
-      // When empty again, should be hidden
-      expect(inputWrapper.classes()).toContain('is-hidden')
-    })
-
-    // #24167: in single mode the empty/blur condition must NOT hide the
-    // input-wrapper, otherwise it falls out of flow and the selection
-    // collapses to zero width inside auto-sized form layouts.
-    test('should not hide input-wrapper in single mode when empty and not focused', async () => {
-      wrapper = getSelectVm({
-        filterable: true,
-      })
-      const inputWrapper = wrapper.find('.el-select__input-wrapper')
-      const input = wrapper.find('input')
-
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      await input.trigger('focus')
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
-
-      await input.trigger('blur')
-      expect(inputWrapper.classes()).not.toContain('is-hidden')
     })
   })
 

--- a/packages/components/select/src/select.vue
+++ b/packages/components/select/src/select.vue
@@ -171,12 +171,7 @@
               :class="[
                 nsSelect.e('selected-item'),
                 nsSelect.e('input-wrapper'),
-                nsSelect.is(
-                  'hidden',
-                  !filterable ||
-                    selectDisabled ||
-                    (multiple && !states.inputValue && !isFocused)
-                ),
+                nsSelect.is('hidden', !filterable || selectDisabled),
               ]"
             >
               <input

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -205,12 +205,16 @@
 
   @include e(input-wrapper) {
     flex: 1;
+    // Allow the wrapper to shrink below the input's intrinsic width so an
+    // empty input never wraps onto its own line (see #23394) while still
+    // occupying its flex slot — auto-sized layouts such as inline forms
+    // rely on it to reserve width (#24167, #24457).
+    min-width: 0;
 
     @include when(hidden) {
-      // Out of the document flow
-      position: absolute;
       opacity: 0;
       z-index: -1;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
Fixes #24457

## Problem

Inside `el-form--inline` (and any auto-sized layout), a `multiple` + `filterable`
`el-select` collapses to the width of its tags: with fewer than two selections
the control is too narrow, `max-collapse-tags=1` clips the first tag, and the
clear icon gets pushed out of reach.

## Root cause

This is the second half of a regression chain:

- `#23394` hid the `input-wrapper` when the input was empty and unfocused, to fix
  the empty input wrapping onto its own line and growing the control's height.
  It did this with `position: absolute` — taking the wrapper **out of the document
  flow**.
- `#24177` (2.14.2) fixed the resulting "select has no width" bug for **single**
  mode only, by scoping the condition with `multiple &&`.

So `multiple` mode was left with the original defect: the wrapper is
`flex: 1` inside a `flex-wrap: wrap` container, and making it `absolute` removes
its flex slot entirely — the auto-sized control then has nothing left to size
against except the tags.

Two fixes were in tension: "don't let the empty input wrap" vs "don't collapse
the width". Taking the element out of flow satisfies the first by breaking the
second.

## Fix

Solve the wrapping problem without leaving the flow:

- **CSS** — `.el-select__input-wrapper` gets `min-width: 0`, so it can shrink
  below the input's intrinsic width and never forces a line break. `is-hidden`
  no longer applies `position: absolute`; it hides with `opacity` +
  `pointer-events: none` and keeps its slot in the flex layout.
- **Template** — the `is-hidden` condition drops the "empty and not focused"
  clause entirely (both `select` and `select-v2`), returning to
  `!filterable || selectDisabled`. The wrapper is now hidden only when there is
  genuinely no input to host.

This keeps both behaviours: no extra line break for an empty input (#23394), and
a real width in auto-sized layouts for **both** single and multiple mode
(#24167, #24457).

## Tests

`packages/components/select` and `select-v2` — replaced the mode-specific
assertions with:

- `input-wrapper` stays in flow in **both** single and multiple mode when empty
  and not focused (focus/blur cycles asserted)
- still hidden when not `filterable`
- still hidden when `disabled`

281 tests pass across `select`, `select-v2`, `options` and downstream
`tree-select`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Filterable single- and multiple-select inputs now remain visible in the layout when empty or unfocused.
  - Input wrappers are hidden consistently when filtering is unavailable or the select is disabled.
  - Improved behavior for shrinking select inputs in constrained layouts.

- **Style**
  - Hidden input wrappers no longer interfere with pointer interactions or content positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->