### PR TITLE
fix(components): [time-picker] avoid triggering `change` twice when clearing

### DIFF
--- a/packages/components/time-picker/__tests__/time-picker.test.tsx
+++ b/packages/components/time-picker/__tests__/time-picker.test.tsx
@@ -585,6 +585,25 @@ describe('TimePicker', () => {
 
     vi.useRealTimers()
   })
+
+  it('should only trigger change once when clearing', async () => {
+    const date = ref(new Date())
+    const changeHandler = vi.fn()
+    const wrapper = mount(() => (
+      <TimePicker
+        modelValue={date.value}
+        clearable
+        onUpdate:modelValue={(val) => (date.value = val ?? '')}
+        onChange={changeHandler}
+      />
+    ))
+
+    await wrapper.find('input').trigger('focus')
+    await wrapper.find('.clear-icon').trigger('click')
+
+    expect(changeHandler).toHaveBeenCalledOnce()
+    expect(changeHandler).toHaveBeenCalledWith(null)
+  })
 })
 
 describe('TimePicker(range)', () => {

--- a/packages/components/time-picker/src/common/picker.vue
+++ b/packages/components/time-picker/src/common/picker.vue
@@ -264,6 +264,7 @@ const refPopper = ref<TooltipInstance>()
 const inputRef = ref<InputInstance>()
 const valueOnOpen = ref<TimePickerDefaultProps['modelValue'] | null>(null)
 let hasJustTabExitedInput = false
+let shouldSkipChange = false
 
 const pickerDisabled = useFormDisabled()
 
@@ -332,9 +333,12 @@ const clearIconKls = computed(() => [
 watch(pickerVisible, (val) => {
   if (!val) {
     userInput.value = null
-    nextTick(() => {
-      emitChange(props.modelValue)
-    })
+    if (!shouldSkipChange) {
+      nextTick(() => {
+        emitChange(props.modelValue)
+      })
+    }
+    shouldSkipChange = false
   } else {
     nextTick(() => {
       if (val) {
@@ -456,6 +460,7 @@ const onClear = (event?: MouseEvent) => {
   if (props.readonly || pickerDisabled.value) return
   if (showClearBtn.value) {
     event?.stopPropagation()
+    shouldSkipChange = true
     // When the handleClear Function was provided, emit null will be executed inside it
     // There is no need for us to execute emit null twice. #14752
     if (pickerOptions.value.handleClear) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

fix #24826

In fact, clearing the value while the component is focused also causes an issue.

The reason is that the parent component sets `model-value` in `@update:modelValue`. When the dropdown closes, `emitChange(props.modelValue)` is called, but `props.modelValue` has already been updated at that point, causing the `change` event to be triggered again.

[demo](https://element-plus.run/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8ZWwtdGltZS1waWNrZXJcbiAgICA6bW9kZWwtdmFsdWU9XCJkYXRlXCJcbiAgICBjbGVhcmFibGVcbiAgICBAdXBkYXRlOm1vZGVsVmFsdWU9XCJoYW5kbGVVcGRhdGVcIlxuICAgIEBjaGFuZ2U9XCJoYW5kbGVDaGFuZ2VcIlxuICAvPlxuPC90ZW1wbGF0ZT5cblxuPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3QgZGF0ZSA9IHJlZigpXG5cbmZ1bmN0aW9uIGhhbmRsZVVwZGF0ZSh2YWwpIHtcbiAgZGF0ZS52YWx1ZSA9IHZhbCA/PyAnJ1xufVxuXG5mdW5jdGlvbiBoYW5kbGVDaGFuZ2UodmFsKSB7XG4gIGNvbnNvbGUubG9nKCdbY2hhbmdlXScsIHZhbClcbn1cbjwvc2NyaXB0PlxuIiwiZWxlbWVudC1wbHVzLmpzIjoiaW1wb3J0IEVsZW1lbnRQbHVzIGZyb20gJ2VsZW1lbnQtcGx1cydcbmltcG9ydCB7IGdldEN1cnJlbnRJbnN0YW5jZSB9IGZyb20gJ3Z1ZSdcblxubGV0IGluc3RhbGxlZCA9IGZhbHNlXG5hd2FpdCBsb2FkU3R5bGUoKVxuXG5leHBvcnQgZnVuY3Rpb24gc2V0dXBFbGVtZW50UGx1cygpIHtcbiAgaWYgKGluc3RhbGxlZCkgcmV0dXJuXG4gIGNvbnN0IGluc3RhbmNlID0gZ2V0Q3VycmVudEluc3RhbmNlKClcbiAgaW5zdGFuY2UuYXBwQ29udGV4dC5hcHAudXNlKEVsZW1lbnRQbHVzKVxuICBpbnN0YWxsZWQgPSB0cnVlXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkU3R5bGUoKSB7XG4gIGNvbnN0IHN0eWxlcyA9IFsnaHR0cHM6Ly9yYXcuZXNtLnNoL3ByL2VsZW1lbnQtcGx1c0AyNDg0MS9kaXN0L2luZGV4LmNzcycsICdodHRwczovL3Jhdy5lc20uc2gvcHIvZWxlbWVudC1wbHVzQDI0ODQxL3RoZW1lLWNoYWxrL2RhcmsvY3NzLXZhcnMuY3NzJ10ubWFwKChzdHlsZSkgPT4ge1xuICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgICBjb25zdCBsaW5rID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnbGluaycpXG4gICAgICBsaW5rLnJlbCA9ICdzdHlsZXNoZWV0J1xuICAgICAgbGluay5ocmVmID0gc3R5bGVcbiAgICAgIGxpbmsuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIHJlc29sdmUpXG4gICAgICBsaW5rLmFkZEV2ZW50TGlzdGVuZXIoJ2Vycm9yJywgcmVqZWN0KVxuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmQobGluaylcbiAgICB9KVxuICB9KVxuICByZXR1cm4gUHJvbWlzZS5hbGxTZXR0bGVkKHN0eWxlcylcbn1cbiIsInRzY29uZmlnLmpzb24iOiJ7XG4gIFwiY29tcGlsZXJPcHRpb25zXCI6IHtcbiAgICBcInRhcmdldFwiOiBcIkVTTmV4dFwiLFxuICAgIFwianN4XCI6IFwicHJlc2VydmVcIixcbiAgICBcIm1vZHVsZVwiOiBcIkVTTmV4dFwiLFxuICAgIFwibW9kdWxlUmVzb2x1dGlvblwiOiBcIkJ1bmRsZXJcIixcbiAgICBcInR5cGVzXCI6IFtcImVsZW1lbnQtcGx1cy9nbG9iYWwuZC50c1wiXSxcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWUsXG4gICAgXCJhbGxvd0pzXCI6IHRydWUsXG4gICAgXCJjaGVja0pzXCI6IHRydWVcbiAgfSxcbiAgXCJ2dWVDb21waWxlck9wdGlvbnNcIjoge1xuICAgIFwidGFyZ2V0XCI6IDMuM1xuICB9XG59XG4iLCJQbGF5Z3JvdW5kTWFpbi52dWUiOiI8c2NyaXB0IHNldHVwPlxuaW1wb3J0IEFwcCBmcm9tICcuL0FwcC52dWUnXG5pbXBvcnQgeyBzZXR1cEVsZW1lbnRQbHVzIH0gZnJvbSAnLi9lbGVtZW50LXBsdXMuanMnXG5zZXR1cEVsZW1lbnRQbHVzKClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxBcHAgLz5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0B2dWUvcnVudGltZS1kb21AbGF0ZXN0L2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvc2hhcmVkXCI6IFwiaHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L25wbS9AdnVlL3NoYXJlZEBsYXRlc3QvZGlzdC9zaGFyZWQuZXNtLWJ1bmRsZXIuanNcIixcbiAgICBcImVsZW1lbnQtcGx1c1wiOiBcImh0dHBzOi8vcmF3LmVzbS5zaC9wci9lbGVtZW50LXBsdXNAMjQ4NDEvZGlzdC9pbmRleC5mdWxsLm1pbi5tanNcIixcbiAgICBcImVsZW1lbnQtcGx1cy9cIjogXCJodHRwczovL3Jhdy5lc20uc2gvcHIvZWxlbWVudC1wbHVzQDI0ODQxL1wiLFxuICAgIFwiQGVsZW1lbnQtcGx1cy9pY29ucy12dWVcIjogXCJodHRwczovL2Nkbi5qc2RlbGl2ci5uZXQvbnBtL0BlbGVtZW50LXBsdXMvaWNvbnMtdnVlQDIvZGlzdC9pbmRleC5taW4uanNcIlxuICB9LFxuICBcInNjb3Blc1wiOiB7fVxufSIsIl9vIjp7InNob3dIaWRkZW4iOnRydWUsInN0eWxlU291cmNlIjoiaHR0cHM6Ly9yYXcuZXNtLnNoL3ByL2VsZW1lbnQtcGx1c0AyNDg0MS9kaXN0L2luZGV4LmNzcyJ9fQ==)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed duplicate change events when clearing date or time picker values.
  - Clearing a value now emits a single change event with a `null` value.
  - Prevented the picker panel from opening when clearing a value while the picker is unfocused.
  - Improved handling when cleared values are normalized to an empty value.
  - Fixed an issue where canceling a clear action could prevent the date picker from reopening when the input regains focus.

- **Tests**
  - Added regression coverage for date and time picker clearing and focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->