### PR TITLE
fix(components): prevent duplicate keyboard handling in dates picker

### DIFF
--- a/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
+++ b/packages/components/date-picker-panel/src/composables/use-basic-date-table.ts
@@ -326,7 +326,7 @@ export const useBasicDateTable = (
   }
 
   const handlePickDate = (
-    event: FocusEvent | MouseEvent,
+    event: FocusEvent | KeyboardEvent | MouseEvent,
     isKeyboardMovement = false
   ) => {
     if (props.disabled) return
@@ -387,6 +387,12 @@ export const useBasicDateTable = (
     return false
   }
 
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (props.selectionMode !== 'dates') return
+    event.preventDefault()
+    event.stopPropagation()
+    handlePickDate(event)
+  }
   return {
     WEEKS,
     rows,
@@ -405,6 +411,7 @@ export const useBasicDateTable = (
     handleMouseDown,
     handleMouseMove,
     handleFocus,
+    handleKeydown,
   }
 }
 

--- a/packages/components/date-picker-panel/src/date-picker-com/basic-date-table.vue
+++ b/packages/components/date-picker-panel/src/date-picker-com/basic-date-table.vue
@@ -42,6 +42,8 @@
           :tabindex="disabled ? undefined : isSelectedCell(cell) ? 0 : -1"
           :aria-disabled="disabled"
           @focus="handleFocus"
+          @keydown.enter="handleKeydown"
+          @keydown.space="handleKeydown"
         >
           <el-date-picker-cell :cell="cell" />
         </td>
@@ -81,6 +83,7 @@ const {
   handleMouseDown,
   handleMouseMove,
   handleFocus,
+  handleKeydown,
 } = useBasicDateTable(props, emit)
 const { tableLabel, tableKls, getCellClasses, getRowKls, weekHeaderClass, t } =
   useBasicDateTableDOM(props, {

--- a/packages/components/date-picker/__tests__/date-picker.test.ts
+++ b/packages/components/date-picker/__tests__/date-picker.test.ts
@@ -1804,6 +1804,45 @@ describe('DatePicker dates', () => {
       document.querySelectorAll('.el-date-table__row .selected').length
     ).toBe(1)
   })
+
+  it('should toggle dates on keyboard enter and space', async () => {
+    const wrapper = _mount(
+      `<el-date-picker
+        type="dates"
+        v-model="value"
+      />`,
+      () => ({ value: [] as Date[] })
+    )
+    const input = wrapper.find('input')
+    input.trigger('blur')
+    input.trigger('focus')
+    await nextTick()
+
+    const date = document.querySelector(
+      '.el-date-table__row .available'
+    ) as HTMLElement
+    date.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Enter',
+        code: EVENT_CODE.enter,
+        bubbles: true,
+      })
+    )
+    await nextTick()
+
+    const vm = wrapper.vm as any
+    expect(vm.value).toHaveLength(1)
+
+    date.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: ' ',
+        code: EVENT_CODE.space,
+        bubbles: true,
+      })
+    )
+    await nextTick()
+    expect(vm.value).toHaveLength(0)
+  })
 })
 
 describe('DatePicker months', () => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## What is fixed

Fixes an error triggered when pressing `Enter` or `Space` on a date cell in a DatePicker with `type="dates"`.

The keyboard event previously bubbled to the parent panel handler, which did not handle the multiple-date selection correctly.

## Changes

- Handle `Enter` and `Space` directly on date cells in `dates` mode.
- Prevent the handled keyboard event from propagating to the parent panel.
- Add a regression test covering keyboard selection and deselection.

## Steps to reproduce

1. Render a DatePicker with `type="dates"`.
2. Open the picker panel.
3. Click a date to select it and focus the date cell.
4. Press `Enter` or `Space`.
5. An error is thrown because the keyboard event bubbles to the parent panel handler.

## Implementation

The fix follows the existing keyboard interaction behavior of the
`quarters` picker.

`Enter` and `Space` are handled directly by the focused date cell in
`dates` mode. After the date is selected or deselected, the event's
default behavior and propagation are prevented so that it is not
processed again by the parent panel.

https://github.com/user-attachments/assets/057f1f77-434c-4c4d-8c9e-def9ad3a773d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Date pickers in dates-selection mode now support selecting and deselecting dates using the Enter and Space keys.
  - Keyboard interactions prevent unintended browser behavior and integrate with existing date selection.

- **Tests**
  - Added coverage verifying that Enter selects a date and Space toggles it off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->