### PR TITLE
fix(components): [loading] memory leak

### DIFF
--- a/packages/components/loading/__tests__/loading.test.tsx
+++ b/packages/components/loading/__tests__/loading.test.tsx
@@ -191,6 +191,27 @@ describe('Loading', () => {
     expect(loadingInstance.visible.value).toBeFalsy()
   })
 
+  test('close service should release detached dom', async () => {
+    loadingInstance = Loading()
+    const mask = document.querySelector('.el-loading-mask') as HTMLElement
+    expect(mask).toBeTruthy()
+
+    vi.useFakeTimers()
+    loadingInstance.close()
+    vi.runAllTimers()
+    vi.useRealTimers()
+    await nextTick()
+
+    // the mask is removed from the document ...
+    expect(mask.parentNode).toBeNull()
+    // ... and no reference on the instance keeps it alive anymore
+    expect(loadingInstance.$el).toBeNull()
+    const internalInstance = loadingInstance.vm.$
+    expect(internalInstance.vnode.el).toBeNull()
+    expect(internalInstance.subTree).toBeNull()
+    expect(internalInstance.appContext.app._container).toBeNull()
+  })
+
   test('target service', async () => {
     const container = document.createElement('div')
     container.className = 'loading-container'

--- a/packages/components/loading/src/loading.ts
+++ b/packages/components/loading/src/loading.ts
@@ -23,6 +23,7 @@ export function createLoadingComponent(
   appContext: AppContext | null
 ) {
   let afterLeaveTimer: ReturnType<typeof setTimeout>
+  let destroyed = false
   // IMPORTANT NOTE: this is only a hacking way to expose the injections on an
   // instance, DO NOT FOLLOW this pattern in your own code.
   const afterLeaveFlag = ref(false)
@@ -38,8 +39,12 @@ export function createLoadingComponent(
   }
 
   function destroySelf() {
+    if (destroyed) return
+    destroyed = true
     const target = data.parent
-    const ns = (vm as any).ns as UseNamespaceReturn
+    // Compatible with the instance data format of vue@3.2.12 and earlier versions #12351
+    const ns =
+      ((vm as any).ns as UseNamespaceReturn) || (vm as any)._.exposed.ns
     if (!target.vLoadingAddClassList) {
       let loadingNumber: number | string | null =
         target.getAttribute('loading-number')
@@ -54,6 +59,11 @@ export function createLoadingComponent(
     }
     removeElLoadingChild()
     loadingInstance.unmount()
+
+    const internalInstance = vm.$ as any
+    internalInstance.vnode.el = null
+    internalInstance.subTree = null
+    loadingInstance._container = null
   }
   function removeElLoadingChild(): void {
     vm.$el?.parentNode?.removeChild(vm.$el)
@@ -165,8 +175,8 @@ export function createLoadingComponent(
     close,
     handleAfterLeave,
     vm,
-    get $el(): HTMLElement {
-      return vm.$el
+    get $el(): HTMLElement | null {
+      return destroyed ? null : vm.$el
     },
   }
 }

--- a/packages/components/loading/src/service.ts
+++ b/packages/components/loading/src/service.ts
@@ -63,7 +63,7 @@ const Loading = function (
   }
   resolved.parent.setAttribute('loading-number', loadingNumber)
 
-  resolved.parent.appendChild(instance.$el)
+  resolved.parent.appendChild(instance.$el!)
 
   // after instance render, then modify visible to trigger transition
   nextTick(() => (instance.visible.value = resolved.visible))
@@ -140,7 +140,7 @@ const addStyle = async (
     instance.originalPosition.value = getStyle(parent, 'position')
   }
   for (const [key, value] of Object.entries(maskStyle)) {
-    instance.$el.style[key] = value
+    instance.$el!.style[key] = value
   }
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.

ref #21431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading overlays being left in the DOM after they are closed.
  * Prevented duplicate cleanup when a loading instance is destroyed.
  * Loading instances now correctly report no element after destruction.
  * Improved cleanup compatibility across supported Vue versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->