### PR TITLE
feat(components): [backtop] add showProgress for scroll progress

### DIFF
--- a/docs/en-US/component/backtop.md
+++ b/docs/en-US/component/backtop.md
@@ -27,16 +27,27 @@ backtop/custom
 
 :::
 
+## Progress
+
+Set `show-progress` to display the current scroll progress around the button edge.
+
+:::demo
+
+backtop/progress
+
+:::
+
 ## API
 
 ### Attributes
 
-| Name              | Description                                                          | Type      | Default |
-| ----------------- | -------------------------------------------------------------------- | --------- | ------- |
-| target            | the target to trigger scroll.                                        | ^[string] | —       |
-| visibility-height | the button will not show until the scroll height reaches this value. | ^[number] | 200     |
-| right             | right distance.                                                      | ^[number] | 40      |
-| bottom            | bottom distance.                                                     | ^[number] | 40      |
+| Name                    | Description                                                          | Type       | Default |
+| ----------------------- | -------------------------------------------------------------------- | ---------- | ------- |
+| target                  | the target to trigger scroll.                                        | ^[string]  | —       |
+| visibility-height       | the button will not show until the scroll height reaches this value. | ^[number]  | 200     |
+| right                   | right distance.                                                      | ^[number]  | 40      |
+| bottom                  | bottom distance.                                                     | ^[number]  | 40      |
+| show-progress ^(2.14.6) | whether to show scroll progress around the button.                   | ^[boolean] | false   |
 
 ### Events
 

--- a/docs/examples/backtop/progress.vue
+++ b/docs/examples/backtop/progress.vue
@@ -1,0 +1,4 @@
+<template>
+  Scroll down to see the bottom-right button and its scroll progress.
+  <el-backtop :right="160" :bottom="100" show-progress />
+</template>

--- a/packages/components/backtop/__tests__/backtop.test.tsx
+++ b/packages/components/backtop/__tests__/backtop.test.tsx
@@ -9,6 +9,9 @@ import type { VNode } from 'vue'
 const _mount = (render: () => VNode) =>
   mount(render, { attachTo: document.body })
 
