### PR TITLE
fix(components): [upload] preserve dropped directory paths

### DIFF
--- a/packages/components/upload/__tests__/upload-dragger.test.tsx
+++ b/packages/components/upload/__tests__/upload-dragger.test.tsx
@@ -60,51 +60,67 @@ describe('<upload-dragger />', () => {
       expect(dragger.emitted('file')).toHaveLength(2)
     })
 
-    test('ondrop works with directory prop', async () => {
-      const onDrop = vi.fn()
-      const wrapper = _mount({ onDrop, directory: true })
-      const dragger = wrapper.findComponent(UploadDragger)
+    test.each([
+      ['/folder/test.txt', '', 'folder/test.txt'],
+      ['/folder/nested/test.txt', '', 'folder/nested/test.txt'],
+      ['/folder/test.txt', 'original/test.txt', 'original/test.txt'],
+      ['', '', ''],
+    ])(
+      'ondrop with directory preserves relative paths (%s, %s)',
+      async (fullPath, webkitRelativePath, expectedPath) => {
+        const onDrop = vi.fn()
+        const wrapper = _mount({ onDrop, directory: true })
+        const dragger = wrapper.findComponent(UploadDragger)
 
-      const mockFileEntry = {
-        isFile: true,
-        isDirectory: false,
-        file: (callback: any) => callback(new File(['test'], 'test.txt')),
+        const file = new File(['test'], 'test.txt')
+        Object.defineProperty(file, 'webkitRelativePath', {
+          get: () => webkitRelativePath,
+          configurable: true,
+        })
+
+        const mockFileEntry = {
+          isFile: true,
+          isDirectory: false,
+          fullPath,
+          file: (callback: FileCallback) => callback(file),
+        }
+
+        const mockDirectoryEntry = {
+          isFile: false,
+          isDirectory: true,
+          createReader: () => {
+            let read = false
+            return {
+              readEntries: (callback: any) => {
+                if (!read) {
+                  read = true
+                  callback([mockFileEntry])
+                } else {
+                  callback([])
+                }
+              },
+            }
+          },
+        }
+
+        await dragger.trigger('drop', {
+          dataTransfer: {
+            files: [],
+            items: [
+              {
+                webkitGetAsEntry: () => mockDirectoryEntry,
+              },
+            ],
+          },
+        })
+
+        await flushPromises()
+        expect(dragger.emitted('file')).toHaveLength(1)
+        const emittedFiles = dragger.emitted('file')![0][0] as File[]
+        expect(emittedFiles).toHaveLength(1)
+        expect(emittedFiles[0]).toBe(file)
+        expect(emittedFiles[0].webkitRelativePath).toBe(expectedPath)
       }
-
-      const mockDirectoryEntry = {
-        isFile: false,
-        isDirectory: true,
-        createReader: () => {
-          let read = false
-          return {
-            readEntries: (callback: any) => {
-              if (!read) {
-                read = true
-                callback([mockFileEntry])
-              } else {
-                callback([])
-              }
-            },
-          }
-        },
-      }
-
-      await dragger.trigger('drop', {
-        dataTransfer: {
-          files: [],
-          items: [
-            {
-              webkitGetAsEntry: () => mockDirectoryEntry,
-            },
-          ],
-        },
-      })
-
-      await flushPromises()
-      expect(dragger.emitted('file')).toHaveLength(1)
-      const emittedFiles = dragger.emitted('file')![0][0] as File[]
-      expect(emittedFiles).toHaveLength(1)
-      expect(emittedFiles[0].name).toBe('test.txt')
-    })
+    )
   })
 })

