### PR TITLE
fix(components): avoid linking form labels to group containers

### DIFF
--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -844,11 +844,10 @@ describe('check-button', () => {
       const formItem = await wrapper.findComponent(ElFormItem)
       const checkboxGroup = await wrapper.findComponent(CheckboxGroup)
       const formItemLabel = formItem.find('.el-form-item__label')
-      expect(formItem.attributes('role')).toBeFalsy()
+      expect(formItem.attributes('role')).toBe('group')
       expect(checkboxGroup.attributes('role')).toBe('group')
-      expect(formItemLabel.attributes('for')).toBe(
-        checkboxGroup.attributes('id')
-      )
+      expect(checkboxGroup.attributes('id')).toBeTruthy()
+      expect(formItemLabel.attributes('for')).toBeFalsy()
       expect(formItemLabel.attributes('id')).toBe(
         checkboxGroup.attributes('aria-labelledby')
       )
@@ -867,9 +866,8 @@ describe('check-button', () => {
       const formItem = await wrapper.findComponent(ElFormItem)
       const checkboxGroup = await wrapper.findComponent(CheckboxGroup)
       const formItemLabel = formItem.find('.el-form-item__label')
-      expect(formItemLabel.attributes('for')).toBe(
-        checkboxGroup.attributes('id')
-      )
+      expect(formItem.attributes('role')).toBe('group')
+      expect(formItemLabel.attributes('for')).toBeFalsy()
       expect(checkboxGroup.attributes('role')).toBe('group')
       expect(checkboxGroup.attributes()['aria-label']).toBe('Foo')
       expect(checkboxGroup.attributes()['aria-labelledby']).toBeFalsy()

--- a/packages/components/checkbox/src/checkbox-group.vue
+++ b/packages/components/checkbox/src/checkbox-group.vue
@@ -60,6 +60,8 @@ const checkboxDisabled = useFormDisabled()
 const { formItem } = useFormItem()
 const { inputId: groupId, isLabeledByFormItem } = useFormItemInputId(props, {
   formItemContext: formItem,
+  // The group root is not labelable; use aria-labelledby instead of label[for].
+  disableIdManagement: computed(() => true),
 })
 
 const changeEvent = async (value: CheckboxGroupValueType) => {

--- a/packages/components/radio/__tests__/radio.test.tsx
+++ b/packages/components/radio/__tests__/radio.test.tsx
@@ -461,9 +461,10 @@ describe('Radio Button', () => {
       const formItem = await wrapper.findComponent(ElFormItem)
       const radioGroup = await wrapper.findComponent(RadioGroup)
       const formItemLabel = formItem.find('.el-form-item__label')
-      expect(formItem.attributes().role).toBeFalsy()
+      expect(formItem.attributes().role).toBe('group')
       expect(radioGroup.attributes().role).toBe('radiogroup')
-      expect(formItemLabel.attributes().for).toBe(radioGroup.attributes().id)
+      expect(radioGroup.attributes().id).toBeTruthy()
+      expect(formItemLabel.attributes().for).toBeFalsy()
       expect(formItemLabel.attributes().id).toBe(
         radioGroup.attributes()['aria-labelledby']
       )
@@ -482,7 +483,8 @@ describe('Radio Button', () => {
       const formItem = await wrapper.findComponent(ElFormItem)
       const radioGroup = await wrapper.findComponent(RadioGroup)
       const formItemLabel = formItem.find('.el-form-item__label')
-      expect(formItemLabel.attributes().for).toBe(radioGroup.attributes().id)
+      expect(formItem.attributes().role).toBe('group')
+      expect(formItemLabel.attributes().for).toBeFalsy()
       expect(radioGroup.attributes().role).toBe('radiogroup')
       expect(radioGroup.attributes()['aria-label']).toBe('Foo')
       expect(radioGroup.attributes()['aria-labelledby']).toBeFalsy()

--- a/packages/components/radio/src/radio-group.vue
+++ b/packages/components/radio/src/radio-group.vue
@@ -60,6 +60,8 @@ const radioGroupRef = ref<HTMLDivElement>()
 const { formItem } = useFormItem()
 const { inputId: groupId, isLabeledByFormItem } = useFormItemInputId(props, {
   formItemContext: formItem,
+  // The group root is not labelable; use aria-labelledby instead of label[for].
+  disableIdManagement: computed(() => true),
 })
 
 const changeEvent = (value: RadioGroupProps['modelValue']) => {

--- a/packages/components/segmented/__tests__/segmented.test.tsx
+++ b/packages/components/segmented/__tests__/segmented.test.tsx
@@ -2,7 +2,7 @@ import { nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vitest'
 import Segmented from '../src/segmented.vue'
-import { ElForm } from '@element-plus/components/form'
+import { ElForm, ElFormItem } from '@element-plus/components/form'
 import { defineGetter } from '@element-plus/test-utils'
 
 describe('Segmented.vue', () => {
@@ -188,6 +188,27 @@ describe('Segmented.vue', () => {
     expect(wrapper.attributes('id')).toEqual('id')
     expect(wrapper.attributes('aria-label')).toEqual('label')
     expect(input.attributes('name')).toEqual('name')
+  })
+
+  test('form item accessibility integration', async () => {
+    const value = ref('Mon')
+    const wrapper = mount(() => (
+      <ElFormItem label="Activity type">
+        <Segmented v-model={value.value} options={['Mon', 'Tue']} />
+      </ElFormItem>
+    ))
+    await nextTick()
+
+    const formItem = wrapper.findComponent(ElFormItem)
+    const segmented = wrapper.findComponent(Segmented)
+    const formItemLabel = formItem.find('.el-form-item__label')
+
+    expect(formItem.attributes('role')).toBe('group')
+    expect(formItemLabel.attributes('for')).toBeFalsy()
+    expect(segmented.attributes('id')).toBeTruthy()
+    expect(formItemLabel.attributes('id')).toBe(
+      segmented.attributes('aria-labelledby')
+    )
   })
 
   test('async disabled', async () => {

--- a/packages/components/segmented/src/segmented.vue
+++ b/packages/components/segmented/src/segmented.vue
@@ -69,6 +69,8 @@ const _disabled = useFormDisabled()
 const { formItem } = useFormItem()
 const { inputId, isLabeledByFormItem } = useFormItemInputId(props, {
   formItemContext: formItem,
+  // The group root is not labelable; use aria-labelledby instead of label[for].
+  disableIdManagement: computed(() => true),
 })
 
 const segmentedRef = ref<HTMLElement | null>(null)


### PR DESCRIPTION
Prevent checkbox, radio, and segmented group container IDs from being used as ElFormItem

label targets.

These containers are not labelable form controls. Linking them through label[for] can trigger

browser accessibility warnings.

Preserve aria-labelledby associations and add regression tests for form-item integration.

Closes #24818

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for checkbox, radio, and segmented controls used within form items.
  * Form item labels now use accessible group labeling instead of invalid label-to-control associations.
  * Ensured appropriate group roles, IDs, and `aria-labelledby` relationships are exposed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->