+const nextFrame = () =>
+  new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
 describe('Backtop.vue', () => {
   test('render', async () => {
     const wrapper = _mount(() => (
@@ -28,12 +31,15 @@ describe('Backtop.vue', () => {
     expect(wrapper.find('.el-backtop').exists()).toBe(false)
     wrapper.element.scrollTop = 2000
     await wrapper.trigger('scroll')
+    await nextFrame()
     expect(wrapper.find('.el-backtop').exists()).toBe(true)
 
     expect(wrapper.find('.el-backtop').attributes('style')).toBe(
       'right: 100px; bottom: 200px;'
     )
     expect(wrapper.findComponent(CaretTop).exists()).toBe(true)
+    expect(wrapper.find('.el-backtop--progress').exists()).toBe(false)
+    expect(wrapper.find('.el-backtop--circle').exists()).toBe(true)
 
     await wrapper.trigger('click')
     expect(wrapper.emitted()).toBeDefined()
@@ -45,5 +51,95 @@ describe('Backtop.vue', () => {
     await nextTick()
 
     expect(wrapper.find('.el-backtop').exists()).toBe(true)
+  })
+
+  test('displays scroll progress when showProgress is enabled', async () => {
+    const wrapper = _mount(() => (
+      <div class="progress-target" style="height: 100px; overflow: auto">
+        <Backtop target=".progress-target" visibilityHeight={0} showProgress />
+      </div>
+    ))
+    await nextTick()
+    Object.defineProperties(wrapper.element, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 1000 },
+    })
+    wrapper.element.scrollTop = 450
+    await wrapper.trigger('scroll')
+    await nextFrame()
+
+    const progress = wrapper.find('.el-backtop--progress')
+    expect(progress.exists()).toBe(true)
+    expect(progress.classes()).toContain('el-backtop--circle')
+    expect(progress.attributes('style')).toContain(
+      '--el-backtop-progress: 0.5turn'
+    )
+
+    wrapper.element.scrollTop = 0
+    await wrapper.trigger('scroll')
+    await nextFrame()
+    expect(progress.attributes('style')).toContain(
+      '--el-backtop-progress: 0turn'
+    )
+
+    wrapper.element.scrollTop = 900
+    await wrapper.trigger('scroll')
+    await nextFrame()
+    expect(progress.attributes('style')).toContain(
+      '--el-backtop-progress: 1turn'
+    )
+  })
+
+  test('updates progress when showProgress is enabled at runtime', async () => {
+    const target = document.createElement('div')
+    target.className = 'runtime-target'
+    document.body.appendChild(target)
+    const wrapper = mount(Backtop, {
+      attachTo: target,
+      props: { target: '.runtime-target', visibilityHeight: 0 },
+    })
+    await nextTick()
+    Object.defineProperties(target, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 1000 },
+    })
+    target.scrollTop = 450
+    target.dispatchEvent(new Event('scroll'))
+    await nextFrame()
+
+    await wrapper.setProps({ showProgress: true })
+
+    expect(wrapper.attributes('style')).toContain(
+      '--el-backtop-progress: 0.5turn'
+    )
+
+    Object.defineProperty(target, 'scrollHeight', {
+      configurable: true,
+      value: 1900,
+    })
+    window.dispatchEvent(new Event('resize'))
+    await nextFrame()
+
+    expect(wrapper.attributes('style')).toContain(
+      '--el-backtop-progress: 0.25turn'
+    )
+    wrapper.unmount()
+    target.remove()
+  })
+
+  test('does not force a circular progress ring for custom content', async () => {
+    const wrapper = mount(Backtop, {
+      attachTo: document.body,
+      props: { showProgress: true, visibilityHeight: 0 },
+      slots: { default: '<div class="custom-content">UP</div>' },
+    })
+    await nextTick()
+
+    const backtop = wrapper.find('.el-backtop')
+    expect(backtop.classes()).toContain('el-backtop--progress')
+    expect(backtop.classes()).not.toContain('el-backtop--circle')
+    expect(wrapper.find('.custom-content').element.parentElement).toBe(
+      backtop.element
+    )
   })
 })

--- a/packages/components/backtop/__tests__/backtop.test.tsx
+++ b/packages/components/backtop/__tests__/backtop.test.tsx
@@ -90,7 +90,7 @@ describe('Backtop.vue', () => {
     )
   })
 
-  test('updates progress when its scroll range changes', async () => {
+  test('updates progress when showProgress is enabled at runtime', async () => {
     const target = document.createElement('div')
     target.className = 'runtime-target'
     document.body.appendChild(target)
@@ -124,78 +124,8 @@ describe('Backtop.vue', () => {
       '--el-backtop-progress: 0.25turn'
     )
 
-    const content = document.createElement('div')
-    target.appendChild(content)
-    await nextTick()
-    await nextFrame()
-
-    expect(wrapper.attributes('style')).toContain(
-      '--el-backtop-progress: 0.25turn'
-    )
-
-    Object.defineProperty(target, 'scrollHeight', {
-      configurable: true,
-      value: 1000,
-    })
-    content.className = 'expanded'
-    await nextTick()
-    await nextFrame()
-
-    expect(wrapper.attributes('style')).toContain(
-      '--el-backtop-progress: 0.5turn'
-    )
-
-    Object.defineProperty(target, 'scrollHeight', {
-      configurable: true,
-      value: 1900,
-    })
-    content.style.height = '100px'
-    await nextTick()
-    await nextFrame()
-
-    expect(wrapper.attributes('style')).toContain(
-      '--el-backtop-progress: 0.25turn'
-    )
     wrapper.unmount()
     target.remove()
-  })
-
-  test('updates document progress when its scroll range changes', async () => {
-    const root = document.documentElement
-    const content = document.createElement('div')
-    const wrapper = mount(Backtop, {
-      attachTo: document.body,
-      props: { showProgress: true, visibilityHeight: 0 },
-    })
-    await nextTick()
-    Object.defineProperties(root, {
-      clientHeight: { configurable: true, value: 100 },
-      scrollHeight: { configurable: true, value: 1000 },
-    })
-    root.scrollTop = 450
-    document.dispatchEvent(new Event('scroll'))
-    await nextFrame()
-
-    expect(wrapper.attributes('style')).toContain(
-      '--el-backtop-progress: 0.5turn'
-    )
-
-    Object.defineProperty(root, 'scrollHeight', {
-      configurable: true,
-      value: 1900,
-    })
-    document.body.appendChild(content)
-    await nextTick()
-    await nextFrame()
-
-    expect(wrapper.attributes('style')).toContain(
-      '--el-backtop-progress: 0.25turn'
-    )
-    wrapper.unmount()
-    content.remove()
-    delete (root as { clientHeight?: number }).clientHeight
-    delete (root as { scrollHeight?: number }).scrollHeight
-    root.scrollTop = 0
   })
 
   test('does not force a circular progress ring for custom content', async () => {

--- a/packages/components/backtop/__tests__/backtop.test.tsx
+++ b/packages/components/backtop/__tests__/backtop.test.tsx
@@ -124,19 +124,78 @@ describe('Backtop.vue', () => {
       '--el-backtop-progress: 0.25turn'
     )
 
+    const content = document.createElement('div')
+    target.appendChild(content)
+    await nextTick()
+    await nextFrame()
+
+    expect(wrapper.attributes('style')).toContain(
+      '--el-backtop-progress: 0.25turn'
+    )
+
     Object.defineProperty(target, 'scrollHeight', {
       configurable: true,
       value: 1000,
     })
-    target.appendChild(document.createElement('div'))
+    content.className = 'expanded'
     await nextTick()
     await nextFrame()
 
     expect(wrapper.attributes('style')).toContain(
       '--el-backtop-progress: 0.5turn'
     )
+
+    Object.defineProperty(target, 'scrollHeight', {
+      configurable: true,
+      value: 1900,
+    })
+    content.style.height = '100px'
+    await nextTick()
+    await nextFrame()
+
+    expect(wrapper.attributes('style')).toContain(
+      '--el-backtop-progress: 0.25turn'
+    )
     wrapper.unmount()
     target.remove()
+  })
+
+  test('updates document progress when its scroll range changes', async () => {
+    const root = document.documentElement
+    const content = document.createElement('div')
+    const wrapper = mount(Backtop, {
+      attachTo: document.body,
+      props: { showProgress: true, visibilityHeight: 0 },
+    })
+    await nextTick()
+    Object.defineProperties(root, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 1000 },
+    })
+    root.scrollTop = 450
+    document.dispatchEvent(new Event('scroll'))
+    await nextFrame()
+
+    expect(wrapper.attributes('style')).toContain(
+      '--el-backtop-progress: 0.5turn'
+    )
+
+    Object.defineProperty(root, 'scrollHeight', {
+      configurable: true,
+      value: 1900,
+    })
+    document.body.appendChild(content)
+    await nextTick()
+    await nextFrame()
+
+    expect(wrapper.attributes('style')).toContain(
+      '--el-backtop-progress: 0.25turn'
+    )
+    wrapper.unmount()
+    content.remove()
+    delete (root as { clientHeight?: number }).clientHeight
+    delete (root as { scrollHeight?: number }).scrollHeight
+    root.scrollTop = 0
   })
 
   test('does not force a circular progress ring for custom content', async () => {
@@ -153,5 +212,6 @@ describe('Backtop.vue', () => {
     expect(wrapper.find('.custom-content').element.parentElement).toBe(
       backtop.element
     )
+    wrapper.unmount()
   })
 })

--- a/packages/components/backtop/__tests__/backtop.test.tsx
+++ b/packages/components/backtop/__tests__/backtop.test.tsx
@@ -90,7 +90,7 @@ describe('Backtop.vue', () => {
     )
   })
 
-  test('updates progress when showProgress is enabled at runtime', async () => {
+  test('updates progress when its scroll range changes', async () => {
     const target = document.createElement('div')
     target.className = 'runtime-target'
     document.body.appendChild(target)
@@ -122,6 +122,18 @@ describe('Backtop.vue', () => {
 
     expect(wrapper.attributes('style')).toContain(
       '--el-backtop-progress: 0.25turn'
+    )
+
+    Object.defineProperty(target, 'scrollHeight', {
+      configurable: true,
+      value: 1000,
+    })
+    target.appendChild(document.createElement('div'))
+    await nextTick()
+    await nextFrame()
+
+    expect(wrapper.attributes('style')).toContain(
+      '--el-backtop-progress: 0.5turn'
     )
     wrapper.unmount()
     target.remove()

--- a/packages/components/backtop/src/backtop.ts
+++ b/packages/components/backtop/src/backtop.ts
@@ -17,6 +17,10 @@ export interface BacktopProps {
    * @description bottom distance.
    */
   bottom?: number
+  /**
+   * @description whether to show scroll progress around the button.
+   */
+  showProgress?: boolean
 }
 
 /**
@@ -51,6 +55,10 @@ export const backtopProps = {
     type: Number,
     default: 40,
   },
+  /**
+   * @description whether to show scroll progress around the button.
+   */
+  showProgress: Boolean,
 } as const
 
 /**

--- a/packages/components/backtop/src/backtop.vue
+++ b/packages/components/backtop/src/backtop.vue
@@ -3,7 +3,13 @@
     <div
       v-if="visible"
       :style="backTopStyle"
-      :class="ns.b()"
+      :class="[
+        ns.b(),
+        {
+          [ns.m('circle')]: !showProgress || !hasCustomContent,
+          [ns.m('progress')]: showProgress,
+        },
+      ]"
       @click.stop="handleClick"
     >
       <slot>
@@ -14,7 +20,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, useSlots } from 'vue'
 import { ElIcon } from '@element-plus/components/icon'
 import { CaretTop } from '@element-plus/icons-vue'
 import { useNamespace } from '@element-plus/hooks'
@@ -34,15 +40,25 @@ const props = withDefaults(defineProps<BacktopProps>(), {
   target: '',
   right: 40,
   bottom: 40,
+  showProgress: false,
 })
 const emit = defineEmits(backtopEmits)
 
 const ns = useNamespace('backtop')
+const slots = useSlots()
+const hasCustomContent = computed(() => !!slots.default)
 
-const { handleClick, visible } = useBackTop(props, emit, COMPONENT_NAME)
+const { handleClick, scrollProgress, visible } = useBackTop(
+  props,
+  emit,
+  COMPONENT_NAME
+)
 
 const backTopStyle = computed(() => ({
   right: `${props.right}px`,
   bottom: `${props.bottom}px`,
+  ...(props.showProgress
+    ? { '--el-backtop-progress': `${scrollProgress.value}turn` }
+    : {}),
 }))
 </script>

--- a/packages/components/backtop/src/use-backtop.ts
+++ b/packages/components/backtop/src/use-backtop.ts
@@ -1,5 +1,5 @@
-import { onMounted, ref, shallowRef } from 'vue'
-import { useEventListener, useThrottleFn } from '@vueuse/core'
+import { onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
+import { useEventListener } from '@vueuse/core'
 import { throwError } from '@element-plus/utils'
 
 import type { SetupContext } from 'vue'
@@ -13,9 +13,19 @@ export const useBackTop = (
   const el = shallowRef<HTMLElement>()
   const container = shallowRef<Document | HTMLElement>()
   const visible = ref(false)
+  const scrollProgress = ref(0)
+  let animationFrameId: number | undefined
 
   const handleScroll = () => {
-    if (el.value) visible.value = el.value.scrollTop >= props.visibilityHeight
+    if (!el.value) return
+
+    const { clientHeight, scrollHeight, scrollTop } = el.value
+    visible.value = scrollTop >= props.visibilityHeight
+    if (!props.showProgress) return
+
+    const maxScrollTop = scrollHeight - clientHeight
+    scrollProgress.value =
+      maxScrollTop > 0 ? Math.min(Math.max(scrollTop / maxScrollTop, 0), 1) : 0
   }
 
   const handleClick = (event: MouseEvent) => {
@@ -23,9 +33,30 @@ export const useBackTop = (
     emit('click', event)
   }
 
-  const handleScrollThrottled = useThrottleFn(handleScroll, 300, true)
+  const scheduleScrollUpdate = () => {
+    if (animationFrameId !== undefined) return
 
-  useEventListener(container, 'scroll', handleScrollThrottled)
+    animationFrameId = requestAnimationFrame(() => {
+      handleScroll()
+      animationFrameId = undefined
+    })
+  }
+
+  const handleResize = () => {
+    if (props.showProgress) scheduleScrollUpdate()
+  }
+
+  useEventListener(container, 'scroll', scheduleScrollUpdate)
+  useEventListener('resize', handleResize)
+  watch(
+    () => props.showProgress,
+    () => handleScroll()
+  )
+  onUnmounted(() => {
+    if (animationFrameId !== undefined) {
+      cancelAnimationFrame(animationFrameId)
+    }
+  })
   onMounted(() => {
     container.value = document
     el.value = document.documentElement
@@ -43,6 +74,7 @@ export const useBackTop = (
 
   return {
     visible,
+    scrollProgress,
     handleClick,
   }
 }

--- a/packages/components/backtop/src/use-backtop.ts
+++ b/packages/components/backtop/src/use-backtop.ts
@@ -1,9 +1,5 @@
-import { computed, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
-import {
-  useEventListener,
-  useMutationObserver,
-  useResizeObserver,
-} from '@vueuse/core'
+import { onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
+import { useEventListener } from '@vueuse/core'
 import { throwError } from '@element-plus/utils'
 
 import type { SetupContext } from 'vue'
@@ -16,10 +12,6 @@ export const useBackTop = (
 ) => {
   const el = shallowRef<HTMLElement>()
   const container = shallowRef<Document | HTMLElement>()
-  // Only observe content changes while progress is shown for the active target.
-  const contentTarget = computed(() =>
-    props.showProgress ? el.value : undefined
-  )
   const visible = ref(false)
   const scrollProgress = ref(0)
   let animationFrameId: number | undefined
@@ -54,24 +46,8 @@ export const useBackTop = (
     if (props.showProgress) scheduleScrollUpdate()
   }
 
-  const handleContentChange = () => {
-    if (props.showProgress) scheduleScrollUpdate()
-  }
-
   useEventListener(container, 'scroll', scheduleScrollUpdate)
-  // Recalculate progress when asynchronous content changes the scroll range.
-  useEventListener(contentTarget, 'load', handleContentChange, {
-    capture: true,
-  })
   useEventListener('resize', handleResize)
-  useMutationObserver(contentTarget, handleContentChange, {
-    childList: true,
-    subtree: true,
-    characterData: true,
-    attributes: true,
-    attributeFilter: ['class', 'style'],
-  })
-  useResizeObserver(contentTarget, handleContentChange)
   watch(
     () => props.showProgress,
     () => handleScroll()

--- a/packages/components/backtop/src/use-backtop.ts
+++ b/packages/components/backtop/src/use-backtop.ts
@@ -1,5 +1,9 @@
-import { onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
-import { useEventListener } from '@vueuse/core'
+import { computed, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
+import {
+  useEventListener,
+  useMutationObserver,
+  useResizeObserver,
+} from '@vueuse/core'
 import { throwError } from '@element-plus/utils'
 
 import type { SetupContext } from 'vue'
@@ -12,6 +16,10 @@ export const useBackTop = (
 ) => {
   const el = shallowRef<HTMLElement>()
   const container = shallowRef<Document | HTMLElement>()
+  // Only observe content changes when progress is shown for an explicit target.
+  const contentTarget = computed(() =>
+    props.showProgress && props.target ? el.value : undefined
+  )
   const visible = ref(false)
   const scrollProgress = ref(0)
   let animationFrameId: number | undefined
@@ -46,8 +54,22 @@ export const useBackTop = (
     if (props.showProgress) scheduleScrollUpdate()
   }
 
+  const handleContentChange = () => {
+    if (props.showProgress) scheduleScrollUpdate()
+  }
+
   useEventListener(container, 'scroll', scheduleScrollUpdate)
+  // Recalculate progress when asynchronous content changes the scroll range.
+  useEventListener(contentTarget, 'load', handleContentChange, {
+    capture: true,
+  })
   useEventListener('resize', handleResize)
+  useMutationObserver(contentTarget, handleContentChange, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  })
+  useResizeObserver(contentTarget, handleContentChange)
   watch(
     () => props.showProgress,
     () => handleScroll()

--- a/packages/components/backtop/src/use-backtop.ts
+++ b/packages/components/backtop/src/use-backtop.ts
@@ -16,9 +16,9 @@ export const useBackTop = (
 ) => {
   const el = shallowRef<HTMLElement>()
   const container = shallowRef<Document | HTMLElement>()
-  // Only observe content changes when progress is shown for an explicit target.
+  // Only observe content changes while progress is shown for the active target.
   const contentTarget = computed(() =>
-    props.showProgress && props.target ? el.value : undefined
+    props.showProgress ? el.value : undefined
   )
   const visible = ref(false)
   const scrollProgress = ref(0)
@@ -68,6 +68,8 @@ export const useBackTop = (
     childList: true,
     subtree: true,
     characterData: true,
+    attributes: true,
+    attributeFilter: ['class', 'style'],
   })
   useResizeObserver(contentTarget, handleContentChange)
   watch(

--- a/packages/theme-chalk/src/backtop.scss
+++ b/packages/theme-chalk/src/backtop.scss
@@ -21,6 +21,7 @@
 
   &:hover {
     background-color: getCssVar('backtop', 'hover-bg-color');
+    --el-backtop-progress-bg-color: #{getCssVar('backtop', 'hover-bg-color')};
   }
 
   @include e(icon) {
@@ -47,9 +48,5 @@
       );
     background-origin: border-box;
     background-clip: padding-box, border-box;
-
-    &:hover {
-      --el-backtop-progress-bg-color: #{getCssVar('backtop', 'hover-bg-color')};
-    }
   }
 }

--- a/packages/theme-chalk/src/backtop.scss
+++ b/packages/theme-chalk/src/backtop.scss
@@ -9,7 +9,7 @@
   background-color: getCssVar('backtop', 'bg-color');
   width: 40px;
   height: 40px;
-  border-radius: 50%;
+  border-radius: 0;
   color: getCssVar('backtop', 'text-color');
   display: flex;
   align-items: center;
@@ -25,5 +25,31 @@
 
   @include e(icon) {
     font-size: 20px;
+  }
+
+  @include m(circle) {
+    border-radius: 50%;
+  }
+
+  @include m(progress) {
+    --el-backtop-progress-bg-color: #{getCssVar('backtop', 'bg-color')};
+
+    box-sizing: border-box;
+    border: 2px solid transparent;
+    background-image:
+      linear-gradient(
+        var(--el-backtop-progress-bg-color),
+        var(--el-backtop-progress-bg-color)
+      ),
+      conic-gradient(
+        getCssVar('backtop', 'text-color') var(--el-backtop-progress, 0turn),
+        getCssVar('border-color-light') 0
+      );
+    background-origin: border-box;
+    background-clip: padding-box, border-box;
+
+    &:hover {
+      --el-backtop-progress-bg-color: #{getCssVar('backtop', 'hover-bg-color')};
+    }
   }
 }


### PR DESCRIPTION
Add a `showProgress` prop to the Backtop component, allowing users to display scroll progress alongside the back-to-top control.


- [X] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [X] Make sure you are merging your commits to `dev` branch.
- [X] Add some descriptions and refer to relative issues for your PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional scroll-progress ring to the Backtop button.
  * Progress updates dynamically as users scroll or resize the page.
  * Custom button content remains supported without forcing the progress ring.

* **Style**
  * Backtop buttons now use a square shape by default, with circular styling available for standard buttons.
  * Added hover-aware styling for the progress indicator.

* **Documentation**
  * Added usage guidance and an interactive example for the progress display option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->