--- a/packages/components/upload/src/upload-dragger.vue
+++ b/packages/components/upload/src/upload-dragger.vue
@@ -56,6 +56,11 @@ const getAllFiles = async (
       const file = (await getFile(
         entry as FileSystemFileEntry
       )) as UploadRawFile
+      if (entry.fullPath && !file.webkitRelativePath) {
+        Object.defineProperty(file, 'webkitRelativePath', {
+          value: entry.fullPath.replace(/^\//, ''),
+        })
+      }
       file.isDirectory = false
       return [file]
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

fix #24833

[demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCB0eXBlIHsgVXBsb2FkUHJvcHMgfSBmcm9tICdlbGVtZW50LXBsdXMnXG5cbmNvbnN0IGhhbmRsZUNoYW5nZTogVXBsb2FkUHJvcHNbJ29uQ2hhbmdlJ10gPSAoZmlsZSkgPT4ge1xuICBjb25zb2xlLmxvZyhmaWxlLnJhdz8ud2Via2l0UmVsYXRpdmVQYXRoKVxufVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGVsLXVwbG9hZFxuICAgIGRpcmVjdG9yeVxuICAgIG11bHRpcGxlXG4gICAgZHJhZ1xuICAgIDphdXRvLXVwbG9hZD1cImZhbHNlXCJcbiAgICA6b24tY2hhbmdlPVwiaGFuZGxlQ2hhbmdlXCJcbiAgPlxuICAgIDxlbC1idXR0b24+6YCJ5oup5paH5Lu25aS5PC9lbC1idXR0b24+XG4gIDwvZWwtdXBsb2FkPlxuPC90ZW1wbGF0ZT5cbiIsImVsZW1lbnQtcGx1cy5qcyI6ImltcG9ydCBFbGVtZW50UGx1cyBmcm9tICdlbGVtZW50LXBsdXMnXG5pbXBvcnQgeyBnZXRDdXJyZW50SW5zdGFuY2UgfSBmcm9tICd2dWUnXG5cbmxldCBpbnN0YWxsZWQgPSBmYWxzZVxuYXdhaXQgbG9hZFN0eWxlKClcblxuZXhwb3J0IGZ1bmN0aW9uIHNldHVwRWxlbWVudFBsdXMoKSB7XG4gIGlmIChpbnN0YWxsZWQpIHJldHVyblxuICBjb25zdCBpbnN0YW5jZSA9IGdldEN1cnJlbnRJbnN0YW5jZSgpXG4gIGluc3RhbmNlLmFwcENvbnRleHQuYXBwLnVzZShFbGVtZW50UGx1cylcbiAgaW5zdGFsbGVkID0gdHJ1ZVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbG9hZFN0eWxlKCkge1xuICBjb25zdCBzdHlsZXMgPSBbJ2h0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vZWxlbWVudC1wbHVzQGxhdGVzdC9kaXN0L2luZGV4LmNzcycsICdodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL2VsZW1lbnQtcGx1c0BsYXRlc3QvdGhlbWUtY2hhbGsvZGFyay9jc3MtdmFycy5jc3MnXS5tYXAoKHN0eWxlKSA9PiB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaW5rJylcbiAgICAgIGxpbmsucmVsID0gJ3N0eWxlc2hlZXQnXG4gICAgICBsaW5rLmhyZWYgPSBzdHlsZVxuICAgICAgbGluay5hZGRFdmVudExpc3RlbmVyKCdsb2FkJywgcmVzb2x2ZSlcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignZXJyb3InLCByZWplY3QpXG4gICAgICBkb2N1bWVudC5ib2R5LmFwcGVuZChsaW5rKVxuICAgIH0pXG4gIH0pXG4gIHJldHVybiBQcm9taXNlLmFsbFNldHRsZWQoc3R5bGVzKVxufVxuIiwidHNjb25maWcuanNvbiI6IntcbiAgXCJjb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IFwiRVNOZXh0XCIsXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXG4gICAgXCJtb2R1bGVSZXNvbHV0aW9uXCI6IFwiQnVuZGxlclwiLFxuICAgIFwidHlwZXNcIjogW1wiZWxlbWVudC1wbHVzL2dsb2JhbC5kLnRzXCJdLFxuICAgIFwiYWxsb3dJbXBvcnRpbmdUc0V4dGVuc2lvbnNcIjogdHJ1ZSxcbiAgICBcImFsbG93SnNcIjogdHJ1ZSxcbiAgICBcImNoZWNrSnNcIjogdHJ1ZVxuICB9LFxuICBcInZ1ZUNvbXBpbGVyT3B0aW9uc1wiOiB7XG4gICAgXCJ0YXJnZXRcIjogMy4zXG4gIH1cbn1cbiIsIlBsYXlncm91bmRNYWluLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgQXBwIGZyb20gJy4vQXBwLnZ1ZSdcbmltcG9ydCB7IHNldHVwRWxlbWVudFBsdXMgfSBmcm9tICcuL2VsZW1lbnQtcGx1cy5qcydcbnNldHVwRWxlbWVudFBsdXMoKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPEFwcCAvPlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vQHZ1ZS9ydW50aW1lLWRvbUBsYXRlc3QvZGlzdC9ydW50aW1lLWRvbS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwiQHZ1ZS9zaGFyZWRcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvc2hhcmVkQGxhdGVzdC9kaXN0L3NoYXJlZC5lc20tYnVuZGxlci5qc1wiLFxuICAgIFwiZWxlbWVudC1wbHVzXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L2Rpc3QvaW5kZXguZnVsbC5taW4ubWpzXCIsXG4gICAgXCJlbGVtZW50LXBsdXMvXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9lbGVtZW50LXBsdXNAbGF0ZXN0L1wiLFxuICAgIFwiQGVsZW1lbnQtcGx1cy9pY29ucy12dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsIl9vIjp7fX0=)

steps:
1. Drag a directory
2. The output path is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Directory uploads now consistently preserve each file’s relative path.
  - Files with missing relative-path metadata correctly derive their path from the directory structure.
  - Existing relative paths continue to be respected, improving folder upload organization and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->